### PR TITLE
Fix the noisy error messages problem on storage

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -73,7 +73,7 @@ func GetServiceType(services []v1alpha1.Service, serviceName string) corev1.Serv
 // tikv uses GB, TB as unit suffix, but it actually means GiB, TiB
 func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 	defaultArgs := "0"
-	if limits == nil {
+	if limits == nil || limits.Storage == ""{
 		return defaultArgs
 	}
 	q, err := resource.ParseQuantity(limits.Storage)


### PR DESCRIPTION
Signed-off-by: huanwei huan@harmonycloud.cn

This PR is derived from [ISSUE #52](https://github.com/pingcap/tidb-operator/issues/52) and  [PR #54 ](https://github.com/pingcap/tidb-operator/pull/54), to fix the noisy error messages problem on tikv storage capacity. 
