### PR TITLE
fix pd_control: not rely on error text

### DIFF
--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -397,6 +397,13 @@ func (pc *pdClient) BeginEvictLeader(storeID uint64) error {
 		return nil
 	}
 
+	// pd will return an error with the body contains "scheduler existed" if the scheduler already exists
+	// this is not the standard response.
+	// so these lines are just a workaround for now:
+	//   - make a new request to get all schedulers
+	//   - return nil if the scheduler already exists
+	//
+	// when PD returns standard json response, we should get rid of this verbose code.
 	evictLeaderSchedulers, err := pc.GetEvictLeaderSchedulers()
 	if err != nil {
 		return err
@@ -427,6 +434,13 @@ func (pc *pdClient) EndEvictLeader(storeID uint64) error {
 		return nil
 	}
 
+	// pd will return an error with the body contains "scheduler not found" if the scheduler is not found
+	// this is not the standard response.
+	// so these lines are just a workaround for now:
+	//   - make a new request to get all schedulers
+	//   - return nil if the scheduler is not found
+	//
+	// when PD returns standard json response, we should get rid of this verbose code.
 	err2 := readErrorBody(res.Body)
 	evictLeaderSchedulers, err := pc.GetEvictLeaderSchedulers()
 	if err != nil {

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// https://github.com/pingcap/tidb/blob/master/owner/manager.go#L183
 	// NotDDLOwnerError is the error message which was returned when the tidb node is not a ddl owner
 	NotDDLOwnerError = "This node is not a ddl owner, can't be resigned."
 )


### PR DESCRIPTION
- just return an error if delete store failed
- use `GetEvictLeaderSchedulers` instead

@tennix @xiaojingchen PTAL