### PR TITLE
Fix issue-64: delete the useless variant called nodeName

### DIFF
--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -541,7 +541,7 @@ func (tkmm *tikvMemberManager) setStoreLabelsForTiKV(pdClient controller.PDClien
 			return err
 		}
 		if updated {
-			glog.Infof("Pod: [%s/%s] set labels successfully,labels: %v ", ns, podName, nodeName, ls)
+			glog.Infof("Pod: [%s/%s] set labels successfully,labels: %v ", ns, podName, ls)
 		}
 	}
 	return nil


### PR DESCRIPTION
#### Modification

1. delete the useless variant called nodeName, fix #64 