### PR TITLE
Failover fix: no longer modify spec.Replicas

### DIFF
--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -89,6 +89,6 @@ func (ftd *FakeTiDBControl) SetHealth(healthInfo map[string]bool) {
 	ftd.healthInfo = healthInfo
 }
 
-func (ftd *FakeTiDBControl) GetHealth(tc *v1alpha1.TidbCluster) map[string]bool {
+func (ftd *FakeTiDBControl) GetHealth(_ *v1alpha1.TidbCluster) map[string]bool {
 	return ftd.healthInfo
 }

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -43,7 +43,7 @@ func (tdc *defaultTiDBControl) GetHealth(tc *v1alpha1.TidbCluster) map[string]bo
 	ns := tc.GetNamespace()
 
 	result := map[string]bool{}
-	for i := 0; i < int(tc.Spec.TiDB.Replicas); i++ {
+	for i := 0; i < int(tc.TiDBRealReplicas()); i++ {
 		hostName := fmt.Sprintf("%s-%d", TiDBMemberName(tcName), i)
 		url := fmt.Sprintf("http://%s.%s-tidb-peer.%s:10080/status", hostName, tcName, ns)
 		_, err := tdc.getBodyOK(url)

--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -70,14 +70,12 @@ type defaultTidbClusterControl struct {
 // UpdateStatefulSet executes the core logic loop for a tidbcluster.
 func (tcc *defaultTidbClusterControl) UpdateTidbCluster(tc *v1alpha1.TidbCluster) error {
 	oldStatus := tc.Status.DeepCopy()
-	oldPDReplicas := tc.Spec.PD.Replicas
-
 	err := tcc.updateTidbCluster(tc)
 	if err != nil {
 		return err
 	}
 
-	if !apiequality.Semantic.DeepEqual(&tc.Status, oldStatus) || tc.Spec.PD.Replicas != oldPDReplicas {
+	if !apiequality.Semantic.DeepEqual(&tc.Status, oldStatus) {
 		tc, err = tcc.tcControl.UpdateTidbCluster(tc.DeepCopy())
 		if err != nil {
 			return err

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -99,7 +99,7 @@ func NewController(
 	podControl := controller.NewRealPodControl(kubeCli, pdControl, podInformer.Lister(), recorder)
 	pdScaler := mm.NewPDScaler(pdControl, pvcInformer.Lister(), pvcControl)
 	tikvScaler := mm.NewTiKVScaler(pdControl, pvcInformer.Lister(), pvcControl)
-	pdFailover := mm.NewPDFailover(cli, tcControl, pdControl, pdFailoverPeriod, podInformer.Lister(), podControl, pvcInformer.Lister(), pvcControl, pvInformer.Lister())
+	pdFailover := mm.NewPDFailover(cli, pdControl, pdFailoverPeriod, podInformer.Lister(), podControl, pvcInformer.Lister(), pvcControl, pvInformer.Lister())
 	pdUpgrader := mm.NewPDUpgrader()
 	tikvFailover := mm.NewTiKVFailover(pdControl)
 	tikvUpgrader := mm.NewTiKVUpgrader()

--- a/pkg/manager/member/pd_failover.go
+++ b/pkg/manager/member/pd_failover.go
@@ -219,7 +219,8 @@ func (pf *pdFailover) markThisMemberAsFailure(tc *v1alpha1.TidbCluster, pdMember
 		MemberDeleted: false,
 	}
 	// we must update TidbCluster immediately before delete member, or data may not be consistent
-	// TODO use RequeueError instead: https://github.com/pingcap/tidb-operator/pull/80
+	// FIXME this realllllllllly can't update the `tc` var outside this method, so MUST use RequeueError instead:
+	// 		https://github.com/pingcap/tidb-operator/pull/80
 	tc, err = pf.tcControl.UpdateTidbCluster(tc)
 	return err
 }

--- a/pkg/manager/member/pd_failover.go
+++ b/pkg/manager/member/pd_failover.go
@@ -64,23 +64,25 @@ func NewPDFailover(cli versioned.Interface,
 func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
+
 	healthCount := 0
 	for _, pdMember := range tc.Status.PD.Members {
 		if pdMember.Health {
 			healthCount++
 		}
 	}
-	inQuorum := healthCount > int(tc.Spec.PD.Replicas/2)
+	inQuorum := healthCount > len(tc.Status.PD.Members)/2
 	if !inQuorum {
-		return fmt.Errorf("TidbCluster: %s/%s's pd cluster is not health: %d/%d, can't failover",
-			ns, tcName, healthCount, tc.Spec.PD.Replicas)
+		return fmt.Errorf("TidbCluster: %s/%s's pd cluster is not health: %d/%d, replicas: %d, failureCount: %d, can't failover",
+			ns, tcName, healthCount, tc.RealReplicas(), tc.Spec.PD.Replicas, len(tc.Status.PD.FailureMembers))
 	}
+
 	if tc.Status.PD.FailureMembers == nil {
 		tc.Status.PD.FailureMembers = map[string]v1alpha1.PDFailureMember{}
 	}
 	notDeletedCount := 0
-	for _, failureMember := range tc.Status.PD.FailureMembers {
-		if !failureMember.MemberDeleted {
+	for _, pdMember := range tc.Status.PD.FailureMembers {
+		if !pdMember.MemberDeleted {
 			notDeletedCount++
 		}
 	}
@@ -102,97 +104,91 @@ func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 			}
 		}
 	}
-	// invoke deleteMember api to delete a member from the pd cluster
-	for podName, failureMember := range tc.Status.PD.FailureMembers {
-		if !failureMember.MemberDeleted {
-			err := pf.pdControl.GetPDClient(tc).DeleteMember(failureMember.PodName)
-			if err != nil {
-				return err
-			}
-			failureMember.MemberDeleted = true
-			tc.Status.PD.FailureMembers[podName] = failureMember
+
+	var failureMember *v1alpha1.PDFailureMember
+	var failurePodName string
+	for podName, pdMember := range tc.Status.PD.FailureMembers {
+		if !pdMember.MemberDeleted {
+			failureMember = &pdMember
+			failurePodName = podName
 			break
 		}
 	}
+	if failureMember == nil {
+		return nil
+	}
+
+	// invoke deleteMember api to delete a member from the pd cluster
+	err := pf.pdControl.GetPDClient(tc).DeleteMember(failureMember.PodName)
+	if err != nil {
+		return err
+	}
+
 	// The order of old PVC deleting and the new Pod creating is not guaranteed by Kubernetes.
 	// If new Pod is created before old PVC deleted, new Pod will reuse old PVC.
 	// So we must try to delete the PVC and Pod of this PD peer over and over,
 	// and let StatefulSet create the new PD peer with the same ordinal, but don't use the tombstone PV
-	for podName, failureMember := range tc.Status.PD.FailureMembers {
-		if !failureMember.MemberDeleted {
-			continue
-		}
-		// increase the replicas to add a new PD peer
-		if failureMember.Replicas+1 > tc.Spec.PD.Replicas {
-			tc.Spec.PD.Replicas = failureMember.Replicas + 1
-		}
-		pod, err := pf.podLister.Pods(ns).Get(podName)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-		ordinal, err := getOrdinalFromPodName(podName)
-		if err != nil {
-			return err
-		}
-		pvcName := ordinalPVCName(v1alpha1.PDMemberType, controller.PDMemberName(tcName), ordinal)
-		pvc, err := pf.pvcLister.PersistentVolumeClaims(ns).Get(pvcName)
-		if errors.IsNotFound(err) {
-			if pod != nil && pod.DeletionTimestamp == nil {
-				err := pf.podControl.DeletePod(tc, pod)
-				if err != nil {
-					return err
-				}
-			}
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		pv, err := pf.pvLister.Get(pvc.Spec.VolumeName)
-		if errors.IsNotFound(err) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		if string(pv.UID) != string(failureMember.PVUID) {
-			continue
-		}
+	pod, err := pf.podLister.Pods(ns).Get(failurePodName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	ordinal, err := getOrdinalFromPodName(failurePodName)
+	if err != nil {
+		return err
+	}
+	pvcName := ordinalPVCName(v1alpha1.PDMemberType, controller.PDMemberName(tcName), ordinal)
+	pvc, err := pf.pvcLister.PersistentVolumeClaims(ns).Get(pvcName)
+	if errors.IsNotFound(err) {
 		if pod != nil && pod.DeletionTimestamp == nil {
 			err := pf.podControl.DeletePod(tc, pod)
 			if err != nil {
 				return err
 			}
 		}
-		if pvc.DeletionTimestamp == nil {
-			err = pf.pvcControl.DeletePVC(tc, pvc)
-			if err != nil {
-				return err
-			}
+		setMemberDeleted(tc, failurePodName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	pv, err := pf.pvLister.Get(pvc.Spec.VolumeName)
+	if errors.IsNotFound(err) {
+		setMemberDeleted(tc, failurePodName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if string(pv.UID) != string(failureMember.PVUID) {
+		setMemberDeleted(tc, failurePodName)
+		return nil
+	}
+	if pod != nil && pod.DeletionTimestamp == nil {
+		err := pf.podControl.DeletePod(tc, pod)
+		if err != nil {
+			return err
 		}
 	}
+	if pvc.DeletionTimestamp == nil {
+		err = pf.pvcControl.DeletePVC(tc, pvc)
+		if err != nil {
+			return err
+		}
+	}
+
+	setMemberDeleted(tc, failurePodName)
 	return nil
 }
 
 func (pf *pdFailover) Recover(tc *v1alpha1.TidbCluster) {
-	defer func() {
-		tc.Status.PD.FailureMembers = nil
-	}()
-	maxReplicas := int32(0)
-	minReplicas := int32(0)
-	for _, failureMember := range tc.Status.PD.FailureMembers {
-		if minReplicas == int32(0) {
-			minReplicas = failureMember.Replicas
-		}
-		if failureMember.Replicas > maxReplicas {
-			maxReplicas = failureMember.Replicas
-		} else if failureMember.Replicas < minReplicas {
-			minReplicas = failureMember.Replicas
-		}
-	}
-	if maxReplicas+1 == tc.Spec.PD.Replicas {
-		tc.Spec.PD.Replicas = minReplicas
-	}
+	tc.Status.PD.FailureMembers = nil
+}
+
+func setMemberDeleted(tc *v1alpha1.TidbCluster, podName string) {
+	failureMember := tc.Status.PD.FailureMembers[podName]
+	failureMember.MemberDeleted = true
+	tc.Status.PD.FailureMembers[podName] = failureMember
 }
 
 func (pf *pdFailover) markThisMemberAsFailure(tc *v1alpha1.TidbCluster, pdMember v1alpha1.PDMember) error {
@@ -223,6 +219,7 @@ func (pf *pdFailover) markThisMemberAsFailure(tc *v1alpha1.TidbCluster, pdMember
 		MemberDeleted: false,
 	}
 	// we must update TidbCluster immediately before delete member, or data may not be consistent
+	// TODO use RequeueError instead: https://github.com/pingcap/tidb-operator/pull/80
 	tc, err = pf.tcControl.UpdateTidbCluster(tc)
 	return err
 }
@@ -234,18 +231,6 @@ func getOrdinalFromPodName(podName string) (int32, error) {
 		return int32(0), err
 	}
 	return int32(ordinalInt), nil
-}
-
-func allPDMembersAreReady(tc *v1alpha1.TidbCluster) bool {
-	if int(tc.Spec.PD.Replicas) != len(tc.Status.PD.Members) {
-		return false
-	}
-	for _, member := range tc.Status.PD.Members {
-		if !member.Health {
-			return false
-		}
-	}
-	return true
 }
 
 type fakePDFailover struct{}

--- a/pkg/manager/member/pd_failover.go
+++ b/pkg/manager/member/pd_failover.go
@@ -71,7 +71,7 @@ func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	inQuorum := healthCount > len(tc.Status.PD.Members)/2
 	if !inQuorum {
 		return fmt.Errorf("TidbCluster: %s/%s's pd cluster is not health: %d/%d, replicas: %d, failureCount: %d, can't failover",
-			ns, tcName, healthCount, tc.RealReplicas(), tc.Spec.PD.Replicas, len(tc.Status.PD.FailureMembers))
+			ns, tcName, healthCount, tc.PDRealReplicas(), tc.Spec.PD.Replicas, len(tc.Status.PD.FailureMembers))
 	}
 
 	if tc.Status.PD.FailureMembers == nil {

--- a/pkg/manager/member/pd_failover_test.go
+++ b/pkg/manager/member/pd_failover_test.go
@@ -113,7 +113,7 @@ func TestPDFailoverFailover(t *testing.T) {
 			},
 		},
 		{
-			name:   "two members are not ready",
+			name:   "two members are not ready, not in quorum",
 			update: twoMembersNotReady,
 			hasPVC: true,
 			hasPV:  true,
@@ -266,10 +266,7 @@ func TestPDFailoverFailover(t *testing.T) {
 			delPodFailed:             false,
 			delPVCFailed:             false,
 			tcUpdateFailed:           true,
-			errExpectFn: func(g *GomegaWithT, err error) {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(strings.Contains(err.Error(), "failover ongoing")).NotTo(Equal(true))
-			},
+			errExpectFn:              errExpectNotNil,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.PD.Replicas)).To(Equal(3))
 				pd1Name := ordinalPodName(v1alpha1.PDMemberType, tc.GetName(), 1)

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -254,11 +254,9 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 	}
 
 	if pmm.autoFailover {
-		if allPDMembersAreReady(tc) {
-			if tc.Status.PD.FailureMembers != nil {
-				pmm.pdFailover.Recover(tc)
-			}
-		} else if tc.Spec.PD.Replicas == tc.Status.PD.StatefulSet.Replicas {
+		if tc.PDAllPodsStarted() && tc.PDAllMembersReady() && tc.Status.PD.FailureMembers != nil {
+			pmm.pdFailover.Recover(tc)
+		} else if tc.PDAllPodsStarted() && !tc.PDAllMembersReady() || tc.PDAutoFailovering() {
 			if err := pmm.pdFailover.Failover(tc); err != nil {
 				return err
 			}
@@ -448,6 +446,12 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 	if storageClassName == "" {
 		storageClassName = controller.DefaultStorageClassName
 	}
+	failureReplicas := 0
+	for _, failureMember := range tc.Status.PD.FailureMembers {
+		if failureMember.MemberDeleted {
+			failureReplicas++
+		}
+	}
 
 	pdSet := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -457,7 +461,7 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: func() *int32 { r := tc.Spec.PD.Replicas; return &r }(),
+			Replicas: func() *int32 { r := tc.Spec.PD.Replicas + int32(failureReplicas); return &r }(),
 			Selector: pdLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_failover.go
+++ b/pkg/manager/member/tidb_failover.go
@@ -58,10 +58,10 @@ func NewFakeTiDBFailover() Failover {
 	return &fakeTiDBFailover{}
 }
 
-func (ftf *fakeTiDBFailover) Failover(tc *v1alpha1.TidbCluster) error {
+func (ftf *fakeTiDBFailover) Failover(_ *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (ftf *fakeTiDBFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (ftf *fakeTiDBFailover) Recover(_ *v1alpha1.TidbCluster) {
 	return
 }

--- a/pkg/manager/member/tidb_failover_test.go
+++ b/pkg/manager/member/tidb_failover_test.go
@@ -87,7 +87,7 @@ func TestFakeTiDBFailoverFailover(t *testing.T) {
 			},
 			expectFn: func(t *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				t.Expect(len(tc.Status.TiDB.FailureMembers)).To(Equal(1))
-				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(3))
+				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestFakeTiDBFailoverFailover(t *testing.T) {
 			},
 			expectFn: func(t *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				t.Expect(len(tc.Status.TiDB.FailureMembers)).To(Equal(1))
-				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(3))
+				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
 			},
 		},
 	}
@@ -183,7 +183,7 @@ func TestFakeTiDBFailoverRecover(t *testing.T) {
 				}
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
+				g.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(3))
 				g.Expect(len(tc.Status.TiDB.FailureMembers)).To(Equal(0))
 			},
 		},
@@ -221,7 +221,7 @@ func TestFakeTiDBFailoverRecover(t *testing.T) {
 				}
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
+				g.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(4))
 				g.Expect(len(tc.Status.TiDB.FailureMembers)).To(Equal(0))
 			},
 		},

--- a/pkg/manager/member/tikv_failover.go
+++ b/pkg/manager/member/tikv_failover.go
@@ -63,7 +63,7 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (tf *tikvFailover) Recover(_ *v1alpha1.TidbCluster) {
 	// Do nothing now
 }
 

--- a/pkg/manager/member/tikv_failover.go
+++ b/pkg/manager/member/tikv_failover.go
@@ -57,7 +57,6 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 				StoreID:  store.ID,
 				Replicas: tc.Spec.TiKV.Replicas,
 			}
-			tc.Spec.TiKV.Replicas++
 		}
 	}
 
@@ -65,19 +64,7 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 }
 
 func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
-	tc.Status.TiKV.FailureStores = nil
-}
-
-func allTiKVStoresAreReady(tc *v1alpha1.TidbCluster) bool {
-	if int(tc.Spec.TiKV.Replicas) != len(tc.Status.TiKV.Stores) {
-		return false
-	}
-	for _, store := range tc.Status.TiKV.Stores {
-		if store.State != v1alpha1.TiKVStateUp {
-			return false
-		}
-	}
-	return true
+	// Do nothing now
 }
 
 type fakeTiKVFailover struct{}

--- a/pkg/manager/member/tikv_failover_test.go
+++ b/pkg/manager/member/tikv_failover_test.go
@@ -82,7 +82,8 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			getCfgErr: false,
 			err:       false,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
-				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(5))
+				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(2))
 			},
 		},
 		{
@@ -92,6 +93,7 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			err:       true,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(0))
 			},
 		},
 		{
@@ -105,6 +107,7 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			err:       false,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(0))
 			},
 		},
 		{
@@ -122,6 +125,7 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			err:       false,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(0))
 			},
 		},
 		{
@@ -138,6 +142,7 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			err:       false,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(0))
 			},
 		},
 		{
@@ -161,33 +166,7 @@ func TestTiKVFailoverFailover(t *testing.T) {
 			err:       false,
 			expectFn: func(tc *v1alpha1.TidbCluster) {
 				g.Expect(int(tc.Spec.TiKV.Replicas)).To(Equal(3))
-			},
-		},
-	}
-	for i := range tests {
-		testFn(&tests[i], t)
-	}
-}
-
-func TestTiKVFailoverRecover(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	type testcase struct {
-		name     string
-		expectFn func(*v1alpha1.TidbCluster)
-	}
-	testFn := func(test *testcase, t *testing.T) {
-		t.Log(test.name)
-		tc := newTidbClusterForPD()
-		tikvFailover, _ := newFakeTiKVFailover()
-		tikvFailover.Recover(tc)
-		test.expectFn(tc)
-	}
-	tests := []testcase{
-		{
-			name: "normal",
-			expectFn: func(tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(0))
+				g.Expect(len(tc.Status.TiKV.FailureStores)).To(Equal(1))
 			},
 		},
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -471,7 +471,7 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 		// avoid LastHeartbeatTime be overwrite by zero time when pd lost LastHeartbeatTime
 		if status.LastHeartbeatTime.IsZero() {
 			if oldStatus, ok := previousStores[status.ID]; ok {
-				glog.Warningf("the pod:%s's store LastHeartbeatTime is zero,so will keep in %v", status.PodName, oldStatus.LastHeartbeatTime)
+				glog.V(4).Infof("the pod:%s's store LastHeartbeatTime is zero,so will keep in %v", status.PodName, oldStatus.LastHeartbeatTime)
 				status.LastHeartbeatTime = oldStatus.LastHeartbeatTime
 			}
 		}


### PR DESCRIPTION
This PR fixes #97 , the failover feature: 
- don't need to modify the `spec.PD.Replicas` to achieve the failover feature
- use `RequeueError` instead of update TidbCluster immediately
- adjust related unit tests

@tennix @onlymellb @xiaojingchen @gregwebs PTAL