### PR TITLE
use the parameterized ServiceAccount in monitor-job.yaml

### DIFF
--- a/charts/tidb-cluster/templates/monitor-job.yaml
+++ b/charts/tidb-cluster/templates/monitor-job.yaml
@@ -18,8 +18,12 @@ spec:
         app.kubernetes.io/component: monitor-configurator
     spec:
       restartPolicy: OnFailure
+    {{- if .Values.monitor.serviceAccount }}
+      serviceAccount: {{ .Values.monitor.serviceAccount }}
+    {{- else }}
     {{- if .Values.rbac.create }}
       serviceAccount: {{ .Values.clusterName }}-monitor
+    {{- end }}
     {{- end }}
       containers:
       - name: tidb-dashboard-installer


### PR DESCRIPTION
Looks like I missed this in my last PR.