### PR TITLE
Add additionalPrintColumns for TidbCluster CRD

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -20,6 +20,51 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - tc
+  additionalPrinterColumns:
+  - name: PD
+    type: string
+    description: The image for PD cluster
+    JSONPath: .spec.pd.image
+  - name: Storage
+    type: string
+    description: The storage size specified for PD node
+    JSONPath: .spec.pd.requests.storage
+  - name: Ready
+    type: integer
+    description: The ready replicas number of PD cluster
+    JSONPath: .status.pd.statefulSet.readyReplicas
+  - name: Desire
+    type: integer
+    description: The desired replicas number of PD cluster
+    JSONPath: .spec.pd.replicas
+  - name: TiKV
+    type: string
+    description: The image for TiKV cluster
+    JSONPath: .spec.tikv.image
+  - name: Storage
+    type: string
+    description: The storage size specified for TiKV node
+    JSONPath: .spec.tikv.requests.storage
+  - name: Ready
+    type: integer
+    description: The ready replicas number of TiKV cluster
+    JSONPath: .status.tikv.statefulSet.readyReplicas
+  - name: Desire
+    type: integer
+    description: The desired replicas number of TiKV cluster
+    JSONPath: .spec.tikv.replicas
+  - name: TiDB
+    type: string
+    description: The image for TiDB cluster
+    JSONPath: .spec.tidb.image
+  - name: Ready
+    type: integer
+    description: The ready replicas number of TiDB cluster
+    JSONPath: .status.tidb.statefulSet.readyReplicas
+  - name: Desire
+    type: integer
+    description: The desired replicas number of TiDB cluster
+    JSONPath: .spec.tidb.replicas
   validation:
    # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:


### PR DESCRIPTION
Testing result in my local 1.13 cluster:

```shell
kubectl get tidbcluster
NAME           PD                  STORAGE   READY   DESIRE   TIKV                  STORAGE   READY   DESIRE   TIDB                  READY   DESIRE
aylei-master   pingcap/pd:v2.1.0   1Gi       3       3        pingcap/tikv:v2.1.0   10Gi      5       5        pingcap/tidb:v2.1.0   4       4
```

Signed-off-by: Aylei <rayingecho@gmail.com>