### PR TITLE
bump tidb to v2.0.7 & allow user specified config files

### DIFF
--- a/charts/tidb-cluster/templates/pd-configmap.yaml
+++ b/charts/tidb-cluster/templates/pd-configmap.yaml
@@ -112,6 +112,9 @@ data:
     echo "/pd-server ${ARGS}"
     exec /pd-server ${ARGS}
   config-file: |-
+    {{- if .Values.pd.config }}
+{{ .Values.pd.config | indent 4 }}
+    {{- else }}
     # PD Configuration.
 
     name = "pd"
@@ -198,3 +201,4 @@ data:
     #  [[label-property.reject-leader]]
     #  key = "zone"
     #  value = "cn1
+    {{- end -}}

--- a/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/privileged-tidb-configmap.yaml
@@ -268,6 +268,14 @@ data:
     # Max gRPC connections that will be established with each tikv-server.
     grpc-connection-count = 16
 
+    # After a duration of this time in seconds if the client doesn't see any activity it pings
+    # the server to see if the transport is still alive.
+    grpc-keepalive-time = 10
+
+    # After having pinged for keepalive check, the client waits for a duration of Timeout in seconds
+    # and if no activity is seen even after that the connection is closed.
+    grpc-keepalive-timeout = 3
+
     # max time for commit command, must be twice bigger than raft election timeout.
     commit-timeout = "41s"
 

--- a/charts/tidb-cluster/templates/tidb-configmap.yaml
+++ b/charts/tidb-cluster/templates/tidb-configmap.yaml
@@ -52,6 +52,9 @@ data:
     exec /tidb-server ${ARGS}
 
   config-file: |-
+    {{- if .Values.tidb.config }}
+{{ .Values.tidb.config | indent 4 }}
+    {{- else }}
     # TiDB Configuration.
 
     # TiDB server host.
@@ -269,6 +272,14 @@ data:
     # Max gRPC connections that will be established with each tikv-server.
     grpc-connection-count = 16
 
+    # After a duration of this time in seconds if the client doesn't see any activity it pings
+    # the server to see if the transport is still alive.
+    grpc-keepalive-time = 10
+
+    # After having pinged for keepalive check, the client waits for a duration of Timeout in seconds
+    # and if no activity is seen even after that the connection is closed.
+    grpc-keepalive-timeout = 3
+
     # max time for commit command, must be twice bigger than raft election timeout.
     commit-timeout = "41s"
 
@@ -283,3 +294,4 @@ data:
     # If IgnoreError is true, when writting binlog meets error, TiDB would stop writting binlog,
     # but still provide service.
     ignore-error = false
+    {{- end -}}

--- a/charts/tidb-cluster/templates/tikv-configmap.yaml
+++ b/charts/tidb-cluster/templates/tikv-configmap.yaml
@@ -49,6 +49,9 @@ data:
     exec /tikv-server ${ARGS}
 
   config-file: |-
+    {{- if .Values.tikv.config }}
+{{ .Values.tikv.config | indent 4 }}
+    {{- else }}
     # TiKV config template
     #  Human-readable big numbers:
     #   File size(based on byte): KB, MB, GB, TB, PB
@@ -142,7 +145,7 @@ data:
     # scheduler-messages-per-tick = 1024
 
     # the number of slots in scheduler latches, concurrency control for write.
-    # scheduler-concurrency = 102400
+    # scheduler-concurrency = 2048000
 
     # scheduler's worker pool size, should increase it in heavy write cases,
     # also should less than total cpu cores.
@@ -341,6 +344,30 @@ data:
     # Allows OS to incrementally sync WAL to disk while it is being written.
     # wal-bytes-per-sync = "0KB"
 
+    # Specify the maximal size of the Rocksdb info log file. If the log file
+    # is larger than `max_log_file_size`, a new info log file will be created.
+    # If max_log_file_size == 0, all logs will be written to one log file.
+    # Default: 1GB
+    # info-log-max-size = "1GB"
+
+    # Time for the Rocksdb info log file to roll (in seconds).
+    # If specified with non-zero value, log file will be rolled
+    # if it has been active longer than `log_file_time_to_roll`.
+    # Default: 0 (disabled)
+    # info-log-roll-time = "0"
+
+    # Maximal Rocksdb info log files to be kept.
+    # Default: 10
+    # info-log-keep-log-file-num = 10
+
+    # This specifies the Rocksdb info LOG dir.
+    # If it is empty, the log files will be in the same dir as data.
+    # If it is non empty, the log files will be in the specified dir,
+    # and the db data dir's absolute path will be used as the log file
+    # name's prefix.
+    # Default: empty
+    # info-log-dir = ""
+
     # Column Family default used to store actual data of the database.
     [rocksdb.defaultcf]
     # compression method (if any) is used to compress a block.
@@ -425,7 +452,7 @@ data:
     # read-amp-bytes-per-bit = 0
 
     # Pick target size of each level dynamically.
-    # dynamic-level-bytes = false
+    # dynamic-level-bytes = true
 
     # Options for Column Family write
     # Column Family write used to store commit informations in MVCC model
@@ -447,7 +474,7 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 3
     # read-amp-bytes-per-bit = 0
-    # dynamic-level-bytes = false
+    # dynamic-level-bytes = true
 
     [rocksdb.lockcf]
     # compression-per-level = ["no", "no", "no", "no", "no", "no", "no"]
@@ -465,7 +492,7 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 0
     # read-amp-bytes-per-bit = 0
-    # dynamic-level-bytes = false
+    # dynamic-level-bytes = true
 
     [raftdb]
     # max-sub-compactions = 1
@@ -483,6 +510,11 @@ data:
     # allow-concurrent-memtable-write = false
     # bytes-per-sync = "0MB"
     # wal-bytes-per-sync = "0KB"
+
+    # info-log-max-size = "1GB"
+    # info-log-roll-time = "0"
+    # info-log-keep-log-file-num = 10
+    # info-log-dir = ""
 
     [raftdb.defaultcf]
     # compression-per-level = ["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
@@ -502,7 +534,7 @@ data:
     # pin-l0-filter-and-index-blocks = true
     # compaction-pri = 0
     # read-amp-bytes-per-bit = 0
-    # dynamic-level-bytes = false
+    # dynamic-level-bytes = true
 
     [security]
     # set the path for certificates. Empty string means disabling secure connectoins.
@@ -517,3 +549,4 @@ data:
     # num-threads = 8
     # stream channel window size, stream will be blocked on channel full.
     # stream-channel-window = 128
+    {{- end -}}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -25,7 +25,7 @@ services:
 
 pd:
   replicas: 3
-  image: pingcap/pd:v2.0.4
+  image: pingcap/pd:v2.0.7
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
@@ -64,7 +64,7 @@ pd:
 
 tikv:
   replicas: 3
-  image: pingcap/tikv:v2.0.4
+  image: pingcap/tikv:v2.0.7
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
@@ -106,7 +106,7 @@ tikvPromGateway:
 
 tidb:
   replicas: 2
-  image: pingcap/tidb:v2.0.4
+  image: pingcap/tidb:v2.0.7
   logLevel: info
   resources: {}
     # limits:
@@ -184,7 +184,7 @@ fullbackup:
   create: false
   binlogImage: pingcap/tidb-binlog:latest
   # https://github.com/tennix/tidb-cloud-backup
-  mydumperImage: tennix/tidb-cloud-backup:latest
+  mydumperImage: pingcap/tidb-cloud-backup:latest
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -23,7 +23,7 @@ services:
 
 pd:
   replicas: 3
-  image: pingcap/pd:v2.0.4
+  image: pingcap/pd:v2.0.7
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
@@ -62,7 +62,7 @@ pd:
 
 tikv:
   replicas: 3
-  image: pingcap/tikv:v2.0.4
+  image: pingcap/tikv:v2.0.7
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
@@ -104,7 +104,7 @@ tikvPromGateway:
 
 tidb:
   replicas: 2
-  image: pingcap/tidb:v2.0.4
+  image: pingcap/tidb:v2.0.7
   logLevel: info
   resources: {}
     # limits:
@@ -178,7 +178,7 @@ fullbackup:
   create: false
   binlogImage: pingcap/tidb-binlog:latest
   # https://github.com/tennix/tidb-cloud-backup
-  mydumperImage: tennix/tidb-cloud-backup:latest
+  mydumperImage: pingcap/tidb-cloud-backup:latest
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -210,4 +210,3 @@ fullbackup:
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"
 metaValue: "{{ $value }}"
-

--- a/tests/e2e/upgrade.go
+++ b/tests/e2e/upgrade.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	upgradeVersion = "v2.0.5"
+	upgradeVersion = "v2.1.0-rc.3"
 )
 
 func testUpgrade() {


### PR DESCRIPTION
This PR bumps TiDB to v2.0.7 as the default TiDB version. And also allow users to specify config files in values.yaml. Normal users don't have to customize config files in values.yaml, so it's hidden there.