### PR TITLE
add tidb-binlog support

### DIFF
--- a/charts/tidb-cluster/templates/drainer-configmap.yaml
+++ b/charts/tidb-cluster/templates/drainer-configmap.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.drainer.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.clusterName }}-drainer
+  labels:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: drainer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+data:
+  drainer-config: |-
+    # drainer Configuration.
+
+    # addr (i.e. 'host:port') to listen on for drainer connections
+    # will register this addr into etcd
+    # addr = "127.0.0.1:8249"
+
+    # the interval time (in seconds) of detect pumps' status
+    detect-interval = 10
+
+    # drainer meta data directory path
+    data-dir = "data.drainer"
+
+    # a comma separated list of PD endpoints
+    pd-urls = "http://127.0.0.1:2379"
+
+    #[security]
+    # Path of file that contains list of trusted SSL CAs for connection with cluster components.
+    # ssl-ca = "/path/to/ca.pem"
+    # Path of file that contains X509 certificate in PEM format for connection with cluster components.
+    # ssl-cert = "/path/to/pump.pem"
+    # Path of file that contains X509 key in PEM format for connection with cluster components.
+    # ssl-key = "/path/to/pump-key.pem"
+
+    # syncer Configuration.
+    [syncer]
+
+    # disable sync these schema
+    ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
+
+    # number of binlog events in a transaction batch
+    txn-batch = 1
+
+    # work count to execute binlogs
+    worker-count = 1
+
+    disable-dispatch = false
+
+    # safe mode will split update to delete and insert
+    safe-mode = false
+
+    # downstream storage, equal to --dest-db-type
+    # valid values are "mysql", "pb", "tidb", "flash", "kafka"
+    db-type = "{{ .Values.drainer.destDBType }}"
+
+    ##replicate-do-db priority over replicate-do-table if have same db name
+    ##and we support regex expression , start with '~' declare use regex expression.
+    #
+    #replicate-do-db = ["~^b.*","s1"]
+    #[[syncer.replicate-do-table]]
+    #db-name ="test"
+    #tbl-name = "log"
+
+    #[[syncer.replicate-do-table]]
+    #db-name ="test"
+    #tbl-name = "~^a.*"
+
+{{- if eq .Values.drainer.destDBType "mysql" }}
+    # the downstream mysql protocol database
+    [syncer.to]
+    host = "{{ .Values.drainer.mysql.host }}"
+    user = "{{ .Values.drainer.mysql.user }}"
+    password = "{{ .Values.drainer.mysql.password }}"
+    port = {{ .Values.drainer.mysql.port }}
+    # Time and size limits for flash batch write
+    time-limit = "{{ .Values.drainer.mysql.timeLimit | default "30s" }}"
+    size-limit = "{{ .Values.drainer.mysql.sizeLimit | default "100000" }}"
+{{- end }}
+
+{{- if eq .Values.drainer.destDBType "pb" }}
+    # Uncomment this if you want to use pb or sql as db-type.
+    # Compress compresses output file, like pb and sql file. Now it supports "gzip" algorithm only.
+    # Values can be "gzip". Leave it empty to disable compression.
+    [syncer.to]
+    dir = "/data/pb"
+    compression = "gzip"
+{{- end }}
+
+
+{{- if eq .Values.drainer.destDBType "kafka" }}
+    # when db-type is kafka, you can uncomment this to config the down stream kafka, it will be the globle config kafka default
+    [syncer.to]
+    # only need config one of zookeeper-addrs and kafka-addrs, will get kafka address if zookeeper-addrs is configed.
+    {{- if .Values.drainer.kafka.zookeeperAddrs }}
+    zookeeper-addrs = {{ .Values.drainer.kafka.zookeeperAddrs }}
+    {{- end }}
+    {{- if .Values.drainer.kafka.kafkaAddrs }}
+    kafka-addrs = {{ .Values.drainer.kafka.kafkaAddrs }}
+    {{- end }}
+    kafka-version = {{ .Values.drainer.kafka.kafkaVersion | default "0.8.2.0" }}
+{{- end }}
+{{- end }}

--- a/charts/tidb-cluster/templates/drainer-service.yaml
+++ b/charts/tidb-cluster/templates/drainer-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.drainer.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.clusterName }}-drainer
+  labels:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: drainer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  clusterIP: None
+  ports:
+  - name: drainer
+    port: {{ .Values.drainer.port | default 8249 }}
+  selector:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: drainer
+{{- end }}

--- a/charts/tidb-cluster/templates/drainer-statefulset.yaml
+++ b/charts/tidb-cluster/templates/drainer-statefulset.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.drainer.create }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.clusterName }}-drainer
+  labels:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: drainer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+      app.kubernetes.io/instance: {{ .Values.clusterName }}
+      app.kubernetes.io/component: drainer
+  serviceName: {{ .Values.clusterName }}-drainer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+        app.kubernetes.io/instance: {{ .Values.clusterName }}
+        app.kubernetes.io/component: drainer
+    spec:
+      containers:
+      - name: drainer
+        image: {{ .Values.drainer.image }}
+        imagePullPolicy: {{ .Values.drainer.imagePullPolicy | default "IfNotPresent" }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+
+          domain=`echo ${HOSTNAME}`.{{ .Values.clusterName }}-drainer
+
+          elapseTime=0
+          period=1
+          threshold=30
+          while true; do
+              sleep ${period}
+              elapseTime=$(( elapseTime+period ))
+
+              if [[ ${elapseTime} -ge ${threshold} ]]
+              then
+                  echo "waiting for drainer domain ready timeout" >&2
+                  exit 1
+              fi
+
+              if nslookup ${domain} 2>/dev/null
+              then
+                  echo "nslookup domain ${domain} success"
+                  break
+              else
+                  echo "nslookup domain ${domain} failed" >&2
+              fi
+          done
+
+          /drainer \
+          -L={{ .Values.drainer.logLevel | default "info" }} \
+          -addr=`echo ${HOSTNAME}`.{{ .Values.clusterName }}-drainer:{{ .Values.drainer.port | default 8249 }} \
+          -c={{ .Values.drainer.c | default 1 }} \
+          -config=/etc/drainer/drainer.toml \
+          -data-dir=/data \
+          -dest-db-type={{ .Values.drainer.destDBType }} \
+          -detect-interval={{ .Values.drainer.detectInterval | default 10 }} \
+          -disable-detect={{ .Values.drainer.disableDetect | default false }} \
+          -disable-dispatch={{ .Values.drainer.disableDispatch | default false }} \
+          -ignore-schemas="{{ .Values.drainer.ignoreSchemas | default "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql,test" }}" \
+          -initial-commit-ts={{ .Values.drainer.initialCommitTs | default 0 }} \
+          -log-file= \
+          -metrics-addr={{ .Values.drainer.metricsAddr }} \
+          -metrics-interval={{ .Values.drainer.metricsInterval | default 15 }} \
+          -pd-urls=http://{{ .Values.clusterName }}-pd:2379 \
+          -safe-mode={{ .Values.drainer.safeMode | default false }} \
+          -txn-batch={{ .Values.drainer.txnBatch | default 1 }}
+        ports:
+        - containerPort: {{ .Values.drainer.port | default 8249 }}
+          name: drainer
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: config
+          mountPath: /etc/drainer
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Values.clusterName }}-drainer
+          items:
+          - key: drainer-config
+            path: drainer.toml
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.drainer.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.drainer.storage }}
+{{- end }}

--- a/charts/tidb-cluster/templates/pump-service.yaml
+++ b/charts/tidb-cluster/templates/pump-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.pump.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.clusterName }}-pump
+  labels:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: pump
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  clusterIP: None
+  ports:
+  - name: pump
+    port: {{ .Values.pump.port | default 8250 }}
+  selector:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: pump
+{{- end }}

--- a/charts/tidb-cluster/templates/pump-statefulset.yaml
+++ b/charts/tidb-cluster/templates/pump-statefulset.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.pump.create }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.clusterName }}-pump
+  labels:
+    app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
+    app.kubernetes.io/component: pump
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+      app.kubernetes.io/instance: {{ .Values.clusterName }}
+      app.kubernetes.io/component: pump
+  serviceName: {{ .Values.clusterName }}-pump
+  replicas: {{ .Values.pump.replicas }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "tidb-cluster.name" . }}
+        app.kubernetes.io/instance: {{ .Values.clusterName }}
+        app.kubernetes.io/component: pump
+    spec:
+      containers:
+      - name: pump
+        image: {{ .Values.pump.image }}
+        imagePullPolicy: {{ .Values.pump.imagePullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          /pump \
+          -L={{ .Values.pump.logLevel | default "info" }} \
+          -addr=0.0.0.0:{{ .Values.pump.port | default 8250 }} \
+          -advertise-addr=`echo ${HOSTNAME}`.{{ .Values.clusterName }}-pump:{{ .Values.pump.port | default 8250 }} \
+          -data-dir=/data \
+          -enable-tolerant={{ .Values.pump.enableTolerant | default true }} \
+          -gc={{ .Values.pump.gc | default 7 }} \
+          -heartbeat-interval={{ .Values.pump.heartbeatInterval | default 2 }} \
+          -log-file= \
+          -metrics-addr={{ .Values.pump.metricsAddr }} \
+          -metrics-interval={{ .Values.pump.metricsInterval | default 15 }} \
+          -pd-urls=http://{{ .Values.clusterName }}-pd:2379
+        ports:
+        - containerPort: {{ .Values.pump.port | default 8250 }}
+          name: pump
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.pump.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.pump.storage }}
+{{- end }}

--- a/charts/tidb-cluster/templates/tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/tidb-configmap.yaml
@@ -42,6 +42,10 @@ data:
     --config=/etc/tidb/tidb.toml
     "
 
+{{- if .Values.binlogEnabled }}
+    ARGS="${ARGS} --enable-binlog=true"
+{{- end }}
+
     echo "start tidb-server ..."
     echo "/tidb-server ${ARGS}"
     exec /tidb-server ${ARGS}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -15,6 +15,9 @@ timezone: Asia/Shanghai
 # default reclaim policy of a PV
 pvReclaimPolicy: Retain
 
+# enable tidb binlog
+binlogEnabled: false
+
 # services is the service list to expose, default is ClusterIP
 # can be ClusterIP | NodePort | LoadBalancer
 services:
@@ -170,6 +173,80 @@ monitor:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+
+pump:
+  create: false
+  replicas: 1
+  image: pingcap/tidb-binlog:new
+  imagePullPolicy: IfNotPresent
+  logLevel: info
+  port: 8250
+  # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
+  # different classes might map to quality-of-service levels, or to backup policies,
+  # or to arbitrary policies determined by the cluster administrators.
+  # refer to https://kubernetes.io/docs/concepts/storage/storage-classes
+  storageClassName: local-storage
+  storage: 10Gi
+  # after enable tolerant, pump wouldn't return error if it fails to write binlog (default true)
+  enableTolerant: true
+  # a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored.
+  # must bigger than 0
+  gc: 7
+  # number of seconds between heartbeat ticks (in 2 seconds)
+  heartbeatInterval: 2
+  # prometheus pushgateway address, leaves it empty will disable prometheus push
+  metricsAddr: ""
+  # prometheus client push interval in second, set "0" to disable prometheus push (default 15)
+  metricsInterval: 15
+
+drainer:
+  create: false
+  image: pingcap/tidb-binlog:new
+  imagePullPolicy: IfNotPresent
+  logLevel: info
+  port: 8249
+  # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
+  # different classes might map to quality-of-service levels, or to backup policies,
+  # or to arbitrary policies determined by the cluster administrators.
+  # refer to https://kubernetes.io/docs/concepts/storage/storage-classes
+  storageClassName: local-storage
+  storage: 10Gi
+  # parallel worker count (default 1)
+  c: 1
+  # the interval time (in seconds) of detect pumps' status (default 10)
+  detectInterval: 10
+  # disbale detect causality
+  disableDetect: false
+  # disable dispatching sqls that in one same binlog; if set true, work-count and txn-batch would be useless
+  disableDispatch: false
+  # # disable sync these schema
+  ignoreSchemas: "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql,test"
+  # if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint
+  initialCommitTs: 0
+  # prometheus pushgateway address, leaves it empty will disable prometheus push
+  metricsAddr: ""
+  # prometheus client push interval in second, set "0" to disable prometheus push (default 15)
+  metricsInterval: 15
+  # enable safe mode to make syncer reentrant
+  safeMode: false
+  # number of binlog events in a transaction batch (default 1)
+  txnBatch: 1
+  # downstream storage, equal to --dest-db-type
+  # valid values are "mysql", "pb", "kafka"
+  destDBType: mysql
+  mysql:
+    host: "127.0.0.1"
+    user: "root"
+    password: ""
+    port: 3306
+    # Time and size limits for flash batch write
+    timeLimit: "30s"
+    sizeLimit: "100000"
+  kafka: {}
+    # only need config one of zookeeper-addrs and kafka-addrs, will get kafka address if zookeeper-addrs is configed.
+    # zookeeperAddrs: "127.0.0.1:2181"
+    # kafkaAddrs: "127.0.0.1:9092"
+    # kafkaVersion: "0.8.2.0"
 
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"


### PR DESCRIPTION
This PR adds tidb-binlog support to operator.

TiDB Binlog is not GA now. So for testing, use these images instead:

```
pingcap/pd:v2.0.7-binlog-dev
pingcap/tikv:v2.0.7-binlog-dev
pingcap/tidb:v2.0.7-binlog-dev

pingcap/tidb-binlog:new
```

@tennix @onlymellb @xiaojingchen @gregwebs PTAL