### PR TITLE
*: Setting TZ env instead of mounting /etc/localtime

### DIFF
--- a/charts/tidb-cluster/templates/monitor-configmap.yaml
+++ b/charts/tidb-cluster/templates/monitor-configmap.yaml
@@ -14,12 +14,12 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    {{- if .Values.alertmanagerURL }}
+    {{- if .Values.monitor.prometheus.alertmanagerURL }}
     alerting:
       alertmanagers:
       - static_configs:
         - targets:
-          - {{ .Values.alertmanagerURL }}
+          - {{ .Values.monitor.prometheus.alertmanagerURL }}
     {{- end }}
     scrape_configs:
       - job_name: 'tidb-cluster'

--- a/charts/tidb-cluster/templates/monitor-deployment.yaml
+++ b/charts/tidb-cluster/templates/monitor-deployment.yaml
@@ -59,11 +59,11 @@ spec:
         - name: prometheus
           containerPort: 9090
           protocol: TCP
+        # `TZ` is unused in Prometheus Docker image, we set it here just to keep consistency
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
         volumeMounts:
-          {{- if .Values.localtime }}
-          - name: timezone
-            mountPath: /etc/localtime
-          {{- end }}
           - name: prometheus-config
             mountPath: /etc/prometheus
             readOnly: true
@@ -92,20 +92,12 @@ spec:
             secretKeyRef:
               name: {{ .Values.clusterName }}-monitor
               key: password
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
         volumeMounts:
-          {{- if .Values.localtime }}
-          - name: timezone
-            readOnly: true
-            mountPath: /etc/localtime
-          {{- end }}
           - name: grafana-data
             mountPath: /data
       volumes:
-      {{- if .Values.localtime }}
-      - name: timezone
-        hostPath:
-          path: /etc/localtime
-      {{- end }}
       - name: prometheus-data
         emptyDir: {}
       - name: grafana-data

--- a/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.privilegedTidb.create }}
+{{- if .Values.privilegedTidb }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tidb-cluster/templates/privileged-tidb-deployment.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.privilegedTidb.create }}
+{{- if .Values.privilegedTidb }}
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -56,12 +56,9 @@ spec:
         env:
         - name: CLUSTER_NAME
           value: {{ .Values.clusterName }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
         volumeMounts:
-        {{- if .Values.localtime }}
-        - name: timezone
-          readOnly: true
-          mountPath: /etc/localtime
-        {{- end }}
         - name: config
           readOnly: true
           mountPath: /etc/tidb
@@ -73,11 +70,6 @@ spec:
           mountPath: /usr/local/bin
       restartPolicy: Always
       volumes:
-      {{- if .Values.localtime }}
-      - name: timezone
-        hostPath:
-          path: /etc/localtime
-      {{- end }}
       - name: config
         configMap:
           name: {{ .Values.clusterName }}-privileged-tidb

--- a/charts/tidb-cluster/templates/privileged-tidb-service.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.privilegedTidb.create }}
+{{- if .Values.privilegedTidb }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
   pvReclaimPolicy: {{ .Values.pvReclaimPolicy }}
-  localtime: {{ .Values.localtime }}
+  timezone: {{ .Values.timezone | default "UTC" }}
   services:
 {{ toYaml .Values.services | indent 4 }}
   pd:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -9,13 +9,8 @@ rbac:
 # if multiple clusters are deployed in the same namespace.
 clusterName: demo
 
-# localtime determines whether containers timezone should be the same as k8s node
-# if localtime is false, container timezone would be UTC+0
-# localtime should be set to false if the K8s environment doesn't have /etc/localtime
-# on host, e.g. Docker for Mac, Minikube, DinD
-localtime: false
-
-# nodeSelectorRequired: true
+# timezone is the default system timzone for TiDB
+timezone: Asia/Shanghai
 
 # default reclaim policy of a PV
 pvReclaimPolicy: Retain
@@ -175,34 +170,6 @@ monitor:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
-
-privilegedTidb:
-  # Whether to deploy privileged tidb
-  create: false
-  replicas: 1
-  image: pingcap/tidb:v2.0.4
-  logLevel: info
-  resources: {}
-  #  limits:
-  #    cpu: 16000m
-  #    memory: 16Gi
-  #  requests:
-  #    cpu: 12000m
-  #    memory: 12Gi
-  nodeSelector: {}
-  #  kind: privileged-tidb
-  #  zone: cn-bj1-01,cn-bj1-02
-  #  region: cn-bj1
-  tolerations: {}
-  # - key: node-role
-  #   operator: Equal
-  #   value: tidb
-  #   effect: "NoSchedule"
-  service:
-    # type is privileged tidb service type, can be ClusterIP, NodePort, LoadBalancer
-    type: ClusterIP
-    # nodePort is optional and only used when type is NodePort
-    # nodePort: 33333
 
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"

--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -44,14 +44,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        {{- if .Values.localtime }}
-        volumeMounts:
-          - name: timezone
-            mountPath: /etc/localtime
-        {{- end }}
-      {{- if .Values.localtime }}
-      volumes:
-      - name: timezone
-        hostPath:
-          path: /etc/localtime
-      {{- end -}}
+          - name: TZ
+            value: {{ .Values.timezone | default "UTC" }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -2,11 +2,6 @@
 rbac:
   create: true
 
-# localtime determines whether container timezone should be the same as k8s node
-# if localtime is false, container timezone would be UTC+0
-# localtime should be set to false if the K8s environment doesn't have /etc/localtime
-# on host, e.g. Docker for Mac, Minikube, DinD
-localtime: false
 # operatorImage is TiDB Operator image
 operatorImage: pingcap/tidb-operator:latest
 imagePullPolicy: IfNotPresent

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.5
 
+RUN apk add tzdata --no-cache
 ADD bin/tidb-controller-manager /usr/local/bin/tidb-controller-manager

--- a/pkg/apis/pingcap.com/v1alpha1/types.go
+++ b/pkg/apis/pingcap.com/v1alpha1/types.go
@@ -95,7 +95,7 @@ type TidbClusterSpec struct {
 	// Services list non-headless services type used in TidbCluster
 	Services        []Service                            `json:"services,omitempty"`
 	PVReclaimPolicy corev1.PersistentVolumeReclaimPolicy `json:"pvReclaimPolicy,omitempty"`
-	Localtime       bool                                 `json:"localtime,omitempty"`
+	Timezone        string                               `json:"timezone,omitempty"`
 }
 
 // TidbClusterStatus represents the current status of a tidb cluster.

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -427,12 +427,6 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 		},
 	}
 
-	if tc.Spec.Localtime {
-		tzMount, tzVolume := timezoneMountVolume()
-		volMounts = append(volMounts, tzMount)
-		vols = append(vols, tzVolume)
-	}
-
 	var q resource.Quantity
 	var err error
 	if tc.Spec.PD.Requests != nil {
@@ -510,6 +504,10 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 								{
 									Name:  "SET_NAME",
 									Value: setName,
+								},
+								{
+									Name:  "TZ",
+									Value: tc.Spec.Timezone,
 								},
 							},
 						},

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -255,12 +255,6 @@ func (tmm *tidbMemberManager) getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbClust
 		},
 	}
 
-	if tc.Spec.Localtime {
-		tzMount, tzVolume := timezoneMountVolume()
-		volMounts = append(volMounts, tzMount)
-		vols = append(vols, tzVolume)
-	}
-
 	tidbLabel := label.New().Cluster(tcName).TiDB()
 
 	tidbSet := &apps.StatefulSet{
@@ -308,6 +302,10 @@ func (tmm *tidbMemberManager) getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbClust
 								{
 									Name:  "CLUSTER_NAME",
 									Value: tc.GetName(),
+								},
+								{
+									Name:  "TZ",
+									Value: tc.Spec.Timezone,
 								},
 							},
 						},

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -281,12 +281,6 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 		},
 	}
 	pgwVolMounts := []corev1.VolumeMount{} // pushgateway volumeMounts
-	if tc.Spec.Localtime {
-		tzMount, tzVolume := timezoneMountVolume()
-		volMounts = append(volMounts, tzMount)
-		vols = append(vols, tzVolume)
-		pgwVolMounts = []corev1.VolumeMount{tzMount}
-	}
 
 	var q resource.Quantity
 	var err error
@@ -344,7 +338,32 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 							},
 							VolumeMounts: volMounts,
 							Resources:    util.ResourceRequirement(tc.Spec.TiKV.ContainerSpec),
-							Env:          tkmm.envVars(tcName, headlessSvcName, capacity),
+							Env: []corev1.EnvVar{
+								{
+									Name: "NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name:  "CLUSTER_NAME",
+									Value: tcName,
+								},
+								{
+									Name:  "HEADLESS_SERVICE_NAME",
+									Value: headlessSvcName,
+								},
+								{
+									Name:  "CAPACITY",
+									Value: capacity,
+								},
+								{
+									Name:  "TZ",
+									Value: tc.Spec.Timezone,
+								},
+							},
 						},
 						{
 							Name:  v1alpha1.PushGatewayMemberType.String(),
@@ -359,6 +378,7 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 							VolumeMounts: pgwVolMounts,
 							Resources: util.ResourceRequirement(tc.Spec.TiKVPromGateway.ContainerSpec,
 								controller.DefaultPushGatewayRequest()),
+							Env: []corev1.EnvVar{{Name: "TZ", Value: tc.Spec.Timezone}}, // Note: `TZ` is unused in pushgateway image, we set it here just to keep consistency
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyAlways,
@@ -375,31 +395,6 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 		},
 	}
 	return tikvset, nil
-}
-
-func (tkmm *tikvMemberManager) envVars(tcName, headlessSvcName, capacity string) []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name: "NAMESPACE",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
-				},
-			},
-		},
-		{
-			Name:  "CLUSTER_NAME",
-			Value: tcName,
-		},
-		{
-			Name:  "HEADLESS_SERVICE_NAME",
-			Value: headlessSvcName,
-		},
-		{
-			Name:  "CAPACITY",
-			Value: capacity,
-		},
-	}
 }
 
 func (tkmm *tikvMemberManager) volumeClaimTemplate(q resource.Quantity, metaName string, storageClassName *string) corev1.PersistentVolumeClaim {


### PR DESCRIPTION
This PR fixes #88. It also removes the mounting /etc/localtime solution for log timestamp.

With this PR the logs for pods will be in the same timezone with TiDB instead of with host machine. This may introduce confusion for users when using `kubectl logs` to view different pod logs in the same Kubernetes cluster, unfortunately this is unavoidable. But assuming there's a log collector, users should reference the collecting timestamp instead of timestamp in the log message.