### PR TITLE
Integrate fully with Google Cloud Shell tutorial framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,12 @@ Read the [Roadmap](./ROADMAP.md).
 
 ## Quick start
 
-Read the [Deploy TiDB using Kubernetes on Your Laptop for development and testing](./docs/local-dind-tutorial.md).
+Read the [Deploy TiDB using Kubernetes on Your Laptop for development and testing](./docs/local-dind-tutorial.md), or follow a [tutorial](./docs/google-kubernetes-tutorial.md) to launch in Google Kubernetes Engine:
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator)
 <!--
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md)
 -->
-
-If you have any issues with this button, you can download the file as markdown and open it:
-
-```sh
-git clone https://github.com/pingcap/tidb-operator
-cd tidb-operator
-teachme docs/google-kubernetes-tutorial.md
-```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Read the [Roadmap](./ROADMAP.md).
 
 Read the [Deploy TiDB using Kubernetes on Your Laptop for development and testing](./docs/local-dind-tutorial.md).
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator)
+<!--
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md)
+-->
+
+If you have any issues with this button, you can download the file as markdown and open it:
+
+```sh
+git clone https://github.com/pingcap/tidb-operator
+cd tidb-operator
+teachme docs/google-kubernetes-tutorial.md
+```
+
 ## Contributing
 
 Contributions are welcome and greatly appreciated. See [CONTRIBUTING.md](./docs/CONTRIBUTING.md) for details on submitting patches and the contribution workflow.

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -10,10 +10,10 @@ category: operations
 
 This tutorial takes you through these steps:
 
-- Creating a new Google Cloud Project (optional)
 - Launching a new 3 node Kubernetes cluster (optional)
 - Installing the Helm package manager for Kubernetes
-- Deploying TiDB to your Kubernetes cluster
+- Deploying the TiDB Operator
+- Deploying your first TiDB cluster
 - Connecting to TiDB
 - Shutting down down the Kubernetes cluster (optional)
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -82,7 +82,7 @@ Helm will also need a couple of permissions to work properly:
 	kubectl apply -f ./manifests/tiller-rbac.yaml &&
 	helm init --service-account tiller --upgrade
 
-It takes a minute for helm to initialize its server component (tiller):
+It takes a minute for helm to initialize `tiller`, its server component:
 
 	watch "kubectl get pods --namespace kube-system | grep tiller"
 
@@ -100,7 +100,7 @@ We can watch the operator come up with:
 
 	watch kubectl get pods --namespace tidb-admin -o wide
 
-When you see `Running`, hit `Control + C` and proceed to launch a TiDB cluster!
+When you see `Running`, `Control + C` and proceed to launch a TiDB cluster!
 
 ## Deploy your first TiDB Cluster
 
@@ -126,11 +126,11 @@ You can connect to the clustered service within the Kubernetes cluster:
 
 	kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb --output json | jq -r '.spec.clusterIP')
 
-For debugging purposes, you can also establish a tunnel between an individual TiDB pod and your Google Cloud Shell.  For example:
+For debugging purposes, you can also establish a tunnel between an individual TiDB pod and your Cloud Shell.  For example:
 
 	kubectl -n tidb port-forward demo-tidb-0 4000:4000 &
 
-From your Google shell:
+From your Cloud Shell:
 
 	sudo apt-get install -y mysql-client &&
 	mysql -h 127.0.0.1 -u root -P 4000

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -37,7 +37,6 @@ This step defaults gcloud to your prefered project and [zone](https://cloud.goog
 
 	gcloud config set project {{project-id}} &&
 	gcloud config set compute/zone us-west1-a
-	
 
 ## Launch a three node Kubernetes cluster
 
@@ -117,7 +116,11 @@ When you see `Running`, it's time to proceed forward!
 
 ## Connecting to TiDB
 
-Now lets connect to our MySQL database. This will connect to the clustered service IP address within the Kubernetes cluster:
+There can be a small delay between the pod being up and running, and the service being available.  When you see `demo-tidb` appear, the service is ready to connect to:
+
+	watch "kubectl get svc -n tidb"
+
+You can connect to the clustered service within the Kubernetes cluster:
 
 	kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb --output json | jq -r '.spec.clusterIP')
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -86,7 +86,7 @@ It takes a minute for helm to initialize its server component (tiller):
 
 	watch "kubectl get pods --namespace kube-system | grep tiller"
 
-When you see `Running`, it's time to proceed to the next step!
+When you see `Running`, it's time to hit `Control + C` and proceed to the next step!
 
 ## Deploy TiDB Operator
 
@@ -100,7 +100,7 @@ We can watch the operator come up with:
 
 	watch kubectl get pods --namespace tidb-admin -o wide
 
-If you see `Running`, the next step is to launch a TiDB cluster!
+When you see `Running`, hit `Control + C` and proceed to launch a TiDB cluster!
 
 ## Deploy your first TiDB Cluster
 
@@ -112,13 +112,15 @@ It will take a few minutes to launch.  You can monitor the progress with:
 
 	watch kubectl get pods --namespace tidb -o wide
 
-When you see all pods `Running`, it's time to proceed forward!
+When you see all pods `Running`, it's time to `Control + C` and proceed forward!
 
 ## Connecting to TiDB
 
-There can be a small delay between the pod being up and running, and the service being available.  When you see `demo-tidb` appear, the service is ready to connect to:
+There can be a small delay between the pod being up and running, and the service being available.  You can watch list services available with:
 
 	watch "kubectl get svc -n tidb"
+
+When you see `demo-tidb` appear, you can `Control + C`.  The service is ready to connect to!
 
 You can connect to the clustered service within the Kubernetes cluster:
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -24,11 +24,11 @@ Please select a project before proceeding.  The approximate cost for running the
 <walkthrough-project-billing-setup key="project-id">
 </walkthrough-project-billing-setup>
 
-## Enable Kubernetes API
+## Enable API Acess
 
-This project will require use of the Kubernetes API.  Please enable it before proceeding.
+This project will require use of the Compute and Container APIs.  Please enable them before proceeding:
 
-<walkthrough-enable-apis apis="container.googleapis.com">
+<walkthrough-enable-apis apis="container.googleapis.com,compute.googleapis.com">
 </walkthrough-enable-apis>
 
 ## Configure gcloud Defaults

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -19,7 +19,7 @@ This tutorial takes you through these steps:
 
 ## Select a Project
 
-Please select a project before proceeding.  The approximate cost for running the compute resources in this tutorial is $75/month.
+Please select a project before proceeding.  The approximate cost for running the compute resources in this tutorial is 10 cents/hour.
 
 <walkthrough-project-billing-setup key="project-id">
 </walkthrough-project-billing-setup>

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -39,7 +39,7 @@ This step defaults gcloud to your prefered project and [zone](https://cloud.goog
 	gcloud config set compute/zone us-west1-a
 	
 
-### Launch a three node Kubernetes cluster
+## Launch a three node Kubernetes cluster
 
 It's now time to launch a 3 node kubernetes cluster! The following command launches a 3 node cluster of `n1-standard-1` machines.
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -112,7 +112,7 @@ It will take a few minutes to launch.  You can monitor the progress with:
 
 	watch kubectl get pods --namespace tidb -o wide
 
-When you see `Running`, it's time to proceed forward!
+When you see all pods `Running`, it's time to proceed forward!
 
 ## Connecting to TiDB
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -83,10 +83,11 @@ Helm will also need a couple of permissions to work properly:
 	kubectl apply -f manifests/tiller-rbac.yaml &&
 	helm init --service-account tiller --upgrade
 
-It takes a minute for helm to initialize its server component (tiller).  When you see `Running`, it's time to proceed to the next step:
+It takes a minute for helm to initialize its server component (tiller):
 
 	watch "kubectl get pods --namespace kube-system | grep tiller"
-        
+
+When you see `Running`, it's time to proceed to the next step!
 
 ## Deploy TiDB Operator
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -6,7 +6,8 @@ category: operations
 
 # Deploy TiDB, a distributed MySQL compatible database, to Kubernetes on Google Cloud
 
-Lets use Google Cloud Kubernetes to have a straight-forward and reliable install of a TiDB, a distributed MySQL compatible database.
+## Introduction
+
 This tutorial takes you through these steps:
 
 - Creating a new Google Cloud Project (optional)
@@ -16,127 +17,119 @@ This tutorial takes you through these steps:
 - Connecting to TiDB
 - Shutting down down the Kubernetes cluster (optional)
 
+## Select a Project
 
-## Deploying Kubernetes on Google
+Please select a project before proceeding.  The approximate cost for running the compute resources in this tutorial is $75/month.
 
-TiDB can be deployed onto any Kubernetes cluster: you can bring up a three node cluster however you see fit or look for our documentation on deploying to other systems.
-But here we will bring up a Kubernetes cluster on Google Cloud designed for TiDB.
-Google provides a free small VM called Google Cloud Shell that you can run this tutorial from.
-Just click the button:
+<walkthrough-project-billing-setup key="project-id">
+</walkthrough-project-billing-setup>
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator)
-<!--
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md)
--->
+## Enable Kubernetes API
 
-If you have any issues with this button, you can download this file as markdown and open it.
+This project will require use of the Kubernetes API.  Please enable it before proceeding.
 
-```sh
-git clone https://github.com/pingcap/tidb-operator
-cd tidb-operator
-teachme docs/google-kubernetes-tutorial.md
-```
+<walkthrough-enable-apis apis="container.googleapis.com">
+</walkthrough-enable-apis>
 
-Alternatively, you can run this from your laptop. You just need to [setup the gcloud tool first](https://cloud.google.com/sdk/docs/quickstarts).
+## Configure gcloud Defaults
 
+This step defaults gcloud to your prefered project and [zone](https://cloud.google.com/compute/docs/regions-zones/), which will simplify the commands used for the rest of this tutorial:
 
-## Create a new GCP Project
-
-First create a project that this demo will be ran in.
-
-	gcloud projects create MY_NEW_PROJECT_NAME
-
-Before you can create a cluster, you must [enable Kubernetes for your project in the console.](https://console.cloud.google.com/projectselector/kubernetes?_ga=2.78459869.-833158988.1529036412)
-
-Now set your gcloud to use this project:
-
-	gcloud config set project MY_NEW_PROJECT_NAME
-
+	gcloud config set project {{project-id}} &&
+	gcloud config set compute/zone us-west1-a
+	
 
 ### Launch a three node Kubernetes cluster
 
-At the end of this cluster creation step, we will have a Kubernetes cluster with kubectl authorized to connect to it.
+It's now time to launch a 3 node kubernetes cluster! The following command launches a 3 node cluster of `n1-standard-1` machines.
 
-For more detailed information, please review the [Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) instructions for setting up a Kubernetes cluster.
-
-Set gcloud to use a [zone](https://cloud.google.com/compute/docs/regions-zones/)
-
-	gcloud config set compute/zone us-west1-a
-
-Now create the kubernetes cluster.
+It will take a few minutes to complete:
 
 	gcloud container clusters create tidb
 
-This could take more than a minute to complete. Now is a good time to do some stretches and refill your beverage.
-
-When the Kubernetes cluster is completed, default gcloud to use it.
+Once the cluster has launched, set it to be the default:
 
 	gcloud config set container/cluster tidb
 
-Now we have a Kubernetes cluster! Verify that kubectl can connect to it and that it has three machines running.
+The last step is to verify that `kubectl` can connect to the cluster, and all three machines are running:
 
 	kubectl get nodes
 
+If you see `ready` for all nodes, congratulations!  You've setup your first Kubernetes cluster.
 
-## Installing the Helm package manager for Kubernetes
+## Installing Helm
 
-We can install TiDB with helm charts. Maske sure [helm is installed](https://github.com/helm/helm#install) on your platform.
-Note that in Google Cloud Shell, system installs do not persist across shell sessions. You can put helm in your home directory:
+Helm is the package manager for Kubernetes, and is what allows us to install all of the distributed components of TiDB in a single step.  Helm requires both a server-side and a client-side component to be installed.
 
-```sh
-mkdir -p ~/bin
-cp /usr/local/bin/helm ~/bin
-echo 'PATH="$PATH:$HOME/bin"' >> ~/.bashrc
-```
+Because Cloud Shell system packages do not persist, we also copy the `helm` command to a local directory.
 
-Helm will need a couple of permissions to work properly.
+Download the `helm` installer:
 
-``` sh
-kubectl create serviceaccount tiller --namespace kube-system
-kubectl apply -f manifests/tiller-rbac.yaml
-helm init --service-account tiller --upgrade
-```
+	curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
 
+Install `helm`:
 
-## Deploy TiDB to your Kubernetes cluster
+	chmod 700 get_helm.sh && ./get_helm.sh
 
-We can get the TiDB helm charts from the tidb-operator source repository.
+Copy `helm` to a local directory:
 
-```sh
-git clone https://github.com/pingcap/tidb-operator
-cd tidb-operator
-git checkout gregwebs/kube-tutorial
-```
+	mkdir -p ~/bin &&
+	cp /usr/local/bin/helm ~/bin &&
+	echo 'PATH="$PATH:$HOME/bin"' >> ~/.bashrc
 
+Helm will also need a couple of permissions to work properly:
 
-Now we can run the TiDB operator and the TiDB cluster
+	kubectl create serviceaccount tiller --namespace kube-system &&
+	kubectl apply -f manifests/tiller-rbac.yaml &&
+	helm init --service-account tiller --upgrade
 
-```sh
-kubectl apply -f ./manifests/crd.yaml
-kubectl apply -f manifests/gke-storage.yml
-helm install charts/tidb-operator -n tidb-admin --namespace=tidb-admin
-```
+It takes a minute for helm to initialize its server component (tiller).  When you see `Running`, it's time to proceed to the next step:
 
-We can watch the operator come up with
+	watch "kubectl get pods --namespace kube-system | grep tiller"
+        
+
+## Deploy TiDB Operator
+
+The first TiDB component we are going to install is the TiDB Operator, using a Helm Chart.  The TiDB Operator is the management system that works with Kubernetes to bootstrap your TiDB cluster and keep it running. This step assumes you are in the `tidb-operator` working directory:
+
+	kubectl apply -f ./manifests/crd.yaml &&
+	kubectl apply -f manifests/gke-storage.yml &&
+	helm install charts/tidb-operator -n tidb-admin --namespace=tidb-admin
+
+We can watch the operator come up with:
 
 	watch kubectl get pods --namespace tidb-admin -o wide
 
-Now with a single command we can bring-up a full TiDB cluster.
+If you see `Running`, the next step is to launch a TiDB cluster!
+
+## Deploy your first TiDB Cluster
+
+Now with a single command we can bring-up a full TiDB cluster:
 
 	helm install charts/tidb-cluster -n tidb --namespace=tidb
 
-Now we can watch our cluster come up
+It will take a few minutes to launch.  You can monitor the progress with:
 
 	watch kubectl get pods --namespace tidb -o wide
 
+When you see `Running`, it's time to proceed forward!
 
 ## Connecting to TiDB
 
-Now lets connect to our MySQL database. This will connect from within the Kubernetes cluster.
+Now lets connect to our MySQL database. This will connect to the clustered service IP address within the Kubernetes cluster:
 
 	kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb --output json | jq -r '.spec.clusterIP')
 
-Now you are up and running with a distributed MySQL database!
+For debugging purposes, you can also establish a tunnel between an individual TiDB pod and your Google Cloud Shell.  For example:
+
+	kubectl -n tidb port-forward demo-tidb-0 4000:4000 &
+
+From your Google shell:
+
+	sudo apt-get install -y mysql-client &&
+	mysql -h 127.0.0.1 -u root -P 4000
+
+Congratulations, you are now up and running with a distributed MySQL database!
 
 ## Shutting down the Kubernetes Cluster
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -79,7 +79,7 @@ Copy `helm` to a local directory:
 Helm will also need a couple of permissions to work properly:
 
 	kubectl create serviceaccount tiller --namespace kube-system &&
-	kubectl apply -f manifests/tiller-rbac.yaml &&
+	kubectl apply -f ./manifests/tiller-rbac.yaml &&
 	helm init --service-account tiller --upgrade
 
 It takes a minute for helm to initialize its server component (tiller):
@@ -93,8 +93,8 @@ When you see `Running`, it's time to proceed to the next step!
 The first TiDB component we are going to install is the TiDB Operator, using a Helm Chart.  The TiDB Operator is the management system that works with Kubernetes to bootstrap your TiDB cluster and keep it running. This step assumes you are in the `tidb-operator` working directory:
 
 	kubectl apply -f ./manifests/crd.yaml &&
-	kubectl apply -f manifests/gke-storage.yml &&
-	helm install charts/tidb-operator -n tidb-admin --namespace=tidb-admin
+	kubectl apply -f ./manifests/gke-storage.yml &&
+	helm install ./charts/tidb-operator -n tidb-admin --namespace=tidb-admin
 
 We can watch the operator come up with:
 
@@ -106,7 +106,7 @@ If you see `Running`, the next step is to launch a TiDB cluster!
 
 Now with a single command we can bring-up a full TiDB cluster:
 
-	helm install charts/tidb-cluster -n tidb --namespace=tidb
+	helm install ./charts/tidb-cluster -n tidb --namespace=tidb
 
 It will take a few minutes to launch.  You can monitor the progress with:
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -55,7 +55,7 @@ The last step is to verify that `kubectl` can connect to the cluster, and all th
 
 	kubectl get nodes
 
-If you see `ready` for all nodes, congratulations!  You've setup your first Kubernetes cluster.
+If you see `Ready` for all nodes, congratulations!  You've setup your first Kubernetes cluster.
 
 ## Installing Helm
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -126,7 +126,7 @@ You can connect to the clustered service within the Kubernetes cluster:
 
 	kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb --output json | jq -r '.spec.clusterIP')
 
-For debugging purposes, you can also establish a tunnel between an individual TiDB pod and your Cloud Shell.  For example:
+For debugging purposes, you can also establish a tunnel between an individual TiDB pod and your Cloud Shell.  It is important to note that this will not survive if the pod `demo-tidb-0` fails our your Google Shell restarts.  For example:
 
 	kubectl -n tidb port-forward demo-tidb-0 4000:4000 &
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -26,7 +26,7 @@ Please select a project before proceeding.  The approximate cost for running the
 
 ## Enable API Acess
 
-This project will require use of the Compute and Container APIs.  Please enable them before proceeding:
+This tutorial will require use of the Compute and Container APIs.  Please enable them before proceeding:
 
 <walkthrough-enable-apis apis="container.googleapis.com,compute.googleapis.com">
 </walkthrough-enable-apis>

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -8,7 +8,7 @@ category: operations
 
 ## Introduction
 
-This tutorial takes you through these steps:
+This tutorial is designed to be [run in Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator).  It takes you through these steps:
 
 - Launching a new 3 node Kubernetes cluster (optional)
 - Installing the Helm package manager for Kubernetes


### PR DESCRIPTION
Changed the flow to be 100% teachme - using integrations for account.
All commands work in sequence (can click directly) without error.

Moved the launch in Google Shell Button to README.md