### PR TITLE
fix wrong parameter AGRS to ARGS

### DIFF
--- a/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
@@ -45,7 +45,7 @@ data:
     "
 
     echo "start privileged-tidb-server ..."
-    echo "/tidb-server ${AGRS}"
+    echo "/tidb-server ${ARGS}"
     exec /tidb-server ${ARGS}
 
   config-file: |-


### PR DESCRIPTION
Privileged TiDB can't started because of this typo:

```
start privileged-tidb-server ...
/usr/local/bin/privileged_tidb_start_script.sh: line 31: AGRS: parameter not set
```