### PR TITLE
fix tikvpromgateway not used in tidbcluster templates

### DIFF
--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -49,6 +49,11 @@ spec:
     tolerations:
 {{ toYaml .Values.tikv.tolerations | indent 4 }}
   {{- end }}
+  tikvPromGateway:
+    image: {{ .Values.tikvPromGateway.image }}
+  {{- if .Values.tikvPromGateway.resources }}
+{{ toYaml .Values.tikvPromGateway.resources | indent 4 }}
+  {{- end }}
   tidb:
     replicas: {{ .Values.tidb.replicas }}
     image: {{ .Values.tidb.image }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -101,12 +101,13 @@ tikv:
 
 tikvPromGateway:
   image: prom/pushgateway:v0.3.1
-  # limits:
-  #   cpu: 100m
-  #   memory: 100Mi
-  # requests:
-  #   cpu: 50m
-  #   memory: 50Mi
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 100Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 50Mi
 
 tidb:
   replicas: 2

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -103,7 +103,7 @@ func DefaultPushGatewayRequest() corev1.ResourceRequirements {
 
 // GetPushgatewayImage returns TidbCluster's pushgateway image
 func GetPushgatewayImage(cluster *v1alpha1.TidbCluster) string {
-	if img, ok := cluster.Annotations["pushgateway-image"]; ok && img != "" {
+	if img := cluster.Spec.TiKVPromGateway.Image; img != "" {
 		return img
 	}
 	return defaultPushgatewayImage


### PR DESCRIPTION
1. Add tikvpromgateway values in tidbcluster template
2. Fix function `controller.GetPushgatewayImage`

Fix issue: #82 