### PR TITLE
set kube client timeout

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -87,6 +87,8 @@ func main() {
 	if err != nil {
 		glog.Fatalf("failed to get config: %v", err)
 	}
+	cfg.Timeout = 30 * time.Second
+
 	cli, err := versioned.NewForConfig(cfg)
 	if err != nil {
 		glog.Fatalf("failed to create Clientset: %v", err)


### PR DESCRIPTION
This pr is related the #154.
the Kubernetes client is not timeout by default, see: [https://github.com/kubernetes/client-go/blob/master/rest/config.go#L117](url). to set timeout may help to resolve the bug of #154, and it is more reasonable than always blocked

PTAL @weekface @tennix @gregwebs @onlymellb 