### PR TITLE
Change binlog/enable from bool to string

### DIFF
--- a/charts/tidb-cluster/templates/config/_tidb-config.tpl
+++ b/charts/tidb-cluster/templates/config/_tidb-config.tpl
@@ -237,7 +237,7 @@ capacity = 10240000
 
 [binlog]
 # enable to write binlog.
-enable = false
+enable = "off"
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.
 write-timeout = "15s"


### PR DESCRIPTION
Change 0dada1ec37df88d0bcdc6b6cf687407ba9393d6f to tidb made binlog/enable a string instead of bool.