### PR TITLE
Fix deepequal result in UpdateTidbCluster always false

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -14,12 +14,11 @@
 package tidbcluster
 
 import (
-	"reflect"
-
 	"github.com/golang/glog"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/manager"
 	"github.com/pingcap/tidb-operator/pkg/util"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 )
@@ -77,7 +76,7 @@ func (tcc *defaultTidbClusterControl) UpdateTidbCluster(tc *v1alpha1.TidbCluster
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if !reflect.DeepEqual(tc.Status, oldStatus) {
+	if !apiequality.Semantic.DeepEqual(&tc.Status, oldStatus) {
 		// update the tidbCluster's status
 		err2 := tcc.updateTidbClusterStatus(tc, &tc.Status)
 		if err2 != nil {

--- a/pkg/controller/tidbcluster/tidb_cluster_control_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	mm "github.com/pingcap/tidb-operator/pkg/manager/member"
 	"github.com/pingcap/tidb-operator/pkg/manager/meta"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -55,6 +56,19 @@ func TestTidbClusterControl(t *testing.T) {
 	newTC, err := setControl.TcLister.TidbClusters(tc.Namespace).Get(tc.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(newTC.Status.PD.StatefulSet).NotTo(Equal(nil))
+}
+
+func TestTidbClusterStatusEquality(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tcStatus := v1alpha1.TidbClusterStatus{}
+
+	tcStatusCopy := tcStatus.DeepCopy()
+	tcStatusCopy.PD = v1alpha1.PDStatus{}
+	g.Expect(apiequality.Semantic.DeepEqual(&tcStatus, tcStatusCopy)).To(Equal(true))
+
+	tcStatusCopy = tcStatus.DeepCopy()
+	tcStatusCopy.PD.Phase = v1alpha1.NormalPhase
+	g.Expect(apiequality.Semantic.DeepEqual(&tcStatus, tcStatusCopy)).To(Equal(false))
 }
 
 func newFakeTidbClusterControl() (ControlInterface, *controller.FakeStatefulSetControl, StatusUpdaterInterface, *controller.FakePDControl) {


### PR DESCRIPTION
1、Fix deepequal result in UpdateTidbCluster always false
2、Replace reflect.DeepEqual with apiequality.Semantic.DeepEqual
3、Add unit test to cover this situation

Fix issue #73 