### PR TITLE
add default value for tidb / tikv / pd log level

### DIFF
--- a/charts/tidb-cluster/templates/config/_pd-config.tpl
+++ b/charts/tidb-cluster/templates/config/_pd-config.tpl
@@ -26,7 +26,7 @@ cert-path = ""
 key-path = ""
 
 [log]
-level = "{{ .Values.pd.logLevel }}"
+level = "{{ .Values.pd.logLevel | default `info` }}"
 
 # log format, one of json, text, console
 #format = "text"

--- a/charts/tidb-cluster/templates/config/_pd-config.tpl
+++ b/charts/tidb-cluster/templates/config/_pd-config.tpl
@@ -26,7 +26,7 @@ cert-path = ""
 key-path = ""
 
 [log]
-level = "{{ .Values.pd.logLevel | default `info` }}"
+level = {{ .Values.pd.logLevel | default "info" | quote }}
 
 # log format, one of json, text, console
 #format = "text"

--- a/charts/tidb-cluster/templates/config/_tidb-config.tpl
+++ b/charts/tidb-cluster/templates/config/_tidb-config.tpl
@@ -43,7 +43,7 @@ lower-case-table-names = 2
 
 [log]
 # Log level: debug, info, warn, error, fatal.
-level = "{{ .Values.tidb.logLevel }}"
+level = "{{ .Values.tidb.logLevel | default `info` }}"
 
 # Log format, one of json, text, console.
 format = "text"

--- a/charts/tidb-cluster/templates/config/_tidb-config.tpl
+++ b/charts/tidb-cluster/templates/config/_tidb-config.tpl
@@ -43,7 +43,7 @@ lower-case-table-names = 2
 
 [log]
 # Log level: debug, info, warn, error, fatal.
-level = "{{ .Values.tidb.logLevel | default `info` }}"
+level = {{ .Values.tidb.logLevel | default "info" | quote }}
 
 # Log format, one of json, text, console.
 format = "text"

--- a/charts/tidb-cluster/templates/config/_tikv-config.tpl
+++ b/charts/tidb-cluster/templates/config/_tikv-config.tpl
@@ -6,7 +6,7 @@
 #    e.g.: 78_000 = "1.3m"
 
 # log level: trace, debug, info, warn, error, off.
-log-level = "{{ .Values.tikv.logLevel | default `info` }}"
+log-level = {{ .Values.tikv.logLevel | default "info" | quote }}
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 

--- a/charts/tidb-cluster/templates/config/_tikv-config.tpl
+++ b/charts/tidb-cluster/templates/config/_tikv-config.tpl
@@ -6,7 +6,7 @@
 #    e.g.: 78_000 = "1.3m"
 
 # log level: trace, debug, info, warn, error, off.
-log-level = "{{ .Values.tikv.logLevel }}"
+log-level = "{{ .Values.tikv.logLevel | default `info` }}"
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 


### PR DESCRIPTION
if `log-level` is empty in tikv config file, starting tikv will fail.  
In this pr, if the `log-level` is empty,  it will be set to `info`. 
@tennix @weekface @xiaojingchen PTAL