### PR TITLE
change default tolerations type to an array

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -73,7 +73,7 @@ pd:
     # region: cn-bj1
   # Tolerations are applied to pods, and allow pods to schedule onto nodes with matching taints.
   # refer to https://kubernetes.io/docs/concepts/configuration/taint-and-toleration
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -108,7 +108,7 @@ tikv:
     # kind: tikv
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -162,7 +162,7 @@ tidb:
     # kind: tidb
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -230,7 +230,7 @@ monitor:
     # kind: monitor
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -64,7 +64,7 @@ pd:
     # region: cn-bj1
   # Tolerations are applied to pods, and allow pods to schedule onto nodes with matching taints.
   # refer to https://kubernetes.io/docs/concepts/configuration/taint-and-toleration
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -97,7 +97,7 @@ tikv:
     # kind: tikv
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -132,7 +132,7 @@ tidb:
     # kind: tidb
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb
@@ -196,7 +196,7 @@ monitor:
     # kind: monitor
     # zone: cn-bj1-01,cn-bj1-02
     # region: cn-bj1
-  tolerations: {}
+  tolerations: []
   # - key: node-role
   #   operator: Equal
   #   value: tidb


### PR DESCRIPTION
I believe the default value is of the incorrect type object.