### PR TITLE
Fix service's nodePort will changing every 30s

### DIFF
--- a/ci/pingcap_tidb_operator_build_dind.groovy
+++ b/ci/pingcap_tidb_operator_build_dind.groovy
@@ -107,6 +107,7 @@ __EOF__
 					period=5
 					threshold=300
 					kubectl delete -f ${operator_yaml} || true
+					sleep 5
 					kubectl create -f ${operator_yaml}
 					while true
 					do

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -85,7 +85,10 @@ func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 	newSvc := pmm.getNewPDServiceForTidbCluster(tc)
 	oldSvc, err := pmm.svcLister.Services(ns).Get(controller.PDMemberName(tcName))
 	if errors.IsNotFound(err) {
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return pmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
@@ -101,7 +104,10 @@ func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		SetServiceLastAppliedConfigAnnotation(&svc)
+		err = SetServiceLastAppliedConfigAnnotation(&svc)
+		if err != nil {
+			return err
+		}
 		return pmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -115,7 +121,10 @@ func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.Tid
 	newSvc := pmm.getNewPDHeadlessServiceForTidbCluster(tc)
 	oldSvc, err := pmm.svcLister.Services(ns).Get(controller.PDPeerMemberName(tcName))
 	if errors.IsNotFound(err) {
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return pmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
@@ -131,7 +140,10 @@ func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.Tid
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return pmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -152,7 +164,10 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		return err
 	}
 	if errors.IsNotFound(err) {
-		SetLastAppliedConfigAnnotation(newPDSet)
+		err = SetLastAppliedConfigAnnotation(newPDSet)
+		if err != nil {
+			return err
+		}
 		if err := pmm.setControl.CreateStatefulSet(tc, newPDSet); err != nil {
 			return err
 		}
@@ -188,7 +203,10 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		set := *oldPDSet
 		set.Spec.Template = newPDSet.Spec.Template
 		*set.Spec.Replicas = *newPDSet.Spec.Replicas
-		SetLastAppliedConfigAnnotation(&set)
+		err = SetLastAppliedConfigAnnotation(&set)
+		if err != nil {
+			return err
+		}
 		return pmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -15,7 +15,6 @@ package member
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/golang/glog"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
@@ -86,17 +85,23 @@ func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 	newSvc := pmm.getNewPDServiceForTidbCluster(tc)
 	oldSvc, err := pmm.svcLister.Services(ns).Get(controller.PDMemberName(tcName))
 	if errors.IsNotFound(err) {
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return pmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return err
 	}
 
-	if !reflect.DeepEqual(oldSvc.Spec, newSvc.Spec) {
+	equal, err := EqualService(newSvc, oldSvc)
+	if err != nil {
+		return err
+	}
+	if !equal {
 		svc := *oldSvc
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+		SetServiceLastAppliedConfigAnnotation(&svc)
 		return pmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -110,17 +115,23 @@ func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.Tid
 	newSvc := pmm.getNewPDHeadlessServiceForTidbCluster(tc)
 	oldSvc, err := pmm.svcLister.Services(ns).Get(controller.PDPeerMemberName(tcName))
 	if errors.IsNotFound(err) {
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return pmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return err
 	}
 
-	if !reflect.DeepEqual(oldSvc.Spec, newSvc.Spec) {
+	equal, err := EqualService(newSvc, oldSvc)
+	if err != nil {
+		return err
+	}
+	if !equal {
 		svc := *oldSvc
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return pmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -141,7 +152,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		return err
 	}
 	if errors.IsNotFound(err) {
-		controller.SetLastAppliedConfigAnnotation(newPDSet)
+		SetLastAppliedConfigAnnotation(newPDSet)
 		if err := pmm.setControl.CreateStatefulSet(tc, newPDSet); err != nil {
 			return err
 		}
@@ -169,7 +180,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		}
 	}
 
-	euqal, err := controller.EqualStatefulSet(*newPDSet, *oldPDSet)
+	euqal, err := EqualStatefulSet(*newPDSet, *oldPDSet)
 	if err != nil {
 		return err
 	}
@@ -177,7 +188,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		set := *oldPDSet
 		set.Spec.Template = newPDSet.Spec.Template
 		*set.Spec.Replicas = *newPDSet.Spec.Replicas
-		controller.SetLastAppliedConfigAnnotation(&set)
+		SetLastAppliedConfigAnnotation(&set)
 		return pmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 
@@ -455,7 +466,7 @@ func (pmm *pdMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.State
 }
 
 func (pmm *pdMemberManager) needUpgrade(tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, oldSet *apps.StatefulSet) (bool, error) {
-	same, err := controller.EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
+	same, err := EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -14,8 +14,6 @@
 package member
 
 import (
-	"reflect"
-
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -67,17 +65,23 @@ func (tmm *tidbMemberManager) syncTiDBServiceForTidbCluster(tc *v1alpha1.TidbClu
 	newSvc := tmm.getNewTiDBServiceForTidbCluster(tc)
 	oldSvc, err := tmm.svcLister.Services(ns).Get(controller.TiDBMemberName(tcName))
 	if errors.IsNotFound(err) {
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return tmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return err
 	}
 
-	if !reflect.DeepEqual(oldSvc.Spec, newSvc.Spec) {
+	equal, err := EqualService(newSvc, oldSvc)
+	if err != nil {
+		return err
+	}
+	if !equal {
 		svc := *oldSvc
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return tmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -91,7 +95,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 	newTiDBSet := tmm.getNewTiDBSetForTidbCluster(tc)
 	oldTiDBSet, err := tmm.setLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))
 	if errors.IsNotFound(err) {
-		controller.SetLastAppliedConfigAnnotation(newTiDBSet)
+		SetLastAppliedConfigAnnotation(newTiDBSet)
 		err = tmm.setControl.CreateStatefulSet(tc, newTiDBSet)
 		if err != nil {
 			return err
@@ -111,7 +115,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		return err
 	}
 
-	equal, err := controller.EqualStatefulSet(*oldTiDBSet, *newTiDBSet)
+	equal, err := EqualStatefulSet(*oldTiDBSet, *newTiDBSet)
 	if err != nil {
 		return err
 	}
@@ -119,7 +123,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		set := *oldTiDBSet
 		set.Spec.Template = newTiDBSet.Spec.Template
 		*set.Spec.Replicas = *newTiDBSet.Spec.Replicas
-		controller.SetLastAppliedConfigAnnotation(&set)
+		SetLastAppliedConfigAnnotation(&set)
 		return tmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 
@@ -289,7 +293,7 @@ func (tmm *tidbMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Sta
 	if upgrade {
 		tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
 	} else {
-		_, podSpec, err := controller.GetLastAppliedConfig(oldSet)
+		_, podSpec, err := GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err
 		}
@@ -307,7 +311,7 @@ func (tmm *tidbMemberManager) needUpgrade(tc *v1alpha1.TidbCluster, newSet *apps
 		return false, nil
 	}
 
-	same, err := controller.EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
+	same, err := EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -65,7 +65,10 @@ func (tmm *tidbMemberManager) syncTiDBServiceForTidbCluster(tc *v1alpha1.TidbClu
 	newSvc := tmm.getNewTiDBServiceForTidbCluster(tc)
 	oldSvc, err := tmm.svcLister.Services(ns).Get(controller.TiDBMemberName(tcName))
 	if errors.IsNotFound(err) {
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return tmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
@@ -81,7 +84,10 @@ func (tmm *tidbMemberManager) syncTiDBServiceForTidbCluster(tc *v1alpha1.TidbClu
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return tmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -95,7 +101,10 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 	newTiDBSet := tmm.getNewTiDBSetForTidbCluster(tc)
 	oldTiDBSet, err := tmm.setLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))
 	if errors.IsNotFound(err) {
-		SetLastAppliedConfigAnnotation(newTiDBSet)
+		err = SetLastAppliedConfigAnnotation(newTiDBSet)
+		if err != nil {
+			return err
+		}
 		err = tmm.setControl.CreateStatefulSet(tc, newTiDBSet)
 		if err != nil {
 			return err
@@ -123,7 +132,10 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		set := *oldTiDBSet
 		set.Spec.Template = newTiDBSet.Spec.Template
 		*set.Spec.Replicas = *newTiDBSet.Spec.Replicas
-		SetLastAppliedConfigAnnotation(&set)
+		err = SetLastAppliedConfigAnnotation(&set)
+		if err != nil {
+			return err
+		}
 		return tmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -105,17 +105,23 @@ func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluste
 	newSvc := tkmm.getNewServiceForTidbCluster(tc, svcConfig)
 	oldSvc, err := tkmm.svcLister.Services(ns).Get(svcConfig.MemberName(tcName))
 	if errors.IsNotFound(err) {
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return tkmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return err
 	}
 
-	if !reflect.DeepEqual(oldSvc.Spec, newSvc.Spec) {
+	equal, err := EqualService(newSvc, oldSvc)
+	if err != nil {
+		return err
+	}
+	if !equal {
 		svc := *oldSvc
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+		SetServiceLastAppliedConfigAnnotation(newSvc)
 		return tkmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -136,7 +142,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		return err
 	}
 	if errors.IsNotFound(err) {
-		controller.SetLastAppliedConfigAnnotation(newSet)
+		SetLastAppliedConfigAnnotation(newSet)
 		err = tkmm.setControl.CreateStatefulSet(tc, newSet)
 		if err != nil {
 			return err
@@ -165,7 +171,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		}
 	}
 
-	equal, err := controller.EqualStatefulSet(*newSet, *oldSet)
+	equal, err := EqualStatefulSet(*newSet, *oldSet)
 	if err != nil {
 		return err
 	}
@@ -173,7 +179,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		set := *oldSet
 		set.Spec.Template = newSet.Spec.Template
 		*set.Spec.Replicas = *newSet.Spec.Replicas
-		controller.SetLastAppliedConfigAnnotation(&set)
+		SetLastAppliedConfigAnnotation(&set)
 		return tkmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 
@@ -395,7 +401,7 @@ func (tkmm *tikvMemberManager) upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.St
 	if upgrade {
 		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
 	} else {
-		_, podSpec, err := controller.GetLastAppliedConfig(oldSet)
+		_, podSpec, err := GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err
 		}
@@ -408,7 +414,7 @@ func (tkmm *tikvMemberManager) needUpgrade(tc *v1alpha1.TidbCluster, newSet *app
 	if tc.Status.PD.Phase == v1alpha1.UpgradePhase {
 		return false, nil
 	}
-	same, err := controller.EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
+	same, err := EqualTemplate(newSet.Spec.Template, oldSet.Spec.Template)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -105,7 +105,10 @@ func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluste
 	newSvc := tkmm.getNewServiceForTidbCluster(tc, svcConfig)
 	oldSvc, err := tkmm.svcLister.Services(ns).Get(svcConfig.MemberName(tcName))
 	if errors.IsNotFound(err) {
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return tkmm.svcControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
@@ -121,7 +124,10 @@ func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluste
 		svc.Spec = newSvc.Spec
 		// TODO add unit test
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		SetServiceLastAppliedConfigAnnotation(newSvc)
+		err = SetServiceLastAppliedConfigAnnotation(newSvc)
+		if err != nil {
+			return err
+		}
 		return tkmm.svcControl.UpdateService(tc, &svc)
 	}
 
@@ -142,7 +148,10 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		return err
 	}
 	if errors.IsNotFound(err) {
-		SetLastAppliedConfigAnnotation(newSet)
+		err = SetLastAppliedConfigAnnotation(newSet)
+		if err != nil {
+			return err
+		}
 		err = tkmm.setControl.CreateStatefulSet(tc, newSet)
 		if err != nil {
 			return err
@@ -179,7 +188,10 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		set := *oldSet
 		set.Spec.Template = newSet.Spec.Template
 		*set.Spec.Replicas = *newSet.Spec.Replicas
-		SetLastAppliedConfigAnnotation(&set)
+		err = SetLastAppliedConfigAnnotation(&set)
+		if err != nil {
+			return err
+		}
 		return tkmm.setControl.UpdateStatefulSet(tc, &set)
 	}
 

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -14,8 +14,19 @@
 package member
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/glog"
 	apps "k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+const (
+	// LastAppliedConfigAnnotation is annotation key of last applied configuration
+	LastAppliedConfigAnnotation = "pingcap.com/last-applied-configuration"
 )
 
 func timezoneMountVolume() (corev1.VolumeMount, corev1.Volume) {
@@ -47,4 +58,114 @@ func annotationsMountVolume() (corev1.VolumeMount, corev1.Volume) {
 // statefulSetInNormal confirms whether the statefulSet is normal phase
 func statefulSetInNormal(set *apps.StatefulSet) bool {
 	return set.Status.CurrentRevision == set.Status.UpdateRevision && set.Generation <= *set.Status.ObservedGeneration
+}
+
+// SetLastAppliedConfigAnnotation set last applied config info to Statefulset's annotation
+func SetLastAppliedConfigAnnotation(set *apps.StatefulSet) error {
+	setApply, err := encode(set.Spec)
+	if err != nil {
+		return err
+	}
+	if set.Annotations == nil {
+		set.Annotations = map[string]string{}
+	}
+	set.Annotations[LastAppliedConfigAnnotation] = setApply
+
+	templateApply, err := encode(set.Spec.Template.Spec)
+	if err != nil {
+		return err
+	}
+	if set.Spec.Template.Annotations == nil {
+		set.Spec.Template.Annotations = map[string]string{}
+	}
+	set.Spec.Template.Annotations[LastAppliedConfigAnnotation] = templateApply
+	return nil
+}
+
+// GetLastAppliedConfig get last applied config info from Statefulset's annotation
+func GetLastAppliedConfig(set *apps.StatefulSet) (*apps.StatefulSetSpec, *corev1.PodSpec, error) {
+	specAppliedConfig, ok := set.Annotations[LastAppliedConfigAnnotation]
+	if !ok {
+		return nil, nil, fmt.Errorf("statefulset:[%s/%s] not found spec's apply config", set.GetNamespace(), set.GetName())
+	}
+	spec := &apps.StatefulSetSpec{}
+	err := json.Unmarshal([]byte(specAppliedConfig), spec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	podSpecAppliedConfig, ok := set.Spec.Template.Annotations[LastAppliedConfigAnnotation]
+	if !ok {
+		return nil, nil, fmt.Errorf("statefulset:[%s/%s] not found template spec's apply config", set.GetNamespace(), set.GetName())
+	}
+	podSpec := &corev1.PodSpec{}
+	err = json.Unmarshal([]byte(podSpecAppliedConfig), podSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return spec, podSpec, nil
+}
+
+func encode(obj interface{}) (string, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// EqualStatefulSet compare the new Statefulset's spec with old Statefulset's last applied config
+func EqualStatefulSet(new apps.StatefulSet, old apps.StatefulSet) (bool, error) {
+	oldConfig := apps.StatefulSetSpec{}
+	if lastAppliedConfig, ok := old.Annotations[LastAppliedConfigAnnotation]; ok {
+		err := json.Unmarshal([]byte(lastAppliedConfig), &oldConfig)
+		if err != nil {
+			glog.Errorf("unmarshal Statefulset: [%s/%s]'s applied config failed,error: %v", old.GetNamespace(), old.GetName(), err)
+			return false, err
+		}
+		return apiequality.Semantic.DeepEqual(oldConfig, new.Spec), nil
+	}
+	return false, nil
+}
+
+// EqualTemplate compare the new podTemplateSpec's spec with old podTemplateSpec's last applied config
+func EqualTemplate(new corev1.PodTemplateSpec, old corev1.PodTemplateSpec) (bool, error) {
+	oldConfig := corev1.PodSpec{}
+	if lastAppliedConfig, ok := old.Annotations[LastAppliedConfigAnnotation]; ok {
+		err := json.Unmarshal([]byte(lastAppliedConfig), &oldConfig)
+		if err != nil {
+			glog.Errorf("unmarshal PodTemplate: [%s/%s]'s applied config failed,error: %v", old.GetNamespace(), old.GetName(), err)
+			return false, err
+		}
+		return apiequality.Semantic.DeepEqual(oldConfig, new.Spec), nil
+	}
+	return false, nil
+}
+
+// SetServiceLastAppliedConfigAnnotation set last applied config info to Service's annotation
+func SetServiceLastAppliedConfigAnnotation(svc *corev1.Service) error {
+	svcApply, err := encode(svc.Spec)
+	if err != nil {
+		return err
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+	svc.Annotations[LastAppliedConfigAnnotation] = svcApply
+	return nil
+}
+
+// EqualService compare the new Service's spec with old Service's last applied config
+func EqualService(new, old *corev1.Service) (bool, error) {
+	oldSpec := corev1.ServiceSpec{}
+	if lastAppliedConfig, ok := old.Annotations[LastAppliedConfigAnnotation]; ok {
+		err := json.Unmarshal([]byte(lastAppliedConfig), &oldSpec)
+		if err != nil {
+			glog.Errorf("unmarshal ServiceSpec: [%s/%s]'s applied config failed,error: %v", old.GetNamespace(), old.GetName(), err)
+			return false, err
+		}
+		return apiequality.Semantic.DeepEqual(oldSpec, new.Spec), nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
This pr rewrites the service comparison logic to avoid frequent update services causing the nodePort to always be changing