### PR TITLE
*: update DinD script & tutorial to simplify DinD setup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -112,14 +112,7 @@ $ make test
 
 For e2e tests, we recommend DinD Kubernetes environment. Follow [this guide](./local-dind-tutorial.md) to spin up a local DinD Kubernetes cluster.
 
-You should also deploy a registry in DinD, so you can push and use your Docker images in DinD Kubernetes.
-
-```sh
-$ ./manifests/local-dind/deploy-registry.sh
-$ kubectl port-forward svc/registry-proxy 5000:5000 --namespace=kube-system
-```
-
-Then you can build and push Docker images to the DinD registry.
+Then you can build and push Docker images to the DinD Docker registry. The DinD Docker registry is available as `localhost:5000` both on the host machine and inside the DinD.
 
 ```sh
 $ make docker-push

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -2,7 +2,7 @@
 
 This document describes how to deploy a TiDB cluster to Kubernetes on your laptop (Linux or macOS) for development or testing.
 
-[Docker in Docker](https://hub.docker.com/_/docker/) (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) uses this technology to run the Kubernetes cluster in Docker containers.
+[Docker in Docker](https://hub.docker.com/_/docker/) (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) uses this technology to run the Kubernetes cluster in Docker containers. TiDB Operator uses a modified DinD script to manage DinD Kubernetes cluster.
 
 ## Prerequisites
 
@@ -13,80 +13,26 @@ Before deploying a TiDB cluster to Kubernetes, make sure the following requireme
     > **Note:** For macOS, you need to allocate 2+ CPU and 4G+ Memory to Docker. For details, see [Docker for Mac configuration](https://docs.docker.com/docker-for-mac/#advanced).
 
 - [Docker](https://docs.docker.com/install/): 17.03 or later
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) 1.10 or later
+- [Helm Client](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client): 2.8.2 or later
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl): 1.10 or later
 
     > **Note:** The outputs of different versions of `kubectl` might be slightly different.
 
-- `md5sha1sum`
-    - For Linux, `md5sha1sum` is already installed by default.
-    - For macOS, make sure `md5sha1sum` is installed. If not, run `brew install md5sha1sum` to install it.
-
 ## Step 1: Deploy a Kubernetes cluster using DinD
 
-1. Use DinD to install and deploy a multiple-node Kubernetes cluster:
-
-    ```sh
-    $ wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/64a2befa65ce23475158b65793e56d4bc1ae0a79/fixed/dind-cluster-v1.10.sh
-    $ chmod +x dind-cluster-v1.10.sh
-    $ CNI_PLUGIN="flannel" NUM_NODES=4 ./dind-cluster-v1.10.sh up
-    ```
-
-    > **Note:** `CNI_PLUGIN=flannel` prevents issues with restarting docker. However, if you have network issues preventing tidb startup, you can re-create the cluster without setting `CNI_PLUGIN`.
-    > **Note:** If you fail to pull the Docker images due to the firewall, you can try the following method (the Docker images used are pulled from [UCloud Docker Registry](https://docs.ucloud.cn/compute/uhub/index)):
-
-    ```sh
-    $ git clone https://github.com/pingcap/kubeadm-dind-cluster
-    $ cd kubeadm-dind-cluster
-    $ NUM_NODES=4 tools/multi_k8s_dind_cluster_manager.sh rebuild e2e-v1.10
-    ```
-
-2. After the DinD cluster bootstrap is done, use the following command to verify the Kubernetes cluster is up and running:
-
-    ```sh
-    $ kubectl get node,componentstatus
-    $ kubectl get po -n kube-system
-    ```
-
-3. Now the cluster is up and running, you need to install the Kubernetes package manager [Helm](https://helm.sh) into the cluster, which is used to deploy and manage TiDB Operator and TiDB clusters later.
-
-    ```sh
-    $ os=`uname -s| tr '[:upper:]' '[:lower:]'`
-    $ wget "https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-${os}-amd64.tar.gz"
-    $ tar xzf helm-v2.9.1-${os}-amd64.tar.gz
-    $ sudo mv ${os}-amd64/helm /usr/local/bin
-
-    $ git clone https://github.com/pingcap/tidb-operator
-    $ cd tidb-operator
-    $ kubectl apply -f manifests/tiller-rbac.yaml
-    $ helm init --service-account=tiller --upgrade
-    $ kubectl get po -n kube-system | grep tiller # verify Tiller is running
-    $ helm version # verify the Helm server is running
-    ```
-
-    > **Note:** If the tiller pod fails to start due to image pull failure because of the firewall, you can replace `helm init --service-account=tiller --upgrade` with the following command:
-    
-    ```
-    helm init --service-account=tiller --upgrade --tiller-image=uhub.ucloud.cn/pingcap/tiller:v2.9.1
-    ```
-
-## Step 2: Configure local volumes
-
-[LocalPersistentVolume](https://kubernetes.io/docs/concepts/storage/volumes/#local) is used to persist the PD/TiKV data. The [local persistent volume provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/local-volume) doesn't work out of the box in DinD, so you need to modify its deployment. And it doesn't support [dynamic provision](https://github.com/kubernetes/community/pull/1914) yet, so you need to manually mount disks or directories to mount points.
-
-To simplify this operation, use the following [scripts](../manifests/local-dind) to help configure the development environment:
-
 ```sh
-$ # create directories for local volumes
-$ ./manifests/local-dind/pv-hosts.sh
-$ # deploy local volume provisioner
-$ kubectl apply -f manifests/local-dind/local-volume-provisioner.yaml
-$ # wait local-volume-provisioner pods running
-$ kubectl get po -n kube-system -l app=local-volume-provisioner
-$ # verify pv created
-$ kubectl get pv
+$ git clone https://github.com/pingcap/tidb-operator
+$ cd tidb-operator
+$ manifests/local-dind/dind-cluster-v1.10.sh up
 ```
 
-## Step 3: Install TiDB Operator in the DinD Kubernetes cluster
+> **Note:** If the cluster fails to pull Docker images during the startup due to the firewall, you can set environment `KUBE_REPO_PREFIX` to `uhub.ucloud.cn/pingcap` before running script `dind-cluster-v1.10.sh` like this (the Docker images used are pulled from [UCloud Docker Registry](https://docs.ucloud.cn/compute/uhub/index)):
+
+```
+$ KUBE_REPO_PREFIX=uhub.ucloud.cn/pingcap manifests/local-dind/dind-cluster-v1.10.sh up
+```
+
+## Step 2: Install TiDB Operator in the DinD Kubernetes cluster
 
 ```sh
 $ kubectl apply -f manifests/crd.yaml
@@ -97,15 +43,15 @@ NAME                             AGE
 tidbclusters.pingcap.com         1m
 
 $ # Install TiDB Operator into Kubernetes
-$ helm install charts/tidb-operator --name=tidb-operator --namespace=pingcap
+$ helm install charts/tidb-operator --name=tidb-operator --namespace=tidb-admin
 
 $ # wait operator running
-$ kubectl get po -n pingcap -l app=tidb-operator
+$ kubectl get po -n tidb-admin -l app=tidb-operator
 NAME                                       READY     STATUS    RESTARTS   AGE
 tidb-controller-manager-5cd94748c7-jlvfs   1/1       Running   0          1m
 ```
 
-## Step 4: Deploy a TiDB cluster in the DinD Kubernetes cluster
+## Step 3: Deploy a TiDB cluster in the DinD Kubernetes cluster
 
 ```sh
 $ helm install charts/tidb-cluster --name=tidb-cluster --namespace=tidb
@@ -224,21 +170,23 @@ $ kubectl get pv -l cluster.pingcap.com/namespace=tidb -o name | xargs -I {} kub
 $ kubectl delete pvc --namespace tidb --all
 ```
 
-## Destroy the DinD Kubernetes cluster
-
-If you do not need the DinD Kubernetes cluster anymore, change to the directory where you put `dind-cluster-v1.10.sh` and run the following command:
-
-```sh
-$ ./dind-cluster-v1.10.sh clean
-```
-
-## Re-start Kubernetes cluster and the TiDB Operator and Cluster
+## Stop and Re-start Kubernetes cluster
 
 Once you have a working DinD setup, you can follow this workflow:
 
 ```sh
-$ ./dind-cluster-v1.10.sh down
-# Run the up command the same way you did previously
-$ NUM_NODES=4 CNI_PLUGIN=flannel ./dind-cluster-v1.10.sh up
-$ hack/dind-run-operators.sh
+$ manifests/local-dind/dind-cluster-v1.10.sh stop
+$ manifests/local-dind/dind-cluster-v1.10.sh start
 ```
+
+## Destroy the DinD Kubernetes cluster
+
+If you want to clean up the DinD Kubernetes cluster and bring up a new cluster, run the following commands:
+
+```sh
+$ manifests/local-dind/dind-cluster-v1.10.sh clean
+$ sudo rm -rf data/kube-node-*
+$ manifests/local-dind/dind-cluster-v1.10.sh up
+```
+
+> **Warning:** You must remember to clean the data after you destroy the DinD Kubernetes, otherwise when you bring it up again and the existing data would case TiDB clusters fail to start.

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -2,7 +2,7 @@
 
 This document describes how to deploy a TiDB cluster to Kubernetes on your laptop (Linux or macOS) for development or testing.
 
-[Docker in Docker](https://hub.docker.com/_/docker/) (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) uses this technology to run the Kubernetes cluster in Docker containers. TiDB Operator uses a modified DinD script to manage DinD Kubernetes cluster.
+[Docker in Docker](https://hub.docker.com/_/docker/) (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. [kubeadm-dind-cluster](https://github.com/kubernetes-sigs/kubeadm-dind-cluster) uses this technology to run the Kubernetes cluster in Docker containers. TiDB Operator uses a modified DinD script to manage the DinD Kubernetes cluster.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ Before deploying a TiDB cluster to Kubernetes, make sure the following requireme
 
 - [Docker](https://docs.docker.com/install/): 17.03 or later
 
-    > **Note:** [Legacy Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_mac/) users must migrate to [Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac), DinD cannot run on Docker Toolbox and Docker Machine.
+    > **Note:** [Legacy Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_mac/) users must migrate to [Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac) by uninstalling Legacy Docker Toolbox and installing Docker for Mac, because DinD cannot run on Docker Toolbox and Docker Machine.
 
 - [Helm Client](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client): 2.8.2 or later
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl): 1.10 or later
@@ -29,7 +29,7 @@ $ cd tidb-operator
 $ manifests/local-dind/dind-cluster-v1.10.sh up
 ```
 
-> **Note:** If the cluster fails to pull Docker images during the startup due to the firewall, you can set environment `KUBE_REPO_PREFIX` to `uhub.ucloud.cn/pingcap` before running script `dind-cluster-v1.10.sh` like this (the Docker images used are pulled from [UCloud Docker Registry](https://docs.ucloud.cn/compute/uhub/index)):
+> **Note:** If the cluster fails to pull Docker images during the startup due to the firewall, you can set the environment variable `KUBE_REPO_PREFIX` to `uhub.ucloud.cn/pingcap` before running the script `dind-cluster-v1.10.sh` as follows (the Docker images used are pulled from [UCloud Docker Registry](https://docs.ucloud.cn/compute/uhub/index)):
 
 ```
 $ KUBE_REPO_PREFIX=uhub.ucloud.cn/pingcap manifests/local-dind/dind-cluster-v1.10.sh up
@@ -173,14 +173,20 @@ $ kubectl get pv -l cluster.pingcap.com/namespace=tidb -o name | xargs -I {} kub
 $ kubectl delete pvc --namespace tidb --all
 ```
 
-## Stop and Re-start Kubernetes cluster
+## Stop and Re-start the Kubernetes cluster
 
-Once you have a working DinD setup, you can follow this workflow:
+* If you want to stop the DinD Kubernetes cluster, run the following command:
 
-```sh
-$ manifests/local-dind/dind-cluster-v1.10.sh stop
-$ manifests/local-dind/dind-cluster-v1.10.sh start
-```
+    ```sh
+    $ manifests/local-dind/dind-cluster-v1.10.sh stop
+
+    ```
+
+* If you want to restart the DinD Kubernetes after you stop it, run the following command:
+
+    ```
+    $ manifests/local-dind/dind-cluster-v1.10.sh start
+    ```
 
 ## Destroy the DinD Kubernetes cluster
 
@@ -192,4 +198,4 @@ $ sudo rm -rf data/kube-node-*
 $ manifests/local-dind/dind-cluster-v1.10.sh up
 ```
 
-> **Warning:** You must remember to clean the data after you destroy the DinD Kubernetes, otherwise when you bring it up again and the existing data would case TiDB clusters fail to start.
+> **Warning:** You must clean the data after you destroy the DinD Kubernetes cluster, otherwise the TiDB cluster would fail to start when you bring it up again.

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -13,6 +13,9 @@ Before deploying a TiDB cluster to Kubernetes, make sure the following requireme
     > **Note:** For macOS, you need to allocate 2+ CPU and 4G+ Memory to Docker. For details, see [Docker for Mac configuration](https://docs.docker.com/docker-for-mac/#advanced).
 
 - [Docker](https://docs.docker.com/install/): 17.03 or later
+
+    > **Note:** [Legacy Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_mac/) users must migrate to [Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac), DinD cannot run on Docker Toolbox and Docker Machine.
+
 - [Helm Client](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client): 2.8.2 or later
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl): 1.10 or later
 

--- a/manifests/local-dind/dind-cluster-v1.10.sh
+++ b/manifests/local-dind/dind-cluster-v1.10.sh
@@ -233,8 +233,8 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
     DEFAULT_POD_NETWORK_CIDR="fd00:10:20::/72"
     USE_HAIRPIN="${USE_HAIRPIN:-true}"  # Default is to use hairpin for IPv6
     if [[ ${DIND_ALLOW_AAAA_USE} && ${GCE_HOSTED} ]]; then
-	echo "ERROR! GCE does not support use of IPv6 for external addresses - aborting."
-	exit 1
+        echo "ERROR! GCE does not support use of IPv6 for external addresses - aborting."
+        exit 1
     fi
 else
     dind::find-or-create-ipv4-dind-subnet
@@ -245,11 +245,11 @@ else
     DEFAULT_POD_NETWORK_CIDR="10.244.0.0/16"
     USE_HAIRPIN="${USE_HAIRPIN:-false}"  # Disabled for IPv4, as issue with Virtlet networking
     if [[ ${DIND_ALLOW_AAAA_USE} ]]; then
-	echo "WARNING! The DIND_ALLOW_AAAA_USE option is for IPv6 mode - ignoring setting."
-	DIND_ALLOW_AAAA_USE=
+        echo "WARNING! The DIND_ALLOW_AAAA_USE option is for IPv6 mode - ignoring setting."
+        DIND_ALLOW_AAAA_USE=
     fi
     if [[ ${CNI_PLUGIN} = "calico" || ${CNI_PLUGIN} = "calico-kdd" ]]; then
-	DEFAULT_POD_NETWORK_CIDR="192.168.0.0/16"
+        DEFAULT_POD_NETWORK_CIDR="192.168.0.0/16"
     fi
 fi
 dns_prefix="$(echo ${SERVICE_CIDR} | sed 's,/.*,,')"
@@ -277,12 +277,12 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
 
     # Will be replacing lowest byte with node ID, so pull off last byte and colon
     if [[ ${num_colons} -gt ${need_zero_pads} ]]; then
-	POD_NET_PREFIX=${POD_NET_PREFIX::-3}
+        POD_NET_PREFIX=${POD_NET_PREFIX::-3}
     fi
     # Add in zeros to pad 16 bits at a time, up to the padding needed, which is
     # need_zero_pads - num_colons.
     while [ ${num_colons} -lt ${need_zero_pads} ]; do
-	POD_NET_PREFIX+="0:"
+        POD_NET_PREFIX+="0:"
         num_colons+=1
     done
 elif [[ ${CNI_PLUGIN} = "bridge" || ${CNI_PLUGIN} = "ptp" ]]; then # IPv4, bridge or ptp
@@ -684,16 +684,16 @@ function dind::ensure-volume {
 function dind::ensure-dns {
     if [[ ${IP_MODE} = "ipv6" ]]; then
         if ! docker inspect bind9 >&/dev/null; then
-	    local force_dns64_for=""
-	    if [[ ! ${DIND_ALLOW_AAAA_USE} ]]; then
-		# Normally, if have an AAAA record, it is used. This clause tells
-		# bind9 to do ignore AAAA records for the specified networks
-		# and/or addresses and lookup A records and synthesize new AAAA
-		# records. In this case, we select "any" networks that have AAAA
-		# records meaning we ALWAYS use A records and do NAT64.
-	        force_dns64_for="exclude { any; };"
-	    fi
-	    read -r -d '' bind9_conf <<BIND9_EOF
+            local force_dns64_for=""
+            if [[ ! ${DIND_ALLOW_AAAA_USE} ]]; then
+                # Normally, if have an AAAA record, it is used. This clause tells
+                # bind9 to do ignore AAAA records for the specified networks
+                # and/or addresses and lookup A records and synthesize new AAAA
+                # records. In this case, we select "any" networks that have AAAA
+                # records meaning we ALWAYS use A records and do NAT64.
+                force_dns64_for="exclude { any; };"
+            fi
+            read -r -d '' bind9_conf <<BIND9_EOF
 options {
     directory "/var/bind";
     allow-query { any; };
@@ -707,14 +707,14 @@ options {
     };
 };
 BIND9_EOF
-	    docker run -d --name bind9 --hostname bind9 --net "$(dind::net-name)" --label "dind-support" \
-		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
-		   --privileged=true --ip6 ${dns_server} --dns ${dns_server} \
-		   -e bind9_conf="${bind9_conf}" \
-		   resystit/bind9:latest /bin/sh -c 'echo "${bind9_conf}" >/named.conf && named -c /named.conf -g -u named' >/dev/null
-	    ipv4_addr="$(docker exec bind9 ip addr list eth0 | grep "inet" | awk '$1 == "inet" {print $2}')"
-	    docker exec bind9 ip addr del ${ipv4_addr} dev eth0
-	    docker exec bind9 ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
+            docker run -d --name bind9 --hostname bind9 --net "$(dind::net-name)" --label "dind-support" \
+                   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
+                   --privileged=true --ip6 ${dns_server} --dns ${dns_server} \
+                   -e bind9_conf="${bind9_conf}" \
+                   resystit/bind9:latest /bin/sh -c 'echo "${bind9_conf}" >/named.conf && named -c /named.conf -g -u named' >/dev/null
+            ipv4_addr="$(docker exec bind9 ip addr list eth0 | grep "inet" | awk '$1 == "inet" {print $2}')"
+            docker exec bind9 ip addr del ${ipv4_addr} dev eth0
+            docker exec bind9 ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
         fi
     fi
 }
@@ -723,16 +723,16 @@ function dind::ensure-nat {
     if [[  ${IP_MODE} = "ipv6" ]]; then
         if ! docker ps | grep tayga >&/dev/null; then
             docker run -d --name tayga --hostname tayga --net "$(dind::net-name)" --label "dind-support" \
-		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
-		   --privileged=true --ip ${NAT64_V4_SUBNET_PREFIX}.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
-		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=${NAT64_V4_SUBNET_PREFIX}.0.200 \
-		   -e TAYGA_CONF_DYNAMIC_POOL=${NAT64_V4_SUBNET_PREFIX}.0.128/25 danehans/tayga:latest >/dev/null
-	    # Need to check/create, as "clean" may remove route
-	    local route="$(ip route | egrep "^${NAT64_V4_SUBNET_PREFIX}.0.128/25")"
-	    if [[ -z "${route}" ]]; then
-	        docker run --net=host --rm --privileged ${busybox_image} ip route add ${NAT64_V4_SUBNET_PREFIX}.0.128/25 via ${NAT64_V4_SUBNET_PREFIX}.0.200
-	    fi
-	fi
+                   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
+                   --privileged=true --ip ${NAT64_V4_SUBNET_PREFIX}.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
+                   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=${NAT64_V4_SUBNET_PREFIX}.0.200 \
+                   -e TAYGA_CONF_DYNAMIC_POOL=${NAT64_V4_SUBNET_PREFIX}.0.128/25 danehans/tayga:latest >/dev/null
+            # Need to check/create, as "clean" may remove route
+            local route="$(ip route | egrep "^${NAT64_V4_SUBNET_PREFIX}.0.128/25")"
+            if [[ -z "${route}" ]]; then
+                docker run --net=host --rm --privileged ${busybox_image} ip route add ${NAT64_V4_SUBNET_PREFIX}.0.128/25 via ${NAT64_V4_SUBNET_PREFIX}.0.200
+            fi
+        fi
     fi
 }
 
@@ -767,13 +767,13 @@ function dind::run {
 
       # For prefix, if node ID will be in the upper byte, push it over
       if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
-	  node_id=$(printf "%02x00\n" "${node_id}")
+          node_id=$(printf "%02x00\n" "${node_id}")
       else
-	  if [[ "${POD_NET_PREFIX: -1}" = ":" ]]; then
-	      node_id=$(printf "%x\n" "${node_id}")
-	  else
-	      node_id=$(printf "%02x\n" "${node_id}")  # In lower byte, so ensure two chars
-	  fi
+          if [[ "${POD_NET_PREFIX: -1}" = ":" ]]; then
+              node_id=$(printf "%x\n" "${node_id}")
+          else
+              node_id=$(printf "%02x\n" "${node_id}")  # In lower byte, so ensure two chars
+          fi
       fi
   fi
 
@@ -832,7 +832,7 @@ function dind::run {
 
   # Start the new container.
   docker run \
-	 -e IP_MODE="${IP_MODE}" \
+         -e IP_MODE="${IP_MODE}" \
          -e KUBEADM_SOURCE="${KUBEADM_SOURCE}" \
          -e HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE}" \
          -d --privileged \
@@ -1172,11 +1172,11 @@ function dind::create-static-routes {
         dest="${POD_NET_PREFIX}${id}.0/24"
         gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
-	instance=$(printf "%02x" ${id})
-	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
-	  instance+="00" # Move node ID to upper byte
-	fi
-	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
+        instance=$(printf "%02x" ${id})
+        if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
+          instance+="00" # Move node ID to upper byte
+        fi
+        dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
         gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec "${node}" ip route add "${dest}" via "${gw}"
@@ -1844,7 +1844,7 @@ function dind::run_tiller {
     dind::step "Deploying tiller"
     hash helm 2>/dev/null
     if [[ $? -eq 0 ]];then
-	helm_version=$(helm version -c --template '{{.Client.SemVer}}')
+        helm_version=$(helm version -c --template '{{.Client.SemVer}}')
         if [[ -n ${KUBE_REPO_PREFIX} ]];then
             helm init --tiller-image ${KUBE_REPO_PREFIX}/tiller:${helm_version}
         else
@@ -1909,7 +1909,7 @@ case "${1:-}" in
     # dind::ensure-kubectl       # users must install kubectl themselves
     dind::up
     dind::run_registry
-    dind::run_tiller		# users must install helm themselves
+    dind::run_tiller            # users must install helm themselves
     dind::run_local_volume_provisioner
     dind::create_e2e_env
     ;;

--- a/manifests/local-dind/dind-cluster-v1.10.sh
+++ b/manifests/local-dind/dind-cluster-v1.10.sh
@@ -300,7 +300,7 @@ BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
-NUM_NODES=${NUM_NODES:-2}
+NUM_NODES=${NUM_NODES:-3}
 EXTRA_PORTS="${EXTRA_PORTS:-}"
 LOCAL_KUBECTL_VERSION=${LOCAL_KUBECTL_VERSION:-}
 KUBECTL_DIR="${KUBECTL_DIR:-${HOME}/.kubeadm-dind-cluster}"
@@ -311,7 +311,6 @@ DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
 APISERVER_PORT="${APISERVER_PORT:-8080}"
 REGISTRY_PORT="${REGISTRY_PORT:-5000}"
-TILLER_VERSION="${TILLER_VERSION:-v2.9.1}"
 PV_NUMS="${PV_NUMS:-4}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
@@ -1845,8 +1844,9 @@ function dind::run_tiller {
     dind::step "Deploying tiller"
     hash helm 2>/dev/null
     if [[ $? -eq 0 ]];then
+	helm_version=$(helm version -c --template '{{.Client.SemVer}}')
         if [[ -n ${KUBE_REPO_PREFIX} ]];then
-            helm init --tiller-image ${KUBE_REPO_PREFIX}/tiller:${TILLER_VERSION}
+            helm init --tiller-image ${KUBE_REPO_PREFIX}/tiller:${helm_version}
         else
             helm init
         fi
@@ -1906,10 +1906,10 @@ case "${1:-}" in
       docker pull "${DIND_IMAGE}" >&2
     fi
     dind::prepare-sys-mounts
-    dind::ensure-kubectl
+    # dind::ensure-kubectl       # users must install kubectl themselves
     dind::up
     dind::run_registry
-    dind::run_tiller
+    dind::run_tiller		# users must install helm themselves
     dind::run_local_volume_provisioner
     dind::create_e2e_env
     ;;


### PR DESCRIPTION
This PR updates DinD tutorial, to simplify DinD setup the script is also updated for `helm` and `kubectl` section. This makes both `helm` client and `kubectl` prerequisites.
PTAL @gregwebs @onlymellb @lilin90 