### PR TITLE
pd should't scale out if not all members are ready

### DIFF
--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -65,9 +65,9 @@ func (psd *pdScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet
 			healthCount++
 		}
 	}
-	if healthCount < int(totalCount/2+1) {
+	if healthCount < int(totalCount) {
 		resetReplicas(newSet, oldSet)
-		return fmt.Errorf("TidbCluster: %s/%s's pd %d/%d is not ready, can't scale out now",
+		return fmt.Errorf("TidbCluster: %s/%s's pd %d/%d is ready, can't scale out now",
 			ns, tcName, healthCount, totalCount)
 	}
 

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -155,13 +155,16 @@ func TestPDScalerScaleOut(t *testing.T) {
 		{
 			name: "pd member not health",
 			update: func(tc *v1alpha1.TidbCluster) {
+				normalPDMember(tc)
 				tcName := tc.GetName()
-				member1 := tc.Status.PD.Members[ordinalPodName(v1alpha1.PDMemberType, tcName, 1)]
+				podName := ordinalPodName(v1alpha1.PDMemberType, tcName, 1)
+				member1 := tc.Status.PD.Members[podName]
 				member1.Health = false
+				tc.Status.PD.Members[podName] = member1
 			},
 			pdUpgrading:      false,
 			hasPVC:           true,
-			hasDeferAnn:      true,
+			hasDeferAnn:      false,
 			pvcDeleteErr:     false,
 			statusSyncFailed: false,
 			err:              true,


### PR DESCRIPTION
This PR try to fix this issue: https://github.com/pingcap/tidb-operator/issues/126#issuecomment-432076798

Operator must ensure all members are ready before scale out. Or the higher ordinal may started before the lower in StatefulSet.
