### PR TITLE
linter: error means exit code 1

### DIFF
--- a/revive.toml
+++ b/revive.toml
@@ -1,7 +1,7 @@
 ignoreGeneratedHeader = false
 severity = "error"
 confidence = 0.8
-errorCode = 0
+errorCode = 1
 warningCode = 0
 
 [rule.blank-imports]


### PR DESCRIPTION
This setting defaulted to zero, which doesn't make sense.
Warnings are still zero.