### PR TITLE
keep scheduler name consistent as defined in values.yml

### DIFF
--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: tidb-scheduler
+  name: {{ .Values.scheduler.schedulerName }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Values.scheduler.serviceAccount }}
     {{- end }}
       containers:
-      - name: tidb-scheduler
+      - name: {{ .Values.scheduler.schedulerName }}
         image: {{ .Values.operatorImage }}
         resources:
 {{ toYaml .Values.scheduler.resources | indent 12 }}

--- a/charts/tidb-operator/templates/scheduler-policy-configmap.yaml
+++ b/charts/tidb-operator/templates/scheduler-policy-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tidb-scheduler-policy
+  name: {{ .Values.scheduler.schedulerName }}-policy
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/tidb-operator/templates/scheduler-rbac.yaml
+++ b/charts/tidb-operator/templates/scheduler-rbac.yaml
@@ -13,7 +13,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -54,7 +54,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -67,14 +67,14 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   apiGroup: rbac.authorization.k8s.io
 {{- if (not .Values.clusterScoped) }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -107,7 +107,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -119,7 +119,7 @@ subjects:
   name: {{ .Values.scheduler.serviceAccount }}
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}:tidb-scheduler
+  name: {{ .Release.Name }}:{{ .Values.scheduler.schedulerName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The scheduler can't use scheduler policy configmap correctly when you change the schedulerName in values.yaml. This PR fix it.