### PR TITLE
Remove unnecessary pod and statefulset update

### DIFF
--- a/pkg/controller/pod_control.go
+++ b/pkg/controller/pod_control.go
@@ -100,7 +100,6 @@ func (rpc *realPodControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.
 	podName := pod.GetName()
 	labels := pod.GetLabels()
 	tcName := tc.GetName()
-	var clusterID, storeID, memberID string
 	if labels == nil {
 		return pod, fmt.Errorf("pod %s/%s has empty labels, TidbCluster: %s", ns, podName, tcName)
 	}
@@ -108,6 +107,9 @@ func (rpc *realPodControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.
 	if !ok {
 		return pod, fmt.Errorf("pod %s/%s doesn't have %s label, TidbCluster: %s", ns, podName, label.InstanceLabelKey, tcName)
 	}
+	clusterID := labels[label.ClusterIDLabelKey]
+	memberID := labels[label.MemberIDLabelKey]
+	storeID := labels[label.StoreIDLabelKey]
 	pdClient := rpc.pdControl.GetPDClient(tc)
 	if labels[label.ClusterIDLabelKey] == "" {
 		cluster, err := pdClient.GetCluster()

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -151,7 +151,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		}
 	}
 
-	if !statefulSetEqual(*oldTiDBSet, *newTiDBSet) {
+	if !statefulSetEqual(*newTiDBSet, *oldTiDBSet) {
 		set := *oldTiDBSet
 		set.Spec.Template = newTiDBSet.Spec.Template
 		*set.Spec.Replicas = *newTiDBSet.Spec.Replicas

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -130,7 +130,8 @@ func statefulSetEqual(new apps.StatefulSet, old apps.StatefulSet) bool {
 			glog.Errorf("unmarshal Statefulset: [%s/%s]'s applied config failed,error: %v", old.GetNamespace(), old.GetName(), err)
 			return false
 		}
-		return apiequality.Semantic.DeepEqual(oldConfig, new.Spec)
+		return apiequality.Semantic.DeepEqual(oldConfig.Replicas, new.Spec.Replicas) &&
+			apiequality.Semantic.DeepEqual(oldConfig.Template, new.Spec.Template)
 	}
 	return false
 }


### PR DESCRIPTION
Currently, pd/tikv/tidb pods and pd/tidb statefulsets are updated all the time, even there's no update. This PR fixes this issue.