### PR TITLE
Don't initialize when there is no tidb.password

### DIFF
--- a/charts/tidb-cluster/templates/NOTES.txt
+++ b/charts/tidb-cluster/templates/NOTES.txt
@@ -1,17 +1,27 @@
+Cluster Startup
 1. Watch tidb-cluster up and running
-   watch kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+     watch kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
 2. List services in the tidb-cluster
-   kubectl get services --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl get services --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- if .Values.tidb.password }}
 3. Wait until tidb-initializer pod becomes completed
-   watch kubectl get po --namespace {{ .Release.Namespace }}  -l app.kubernetes.io/component=tidb-initializer
+     watch kubectl get po --namespace {{ .Release.Namespace }}  -l app.kubernetes.io/component=tidb-initializer
 4. Get the TiDB password
-   PASSWORD=$(kubectl get secret -n {{ .Release.Namespace }} {{ .Values.clusterName }}-tidb -o jsonpath="{.data.password}" | base64 --decode | awk '{print $6}')
-   echo ${PASSWORD}
-5. Access tidb-cluster using the MySQL client
-   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Values.clusterName }}-tidb 4000:4000 &
-   mysql -h 127.0.0.1 -P 4000 -u root -D test -p
+     kubectl get secret -n {{ .Release.Namespace }} {{ .Values.clusterName }}-tidb -o jsonpath="{.data.password}" | base64 --decode | awk '{print $6}'
+{{- end -}}
+
+Cluster access
+* Access tidb-cluster using the MySQL client
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Values.clusterName }}-tidb 4000:4000 &
+{{- if .Values.tidb.password }}
+    mysql -h 127.0.0.1 -P 4000 -u root -D test -p
+{{- else -}}
+    mysql -h 127.0.0.1 -P 4000 -u root -D test
+  Set a password for your user
+    SET PASSWORD FOR 'root'@'%' = '{{ (randAlphaNum 10) }}'; FLUSH PRIVILEGES
+{{- end -}}
 {{- if .Values.monitor.create }}
-6. View monitor dashboard for TiDB cluster
+* View monitor dashboard for TiDB cluster
    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Values.clusterName }}-grafana 3000:3000
    Open browser at http://localhost:3000. The default username and password is admin/admin.
 {{- end -}}

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tidb.password }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,3 +41,4 @@ spec:
           items:
           - key: password
             path: init-password.sql
+{{- end }}

--- a/charts/tidb-cluster/templates/tidb-secret.yaml
+++ b/charts/tidb-cluster/templates/tidb-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tidb.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,8 +11,5 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 type: Opaque
 data:
-  {{- if .Values.tidb.password }}
   password: {{ printf "SET PASSWORD FOR 'root'@'%%' = '%s' ; FLUSH PRIVILEGES;" .Values.tidb.password | b64enc }}
-  {{- else }}
-  password: {{ printf "SET PASSWORD FOR 'root'@'%%' = '%s' ; FLUSH PRIVILEGES;" (randAlphaNum 10) | b64enc }}
-  {{- end }}
+{{- end }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -145,7 +145,9 @@ tikvPromGateway:
 
 tidb:
   replicas: 2
-  # password is TiDB's password, if omit password, a random password is generated
+  # The password to access TiDB
+  # If set, the password will be stored both in helm and in a Secret
+  # If unset, the root password will be empty and you can set it after connecting
   # password: "admin"
   image: pingcap/tidb:v2.1.0
   # Image pull policy.

--- a/docs/aws-eks-tutorial.md
+++ b/docs/aws-eks-tutorial.md
@@ -392,30 +392,30 @@ watch "kubectl get svc -n tidb"
 When you see `demo-tidb` appear, you can `Control + C` to stop watching. Then the service is ready to connect to!
 
 ```sh
-# Get the TiDB password
-PASSWORD=$(kubectl get secret -n tidb demo-tidb -o jsonpath="{.data.password}" | base64 --decode | awk '{print $6}')
-echo ${PASSWORD}
-
-# Connect to TiDB
 kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb -o jsonpath='{.spec.clusterIP}') -p
 ```
 
-Or just:
+Or you can forward ports and run a mysql client locally:
 
 ```sh
 kubectl -n tidb port-forward demo-tidb-0 4000:4000 &>/tmp/port-forward.log &
+mysql -h 127.0.0.1 -u root -P 4000 --default-character-set=utf8 -p
 ```
 
-Then open a new terminal:
+Try out some mysql commands:
 
 ```sh
-mysql -h 127.0.0.1 -u root -P 4000 --default-character-set=utf8 -p
-
-# Then try some sql command:
 select tidb_version();
 ```
 
 It works! :tada:
+
+If you did not specify a password in helm, set one now:
+
+```sh
+SET PASSWORD FOR 'root'@'%' =
+```
+
 
 ### Monitoring with Grafana
 

--- a/docs/google-kubernetes-tutorial.md
+++ b/docs/google-kubernetes-tutorial.md
@@ -126,8 +126,6 @@ When you see `demo-tidb` appear, you can `Control + C`. The service is ready to 
 
 You can connect to the clustered service within the Kubernetes cluster:
 
-    PASSWORD=$(kubectl get secret -n tidb demo-tidb -o jsonpath="{.data.password}" | base64 --decode | awk '{print $6}') &&
-	echo ${PASSWORD} &&
 	kubectl run -n tidb mysql-client --rm -i --tty --image mysql -- mysql -P 4000 -u root -h $(kubectl get svc demo-tidb -n tidb -o jsonpath='{.spec.clusterIP}') -p
 
 Congratulations, you are now up and running with a distributed TiDB database compatible with MySQL!
@@ -141,9 +139,14 @@ From your Cloud Shell:
 	sudo apt-get install -y mysql-client &&
 	mysql -h 127.0.0.1 -u root -P 4000 -p
 
-If you like, you can check your connection to TiDB inside your MySQL terminal and see the latest TiDB version being deployed, using the command:
+Try out a MySQL command inside your MySQL terminal:
 
 	select tidb_version();
+
+If you did not specify a password in helm, set one now:
+
+	SET PASSWORD FOR 'root'@'%' =
+
 
 ## Scale out the TiDB cluster
 

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -109,13 +109,6 @@ To access the TiDB cluster, use `kubectl port-forward` to expose the services to
 
 - Access TiDB using the MySQL client
 
-    1. Get the TiDB password
-
-	    ```sh
-		$ PASSWORD=$(kubectl get secret -n tidb demo-tidb -ojsonpath="{.data.password}" | base64 --decode | awk '{print $6}')
-		$ echo ${PASSWORD}
-		```
-
     1. Use `kubectl` to forward the host machine port to the TiDB service port:
 
         ```sh

--- a/docs/operation-guide.md
+++ b/docs/operation-guide.md
@@ -31,12 +31,15 @@ For other settings, the variables in `values.yaml` are self-explanatory with com
 
 By default TiDB service is exposed using [`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). You can modify it to `ClusterIP` which will disable access from outside of the cluster. Or modify it to [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) if the underlining Kubernetes supports this kind of service.
 
-By default TiDB cluster is deployed with a random generated password. You can specify a password by setting `tidb.password` in `values.yaml` before deploying. Whether you specify the password or not, you can retrieve the password through `Secret`:
+```shell
+$ kubectl get svc -n ${namespace} # check the available services
+```
+
+By default the TiDB cluster has no password set. You can specify a password by setting `tidb.password` in `values.yaml` before deploying. You can retrieve the password from the initialization `Secret`:
 
 ```shell
 $ PASSWORD=$(kubectl get secret -n ${namespace} ${clusterName}-tidb -ojsonpath="{.data.password}" | base64 --decode | awk '{print $6}')
 $ echo ${PASSWORD}
-$ kubectl get svc -n ${namespace} # check the available services
 ```
 
 * Access inside of the Kubernetes cluster


### PR DESCRIPTION
## Changes

Don't create
* a secret
* an initializer job

## Motivation

From my reading, random password initialization is broken: https://github.com/helm/helm/issues/3053

The user can manage users from the MySQL connection
As a benefit this allows users manage their password such that it is never stored in K8s. Or they can create their own init job, etc.

## Testing

- [ ] Run with -set tidb.password=password
- [X] Run without setting the tidb password

 For both options:
* Perform output suggested in NOTES
* Verify whether secret/initializer are created