### PR TITLE
*: Make gofmt & lint check work for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS += -X "github.com/pingcap/tidb-operator/version.GitSHA=$(shell git rev-p
 
 DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
 
-PACKAGE_LIST := go list ./... | grep -vE "vendor" | grep -vE "pkg/client"
+PACKAGE_LIST := go list ./... | grep -vE "vendor" | grep -vE "pkg/client" | grep -vE "zz_generated"
 PACKAGES := $$($(PACKAGE_LIST))
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'
 FILES := $$(find $$($(PACKAGE_DIRECTORIES)) -name "*.go")

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ LDFLAGS += -X "github.com/pingcap/tidb-operator/version.GitSHA=$(shell git rev-p
 
 DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
 
-PACKAGES := go list ./...
-PACKAGE_DIRECTORIES := $(PACKAGES) | sed 's|github.com/pingcap/tidb-operator/||'
+PACKAGE_LIST := go list ./... | grep -vE "vendor" | grep -vE "pkg/client"
+PACKAGES := $$($(PACKAGE_LIST))
+PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'
+FILES := $$(find $$($(PACKAGE_DIRECTORIES)) -name "*.go")
 FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1 } }'
 
 default: build
@@ -37,32 +39,54 @@ e2e-build:
 	$(GOENV) ginkgo build tests/e2e
 
 test:
-	@ CGO_ENABLED=0 go test ./pkg/... -v -cover && echo success
+	@echo "run unit tests"
+	@$(GO) test ./pkg/... -v -cover && echo success
 
-check-all: static lint
-	@echo "checking"
+check-all: lint check-static check-shadow check-gosec megacheck errcheck
 
 check-setup:
 	@which retool >/dev/null 2>&1 || go get github.com/twitchtv/retool
 	@retool sync
 
-check: check-setup check-all
+check: check-setup lint check-static
 
-static:
+check-static:
 	@ # Not running vet and fmt through metalinter becauase it ends up looking at vendor
-	gofmt -s -l $$($(PACKAGE_DIRECTORIES)) 2>&1 | $(FAIL_ON_STDOUT)
-	retool do govet --shadow $$($(PACKAGE_DIRECTORIES)) 2>&1 | $(FAIL_ON_STDOUT)
-
-	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --deadline 120s \
+	@echo "gofmt checking"
+	gofmt -s -l -w $(FILES) 2>&1| $(FAIL_ON_STDOUT)
+	@echo "govet checking"
+	retool do govet -all $$($(PACKAGE_DIRECTORIES)) 2>&1
+	@echo "mispell and ineffassign checking"
+	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all \
 	  --enable misspell \
-	  --enable megacheck \
 	  --enable ineffassign \
+	  $$($(PACKAGE_DIRECTORIES))
+
+# TODO: megacheck is too slow currently
+megacheck:
+	@echo "gometalinter megacheck"
+	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --deadline 120s \
+	  --enable megacheck \
+	  $$($(PACKAGE_DIRECTORIES))
+
+# TODO: errcheck is too slow currently
+errcheck:
+	@echo "gometalinter errcheck"
+	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --deadline 120s \
 	  --enable errcheck \
 	  $$($(PACKAGE_DIRECTORIES))
+
+# TODO: shadow check fails at the moment
+check-shadow:
+	@echo "govet shadow checking"
+	retool do govet -shadow $$($(PACKAGE_DIRECTORIES))
 
 lint:
 	@echo "linting"
 	CGO_ENABLED=0 retool do revive -formatter friendly -config revive.toml $$($(PACKAGES))
 
 check-gosec:
+	@echo "security checking"
 	CGO_ENABLED=0 retool do gosec $$($(PACKAGE_DIRECTORIES))
+
+.PHONY: check check-all build e2e-build

--- a/ci/pingcap_tidb_operator_build_dind.groovy
+++ b/ci/pingcap_tidb_operator_build_dind.groovy
@@ -51,6 +51,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID) {
 					GITHASH = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
 					sh """
 					export GOPATH=${WORKSPACE}/go:$GOPATH
+					make check
 					make test
 					make
 					make e2e-build

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -73,7 +73,7 @@ func GetServiceType(services []v1alpha1.Service, serviceName string) corev1.Serv
 // tikv uses GB, TB as unit suffix, but it actually means GiB, TiB
 func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 	defaultArgs := "0"
-	if limits == nil || limits.Storage == ""{
+	if limits == nil || limits.Storage == "" {
 		return defaultArgs
 	}
 	q, err := resource.ParseQuantity(limits.Storage)

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -28,7 +28,7 @@ type fakeIndexer struct {
 	getError error
 }
 
-func (f *fakeIndexer) GetByKey(key string) (interface{}, bool, error) {
+func (f *fakeIndexer) GetByKey(_ string) (interface{}, bool, error) {
 	return nil, false, f.getError
 }
 
@@ -56,17 +56,7 @@ func newTidbCluster() *v1alpha1.TidbCluster {
 	return tc
 }
 
-func newSecret(tc *v1alpha1.TidbCluster, name string) *corev1.Secret {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetName(tc.Name, "image"),
-			Namespace: metav1.NamespaceDefault,
-		},
-	}
-	return secret
-}
-
-func newService(tc *v1alpha1.TidbCluster, name string) *corev1.Service {
+func newService(tc *v1alpha1.TidbCluster, _ string) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetName(tc.Name, "pd"),
@@ -76,7 +66,7 @@ func newService(tc *v1alpha1.TidbCluster, name string) *corev1.Service {
 	return svc
 }
 
-func newStatefulSet(tc *v1alpha1.TidbCluster, name string) *apps.StatefulSet {
+func newStatefulSet(tc *v1alpha1.TidbCluster, _ string) *apps.StatefulSet {
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetName(tc.Name, "pd"),
@@ -84,16 +74,6 @@ func newStatefulSet(tc *v1alpha1.TidbCluster, name string) *apps.StatefulSet {
 		},
 	}
 	return set
-}
-
-func newDeployment(tc *v1alpha1.TidbCluster, name string) *apps.Deployment {
-	deploy := &apps.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetName(tc.Name, "monitor"),
-			Namespace: metav1.NamespaceDefault,
-		},
-	}
-	return deploy
 }
 
 // GetName concatenate tidb cluster name and member name, used for controller managed resource name

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -463,9 +463,8 @@ func readErrorBody(body io.Reader) (err error) {
 	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		return err
-	} else {
-		return fmt.Errorf(string(bodyBytes))
 	}
+	return fmt.Errorf(string(bodyBytes))
 }
 
 type FakePDControl struct {
@@ -529,7 +528,7 @@ func (pc *FakePDClient) AddReaction(actionType ActionType, reaction Reaction) {
 }
 
 // fakeAPI is a small helper for fake API calls
-func (pc *FakePDClient) fakeApi(actionType ActionType, action *Action) (interface{}, error) {
+func (pc *FakePDClient) fakeAPI(actionType ActionType, action *Action) (interface{}, error) {
 	if reaction, ok := pc.reactions[actionType]; ok {
 		result, err := reaction(action)
 		if err != nil {
@@ -542,7 +541,7 @@ func (pc *FakePDClient) fakeApi(actionType ActionType, action *Action) (interfac
 
 func (pc *FakePDClient) GetHealth() (*HealthInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetHealthActionType, action)
+	result, err := pc.fakeAPI(GetHealthActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +550,7 @@ func (pc *FakePDClient) GetHealth() (*HealthInfo, error) {
 
 func (pc *FakePDClient) GetConfig() (*server.Config, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetConfigActionType, action)
+	result, err := pc.fakeAPI(GetConfigActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +559,7 @@ func (pc *FakePDClient) GetConfig() (*server.Config, error) {
 
 func (pc *FakePDClient) GetCluster() (*metapb.Cluster, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetClusterActionType, action)
+	result, err := pc.fakeAPI(GetClusterActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +568,7 @@ func (pc *FakePDClient) GetCluster() (*metapb.Cluster, error) {
 
 func (pc *FakePDClient) GetMembers() (*MembersInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetMembersActionType, action)
+	result, err := pc.fakeAPI(GetMembersActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +577,7 @@ func (pc *FakePDClient) GetMembers() (*MembersInfo, error) {
 
 func (pc *FakePDClient) GetStores() (*StoresInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetStoresActionType, action)
+	result, err := pc.fakeAPI(GetStoresActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +586,7 @@ func (pc *FakePDClient) GetStores() (*StoresInfo, error) {
 
 func (pc *FakePDClient) GetTombStoneStores() (*StoresInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeApi(GetTombStoneStoresActionType, action)
+	result, err := pc.fakeAPI(GetTombStoneStoresActionType, action)
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +597,7 @@ func (pc *FakePDClient) GetStore(id uint64) (*StoreInfo, error) {
 	action := &Action{
 		ID: id,
 	}
-	result, err := pc.fakeApi(GetStoreActionType, action)
+	result, err := pc.fakeAPI(GetStoreActionType, action)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/pod_control.go
+++ b/pkg/controller/pod_control.go
@@ -149,9 +149,9 @@ func (rpc *realPodControl) recordPodEvent(verb string, tc *v1alpha1.TidbCluster,
 var _ PodControlInterface = &realPodControl{}
 
 var (
-	TestStoreId     string = "000"
-	TestMemberId    string = "111"
-	TestClusterId   string = "222"
+	TestStoreID     string = "000"
+	TestMemberID    string = "111"
+	TestClusterID   string = "222"
 	TestAppName     string = "tikv"
 	TestPodName     string = "pod-1"
 	TestOwnerName   string = "tidbCluster"
@@ -203,7 +203,7 @@ func (fpc *FakePodControl) SetGetStoreError(err error, after int) {
 }
 
 // UpdateMetaInfo update the meta info of Pod
-func (fpc *FakePodControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.Pod) error {
+func (fpc *FakePodControl) UpdateMetaInfo(_ *v1alpha1.TidbCluster, pod *corev1.Pod) error {
 	defer fpc.updatePodTracker.inc()
 	if fpc.updatePodTracker.errorReady() {
 		defer fpc.updatePodTracker.reset()
@@ -231,9 +231,9 @@ func (fpc *FakePodControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.
 	setIfNotEmpty(pod.Labels, label.AppLabelKey, TestAppName)
 	setIfNotEmpty(pod.Labels, label.OwnerLabelKey, TestOwnerName)
 	setIfNotEmpty(pod.Labels, label.ClusterLabelKey, TestClusterName)
-	setIfNotEmpty(pod.Labels, label.ClusterIDLabelKey, TestClusterId)
-	setIfNotEmpty(pod.Labels, label.MemberIDLabelKey, TestMemberId)
-	setIfNotEmpty(pod.Labels, label.StoreIDLabelKey, TestStoreId)
+	setIfNotEmpty(pod.Labels, label.ClusterIDLabelKey, TestClusterID)
+	setIfNotEmpty(pod.Labels, label.MemberIDLabelKey, TestMemberID)
+	setIfNotEmpty(pod.Labels, label.StoreIDLabelKey, TestStoreID)
 	return fpc.PodIndexer.Update(pod)
 }
 

--- a/pkg/controller/pv_control.go
+++ b/pkg/controller/pv_control.go
@@ -177,7 +177,7 @@ func (fpc *FakePVControl) SetUpdatePVError(err error, after int) {
 }
 
 // PatchPVReclaimPolicy patchs the reclaim policy of PV
-func (fpc *FakePVControl) PatchPVReclaimPolicy(tc *v1alpha1.TidbCluster, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
+func (fpc *FakePVControl) PatchPVReclaimPolicy(_ *v1alpha1.TidbCluster, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
 	defer fpc.updatePVTracker.inc()
 	if fpc.updatePVTracker.errorReady() {
 		defer fpc.updatePVTracker.reset()

--- a/pkg/controller/pvc_control.go
+++ b/pkg/controller/pvc_control.go
@@ -197,7 +197,7 @@ func (fpc *FakePVCControl) SetDeletePVCError(err error, after int) {
 }
 
 // DeletePVC deletes the pvc
-func (fpc *FakePVCControl) DeletePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
+func (fpc *FakePVCControl) DeletePVC(_ *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
 	defer fpc.deletePVCTracker.inc()
 	if fpc.deletePVCTracker.errorReady() {
 		defer fpc.deletePVCTracker.reset()
@@ -208,7 +208,7 @@ func (fpc *FakePVCControl) DeletePVC(tc *v1alpha1.TidbCluster, pvc *corev1.Persi
 }
 
 // Update updates the annotation, labels and spec of pvc
-func (fpc *FakePVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
+func (fpc *FakePVCControl) UpdatePVC(_ *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim) error {
 	defer fpc.updatePVCTracker.inc()
 	if fpc.updatePVCTracker.errorReady() {
 		defer fpc.updatePVCTracker.reset()
@@ -219,7 +219,7 @@ func (fpc *FakePVCControl) UpdatePVC(tc *v1alpha1.TidbCluster, pvc *corev1.Persi
 }
 
 // UpdateMetaInfo updates the meta info of pvc
-func (fpc *FakePVCControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) error {
+func (fpc *FakePVCControl) UpdateMetaInfo(_ *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) error {
 	defer fpc.updatePVCTracker.inc()
 	if fpc.updatePVCTracker.errorReady() {
 		defer fpc.updatePVCTracker.reset()

--- a/pkg/controller/service_control.go
+++ b/pkg/controller/service_control.go
@@ -149,7 +149,7 @@ func (ssc *FakeServiceControl) SetDeleteServiceError(err error, after int) {
 }
 
 // CreateService adds the service to SvcIndexer
-func (ssc *FakeServiceControl) CreateService(tc *v1alpha1.TidbCluster, svc *corev1.Service) error {
+func (ssc *FakeServiceControl) CreateService(_ *v1alpha1.TidbCluster, svc *corev1.Service) error {
 	defer ssc.createServiceTracker.inc()
 	if ssc.createServiceTracker.errorReady() {
 		defer ssc.createServiceTracker.reset()
@@ -160,7 +160,7 @@ func (ssc *FakeServiceControl) CreateService(tc *v1alpha1.TidbCluster, svc *core
 }
 
 // UpdateService updates the service of SvcIndexer
-func (ssc *FakeServiceControl) UpdateService(tc *v1alpha1.TidbCluster, svc *corev1.Service) error {
+func (ssc *FakeServiceControl) UpdateService(_ *v1alpha1.TidbCluster, svc *corev1.Service) error {
 	defer ssc.updateServiceTracker.inc()
 	if ssc.updateServiceTracker.errorReady() {
 		defer ssc.updateServiceTracker.reset()
@@ -171,7 +171,7 @@ func (ssc *FakeServiceControl) UpdateService(tc *v1alpha1.TidbCluster, svc *core
 }
 
 // DeleteService deletes the service of SvcIndexer
-func (ssc *FakeServiceControl) DeleteService(tc *v1alpha1.TidbCluster, svc *corev1.Service) error {
+func (ssc *FakeServiceControl) DeleteService(_ *v1alpha1.TidbCluster, _ *corev1.Service) error {
 	return nil
 }
 

--- a/pkg/controller/stateful_set_control.go
+++ b/pkg/controller/stateful_set_control.go
@@ -158,7 +158,7 @@ func (ssc *FakeStatefulSetControl) SetStatusChange(fn func(*apps.StatefulSet)) {
 }
 
 // CreateStatefulSet adds the statefulset to SetIndexer
-func (ssc *FakeStatefulSetControl) CreateStatefulSet(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (ssc *FakeStatefulSetControl) CreateStatefulSet(_ *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	defer func() {
 		ssc.createStatefulSetTracker.inc()
 		ssc.statusChange = nil
@@ -177,7 +177,7 @@ func (ssc *FakeStatefulSetControl) CreateStatefulSet(tc *v1alpha1.TidbCluster, s
 }
 
 // UpdateStatefulSet updates the statefulset of SetIndexer
-func (ssc *FakeStatefulSetControl) UpdateStatefulSet(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (ssc *FakeStatefulSetControl) UpdateStatefulSet(_ *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	defer func() {
 		ssc.updateStatefulSetTracker.inc()
 		ssc.statusChange = nil
@@ -195,7 +195,7 @@ func (ssc *FakeStatefulSetControl) UpdateStatefulSet(tc *v1alpha1.TidbCluster, s
 }
 
 // DeleteStatefulSet deletes the statefulset of SetIndexer
-func (ssc *FakeStatefulSetControl) DeleteStatefulSet(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (ssc *FakeStatefulSetControl) DeleteStatefulSet(_ *v1alpha1.TidbCluster, _ *apps.StatefulSet) error {
 	return nil
 }
 

--- a/pkg/controller/tidbcluster/tidb_cluster_control_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control_test.go
@@ -92,7 +92,7 @@ func newFakeTidbClusterControl() (ControlInterface, *controller.FakeStatefulSetC
 	return control, setControl, statusUpdater, pdControl
 }
 
-func syncTidbClusterControl(tc *v1alpha1.TidbCluster, setControl *controller.FakeStatefulSetControl, control ControlInterface) error {
+func syncTidbClusterControl(tc *v1alpha1.TidbCluster, _ *controller.FakeStatefulSetControl, control ControlInterface) error {
 	for tc.Status.PD.StatefulSet == nil {
 		err := control.UpdateTidbCluster(tc)
 		if err != nil {

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -195,6 +195,7 @@ func (tcc *Controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
 func (tcc *Controller) worker() {
 	for tcc.processNextWorkItem() {
+		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -74,11 +74,7 @@ func (pmm *pdMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	}
 
 	// Sync PD StatefulSet
-	if err := pmm.syncPDStatefulSetForTidbCluster(tc); err != nil {
-		return err
-	}
-
-	return nil
+	return pmm.syncPDStatefulSetForTidbCluster(tc)
 }
 
 func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -110,10 +110,10 @@ func TestPDMemberManagerSyncCreate(t *testing.T) {
 			errWhenCreateStatefulSet:   false,
 			errWhenCreatePDService:     false,
 			errWhenCreatePDPeerService: false,
-			err:              false,
-			pdSvcCreated:     true,
-			pdPeerSvcCreated: true,
-			setCreated:       true,
+			err:                        false,
+			pdSvcCreated:               true,
+			pdPeerSvcCreated:           true,
+			setCreated:                 true,
 		},
 		{
 			name: "tidbcluster's storage format is wrong",
@@ -123,10 +123,10 @@ func TestPDMemberManagerSyncCreate(t *testing.T) {
 			errWhenCreateStatefulSet:   false,
 			errWhenCreatePDService:     false,
 			errWhenCreatePDPeerService: false,
-			err:              true,
-			pdSvcCreated:     true,
-			pdPeerSvcCreated: true,
-			setCreated:       false,
+			err:                        true,
+			pdSvcCreated:               true,
+			pdPeerSvcCreated:           true,
+			setCreated:                 false,
 		},
 		{
 			name:                       "error when create statefulset",
@@ -134,10 +134,10 @@ func TestPDMemberManagerSyncCreate(t *testing.T) {
 			errWhenCreateStatefulSet:   true,
 			errWhenCreatePDService:     false,
 			errWhenCreatePDPeerService: false,
-			err:              true,
-			pdSvcCreated:     true,
-			pdPeerSvcCreated: true,
-			setCreated:       false,
+			err:                        true,
+			pdSvcCreated:               true,
+			pdPeerSvcCreated:           true,
+			setCreated:                 false,
 		},
 		{
 			name:                       "error when create pd service",
@@ -145,10 +145,10 @@ func TestPDMemberManagerSyncCreate(t *testing.T) {
 			errWhenCreateStatefulSet:   false,
 			errWhenCreatePDService:     true,
 			errWhenCreatePDPeerService: false,
-			err:              true,
-			pdSvcCreated:     false,
-			pdPeerSvcCreated: false,
-			setCreated:       false,
+			err:                        true,
+			pdSvcCreated:               false,
+			pdPeerSvcCreated:           false,
+			setCreated:                 false,
 		},
 		{
 			name:                       "error when create pd peer service",
@@ -156,10 +156,10 @@ func TestPDMemberManagerSyncCreate(t *testing.T) {
 			errWhenCreateStatefulSet:   false,
 			errWhenCreatePDService:     false,
 			errWhenCreatePDPeerService: true,
-			err:              true,
-			pdSvcCreated:     true,
-			pdPeerSvcCreated: false,
-			setCreated:       false,
+			err:                        true,
+			pdSvcCreated:               true,
+			pdPeerSvcCreated:           false,
+			setCreated:                 false,
 		},
 	}
 
@@ -295,9 +295,9 @@ func TestPDMemberManagerSyncUpdate(t *testing.T) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.NormalPhase))
 				g.Expect(*tc.Status.PD.StatefulSet.ObservedGeneration).To(Equal(int64(1)))
 				g.Expect(tc.Status.PD.Members).To(Equal(map[string]v1alpha1.PDMember{
-					"pd1": v1alpha1.PDMember{Name: "pd1", ID: "1", ClientURL: "http://pd1:2379", Health: true},
-					"pd2": v1alpha1.PDMember{Name: "pd2", ID: "2", ClientURL: "http://pd2:2379", Health: true},
-					"pd3": v1alpha1.PDMember{Name: "pd3", ID: "3", ClientURL: "http://pd3:2379", Health: false},
+					"pd1": {Name: "pd1", ID: "1", ClientURL: "http://pd1:2379", Health: true},
+					"pd2": {Name: "pd2", ID: "2", ClientURL: "http://pd2:2379", Health: true},
+					"pd3": {Name: "pd3", ID: "3", ClientURL: "http://pd3:2379", Health: false},
 				}))
 			},
 		},
@@ -314,10 +314,10 @@ func TestPDMemberManagerSyncUpdate(t *testing.T) {
 			errWhenUpdateStatefulSet:   false,
 			errWhenUpdatePDService:     false,
 			errWhenUpdatePDPeerService: false,
-			err:                   true,
-			expectPDServiceFn:     nil,
-			expectPDPeerServiceFn: nil,
-			expectStatefulSetFn:   nil,
+			err:                        true,
+			expectPDServiceFn:          nil,
+			expectPDPeerServiceFn:      nil,
+			expectStatefulSetFn:        nil,
 		},
 		{
 			name: "error when update pd service",
@@ -334,10 +334,10 @@ func TestPDMemberManagerSyncUpdate(t *testing.T) {
 			errWhenUpdateStatefulSet:   false,
 			errWhenUpdatePDService:     true,
 			errWhenUpdatePDPeerService: false,
-			err:                   true,
-			expectPDServiceFn:     nil,
-			expectPDPeerServiceFn: nil,
-			expectStatefulSetFn:   nil,
+			err:                        true,
+			expectPDServiceFn:          nil,
+			expectPDPeerServiceFn:      nil,
+			expectStatefulSetFn:        nil,
 		},
 		{
 			name: "error when update statefulset",
@@ -352,9 +352,9 @@ func TestPDMemberManagerSyncUpdate(t *testing.T) {
 			errWhenUpdateStatefulSet:   true,
 			errWhenUpdatePDService:     false,
 			errWhenUpdatePDPeerService: false,
-			err:                   true,
-			expectPDServiceFn:     nil,
-			expectPDPeerServiceFn: nil,
+			err:                        true,
+			expectPDServiceFn:          nil,
+			expectPDPeerServiceFn:      nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
@@ -532,9 +532,9 @@ func TestPDMemberManagerUpgrade(t *testing.T) {
 			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
 				g.Expect(tc.Status.PD.Members).To(Equal(map[string]v1alpha1.PDMember{
-					"pd1": v1alpha1.PDMember{Name: "pd1", ID: "1", ClientURL: "http://pd1:2379", Health: true},
-					"pd2": v1alpha1.PDMember{Name: "pd2", ID: "2", ClientURL: "http://pd2:2379", Health: true},
-					"pd3": v1alpha1.PDMember{Name: "pd3", ID: "3", ClientURL: "http://pd3:2379", Health: false},
+					"pd1": {Name: "pd1", ID: "1", ClientURL: "http://pd1:2379", Health: true},
+					"pd2": {Name: "pd2", ID: "2", ClientURL: "http://pd2:2379", Health: true},
+					"pd3": {Name: "pd3", ID: "3", ClientURL: "http://pd3:2379", Health: false},
 				}))
 			},
 		},

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -51,8 +51,8 @@ func (psd *pdScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet
 		return err
 	}
 
-	var i int32 = 0
-	for ; i<*oldSet.Spec.Replicas; i++ {
+	var i int32
+	for ; i < *oldSet.Spec.Replicas; i++ {
 		podName := ordinalPodName(v1alpha1.PDMemberType, tcName, i)
 		if member, ok := tc.Status.PD.Members[podName]; !ok || !member.Health {
 			resetReplicas(newSet, oldSet)
@@ -112,12 +112,12 @@ func NewFakePDScaler() Scaler {
 	return &fakePDScaler{}
 }
 
-func (fsd *fakePDScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (fsd *fakePDScaler) ScaleOut(_ *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	increaseReplicas(newSet, oldSet)
 	return nil
 }
 
-func (fsd *fakePDScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (fsd *fakePDScaler) ScaleIn(_ *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	decreaseReplicas(newSet, oldSet)
 	return nil
 }

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -35,7 +35,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
 		name         string
-		update func(cluster *v1alpha1.TidbCluster)
+		update       func(cluster *v1alpha1.TidbCluster)
 		pdUpgrading  bool
 		hasPVC       bool
 		hasDeferAnn  bool
@@ -94,7 +94,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 	tests := []testcase{
 		{
 			name:         "normal",
-			update: normalPDMember,
+			update:       normalPDMember,
 			pdUpgrading:  false,
 			hasPVC:       true,
 			hasDeferAnn:  false,
@@ -104,7 +104,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 		},
 		{
 			name:         "pd is upgrading",
-			update: normalPDMember,
+			update:       normalPDMember,
 			pdUpgrading:  true,
 			hasPVC:       true,
 			hasDeferAnn:  false,
@@ -114,7 +114,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 		},
 		{
 			name:         "cache don't have pvc",
-			update: normalPDMember,
+			update:       normalPDMember,
 			pdUpgrading:  false,
 			hasPVC:       false,
 			hasDeferAnn:  false,
@@ -124,7 +124,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 		},
 		{
 			name:         "pvc annotations defer deletion is not nil, pvc delete failed",
-			update: normalPDMember,
+			update:       normalPDMember,
 			pdUpgrading:  false,
 			hasPVC:       true,
 			hasDeferAnn:  true,
@@ -133,7 +133,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 			changed:      false,
 		},
 		{
-			name:         "don't have members",
+			name: "don't have members",
 			update: func(tc *v1alpha1.TidbCluster) {
 				tc.Status.PD.Members = nil
 			},
@@ -145,11 +145,11 @@ func TestPDScalerScaleOut(t *testing.T) {
 			changed:      false,
 		},
 		{
-			name:         "pd member not health",
+			name: "pd member not health",
 			update: func(tc *v1alpha1.TidbCluster) {
 				tcName := tc.GetName()
 				member1 := tc.Status.PD.Members[ordinalPodName(v1alpha1.PDMemberType, tcName, 1)]
-				member1.Health= false
+				member1.Health = false
 			},
 			pdUpgrading:  false,
 			hasPVC:       true,
@@ -316,10 +316,10 @@ func int32Pointer(num int) *int32 {
 func normalPDMember(tc *v1alpha1.TidbCluster) {
 	tcName := tc.GetName()
 	tc.Status.PD.Members = map[string]v1alpha1.PDMember{
-		ordinalPodName(v1alpha1.PDMemberType, tcName, 0): v1alpha1.PDMember{Health: true},
-		ordinalPodName(v1alpha1.PDMemberType, tcName, 1): v1alpha1.PDMember{Health: true},
-		ordinalPodName(v1alpha1.PDMemberType, tcName, 2): v1alpha1.PDMember{Health: true},
-		ordinalPodName(v1alpha1.PDMemberType, tcName, 3): v1alpha1.PDMember{Health: true},
-		ordinalPodName(v1alpha1.PDMemberType, tcName, 4): v1alpha1.PDMember{Health: true},
+		ordinalPodName(v1alpha1.PDMemberType, tcName, 0): {Health: true},
+		ordinalPodName(v1alpha1.PDMemberType, tcName, 1): {Health: true},
+		ordinalPodName(v1alpha1.PDMemberType, tcName, 2): {Health: true},
+		ordinalPodName(v1alpha1.PDMemberType, tcName, 3): {Health: true},
+		ordinalPodName(v1alpha1.PDMemberType, tcName, 4): {Health: true},
 	}
 }

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -25,7 +25,7 @@ func NewPDUpgrader() Upgrader {
 	return &pdUpgrader{}
 }
 
-func (pu *pdUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (pu *pdUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc.Status.PD.Phase = v1alpha1.UpgradePhase
 	return nil
 }
@@ -37,7 +37,7 @@ func NewFakePDUpgrader() Upgrader {
 	return &fakePDUpgrader{}
 }
 
-func (fpu *fakePDUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (fpu *fakePDUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc.Status.PD.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -93,27 +93,27 @@ func TestTiDBMemberManagerSyncCreate(t *testing.T) {
 			prepare:                  nil,
 			errWhenCreateStatefulSet: false,
 			errWhenCreateTiDBService: false,
-			err:            false,
-			tidbSvcCreated: true,
-			setCreated:     true,
+			err:                      false,
+			tidbSvcCreated:           true,
+			setCreated:               true,
 		},
 		{
 			name:                     "error when create statefulset",
 			prepare:                  nil,
 			errWhenCreateStatefulSet: true,
 			errWhenCreateTiDBService: false,
-			err:            true,
-			tidbSvcCreated: true,
-			setCreated:     false,
+			err:                      true,
+			tidbSvcCreated:           true,
+			setCreated:               false,
 		},
 		{
 			name:                     "error when create tidb service",
 			prepare:                  nil,
 			errWhenCreateStatefulSet: false,
 			errWhenCreateTiDBService: true,
-			err:            true,
-			tidbSvcCreated: false,
-			setCreated:     false,
+			err:                      true,
+			tidbSvcCreated:           false,
+			setCreated:               false,
 		},
 	}
 
@@ -202,7 +202,7 @@ func TestTiDBMemberManagerSyncUpdate(t *testing.T) {
 			},
 			errWhenUpdateStatefulSet: false,
 			errWhenUpdateTiDBService: false,
-			err: false,
+			err:                      false,
 			expectTiDBServieFn: func(g *GomegaWithT, svc *corev1.Service, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
@@ -223,7 +223,7 @@ func TestTiDBMemberManagerSyncUpdate(t *testing.T) {
 			},
 			errWhenUpdateStatefulSet: false,
 			errWhenUpdateTiDBService: true,
-			err: true,
+			err:                      true,
 			expectTiDBServieFn: func(g *GomegaWithT, svc *corev1.Service, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
@@ -239,8 +239,8 @@ func TestTiDBMemberManagerSyncUpdate(t *testing.T) {
 			},
 			errWhenUpdateStatefulSet: true,
 			errWhenUpdateTiDBService: false,
-			err:                true,
-			expectTiDBServieFn: nil,
+			err:                      true,
+			expectTiDBServieFn:       nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},

--- a/pkg/manager/member/tidb_upgrader.go
+++ b/pkg/manager/member/tidb_upgrader.go
@@ -45,7 +45,7 @@ func NewFakeTiDBUpgrader() Upgrader {
 	return &fakeTiDBUpgrader{}
 }
 
-func (ftdu *fakeTiDBUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (ftdu *fakeTiDBUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -111,11 +111,11 @@ func TestTiKVMemberManagerSyncCreate(t *testing.T) {
 
 			errWhenCreateStatefulSet:     false,
 			errWhenCreateTiKVPeerService: false,
-			err:                false,
-			tikvPeerSvcCreated: true,
-			setCreated:         true,
-			pdStores:           &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
-			tombstoneStores:    &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			err:                          false,
+			tikvPeerSvcCreated:           true,
+			setCreated:                   true,
+			pdStores:                     &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 		},
 		{
 			name: "tidbcluster's storage format is wrong",
@@ -124,33 +124,33 @@ func TestTiKVMemberManagerSyncCreate(t *testing.T) {
 			},
 			errWhenCreateStatefulSet:     false,
 			errWhenCreateTiKVPeerService: false,
-			err:                true,
-			tikvPeerSvcCreated: true,
-			setCreated:         false,
-			pdStores:           &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
-			tombstoneStores:    &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			err:                          true,
+			tikvPeerSvcCreated:           true,
+			setCreated:                   false,
+			pdStores:                     &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 		},
 		{
 			name:                         "error when create statefulset",
 			prepare:                      nil,
 			errWhenCreateStatefulSet:     true,
 			errWhenCreateTiKVPeerService: false,
-			err:                true,
-			tikvPeerSvcCreated: true,
-			setCreated:         false,
-			pdStores:           &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
-			tombstoneStores:    &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			err:                          true,
+			tikvPeerSvcCreated:           true,
+			setCreated:                   false,
+			pdStores:                     &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 		},
 		{
 			name:                         "error when create tikv peer service",
 			prepare:                      nil,
 			errWhenCreateStatefulSet:     false,
 			errWhenCreateTiKVPeerService: true,
-			err:                true,
-			tikvPeerSvcCreated: false,
-			setCreated:         false,
-			pdStores:           &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
-			tombstoneStores:    &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			err:                          true,
+			tikvPeerSvcCreated:           false,
+			setCreated:                   false,
+			pdStores:                     &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
+			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 		},
 	}
 
@@ -212,6 +212,7 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 		}
 
 		err := tkmm.Sync(tc)
+		g.Expect(err).NotTo(HaveOccurred())
 
 		_, err = tkmm.svcLister.Services(ns).Get(controller.TiKVPeerMemberName(tcName))
 		g.Expect(err).NotTo(HaveOccurred())
@@ -265,7 +266,7 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			errWhenUpdateTiKVPeerService: false,
 			errWhenGetStores:             false,
 			err:                          false,
-			expectTiKVPeerServiceFn: nil,
+			expectTiKVPeerServiceFn:      nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(int(*set.Spec.Replicas)).To(Equal(4))
@@ -289,9 +290,9 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 			errWhenUpdateStatefulSet:     false,
 			errWhenUpdateTiKVPeerService: false,
-			err: true,
-			expectTiKVPeerServiceFn: nil,
-			expectStatefulSetFn:     nil,
+			err:                          true,
+			expectTiKVPeerServiceFn:      nil,
+			expectStatefulSetFn:          nil,
 		},
 		{
 			name: "error when update statefulset",
@@ -303,8 +304,8 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			tombstoneStores:              &controller.StoresInfo{Count: 0, Stores: []*controller.StoreInfo{}},
 			errWhenUpdateStatefulSet:     true,
 			errWhenUpdateTiKVPeerService: false,
-			err: true,
-			expectTiKVPeerServiceFn: nil,
+			err:                          true,
+			expectTiKVPeerServiceFn:      nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
@@ -321,7 +322,7 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			errWhenUpdateTiKVPeerService: false,
 			errWhenGetStores:             true,
 			err:                          true,
-			expectTiKVPeerServiceFn: nil,
+			expectTiKVPeerServiceFn:      nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(int(*set.Spec.Replicas)).To(Equal(3))

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -135,12 +135,12 @@ func NewFakeTiKVScaler() Scaler {
 	return &fakeTiKVScaler{}
 }
 
-func (fsd *fakeTiKVScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (fsd *fakeTiKVScaler) ScaleOut(_ *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	increaseReplicas(newSet, oldSet)
 	return nil
 }
 
-func (fsd *fakeTiKVScaler) ScaleIn(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (fsd *fakeTiKVScaler) ScaleIn(_ *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	decreaseReplicas(newSet, oldSet)
 	return nil
 }

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -345,7 +345,7 @@ func newFakeTiKVScaler() (*tikvScaler, *controller.FakePDControl, cache.Indexer,
 func normalStoreFun(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiKV.Stores = v1alpha1.TiKVStores{
 		CurrentStores: map[string]v1alpha1.TiKVStore{
-			"1": v1alpha1.TiKVStore{
+			"1": {
 				ID:      "1",
 				PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 4),
 				State:   util.StoreUpState,
@@ -357,7 +357,7 @@ func normalStoreFun(tc *v1alpha1.TidbCluster) {
 func tombstoneStoreFun(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiKV.Stores = v1alpha1.TiKVStores{
 		TombStoneStores: map[string]v1alpha1.TiKVStore{
-			"1": v1alpha1.TiKVStore{
+			"1": {
 				ID:      "1",
 				PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 4),
 				State:   util.StoreTombstoneState,

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -45,7 +45,7 @@ func NewFakeTiKVUpgrader() Upgrader {
 	return &fakeTiKVUpgrader{}
 }
 
-func (tku *fakeTiKVUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (tku *fakeTiKVUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/meta/meta_manager.go
+++ b/pkg/manager/meta/meta_manager.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
-	"github.com/pingcap/tidb-operator/pkg/manager"
 	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/manager"
 	corev1 "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
-var PVCNotFound = errors.New("PVC is not found")
+var errPVCNotFound = errors.New("PVC is not found")
 
 type metaManager struct {
 	pvcLister  corelisters.PersistentVolumeClaimLister
@@ -107,7 +107,7 @@ func (pmm *metaManager) resolvePVCFromPod(pod *corev1.Pod) (*corev1.PersistentVo
 		}
 	}
 	if len(pvcName) == 0 {
-		return nil, PVCNotFound
+		return nil, errPVCNotFound
 	}
 
 	pvc, err := pmm.pvcLister.PersistentVolumeClaims(pod.Namespace).Get(pvcName)

--- a/pkg/manager/meta/meta_manager_test.go
+++ b/pkg/manager/meta/meta_manager_test.go
@@ -354,18 +354,18 @@ func newFakeMetaManager() (
 }
 
 func podMetaInfoMatchDesire(pod *corev1.Pod) bool {
-	return pod.Labels[label.ClusterIDLabelKey] == controller.TestClusterId &&
-		pod.Labels[label.MemberIDLabelKey] == controller.TestMemberId &&
-		pod.Labels[label.StoreIDLabelKey] == controller.TestStoreId
+	return pod.Labels[label.ClusterIDLabelKey] == controller.TestClusterID &&
+		pod.Labels[label.MemberIDLabelKey] == controller.TestMemberID &&
+		pod.Labels[label.StoreIDLabelKey] == controller.TestStoreID
 }
 
 func pvcMetaInfoMatchDesire(pvc *corev1.PersistentVolumeClaim) bool {
 	return pvc.Labels[label.AppLabelKey] == controller.TestAppName &&
 		pvc.Labels[label.OwnerLabelKey] == controller.TestOwnerName &&
 		pvc.Labels[label.ClusterLabelKey] == controller.TestClusterName &&
-		pvc.Labels[label.ClusterIDLabelKey] == controller.TestClusterId &&
-		pvc.Labels[label.MemberIDLabelKey] == controller.TestMemberId &&
-		pvc.Labels[label.StoreIDLabelKey] == controller.TestStoreId &&
+		pvc.Labels[label.ClusterIDLabelKey] == controller.TestClusterID &&
+		pvc.Labels[label.MemberIDLabelKey] == controller.TestMemberID &&
+		pvc.Labels[label.StoreIDLabelKey] == controller.TestStoreID &&
 		pvc.Annotations[label.AnnPodNameKey] == controller.TestPodName
 }
 
@@ -374,9 +374,9 @@ func pvMetaInfoMatchDesire(ns string, pv *corev1.PersistentVolume) bool {
 		pv.Labels[label.OwnerLabelKey] == controller.TestOwnerName &&
 		pv.Labels[label.ClusterLabelKey] == controller.TestClusterName &&
 		pv.Labels[label.AppLabelKey] == controller.TestAppName &&
-		pv.Labels[label.ClusterIDLabelKey] == controller.TestClusterId &&
-		pv.Labels[label.MemberIDLabelKey] == controller.TestMemberId &&
-		pv.Labels[label.StoreIDLabelKey] == controller.TestStoreId &&
+		pv.Labels[label.ClusterIDLabelKey] == controller.TestClusterID &&
+		pv.Labels[label.MemberIDLabelKey] == controller.TestMemberID &&
+		pv.Labels[label.StoreIDLabelKey] == controller.TestStoreID &&
 		pv.Annotations[label.AnnPodNameKey] == controller.TestPodName
 }
 

--- a/pkg/manager/meta/reclaim_policy_manager.go
+++ b/pkg/manager/meta/reclaim_policy_manager.go
@@ -16,8 +16,8 @@ package meta
 import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
-	"github.com/pingcap/tidb-operator/pkg/manager"
 	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/manager"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 

--- a/tests/e2e/create.go
+++ b/tests/e2e/create.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	_ "github.com/go-sql-driver/mysql" // init mysql driver
+	. "github.com/onsi/ginkgo"         // revive:disable:dot-imports
+	. "github.com/onsi/gomega"         // revive:disable:dot-imports
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -16,8 +16,8 @@ package e2e
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo" // revive:disable:dot-imports
+	. "github.com/onsi/gomega" // revive:disable:dot-imports
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -56,7 +56,7 @@ var _ = Describe("Smoke", func() {
 	It("should create a tidb cluster", func() {
 		testCreate()
 	})
-	It("should upgarde a tidb cluster", func() {
+	It("should upgrade a tidb cluster", func() {
 		testUpgrade()
 	})
 	It("should scale in/out a tidb cluster", func() {

--- a/tests/e2e/scale.go
+++ b/tests/e2e/scale.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo" // revive:disable:dot-imports
+	. "github.com/onsi/gomega" // revive:disable:dot-imports
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/e2e/upgrade.go
+++ b/tests/e2e/upgrade.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo" // revive:disable:dot-imports
+	. "github.com/onsi/gomega" // revive:disable:dot-imports
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	apps "k8s.io/api/apps/v1beta1"
@@ -114,25 +114,24 @@ func memberUpgraded() (bool, error) {
 		Expect(podsUpgraded(tikvSet)).To(BeTrue())
 		Expect(imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet)).To(BeTrue())
 		return false, nil
-	} else {
-		if !imageUpgraded(tc, v1alpha1.PDMemberType, pdSet) {
-			return false, nil
-		}
-		if !podsUpgraded(pdSet) {
-			return false, nil
-		}
-		if !imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet) {
-			return false, nil
-		}
-		if !podsUpgraded(tikvSet) {
-			return false, nil
-		}
-		if !imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet) {
-			return false, nil
-		}
-		return podsUpgraded(tidbSet), nil
 	}
-	return false, nil
+	if !imageUpgraded(tc, v1alpha1.PDMemberType, pdSet) {
+		return false, nil
+	}
+	if !podsUpgraded(pdSet) {
+		return false, nil
+	}
+	if !imageUpgraded(tc, v1alpha1.TiKVMemberType, tikvSet) {
+		return false, nil
+	}
+	if !podsUpgraded(tikvSet) {
+		return false, nil
+	}
+	if !imageUpgraded(tc, v1alpha1.TiDBMemberType, tidbSet) {
+		return false, nil
+	}
+	return podsUpgraded(tidbSet), nil
+
 }
 
 func imageUpgraded(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType, set *apps.StatefulSet) bool {

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo" // revive:disable:dot-imports
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This PR fixes #56. With this PR it will automatically do the following checks on CI:
* code format check
* go vet default check
* [gometalinter](https://github.com/alecthomas/gometalinter) misspell and ineffassign check
* [revive](https://github.com/mgechev/revive) lint check

But go vet shadow check and gometalinter megacheck/errcheck fails, so leaving these checks alone.