### PR TITLE
Add compiler version info in tidb-operator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 GO     := $(GOENV) GO111MODULE=on go build -mod=vendor
 GOTEST := CGO_ENABLED=0 GO111MODULE=on go test -v -mod=vendor -cover
 
-LDFLAGS += -X "github.com/pingcap/tidb-operator/version.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
-LDFLAGS += -X "github.com/pingcap/tidb-operator/version.GitSHA=$(shell git rev-parse HEAD)"
+LDFLAGS = $(shell ./hack/version.sh) 
 
 DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIDB_VERSION=${TIDB_VERSION:-2.1.0}
+
+# -----------------------------------------------------------------------------
+# Version management helpers.  These functions help to set the
+# following variables:
+#
+#    GIT_COMMIT - The git commit id corresponding to this
+#          source code.
+#    GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#        "dirty" indicates source code changes after the git commit id
+#        "archive" indicates the tree was produced by 'git archive'
+#    GIT_VERSION - "vX.Y" used to indicate the last release version.
+function tidb_operator::version::get_version_vars() {
+  if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
+    if [[ -z ${GIT_TREE_STATE-} ]]; then
+      # Check if the tree is dirty.  default to dirty
+      if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+      else
+        GIT_TREE_STATE="dirty"
+      fi
+    fi
+  
+    # Use git describe to find the version based on tags.
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
+      # This translates the "git describe" to an actual semver.org
+      # compatible semantic version that looks something like this:
+      #   v1.0.0-beta.0.10+4c183422345d8f
+      #
+      # TODO: We continue calling this "git version" because so many
+      # downstream consumers are expecting it there.
+      DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      fi
+      if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+        # git describe --dirty only considers changes to existing files, but
+        # that is problematic since new untracked .go files affect the build,
+        # so use our idea of "dirty" from git status instead.
+        GIT_VERSION+="-dirty"
+      fi
+
+
+      # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+      if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+        echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+        echo "Please see more details here: https://semver.org"
+        exit 1
+      fi
+    fi
+  fi
+}
+
+function tidb_operator::version::ldflag() {
+  local key=${1}
+  local val=${2}
+
+  echo "-X 'github.com/pingcap/tidb-operator/version.${key}=${val}'"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+function tidb_operator::version::ldflags() {
+  tidb_operator::version::get_version_vars
+
+  local buildDate=
+  [[ -z ${SOURCE_DATE_EPOCH-} ]] || buildDate="--date=@${SOURCE_DATE_EPOCH}"
+  local -a ldflags=($(tidb_operator::version::ldflag "buildDate" "$(date ${buildDate} -u +'%Y-%m-%dT%H:%M:%SZ')"))
+  if [[ -n ${GIT_COMMIT-} ]]; then
+    ldflags+=($(tidb_operator::version::ldflag "gitCommit" "${GIT_COMMIT}"))
+    ldflags+=($(tidb_operator::version::ldflag "gitTreeState" "${GIT_TREE_STATE}"))
+  fi
+
+  if [[ -n ${GIT_VERSION-} ]]; then
+    ldflags+=($(tidb_operator::version::ldflag "gitVersion" "${GIT_VERSION}"))
+  fi
+
+  if [[ -n ${TIDB_VERSION-} ]]; then
+    ldflags+=($(tidb_operator::version::ldflag "tidbVersion" "${TIDB_VERSION}"))
+  fi
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}
+
+# output -ldflags parameters
+tidb_operator::version::ldflags

--- a/version/types.go
+++ b/version/types.go
@@ -1,0 +1,31 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Info contains versioning information.
+type Info struct {
+	TiDBVersion  string `json:"tidbVersion"`
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}

--- a/version/version.go
+++ b/version/version.go
@@ -15,26 +15,45 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/golang/glog"
 )
 
 var (
-	// GitSHA will be set during make
-	GitSHA = "None"
-	// BuildTS and BuildTS will be set during make
-	BuildTS = "None"
+	// tidbVersion and tidbVersion will be set during make
+	tidbVersion = "None"
+
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
 // PrintVersionInfo show version info to Stdout
 func PrintVersionInfo() {
-	fmt.Println("Git Commit Hash:", GitSHA)
-	fmt.Println("UTC Build Time: ", BuildTS)
+	fmt.Printf("TiDB Operator Version: %#v\n", Get())
 }
 
 // LogVersionInfo print version info at startup
 func LogVersionInfo() {
 	glog.Infof("Welcome to TiDB Operator.")
-	glog.Infof("Git Commit Hash: %s", GitSHA)
-	glog.Infof("UTC Build Time:  %s", BuildTS)
+	glog.Infof("TiDB Operator Version: %#v", Get())
+}
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() Info {
+	// These variables typically come from -ldflags settings and in
+	return Info{
+		TiDBVersion:  tidbVersion,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
 }


### PR DESCRIPTION
Add more  compiler version infos into tidb-operator version, like go version、Compiler. fix: #173