### PR TITLE
Directly open GKE tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ Read the [Roadmap](./ROADMAP.md).
 
 Read the [Deploy TiDB using Kubernetes on Your Laptop for development and testing](./docs/local-dind-tutorial.md), or follow a [tutorial](./docs/google-kubernetes-tutorial.md) to launch in Google Kubernetes Engine:
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator)
-<!--
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md)
--->
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ This document defines the roadmap for TiDB Operator development.
 - [x] Stop the TiDB process without terminating Pod
 - [x] Synchronize cluster meta info to POD/PV/PVC labels
 - [x] Basic unit tests & E2E tests
-- [ ] Tutorials for GKE, local DinD
+- [x] Tutorials for GKE, local DinD
 
 ## v0.2.0: (2018-09-10)
 - [ ] Automatic failover for network PV

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -8,7 +8,7 @@ category: operations
 
 ## Introduction
 
-This tutorial is designed to be [run in Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator).  It takes you through these steps:
+This tutorial is designed to be [run in Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md).  It takes you through these steps:
 
 - Launching a new 3-node Kubernetes cluster (optional)
 - Installing the Helm package manager for Kubernetes


### PR DESCRIPTION
This small change to the button on `README.md` opens the tutorial file (not just the repo) in Cloud Shell.

I had to wait to make this change until the tutorial was pushed, as the Cloud Shell only checks out master -- and the tutorial file previously did not exist.

Tested manually, works as expected.