### PR TITLE
Safely scale out after a scale in operation for pd

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,26 @@
 
 This document defines the roadmap for TiDB Operator development.
 
-- [x] Synchronize cluster meta info to PV/PVC labels
-- [x] Upgrade the TiDB cluster in order: PD -> TiKV -> TiDB
-- [x] Safely scale in the TiDB cluster
-- [ ] Gracefully upgrade PD/TiKV/TiDB: evict the Raft leader or the DDL owner before upgrade
-- [ ] Automatic failover
-- [ ] Customize the LoadBalancer service on public cloud
-- [ ] Full Local Volume support
+## v0.1.0: (2018-08-21)
+- [x] Bootstrap multiple TiDB clusters
+- [x] Monitor deployment support
+- [x] Helm charts support
+- [x] Basic Network PV/Local PV support
+- [ ] Safely scale the TiDB cluster
+- [x] Upgrade the TiDB cluster in order
+- [x] Stop the TiDB process without terminating Pod
+- [x] Synchronize cluster meta info to POD/PV/PVC labels
+- [x] Basic unit tests & E2E tests
+- [ ] Tutorials for GKE, local DinD
+
+## v0.2.0: (2018-09-10)
+- [ ] Automatic failover for network PV
+- [ ] Automatic failover for local PV
+- [ ] Customize the Load Balancer service parameters on public cloud
+
+## v0.3.0: (2018-09-30)
+- [ ] Gracefully upgrade PD/TiKV/TiDB: evict the Raft leader or DDL owner before upgrade
+- [ ] TiDB Cluster configuration version management
+- [ ] Backup via Binlog
+- [ ] Backup via Mydumper
+- [ ] Import data via TiDB Lightning

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -26,11 +26,12 @@ Before deploying a TiDB cluster to Kubernetes, make sure the following requireme
 1. Use DinD to install and deploy a multiple-node Kubernetes cluster:
 
     ```sh
-    $ wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.10.sh
+    $ wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/64a2befa65ce23475158b65793e56d4bc1ae0a79/fixed/dind-cluster-v1.10.sh
     $ chmod +x dind-cluster-v1.10.sh
-    $ CNI_PLUGIN=flannel NUM_NODES=4 ./dind-cluster-v1.10.sh up
+    $ CNI_PLUGIN="flannel" NUM_NODES=4 ./dind-cluster-v1.10.sh up
     ```
 
+    > **Note:** `CNI_PLUGIN=flannel` prevents issues with restarting docker. However, if you have network issues preventing tidb startup, you can re-create the cluster without setting `CNI_PLUGIN`.
     > **Note:** If you fail to pull the Docker images due to the firewall, you can try the following method (the Docker images used are pulled from [UCloud Docker Registry](https://docs.ucloud.cn/compute/uhub/index)):
 
     ```sh
@@ -229,4 +230,15 @@ If you do not need the DinD Kubernetes cluster anymore, change to the directory 
 
 ```sh
 $ ./dind-cluster-v1.10.sh clean
+```
+
+## Re-start Kubernetes cluster and the TiDB Operator and Cluster
+
+Once you have a working DinD setup, you can follow this workflow:
+
+```sh
+$ ./dind-cluster-v1.10.sh down
+# Run the up command the same way you did previously
+$ NUM_NODES=4 CNI_PLUGIN=flannel ./dind-cluster-v1.10.sh up
+$ hack/dind-run-operators.sh
 ```

--- a/hack/dind-run-operators.sh
+++ b/hack/dind-run-operators.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+helm init --upgrade
 ./manifests/local-dind/setup.sh
 kubectl apply -f ./manifests/crd.yaml
-helm install charts/tidb-operator --name tidb-operator --namespace=tidb-operator
+helm install charts/tidb-operator --name tidb-operator --namespace=tidb-admin --set "imagePullPolicy=Always"
 helm install charts/tidb-cluster --name tidb-cluster --namespace=tidb

--- a/pkg/controller/pvc_control.go
+++ b/pkg/controller/pvc_control.go
@@ -21,8 +21,10 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -31,22 +33,55 @@ import (
 // PVCControlInterface manages PVCs used in TidbCluster
 type PVCControlInterface interface {
 	UpdateMetaInfo(*v1alpha1.TidbCluster, *corev1.PersistentVolumeClaim, *corev1.Pod) error
+	UpdatePVC(*v1alpha1.TidbCluster, *corev1.PersistentVolumeClaim) error
 }
 
 type realPVCControl struct {
-	kubeCli  kubernetes.Interface
-	recorder record.EventRecorder
+	kubeCli   kubernetes.Interface
+	recorder  record.EventRecorder
+	pvcLister corelisters.PersistentVolumeClaimLister
 }
 
 // NewRealPVCControl creates a new PVCControlInterface
 func NewRealPVCControl(
 	kubeCli kubernetes.Interface,
 	recorder record.EventRecorder,
-) PVCControlInterface {
+	pvcLister corelisters.PersistentVolumeClaimLister) PVCControlInterface {
 	return &realPVCControl{
-		kubeCli:  kubeCli,
-		recorder: recorder,
+		kubeCli:   kubeCli,
+		recorder:  recorder,
+		pvcLister: pvcLister,
 	}
+}
+
+func (rpc *realPVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
+	ns := tc.GetNamespace()
+	tcName := tc.GetName()
+	pvcName := pvc.GetName()
+	pvcDup := pvc.DeepCopy()
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		_, updateErr := rpc.kubeCli.CoreV1().PersistentVolumeClaims(ns).Update(pvc)
+		if updateErr == nil {
+			glog.V(4).Infof("update PVC: [%s/%s] successfully, TidbCluster: %s", ns, pvcName, tcName)
+			return nil
+		}
+		glog.Errorf("failed to update PVC: [%s/%s], TidbCluster: %s, error: %v", ns, pvcName, tcName, updateErr)
+
+		if updated, err := rpc.pvcLister.PersistentVolumeClaims(ns).Get(pvcName); err == nil {
+			// make a copy so we don't mutate the shared cache
+			pvc = updated.DeepCopy()
+			pvc.Annotations = pvcDup.Annotations
+			pvc.Labels = pvcDup.Labels
+			pvc.Spec = pvcDup.Spec
+		} else {
+			utilruntime.HandleError(fmt.Errorf("error getting updated PVC %s/%s from lister: %v", ns, pvcName, err))
+		}
+
+		return updateErr
+	})
+	rpc.recordPVCEvent("update", tc, pvcName, err)
+	return nil
 }
 
 func (rpc *realPVCControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) error {
@@ -136,6 +171,17 @@ func NewFakePVCControl(pvcInformer coreinformers.PersistentVolumeClaimInformer) 
 func (fpc *FakePVCControl) SetUpdatePVCError(err error, after int) {
 	fpc.updatePVCTracker.err = err
 	fpc.updatePVCTracker.after = after
+}
+
+// Update update the annotation, labels and spec of pvc
+func (fpc *FakePVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
+	defer fpc.updatePVCTracker.inc()
+	if fpc.updatePVCTracker.errorReady() {
+		defer fpc.updatePVCTracker.reset()
+		return fpc.updatePVCTracker.err
+	}
+
+	return fpc.PVCIndexer.Update(pvc)
 }
 
 // UpdateMetaInfo update the meta info of pvc

--- a/pkg/controller/pvc_control.go
+++ b/pkg/controller/pvc_control.go
@@ -91,7 +91,7 @@ func (rpc *realPVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.Persi
 		return updateErr
 	})
 	rpc.recordPVCEvent("update", tc, pvcName, err)
-	return nil
+	return err
 }
 
 func (rpc *realPVCControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) error {
@@ -191,7 +191,7 @@ func (fpc *FakePVCControl) SetDeletePVCError(err error, after int) {
 	fpc.deletePVCTracker.after = after
 }
 
-// DeletePVC delete the pvc
+// DeletePVC deletes the pvc
 func (fpc *FakePVCControl) DeletePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
 	defer fpc.deletePVCTracker.inc()
 	if fpc.deletePVCTracker.errorReady() {
@@ -202,7 +202,7 @@ func (fpc *FakePVCControl) DeletePVC(tc *v1alpha1.TidbCluster, pvc *corev1.Persi
 	return fpc.PVCIndexer.Delete(pvc)
 }
 
-// Update update the annotation, labels and spec of pvc
+// Update updates the annotation, labels and spec of pvc
 func (fpc *FakePVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
 	defer fpc.updatePVCTracker.inc()
 	if fpc.updatePVCTracker.errorReady() {
@@ -213,7 +213,7 @@ func (fpc *FakePVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.Persi
 	return fpc.PVCIndexer.Update(pvc)
 }
 
-// UpdateMetaInfo update the meta info of pvc
+// UpdateMetaInfo updates the meta info of pvc
 func (fpc *FakePVCControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) error {
 	defer fpc.updatePVCTracker.inc()
 	if fpc.updatePVCTracker.errorReady() {

--- a/pkg/controller/pvc_control.go
+++ b/pkg/controller/pvc_control.go
@@ -58,8 +58,14 @@ func NewRealPVCControl(
 }
 
 func (rpc *realPVCControl) DeletePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
+	ns := tc.GetNamespace()
+	tcName := tc.GetName()
 	pvcName := pvc.GetName()
 	err := rpc.kubeCli.CoreV1().PersistentVolumeClaims(tc.GetNamespace()).Delete(pvcName, nil)
+	if err != nil {
+		glog.Errorf("failed to delete PVC: [%s/%s], TidbCluster: %s, %v", ns, pvcName, tcName, err)
+	}
+	glog.V(4).Infof("delete PVC: [%s/%s] successfully, TidbCluster: %s", ns, pvcName, tcName)
 	rpc.recordPVCEvent("delete", tc, pvcName, err)
 	return err
 }

--- a/pkg/controller/tidbcluster/tidb_cluster_control_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control_test.go
@@ -73,7 +73,7 @@ func newFakeTidbClusterControl() (ControlInterface, *controller.FakeStatefulSetC
 	setControl := controller.NewFakeStatefulSetControl(setInformer, tcInformer)
 	svcControl := controller.NewFakeServiceControl(svcInformer, tcInformer)
 	pvControl := controller.NewRealPVControl(kubeCli, pvcInformer.Lister(), recorder)
-	pvcControl := controller.NewRealPVCControl(kubeCli, recorder)
+	pvcControl := controller.NewRealPVCControl(kubeCli, recorder, pvcInformer.Lister())
 	podControl := controller.NewRealPodControl(kubeCli, pdControl, recorder)
 	statusUpdater := newFakeTidbClusterStatusUpdater(tcInformer)
 	pdScaler := mm.NewFakePDScaler()

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -89,9 +89,9 @@ func NewController(
 	setControl := controller.NewRealStatefuSetControl(kubeCli, setInformer.Lister(), recorder)
 	svcControl := controller.NewRealServiceControl(kubeCli, svcInformer.Lister(), recorder)
 	pvControl := controller.NewRealPVControl(kubeCli, pvcInformer.Lister(), recorder)
-	pvcControl := controller.NewRealPVCControl(kubeCli, recorder)
+	pvcControl := controller.NewRealPVCControl(kubeCli, recorder, pvcInformer.Lister())
 	podControl := controller.NewRealPodControl(kubeCli, pdControl, recorder)
-	pdScaler := mm.NewPDScaler(pdControl)
+	pdScaler := mm.NewPDScaler(pdControl, pvcInformer.Lister(), pvcControl)
 
 	tcc := &Controller{
 		kubeClient: kubeCli,

--- a/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
@@ -246,9 +246,9 @@ func newFakeTidbClusterController() (*Controller, cache.Indexer, cache.Indexer) 
 		recorder,
 	)
 	pvControl := controller.NewRealPVControl(kubeCli, pvcInformer.Lister(), recorder)
-	pvcControl := controller.NewRealPVCControl(kubeCli, recorder)
+	pvcControl := controller.NewRealPVCControl(kubeCli, recorder, pvcInformer.Lister())
 	podControl := controller.NewRealPodControl(kubeCli, pdControl, recorder)
-	pdScaler := mm.NewPDScaler(pdControl)
+	pdScaler := mm.NewPDScaler(pdControl, pvcInformer.Lister(), pvcControl)
 
 	tcc.control = NewDefaultTidbClusterControl(
 		NewRealTidbClusterStatusUpdater(cli, tcInformer.Lister()),

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -33,8 +33,6 @@ const (
 	StoreIDLabelKey string = "cluster.pingcap.com/storeId"
 	// MemberIDLabelKey is member id label key
 	MemberIDLabelKey string = "cluster.pingcap.com/memberId"
-	// AnnInitialPDReplicas is cluster initial-pd-replicas annotation
-	AnnInitialPDReplicas = "cluster.pingcap.com/initial-pd-replicas"
 	// AnnPodNameKey is podName annotations key
 	AnnPodNameKey string = "volume.pingcap.com/podName"
 	// AnnPVCDeferDeleting is pvc defer deletion key

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -37,6 +37,8 @@ const (
 	AnnInitialPDReplicas = "cluster.pingcap.com/initial-pd-replicas"
 	// AnnPodNameKey is podName annotations key
 	AnnPodNameKey string = "volume.pingcap.com/podName"
+	// AnnPVCDeferDeletion is pvc defer deletion key
+	AnnPVCDeferDeletion = "cluster.pingcap.com/pvc-defer-deletion"
 	// AnnPaused is the annotation that the object is paused
 	AnnPaused string = "cluster.pingcap.com/paused"
 	// PDLabelVal is PD label value

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -37,8 +37,8 @@ const (
 	AnnInitialPDReplicas = "cluster.pingcap.com/initial-pd-replicas"
 	// AnnPodNameKey is podName annotations key
 	AnnPodNameKey string = "volume.pingcap.com/podName"
-	// AnnPVCDeferDeletion is pvc defer deletion key
-	AnnPVCDeferDeletion = "cluster.pingcap.com/pvc-defer-deletion"
+	// AnnPVCDeferDeleting is pvc defer deletion key
+	AnnPVCDeferDeleting = "cluster.pingcap.com/pvc-defer-deleting"
 	// AnnPaused is the annotation that the object is paused
 	AnnPaused string = "cluster.pingcap.com/paused"
 	// PDLabelVal is PD label value

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -158,6 +158,12 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		return err
 	}
 
+	if *newPDSet.Spec.Replicas > *oldPDSet.Spec.Replicas {
+		if err := pmm.pdScaler.ScaleOut(tc, oldPDSet, newPDSet); err != nil {
+			return err
+		}
+	}
+
 	if *newPDSet.Spec.Replicas < *oldPDSet.Spec.Replicas {
 		if err := pmm.pdScaler.ScaleIn(tc, oldPDSet, newPDSet); err != nil {
 			return err

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -217,6 +217,12 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 
 	tc.Status.PD.Members = pdStatus
 
+	if statefulSetInNormal(set) {
+		tc.Status.PD.Phase = v1alpha1.NormalPhase
+	} else {
+		tc.Status.PD.Phase = v1alpha1.UpgradePhase
+	}
+
 	return nil
 }
 
@@ -432,9 +438,7 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 }
 
 func (pmm *pdMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	if oldSet.Status.CurrentRevision == oldSet.Status.UpdateRevision {
-		tc.Status.PD.Phase = v1alpha1.NormalPhase
-	}
+
 	upgrade, err := pmm.needUpgrade(tc, newSet, oldSet)
 	if err != nil {
 		return err

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -65,7 +65,7 @@ func (psd *pdScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet
 		increaseReplicas(newSet, oldSet)
 		return nil
 	}
-	if _, ok := pvc.Annotations[label.AnnPVCDeferDeletion]; !ok {
+	if _, ok := pvc.Annotations[label.AnnPVCDeferDeleting]; !ok {
 		increaseReplicas(newSet, oldSet)
 		return nil
 	}
@@ -109,7 +109,7 @@ func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 	if pvc.Annotations == nil {
 		pvc.Annotations = map[string]string{}
 	}
-	pvc.Annotations[label.AnnPVCDeferDeletion] = time.Now().Format(time.RFC3339)
+	pvc.Annotations[label.AnnPVCDeferDeleting] = time.Now().Format(time.RFC3339)
 
 	err = psd.pvcControl.UpdatePVC(tc, pvc)
 	if err != nil {

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -121,8 +121,6 @@ func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 	return nil
 }
 
-var _ Scaler = &pdScaler{}
-
 type fakePDScaler struct{}
 
 // NewFakePDScaler returns a fake Scaler
@@ -137,5 +135,3 @@ func (fsd *fakePDScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 func (fsd *fakePDScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	return nil
 }
-
-var _ Scaler = &fakePDScaler{}

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -121,6 +121,8 @@ func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 	return nil
 }
 
+var _ Scaler = &pdScaler{}
+
 type fakePDScaler struct{}
 
 // NewFakePDScaler returns a fake Scaler
@@ -135,3 +137,5 @@ func (fsd *fakePDScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 func (fsd *fakePDScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	return nil
 }
+
+var _ Scaler = &fakePDScaler{}

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -54,6 +54,8 @@ func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 	return nil
 }
 
+var _ Scaler = &pdScaler{}
+
 type fakePDScaler struct{}
 
 // NewFakePDScaler returns a fake Scaler
@@ -68,3 +70,5 @@ func (fsd *fakePDScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 func (fsd *fakePDScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	return nil
 }
+
+var _ Scaler = &fakePDScaler{}

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -15,15 +15,17 @@ package member
 
 import (
 	"fmt"
-
 	"time"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	apps "k8s.io/api/apps/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
+
+// TODO add e2e test specs
 
 type pdScaler struct {
 	pdControl  controller.PDControlInterface
@@ -39,30 +41,68 @@ func NewPDScaler(pdControl controller.PDControlInterface,
 }
 
 func (psd *pdScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+	ns := tc.GetNamespace()
+	ordinal := *oldSet.Spec.Replicas + 1
+	setName := oldSet.GetName()
+
+	if tc.PDUpgrading() {
+		resetReplicas(newSet, oldSet)
+		return nil
+	}
+
+	pvcName := fmt.Sprintf("%s-%s-%d", v1alpha1.PDMemberType, setName, ordinal)
+	pvc, err := psd.pvcLister.PersistentVolumeClaims(ns).Get(pvcName)
+	if errors.IsNotFound(err) {
+		increaseReplicas(newSet, oldSet)
+		return nil
+	}
+	if err != nil {
+		resetReplicas(newSet, oldSet)
+		return err
+	}
+
+	if pvc.Annotations == nil {
+		increaseReplicas(newSet, oldSet)
+		return nil
+	}
+	if _, ok := pvc.Annotations[label.AnnPVCDeferDeletion]; !ok {
+		increaseReplicas(newSet, oldSet)
+		return nil
+	}
+
+	err = psd.pvcControl.DeletePVC(tc, pvc)
+	if err != nil {
+		resetReplicas(newSet, oldSet)
+		return err
+	}
+
+	increaseReplicas(newSet, oldSet)
 	return nil
 }
 
 // We need remove member from cluster before reducing statefulset replicas
 // only remove one member at a time when scale down
 func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	if tc.PDUpgrading() {
-		*newSet.Spec.Replicas = *oldSet.Spec.Replicas
-		return nil
-	}
-
 	ns := tc.GetNamespace()
 	ordinal := *oldSet.Spec.Replicas - 1
 	memberName := fmt.Sprintf("%s-pd-%d", tc.GetName(), ordinal)
 	setName := oldSet.GetName()
-	if err := psd.pdControl.GetPDClient(tc).DeleteMember(memberName); err != nil {
-		// for unit test
-		*newSet.Spec.Replicas = *oldSet.Spec.Replicas
+
+	if tc.PDUpgrading() {
+		resetReplicas(newSet, oldSet)
+		return nil
+	}
+
+	err := psd.pdControl.GetPDClient(tc).DeleteMember(memberName)
+	if err != nil {
+		resetReplicas(newSet, oldSet)
 		return err
 	}
 
 	pvcName := fmt.Sprintf("%s-%s-%d", v1alpha1.PDMemberType, setName, ordinal)
 	pvc, err := psd.pvcLister.PersistentVolumeClaims(ns).Get(pvcName)
 	if err != nil {
+		resetReplicas(newSet, oldSet)
 		return err
 	}
 
@@ -70,12 +110,14 @@ func (psd *pdScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 		pvc.Annotations = map[string]string{}
 	}
 	pvc.Annotations[label.AnnPVCDeferDeletion] = time.Now().Format(time.RFC3339)
+
 	err = psd.pvcControl.UpdatePVC(tc, pvc)
 	if err != nil {
+		resetReplicas(newSet, oldSet)
 		return err
 	}
 
-	*newSet.Spec.Replicas = ordinal
+	decreaseReplicas(newSet, oldSet)
 	return nil
 }
 

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -16,7 +16,6 @@ package member
 import (
 	"fmt"
 	"testing"
-
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -62,7 +61,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 		pvc.Name = fmt.Sprintf("pd-%s-%d", oldSet.GetName(), int(*oldSet.Spec.Replicas)+1)
 		if test.hasDeferAnn {
 			pvc.Annotations = map[string]string{}
-			pvc.Annotations[label.AnnPVCDeferDeletion] = time.Now().Format(time.RFC3339)
+			pvc.Annotations[label.AnnPVCDeferDeleting] = time.Now().Format(time.RFC3339)
 		}
 		if test.hasPVC {
 			pvcIndexer.Add(pvc)

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -21,15 +21,21 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	apps "k8s.io/api/apps/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestPDScalerScaleIn(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
 		name            string
-		modify          func(*apps.StatefulSet) *apps.StatefulSet
 		pdUpgrading     bool
+		hasPVC          bool
+		pvcUpdateErr    bool
 		deleteMemberErr bool
 		err             bool
 		changed         bool
@@ -47,7 +53,13 @@ func TestPDScalerScaleIn(t *testing.T) {
 		newSet := oldSet.DeepCopy()
 		newSet.Spec.Replicas = int32Pointer(3)
 
-		scaler, pdControl := newFakePDScaler()
+		scaler, pdControl, pvcIndexer, pvcControl := newFakePDScaler()
+
+		if test.hasPVC {
+			pvc := newPVCForStatefulSet(oldSet)
+			pvcIndexer.Add(pvc)
+		}
+
 		pdClient := controller.NewFakePDClient()
 		pdControl.SetPDClient(tc, pdClient)
 
@@ -55,6 +67,9 @@ func TestPDScalerScaleIn(t *testing.T) {
 			pdClient.AddReaction(controller.DeleteMemberActionType, func(action *controller.Action) (interface{}, error) {
 				return nil, fmt.Errorf("error")
 			})
+		}
+		if test.pvcUpdateErr {
+			pvcControl.SetUpdatePVCError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
 		}
 
 		err := scaler.ScaleIn(tc, oldSet, newSet)
@@ -72,6 +87,8 @@ func TestPDScalerScaleIn(t *testing.T) {
 		{
 			name:            "normal",
 			pdUpgrading:     false,
+			hasPVC:          true,
+			pvcUpdateErr:    false,
 			deleteMemberErr: false,
 			err:             false,
 			changed:         true,
@@ -79,14 +96,36 @@ func TestPDScalerScaleIn(t *testing.T) {
 		{
 			name:            "pd is upgrading",
 			pdUpgrading:     true,
+			hasPVC:          true,
+			pvcUpdateErr:    false,
 			deleteMemberErr: false,
 			err:             false,
 			changed:         false,
 		},
 		{
 			name:            "error when delete member",
+			hasPVC:          true,
+			pvcUpdateErr:    false,
 			pdUpgrading:     false,
 			deleteMemberErr: true,
+			err:             true,
+			changed:         false,
+		},
+		{
+			name:            "cache don't have pvc",
+			pdUpgrading:     false,
+			hasPVC:          false,
+			pvcUpdateErr:    false,
+			deleteMemberErr: false,
+			err:             true,
+			changed:         false,
+		},
+		{
+			name:            "error when update pvc",
+			pdUpgrading:     false,
+			hasPVC:          true,
+			pvcUpdateErr:    true,
+			deleteMemberErr: false,
 			err:             true,
 			changed:         false,
 		},
@@ -97,15 +136,22 @@ func TestPDScalerScaleIn(t *testing.T) {
 	}
 }
 
-func newFakePDScaler() (*pdScaler, *controller.FakePDControl) {
+func newFakePDScaler() (*pdScaler, *controller.FakePDControl, cache.Indexer, *controller.FakePVCControl) {
+	kubeCli := kubefake.NewSimpleClientset()
+
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeCli, 0)
+	pvcInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	pdControl := controller.NewFakePDControl()
-	return &pdScaler{pdControl}, pdControl
+	pvcControl := controller.NewFakePVCControl(pvcInformer)
+
+	return &pdScaler{pdControl, pvcInformer.Lister(), pvcControl},
+		pdControl, pvcInformer.Informer().GetIndexer(), pvcControl
 }
 
 func newStatefulSetForPDScaleIn() *apps.StatefulSet {
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pd-scale-down",
+			Name:      "scaler",
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: apps.StatefulSetSpec{
@@ -113,6 +159,15 @@ func newStatefulSetForPDScaleIn() *apps.StatefulSet {
 		},
 	}
 	return set
+}
+
+func newPVCForStatefulSet(set *apps.StatefulSet) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("pd-%s-%d", set.GetName(), int(*set.Spec.Replicas)-1),
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
 }
 
 func int32Pointer(num int) *int32 {

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -271,13 +271,16 @@ func (tmm *tidbMemberManager) getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbClust
 
 func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	tc.Status.TiDB.StatefulSet = &set.Status
+
+	if statefulSetInNormal(set) {
+		tc.Status.TiDB.Phase = v1alpha1.NormalPhase
+	} else {
+		tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
+	}
 	return nil
 }
 
 func (tmm *tidbMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	if oldSet.Status.CurrentRevision == oldSet.Status.UpdateRevision {
-		tc.Status.TiDB.Phase = v1alpha1.NormalPhase
-	}
 
 	upgrade, err := tmm.needUpgrade(tc, newSet, oldSet)
 	if err != nil {
@@ -285,9 +288,7 @@ func (tmm *tidbMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Sta
 	}
 	if upgrade {
 		tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
-	}
-
-	if tc.Status.TiDB.Phase != v1alpha1.UpgradePhase {
+	} else {
 		_, podSpec, err := controller.GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -142,7 +142,15 @@ func TestTiDBMemberManagerSyncUpdate(t *testing.T) {
 
 		tmm, fakeSetControl, fakeSvcControl := newFakeTiDBMemberManager()
 
-		if test.statusChange != nil {
+		if test.statusChange == nil {
+			fakeSetControl.SetStatusChange(func(set *apps.StatefulSet) {
+				set.Status.Replicas = *set.Spec.Replicas
+				set.Status.CurrentRevision = "tidb-1"
+				set.Status.UpdateRevision = "tidb-1"
+				observedGeneration := int64(1)
+				set.Status.ObservedGeneration = &observedGeneration
+			})
+		} else {
 			fakeSetControl.SetStatusChange(test.statusChange)
 		}
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -377,9 +377,6 @@ func (tkmm *tikvMemberManager) labelTiKV(tc *v1alpha1.TidbCluster) label.Label {
 }
 
 func (tkmm *tikvMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	if oldSet.Status.CurrentRevision == oldSet.Status.UpdateRevision {
-		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
-	}
 
 	upgrade, err := tkmm.needUpgrade(tc, newSet, oldSet)
 	if err != nil {
@@ -542,6 +539,13 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	}
 
 	tc.Status.TiKV.Stores = tikvStores
+
+	if statefulSetInNormal(set) {
+		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	} else {
+		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
+	}
+
 	return nil
 }
 

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -13,7 +13,10 @@
 
 package member
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	apps "k8s.io/api/apps/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
 
 func timezoneMountVolume() (corev1.VolumeMount, corev1.Volume) {
 	return corev1.VolumeMount{Name: "timezone", MountPath: "/etc/localtime", ReadOnly: true},
@@ -39,4 +42,9 @@ func annotationsMountVolume() (corev1.VolumeMount, corev1.Volume) {
 		},
 	}
 	return m, v
+}
+
+// statefulSetInNormal confirms whether the statefulSet is normal phase
+func statefulSetInNormal(set *apps.StatefulSet) bool {
+	return set.Status.CurrentRevision == set.Status.UpdateRevision && set.Generation <= *set.Status.ObservedGeneration
 }

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -48,3 +48,15 @@ func annotationsMountVolume() (corev1.VolumeMount, corev1.Volume) {
 func statefulSetInNormal(set *apps.StatefulSet) bool {
 	return set.Status.CurrentRevision == set.Status.UpdateRevision && set.Generation <= *set.Status.ObservedGeneration
 }
+
+func resetReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
+	*newSet.Spec.Replicas = *oldSet.Spec.Replicas
+}
+
+func increaseReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
+	*newSet.Spec.Replicas = *oldSet.Spec.Replicas + 1
+}
+
+func decreaseReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
+	*newSet.Spec.Replicas = *oldSet.Spec.Replicas - 1
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -56,4 +56,8 @@ var _ = Describe("Smoke", func() {
 	It("should create a tidb cluster", func() {
 		testCreate()
 	})
+	It("should upgarde a tidb cluster", func() {
+		testUpgrade()
+	})
+
 })

--- a/tests/e2e/upgrade.go
+++ b/tests/e2e/upgrade.go
@@ -1,0 +1,169 @@
+package e2e
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	apps "k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	upgradeVersion = "v2.0.5"
+)
+
+func testUpgrade() {
+	By("When upgrade TiDB cluster to newer version")
+	err := wait.Poll(5*time.Second, 5*time.Minute, upgrade)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Then members should be upgrade in order: pd ==> tikv ==> tidb")
+	err = wait.Poll(5*time.Second, 10*time.Minute, memberUpgraded)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Then all members should running")
+	err = wait.Poll(5*time.Second, 5*time.Minute, allMembersRunning)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("And the data is correct")
+	err = wait.Poll(5*time.Second, 5*time.Minute, dataIsCorrect)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func upgrade() (bool, error) {
+	tc, err := cli.PingcapV1alpha1().TidbClusters(ns).Get(clusterName, metav1.GetOptions{})
+	if err != nil {
+		logf("failed to get tidbcluster, error: %v", err)
+		return false, err
+	}
+
+	tc.Spec.PD.Image = strings.Replace(tc.Spec.PD.Image, getImageTag(tc.Spec.PD.Image), upgradeVersion, -1)
+	tc.Spec.TiKV.Image = strings.Replace(tc.Spec.TiKV.Image, getImageTag(tc.Spec.TiKV.Image), upgradeVersion, -1)
+	tc.Spec.TiDB.Image = strings.Replace(tc.Spec.TiDB.Image, getImageTag(tc.Spec.TiDB.Image), upgradeVersion, -1)
+
+	_, err = cli.PingcapV1alpha1().TidbClusters(ns).Update(tc)
+	if err != nil {
+		logf("failed to update tidbcluster, error: %v", err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+func memberUpgraded() (bool, error) {
+	tc, err := cli.PingcapV1alpha1().TidbClusters(ns).Get(clusterName, metav1.GetOptions{})
+	if err != nil {
+		logf("failed to get tidbcluster: [%s], error: %v", clusterName, err)
+		return false, err
+	}
+
+	pdSetName := controller.PDMemberName(clusterName)
+	pdSet, err := kubeCli.AppsV1beta1().StatefulSets(ns).Get(pdSetName, metav1.GetOptions{})
+	if err != nil {
+		logf("failed to get pd statefulset: [%s], error: %v", pdSetName, err)
+		return false, err
+	}
+
+	tikvSetName := controller.TiKVMemberName(clusterName)
+	tikvSet, err := kubeCli.AppsV1beta1().StatefulSets(ns).Get(tikvSetName, metav1.GetOptions{})
+	if err != nil {
+		logf("failed to get tikvSet statefulset: [%s], error: %v", pdSetName, err)
+		return false, err
+	}
+
+	tidbSetName := controller.TiDBMemberName(clusterName)
+	tidbSet, err := kubeCli.AppsV1beta1().StatefulSets(ns).Get(tidbSetName, metav1.GetOptions{})
+	if err != nil {
+		logf("failed to get tikvSet statefulset: [%s], error: %v", pdSetName, err)
+		return false, err
+	}
+
+	if !imageUpgraded(tc, v1alpha1.PDMemberType, pdSet) {
+		return false, nil
+	}
+	if tc.Status.PD.Phase == v1alpha1.UpgradePhase {
+		logf("pd is upgrading")
+		Expect(tc.Status.TiKV.Phase).NotTo(Equal(v1alpha1.UpgradePhase))
+		Expect(tc.Status.TiDB.Phase).NotTo(Equal(v1alpha1.UpgradePhase))
+		Expect(imageUpgraded(tc, v1alpha1.PDMemberType, pdSet)).To(BeTrue())
+		if !podsUpgraded(pdSet) {
+			Expect(imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet)).To(BeFalse())
+			Expect(imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet)).To(BeFalse())
+		}
+		return false, nil
+	} else if tc.Status.TiKV.Phase == v1alpha1.UpgradePhase {
+		logf("tikv is upgrading")
+		Expect(tc.Status.TiDB.Phase).NotTo(Equal(v1alpha1.UpgradePhase))
+		Expect(imageUpgraded(tc, v1alpha1.PDMemberType, pdSet)).To(BeTrue())
+		Expect(podsUpgraded(pdSet)).To(BeTrue())
+		Expect(imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet)).To(BeTrue())
+		if !podsUpgraded(tikvSet) {
+			Expect(imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet)).To(BeFalse())
+		}
+		return false, nil
+	} else if tc.Status.TiDB.Phase == v1alpha1.UpgradePhase {
+		logf("tidb is upgrading")
+		Expect(imageUpgraded(tc, v1alpha1.PDMemberType, pdSet)).To(BeTrue())
+		Expect(podsUpgraded(pdSet)).To(BeTrue())
+		Expect(imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet)).To(BeTrue())
+		Expect(podsUpgraded(tikvSet)).To(BeTrue())
+		Expect(imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet)).To(BeTrue())
+		return false, nil
+	} else {
+		if !imageUpgraded(tc, v1alpha1.PDMemberType, pdSet) {
+			return false, nil
+		}
+		if !podsUpgraded(pdSet) {
+			return false, nil
+		}
+		if !imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet) {
+			return false, nil
+		}
+		if !podsUpgraded(tikvSet) {
+			return false, nil
+		}
+		if !imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet) {
+			return false, nil
+		}
+		return podsUpgraded(tidbSet), nil
+	}
+	return false, nil
+}
+
+func imageUpgraded(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType, set *apps.StatefulSet) bool {
+	for _, container := range set.Spec.Template.Spec.Containers {
+		if container.Name == memberType.String() {
+			if container.Image == getImage(tc, memberType) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func podsUpgraded(set *apps.StatefulSet) bool {
+	return set.Generation <= *set.Status.ObservedGeneration && set.Status.CurrentRevision == set.Status.UpdateRevision
+}
+
+func getImage(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType) string {
+	switch memberType {
+	case v1alpha1.PDMemberType:
+		return tc.Spec.PD.Image
+	case v1alpha1.TiKVMemberType:
+		return tc.Spec.TiKV.Image
+	case v1alpha1.TiDBMemberType:
+		return tc.Spec.TiDB.Image
+	default:
+		return ""
+	}
+}
+
+func getImageTag(image string) string {
+	strs := strings.Split(image, ":")
+	return strs[len(strs)-1]
+}


### PR DESCRIPTION
Now, when a pd cluster scales in, the related PVC will not be deleted, but the data were tombstoned. If we scale out again, the scaled pod will use the tombstoned data.

This pr try to delete the tombstoned PVC when scale out again.

@tennix @onlymellb @xiaojingchen @gregwebs PTAL