### PR TITLE
binglog remove enable tolerant config

### DIFF
--- a/charts/tidb-cluster/templates/pump-statefulset.yaml
+++ b/charts/tidb-cluster/templates/pump-statefulset.yaml
@@ -41,7 +41,6 @@ spec:
           -L={{ .Values.binlog.pump.logLevel | default "info" }} \
           -advertise-addr=`echo ${HOSTNAME}`.{{ .Values.clusterName }}-pump:8250 \
           -config=/etc/pump/pump.toml \
-          -enable-tolerant={{ .Values.binlog.pump.enableTolerant | default true }} \
           -log-file=
         ports:
         - containerPort: 8250

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -226,8 +226,6 @@ binlog:
     # refer to https://kubernetes.io/docs/concepts/storage/storage-classes
     storageClassName: local-storage
     storage: 10Gi
-    # after enable tolerant, pump wouldn't return error if it fails to write binlog (default true)
-    enableTolerant: true
     # a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored.
     # must bigger than 0
     gc: 7


### PR DESCRIPTION
Binlog have remove the `enable tolerant` config in the PR: https://github.com/pingcap/tidb-binlog/pull/366 .
So the charts should  remove `enable tolerant`  too