### PR TITLE
charts: update TiDB configuration and monitor versions

### DIFF
--- a/charts/tidb-cluster/templates/monitor-configmap.yaml
+++ b/charts/tidb-cluster/templates/monitor-configmap.yaml
@@ -970,7 +970,7 @@ data:
     ;mode = console file
 
     # Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
-    ;level = info
+    level = {{ .Values.monitor.grafana.logLevel }}
 
     # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
     ;filters =

--- a/charts/tidb-cluster/templates/monitor-deployment.yaml
+++ b/charts/tidb-cluster/templates/monitor-deployment.yaml
@@ -51,6 +51,7 @@ spec:
         {{- end }}
         command:
         - /bin/prometheus
+        - --log.level={{ .Values.monitor.prometheus.logLevel }}
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus
         - --storage.tsdb.retention={{ .Values.monitor.prometheus.reserveDays }}d

--- a/charts/tidb-cluster/templates/pd-configmap.yaml
+++ b/charts/tidb-cluster/templates/pd-configmap.yaml
@@ -90,6 +90,14 @@ data:
     lease = 3
     tso-save-interval = "3s"
 
+    [security]
+    # Path of file that contains list of trusted SSL CAs. if set, following four settings shouldn't be empty
+    cacert-path = ""
+    # Path of file that contains X509 certificate in PEM format.
+    cert-path = ""
+    # Path of file that contains X509 key in PEM format.
+    key-path = ""
+
     [log]
     level = "{{ .Values.pd.logLevel }}"
 
@@ -118,18 +126,22 @@ data:
     address = ""
 
     [schedule]
+    max-merge-region-size = 0
+    split-merge-interval = "1h"
     max-snapshot-count = 3
+    max-pending-peer-count = 16
     max-store-down-time = "{{ .Values.pd.maxStoreDownTime }}"
-    leader-schedule-limit = 64
-    region-schedule-limit = 16
-    replica-schedule-limit = 24
+    leader-schedule-limit = 4
+    region-schedule-limit = 4
+    replica-schedule-limit = 8
+    merge-schedule-limit = 8
+    tolerant-size-ratio = 5.0
 
     # customized schedulers, the format is as below
     # if empty, it will use balance-leader, balance-region, hot-region as default
     # [[schedule.schedulers]]
     # type = "evict-leader"
     # args = ["1"]
-
 
     [replication]
     # The number of replicas for each region.
@@ -139,3 +151,9 @@ data:
     # For example, ["zone", "rack"] means that we should place replicas to
     # different zones first, then to different racks if we don't have enough zones.
     location-labels = ["zone", "rack", "host"]
+
+    [label-property]
+    # Do not assign region leaders to stores that have these tags.
+    #  [[label-property.reject-leader]]
+    #  key = "zone"
+    #  value = "cn1

--- a/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
@@ -57,45 +57,59 @@ data:
     # TiDB server port.
     port = 4000
 
-    # Registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]
+    # Registered store name, [tikv, mocktikv]
     store = "mocktikv"
 
     # TiDB storage path.
     path = "/tmp/tidb"
 
     # The socket file to use for connection.
-    #socket = ""
-
-    # Socket file to write binlog.
-    # binlog-socket = ""
+    socket = ""
 
     # Run ddl worker on this tidb-server.
     run-ddl = true
 
     # Schema lease duration, very dangerous to change only if you know what you do.
-    lease = "10s"
+    lease = "45s"
 
-    # When create table, split a separated region for it.
-    # split-table = false
+    # When create table, split a separated region for it. It is recommended to
+    # turn off this option if there will be a large number of tables created.
+    split-table = true
 
     # The limit of concurrent executed sessions.
-    # token-limit = 1000
+    token-limit = 1000
+
+    # Only print a log when out of memory quota.
+    # Valid options: ["log", "cancel"]
+    oom-action = "log"
+
+    # Set the memory quota for a query in bytes. Default: 32GB
+    mem-quota-query = 34359738368
+
+    # Enable coprocessor streaming.
+    enable-streaming = false
+
+    # Set system variable 'lower_case_table_names'
+    lower-case-table-names = 2
 
     [log]
-    # Log level: info, debug, warn, error, fatal.
-    level = "info"
+    # Log level: debug, info, warn, error, fatal.
+    level = "{{ .Values.privilegedTidb.logLevel }}"
 
     # Log format, one of json, text, console.
     format = "text"
 
-    # Disable automatic timestamps in output
+    # Disable automatic timestamp in output
     disable-timestamp = false
 
-    # Stores slow query log into seperate files.
-    #slow-query-file = ""
+    # Stores slow query log into separated files.
+    slow-query-file = ""
 
     # Queries with execution time greater than this value will be logged. (Milliseconds)
     slow-threshold = 300
+
+    # Queries with internal result greater than this value will be logged.
+    expensive-threshold = 10000
 
     # Maximum query length recorded in log.
     query-log-max-len = 2048
@@ -105,14 +119,14 @@ data:
     # Log file name.
     filename = ""
 
-    # Max log file size in MB.
-    #max-size = 300
+    # Max log file size in MB (upper limit to 4096MB).
+    max-size = 300
 
-    # Max log file keep days.
-    #max-days = 28
+    # Max log file keep days. No clean up by default.
+    max-days = 0
 
-    # Maximum number of old log files to retain.
-    #max-backups = 7
+    # Maximum number of old log files to retain. No clean up by default.
+    max-backups = 0
 
     # Rotate log by day
     log-rotate = true
@@ -120,14 +134,23 @@ data:
     [security]
     # This option causes the server to start without using the privilege system at all.
     skip-grant-table = true
-    # Path of file that contains list of trusted SSL CAs.
+    # Path of file that contains list of trusted SSL CAs for connection with mysql client.
     ssl-ca = ""
 
-    # Path of file that contains X509 certificate in PEM format.
+    # Path of file that contains X509 certificate in PEM format for connection with mysql client.
     ssl-cert = ""
 
-    # Path of file that contains X509 key in PEM format.
+    # Path of file that contains X509 key in PEM format for connection with mysql client.
     ssl-key = ""
+
+    # Path of file that contains list of trusted SSL CAs for connection with cluster components.
+    cluster-ssl-ca = ""
+
+    # Path of file that contains X509 certificate in PEM format for connection with cluster components.
+    cluster-ssl-cert = ""
+
+    # Path of file that contains X509 key in PEM format for connection with cluster components.
+    cluster-ssl-key = ""
 
     [status]
     # If enable status report HTTP service.
@@ -137,45 +160,126 @@ data:
     status-port = 10080
 
     # Prometheus pushgateway address, leaves it empty will disable prometheus push.
-    # metrics-addr = ""
+    metrics-addr = ""
 
     # Prometheus client push interval in second, set \"0\" to disable prometheus push.
     metrics-interval = 15
 
     [performance]
+    # Max CPUs to use, 0 use number of CPUs in the machine.
+    max-procs = 0
+    # StmtCountLimit limits the max count of statement inside a transaction.
+    stmt-count-limit = 5000
+
     # Set keep alive option for tcp connection.
     tcp-keep-alive = true
 
     # The maximum number of retries when commit a transaction.
     retry-limit = 10
 
-    # The number of goroutines that participate joining.
-    join-concurrency = 5
-
     # Whether support cartesian product.
     cross-join = true
 
-    # Stats lease duration, which inflences the time of analyze and stats load.
+    # Stats lease duration, which influences the time of analyze and stats load.
     stats-lease = "3s"
 
     # Run auto analyze worker on this tidb-server.
     run-auto-analyze = true
 
-    [xprotocol]
-    # Start TiDB x server.
-    xserver = false
+    # Probability to use the query feedback to update stats, 0 or 1 for always false/true.
+    feedback-probability = 0.0
 
-    # TiDB x protocol server host.
-    xhost = "0.0.0.0"
+    # The max number of query feedback that cache in memory.
+    query-feedback-limit = 1024
 
-    # TiDB x protocol server port.
-    xport = 14000
+    # Pseudo stats will be used if the ratio between the modify count and
+    # row count in statistics of a table is greater than it.
+    pseudo-estimate-ratio = 0.7
 
-    # The socket file to use for x protocol connection.
-    xsocket = ""
+    [proxy-protocol]
+    # PROXY protocol acceptable client networks.
+    # Empty string means disable PROXY protocol, * means all networks.
+    networks = ""
+
+    # PROXY protocol header read timeout, unit is second
+    header-timeout = 5
 
     [plan-cache]
-    plan-cache-enabled = false
-    plan-cache-capacity = 2560
-    plan-cache-shards = 256
+    enabled = false
+    capacity = 2560
+    shards = 256
+
+    [prepared-plan-cache]
+    enabled = false
+    capacity = 100
+
+    [opentracing]
+    # Enable opentracing.
+    enable = false
+
+    # Whether to enable the rpc metrics.
+    rpc-metrics = false
+
+    [opentracing.sampler]
+    # Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+    type = "const"
+
+    # Param is a value passed to the sampler.
+    # Valid values for Param field are:
+    # - for "const" sampler, 0 or 1 for always false/true respectively
+    # - for "probabilistic" sampler, a probability between 0 and 1
+    # - for "rateLimiting" sampler, the number of spans per second
+    # - for "remote" sampler, param is the same as for "probabilistic"
+    # and indicates the initial sampling rate before the actual one
+    # is received from the mothership
+    param = 1.0
+
+    # SamplingServerURL is the address of jaeger-agent's HTTP sampling server
+    sampling-server-url = ""
+
+    # MaxOperations is the maximum number of operations that the sampler
+    # will keep track of. If an operation is not tracked, a default probabilistic
+    # sampler will be used rather than the per operation specific sampler.
+    max-operations = 0
+
+    # SamplingRefreshInterval controls how often the remotely controlled sampler will poll
+    # jaeger-agent for the appropriate sampling strategy.
+    sampling-refresh-interval = 0
+
+    [opentracing.reporter]
+    # QueueSize controls how many spans the reporter can keep in memory before it starts dropping
+    # new spans. The queue is continuously drained by a background go-routine, as fast as spans
+    # can be sent out of process.
+    queue-size = 0
+
+    # BufferFlushInterval controls how often the buffer is force-flushed, even if it's not full.
+    # It is generally not useful, as it only matters for very low traffic services.
+    buffer-flush-interval = 0
+
+    # LogSpans, when true, enables LoggingReporter that runs in parallel with the main reporter
+    # and logs all submitted spans. Main Configuration.Logger must be initialized in the code
+    # for this option to have any effect.
+    log-spans = false
+
+    #  LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
+    local-agent-host-port = ""
+
+    [tikv-client]
+    # Max gRPC connections that will be established with each tikv-server.
+    grpc-connection-count = 16
+
+    # max time for commit command, must be twice bigger than raft election timeout.
+    commit-timeout = "41s"
+
+    [binlog]
+
+    # Socket file to write binlog.
+    binlog-socket = ""
+
+    # WriteTimeout specifies how long it will wait for writing binlog to pump.
+    write-timeout = "15s"
+
+    # If IgnoreError is true, when writting binlog meets error, TiDB would stop writting binlog,
+    # but still provide service.
+    ignore-error = false
 {{- end }}

--- a/charts/tidb-cluster/templates/tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/tidb-configmap.yaml
@@ -55,45 +55,59 @@ data:
     # TiDB server port.
     port = 4000
 
-    # Registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]
+    # Registered store name, [tikv, mocktikv]
     store = "mocktikv"
 
     # TiDB storage path.
     path = "/tmp/tidb"
 
     # The socket file to use for connection.
-    #socket = ""
-
-    # Socket file to write binlog.
-    # binlog-socket = ""
+    socket = ""
 
     # Run ddl worker on this tidb-server.
     run-ddl = true
 
     # Schema lease duration, very dangerous to change only if you know what you do.
-    lease = "10s"
+    lease = "45s"
 
-    # When create table, split a separated region for it.
-    # split-table = false
+    # When create table, split a separated region for it. It is recommended to
+    # turn off this option if there will be a large number of tables created.
+    split-table = true
 
     # The limit of concurrent executed sessions.
-    # token-limit = 1000
+    token-limit = 1000
+
+    # Only print a log when out of memory quota.
+    # Valid options: ["log", "cancel"]
+    oom-action = "log"
+
+    # Set the memory quota for a query in bytes. Default: 32GB
+    mem-quota-query = 34359738368
+
+    # Enable coprocessor streaming.
+    enable-streaming = false
+
+    # Set system variable 'lower_case_table_names'
+    lower-case-table-names = 2
 
     [log]
-    # Log level: info, debug, warn, error, fatal.
+    # Log level: debug, info, warn, error, fatal.
     level = "{{ .Values.tidb.logLevel }}"
 
     # Log format, one of json, text, console.
     format = "text"
 
-    # Disable automatic timestamps in output
+    # Disable automatic timestamp in output
     disable-timestamp = false
 
-    # Stores slow query log into seperate files.
-    #slow-query-file = ""
+    # Stores slow query log into separated files.
+    slow-query-file = ""
 
     # Queries with execution time greater than this value will be logged. (Milliseconds)
     slow-threshold = 300
+
+    # Queries with internal result greater than this value will be logged.
+    expensive-threshold = 10000
 
     # Maximum query length recorded in log.
     query-log-max-len = 2048
@@ -103,27 +117,36 @@ data:
     # Log file name.
     filename = ""
 
-    # Max log file size in MB.
-    #max-size = 300
+    # Max log file size in MB (upper limit to 4096MB).
+    max-size = 300
 
-    # Max log file keep days.
-    #max-days = 28
+    # Max log file keep days. No clean up by default.
+    max-days = 0
 
-    # Maximum number of old log files to retain.
-    #max-backups = 7
+    # Maximum number of old log files to retain. No clean up by default.
+    max-backups = 0
 
     # Rotate log by day
     log-rotate = true
 
     [security]
-    # Path of file that contains list of trusted SSL CAs.
+    # Path of file that contains list of trusted SSL CAs for connection with mysql client.
     ssl-ca = ""
 
-    # Path of file that contains X509 certificate in PEM format.
+    # Path of file that contains X509 certificate in PEM format for connection with mysql client.
     ssl-cert = ""
 
-    # Path of file that contains X509 key in PEM format.
+    # Path of file that contains X509 key in PEM format for connection with mysql client.
     ssl-key = ""
+
+    # Path of file that contains list of trusted SSL CAs for connection with cluster components.
+    cluster-ssl-ca = ""
+
+    # Path of file that contains X509 certificate in PEM format for connection with cluster components.
+    cluster-ssl-cert = ""
+
+    # Path of file that contains X509 key in PEM format for connection with cluster components.
+    cluster-ssl-key = ""
 
     [status]
     # If enable status report HTTP service.
@@ -139,38 +162,119 @@ data:
     metrics-interval = 15
 
     [performance]
+    # Max CPUs to use, 0 use number of CPUs in the machine.
+    max-procs = 0
+    # StmtCountLimit limits the max count of statement inside a transaction.
+    stmt-count-limit = 5000
+
     # Set keep alive option for tcp connection.
     tcp-keep-alive = true
 
     # The maximum number of retries when commit a transaction.
     retry-limit = 10
 
-    # The number of goroutines that participate joining.
-    join-concurrency = 5
-
     # Whether support cartesian product.
     cross-join = true
 
-    # Stats lease duration, which inflences the time of analyze and stats load.
+    # Stats lease duration, which influences the time of analyze and stats load.
     stats-lease = "3s"
 
     # Run auto analyze worker on this tidb-server.
     run-auto-analyze = true
 
-    [xprotocol]
-    # Start TiDB x server.
-    xserver = false
+    # Probability to use the query feedback to update stats, 0 or 1 for always false/true.
+    feedback-probability = 0.0
 
-    # TiDB x protocol server host.
-    xhost = "0.0.0.0"
+    # The max number of query feedback that cache in memory.
+    query-feedback-limit = 1024
 
-    # TiDB x protocol server port.
-    xport = 14000
+    # Pseudo stats will be used if the ratio between the modify count and
+    # row count in statistics of a table is greater than it.
+    pseudo-estimate-ratio = 0.7
 
-    # The socket file to use for x protocol connection.
-    xsocket = ""
+    [proxy-protocol]
+    # PROXY protocol acceptable client networks.
+    # Empty string means disable PROXY protocol, * means all networks.
+    networks = ""
+
+    # PROXY protocol header read timeout, unit is second
+    header-timeout = 5
 
     [plan-cache]
-    plan-cache-enabled = false
-    plan-cache-capacity = 2560
-    plan-cache-shards = 256
+    enabled = false
+    capacity = 2560
+    shards = 256
+
+    [prepared-plan-cache]
+    enabled = false
+    capacity = 100
+
+    [opentracing]
+    # Enable opentracing.
+    enable = false
+
+    # Whether to enable the rpc metrics.
+    rpc-metrics = false
+
+    [opentracing.sampler]
+    # Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+    type = "const"
+
+    # Param is a value passed to the sampler.
+    # Valid values for Param field are:
+    # - for "const" sampler, 0 or 1 for always false/true respectively
+    # - for "probabilistic" sampler, a probability between 0 and 1
+    # - for "rateLimiting" sampler, the number of spans per second
+    # - for "remote" sampler, param is the same as for "probabilistic"
+    # and indicates the initial sampling rate before the actual one
+    # is received from the mothership
+    param = 1.0
+
+    # SamplingServerURL is the address of jaeger-agent's HTTP sampling server
+    sampling-server-url = ""
+
+    # MaxOperations is the maximum number of operations that the sampler
+    # will keep track of. If an operation is not tracked, a default probabilistic
+    # sampler will be used rather than the per operation specific sampler.
+    max-operations = 0
+
+    # SamplingRefreshInterval controls how often the remotely controlled sampler will poll
+    # jaeger-agent for the appropriate sampling strategy.
+    sampling-refresh-interval = 0
+
+    [opentracing.reporter]
+    # QueueSize controls how many spans the reporter can keep in memory before it starts dropping
+    # new spans. The queue is continuously drained by a background go-routine, as fast as spans
+    # can be sent out of process.
+    queue-size = 0
+
+    # BufferFlushInterval controls how often the buffer is force-flushed, even if it's not full.
+    # It is generally not useful, as it only matters for very low traffic services.
+    buffer-flush-interval = 0
+
+    # LogSpans, when true, enables LoggingReporter that runs in parallel with the main reporter
+    # and logs all submitted spans. Main Configuration.Logger must be initialized in the code
+    # for this option to have any effect.
+    log-spans = false
+
+    #  LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
+    local-agent-host-port = ""
+
+    [tikv-client]
+    # Max gRPC connections that will be established with each tikv-server.
+    grpc-connection-count = 16
+
+    # max time for commit command, must be twice bigger than raft election timeout.
+    commit-timeout = "41s"
+
+    [binlog]
+
+    # Socket file to write binlog.
+    binlog-socket = ""
+
+    # WriteTimeout specifies how long it will wait for writing binlog to pump.
+    write-timeout = "15s"
+
+    # If IgnoreError is true, when writting binlog meets error, TiDB would stop writting binlog,
+    # but still provide service.
+    ignore-error = false

--- a/charts/tidb-cluster/templates/tikv-configmap.yaml
+++ b/charts/tidb-cluster/templates/tikv-configmap.yaml
@@ -61,6 +61,34 @@ data:
     # file to store log, write to stderr if it's empty.
     # log-file = ""
 
+    [readpool.storage]
+    # size of thread pool for high-priority operations
+    # high-concurrency = 4
+    # size of thread pool for normal-priority operations
+    # normal-concurrency = 4
+    # size of thread pool for low-priority operations
+    # low-concurrency = 4
+    # max running high-priority operations, reject if exceed
+    # max-tasks-high = 8000
+    # max running normal-priority operations, reject if exceed
+    # max-tasks-normal = 8000
+    # max running low-priority operations, reject if exceed
+    # max-tasks-low = 8000
+    # size of stack size for each thread pool
+    # stack-size = "10MB"
+
+    [readpool.coprocessor]
+    # Notice: if CPU_NUM > 8, default thread pool size for coprocessors
+    # will be set to CPU_NUM * 0.8.
+
+    # high-concurrency = 8
+    # normal-concurrency = 8
+    # low-concurrency = 8
+    # max-tasks-high = 16000
+    # max-tasks-normal = 16000
+    # max-tasks-low = 16000
+    # stack-size = "10MB"
+
     [server]
     # set listening address.
     # addr = "127.0.0.1:20160"
@@ -71,6 +99,8 @@ data:
     # maximum number of messages can be processed in one tick.
     # messages-per-tick = 4096
 
+    # compression type for grpc channel, available values are no, deflate and gzip.
+    # grpc-compression-type = "no"
     # size of thread pool for grpc server.
     # grpc-concurrency = 4
     # The number of max concurrent streams/requests on a client connection.
@@ -80,14 +110,23 @@ data:
     # Amount to read ahead on individual grpc streams.
     # grpc-stream-initial-window-size = "2MB"
 
-    # size of thread pool for endpoint task, should less than total cpu cores.
-    # end-point-concurrency = 8
+    # How many snapshots can be sent concurrently.
+    # concurrent-send-snap-limit = 32
+    # How many snapshots can be recv concurrently.
+    # concurrent-recv-snap-limit = 32
 
     # max count of tasks being handled, new tasks will be rejected.
     # end-point-max-tasks = 2000
 
-    # stack size of endpoint, complicated tasks may involve very deep recursion.
-    # end-point-stack-size = "10MB"
+    # max recursion level allowed when decoding dag expression
+    # end-point-recursion-limit = 1000
+
+    # max time to handle coprocessor request before timeout
+    # end-point-request-max-handle-duration = "60s"
+
+    # the max bytes that snapshot can be written to disk in one second,
+    # should be set based on your disk performance
+    # snap-max-write-bytes-per-sec = "100MB"
 
     # set attributes about this server, e.g. { zone = "us-west-1", disk = "ssd" }.
     # labels = {}
@@ -146,11 +185,6 @@ data:
     # Store heartbeat tick interval for reporting to pd.
     # pd-store-heartbeat-tick-interval = "10s"
 
-    # When the region's size exceeds region-max-size, we will split the region
-    # into two which the left region's size will be region-split-size or a little
-    # bit smaller.
-    # region-max-size = "144MB"
-    # region-split-size = "96MB"
     # When region size changes exceeds region-split-check-diff, we should check
     # whether the region should be split or not.
     # region-split-check-diff = "6MB"
@@ -176,10 +210,11 @@ data:
     # max-peer-down-duration = "5m"
 
     # Interval to check whether start manual compaction for a region,
-    # 0 is the default value, means disable manual compaction.
     # region-compact-check-interval = "5m"
-    # When delete keys of a region exceeds the size, a compaction will be started.
-    # region-compact-delete-keys-count = 1000000
+    # Number of regions for each time to check.
+    # region-compact-check-step = 100
+    # The minimum number of delete tombstones to trigger manual compaction.
+    # region-compact-min-tombstones = 10000
     # Interval to check whether should start a manual compaction for lock column family,
     # if written bytes reach lock-cf-compact-threshold for lock column family, will fire
     # a manual compaction for lock column family.
@@ -188,6 +223,26 @@ data:
 
     # Interval (s) to check region whether the data are consistent.
     # consistency-check-interval = 0
+
+    # Use delete range to drop a large number of continuous keys.
+    # use-delete-range = false
+
+    # delay time before deleting a stale peer
+    # clean-stale-peer-delay = "10m"
+
+    # Interval to cleanup import sst files.
+    # cleanup-import-sst-interval = "10m"
+
+    [coprocessor]
+    # When it is true, it will try to split a region with table prefix if
+    # that region crosses tables. It is recommended to turn off this option
+    # if there will be a large number of tables created.
+    # split-region-on-table = true
+    # When the region's size exceeds region-max-size, we will split the region
+    # into two which the left region's size will be region-split-size or a little
+    # bit smaller.
+    # region-max-size = "144MB"
+    # region-split-size = "96MB"
 
     [rocksdb]
     # Maximum number of concurrent background jobs (compactions and flushes)
@@ -250,9 +305,6 @@ data:
     # rocksdb max total wal size
     # max-total-wal-size = "4GB"
 
-    # rocksdb writable file max buffer size
-    # writable-file-max-buffer-size = "1MB"
-
     # Rocksdb Statistics provides cumulative stats over time.
     # Turn statistics on will introduce about 5%-10% overhead for RocksDB,
     # but it is worthy to know the internal status of RocksDB.
@@ -282,11 +334,12 @@ data:
     # Enable or disable the pipelined write
     # enable-pipelined-write = true
 
-    # set backup path, if not set, use "backup" under store path.
-    # backup-dir = "/tmp/tikv/store/backup"
+    # Allows OS to incrementally sync files to disk while they are being
+    # written, asynchronously, in the background.
+    # bytes-per-sync = "0MB"
 
     # Allows OS to incrementally sync WAL to disk while it is being written.
-    # wal-bytes-per-sync = 0
+    # wal-bytes-per-sync = "0KB"
 
     # Column Family default used to store actual data of the database.
     [rocksdb.defaultcf]
@@ -371,6 +424,9 @@ data:
     # 16     =>  00.78 %
     # read-amp-bytes-per-bit = 0
 
+    # Pick target size of each level dynamically.
+    # dynamic-level-bytes = false
+
     # Options for Column Family write
     # Column Family write used to store commit informations in MVCC model
     [rocksdb.writecf]
@@ -391,6 +447,7 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 3
     # read-amp-bytes-per-bit = 0
+    # dynamic-level-bytes = false
 
     [rocksdb.lockcf]
     # compression-per-level = ["no", "no", "no", "no", "no", "no", "no"]
@@ -408,13 +465,13 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 0
     # read-amp-bytes-per-bit = 0
+    # dynamic-level-bytes = false
 
     [raftdb]
     # max-sub-compactions = 1
     # max-open-files = 40960
     # max-manifest-file-size = "20MB"
     # create-if-missing = true
-    # writable-file-max-buffer-size = "1MB"
 
     # enable-statistics = true
     # stats-dump-period = "10m"
@@ -424,6 +481,8 @@ data:
     # use-direct-io-for-flush-and-compaction = false
     # enable-pipelined-write = true
     # allow-concurrent-memtable-write = false
+    # bytes-per-sync = "0MB"
+    # wal-bytes-per-sync = "0KB"
 
     [raftdb.defaultcf]
     # compression-per-level = ["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
@@ -443,4 +502,18 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 0
     # read-amp-bytes-per-bit = 0
-    # wal-bytes-per-sync = 0
+    # dynamic-level-bytes = false
+
+    [security]
+    # set the path for certificates. Empty string means disabling secure connectoins.
+    # ca-path = ""
+    # cert-path = ""
+    # key-path = ""
+
+    [import]
+    # the directory to store importing kv data.
+    # import-dir = "/tmp/tikv/import"
+    # number of threads to handle RPC requests.
+    # num-threads = 8
+    # stream channel window size, stream will be blocked on channel full.
+    # stream-channel-window = 128

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -114,9 +114,10 @@ tidb:
 monitor:
   create: true
   dashboardInstaller:
-    image: pingcap/tidb-dashboard-installer:v1.0.7
+    image: pingcap/tidb-dashboard-installer:v2.0.0
   grafana:
-    image: grafana/grafana:4.2.0
+    image: grafana/grafana:4.6.3
+    logLevel: info
     resources: {}
       # limits:
       #   cpu: 8000m
@@ -130,7 +131,8 @@ monitor:
       type: NodePort
     grafanaUrl: http://localhost:3000
   prometheus:
-    image: prom/prometheus:v2.0.0
+    image: prom/prometheus:v2.2.1
+    logLevel: info
     resources: {}
       # limits:
       #   cpu: 8000m
@@ -152,6 +154,7 @@ privilegedTidb:
   create: false
   replicas: 1
   image: pingcap/tidb:v2.0.4
+  logLevel: info
   resources: {}
   #  limits:
   #    cpu: 16000m

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -106,9 +106,10 @@ tidb:
 monitor:
   create: true
   dashboardInstaller:
-    image: pingcap/tidb-dashboard-installer:v1.0.7
+    image: pingcap/tidb-dashboard-installer:v2.0.0
   grafana:
-    image: grafana/grafana:4.2.0
+    image: grafana/grafana:4.6.3
+    logLevel: info
     resources: {}
       # limits:
       #   cpu: 8000m
@@ -122,7 +123,8 @@ monitor:
       type: NodePort
     grafanaUrl: http://localhost:3000
   prometheus:
-    image: prom/prometheus:v2.0.0
+    image: prom/prometheus:v2.2.1
+    logLevel: info
     resources: {}
       # limits:
       #   cpu: 8000m
@@ -144,6 +146,7 @@ privilegedTidb:
   create: false
   replicas: 1
   image: pingcap/tidb:v2.0.4
+  logLevel: info
   resources: {}
   #  limits:
   #    cpu: 16000m
@@ -164,4 +167,3 @@ privilegedTidb:
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"
 metaValue: "{{ $value }}"
-


### PR DESCRIPTION
This PR updates TiDB configuration to v2.0.4, and bumps monitor images version:
Prometheus: v2.0.0 -> v2.2.1
Grafana: 4.2.0 -> 4.6.3
tidb-dashboard-installer: v1.0.7 -> v2.0.0
PTAL @weekface @onlymellb