### PR TITLE
ensure test env normal and completed before cases run

### DIFF
--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -39,6 +39,11 @@ func main() {
 	conf := tests.ParseConfigOrDie()
 	cli, kubeCli := client.NewCliOrDie()
 	oa := tests.NewOperatorActions(cli, kubeCli, conf)
+	fta := tests.NewFaultTriggerAction(cli, kubeCli, conf)
+	err := fta.CheckAndRecoverEnv()
+	if err != nil {
+		glog.Fatal(err)
+	}
 
 	tidbVersion := conf.GetTiDBVersionOrDie()
 	upgardeTiDBVersions := conf.GetUpgradeTidbVersionsOrDie()
@@ -203,7 +208,6 @@ func main() {
 	backup.NewBackupCase(oa, clusterBackupFrom, clusterRestoreTo).RunOrDie()
 
 	// stop a node and failover automatically
-	fta := tests.NewFaultTriggerAction(cli, kubeCli, conf)
 	physicalNode, node, faultTime := fta.StopNodeOrDie()
 	oa.CheckFailoverPendingOrDie(allClusters, &faultTime)
 	oa.CheckFailoverOrDie(allClusters, node)

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -40,10 +40,7 @@ func main() {
 	cli, kubeCli := client.NewCliOrDie()
 	oa := tests.NewOperatorActions(cli, kubeCli, conf)
 	fta := tests.NewFaultTriggerAction(cli, kubeCli, conf)
-	err := fta.CheckAndRecoverEnv()
-	if err != nil {
-		glog.Fatal(err)
-	}
+	fta.CheckAndRecoverEnvOrDie()
 
 	tidbVersion := conf.GetTiDBVersionOrDie()
 	upgardeTiDBVersions := conf.GetUpgradeTidbVersionsOrDie()

--- a/tests/fault.go
+++ b/tests/fault.go
@@ -24,6 +24,7 @@ const (
 
 type FaultTriggerActions interface {
 	CheckAndRecoverEnv() error
+	CheckAndRecoverEnvOrDie()
 	StopNode() (string, string, time.Time, error)
 	StopNodeOrDie() (string, string, time.Time)
 	StartNode(physicalNode string, node string) error
@@ -106,6 +107,12 @@ func (fa *faultTriggerActions) CheckAndRecoverEnv() error {
 	}
 
 	return nil
+}
+
+func (fa *faultTriggerActions) CheckAndRecoverEnvOrDie() {
+	if err:=fa.CheckAndRecoverEnv();err!=nil{
+		glog.Fatal(err)
+	}
 }
 
 func (fa *faultTriggerActions) StopNode() (string, string, time.Time, error) {

--- a/tests/fault.go
+++ b/tests/fault.go
@@ -64,7 +64,7 @@ type faultTriggerActions struct {
 }
 
 func (fa *faultTriggerActions) CheckAndRecoverEnv() error {
-	// ensure all nodes are running
+	glog.Infof("ensure all nodes are running")
 	for _, physicalNode := range fa.cfg.Nodes {
 		for _, vNode := range physicalNode.Nodes {
 			err := fa.StartNode(physicalNode.PhysicalNode, vNode)
@@ -73,12 +73,12 @@ func (fa *faultTriggerActions) CheckAndRecoverEnv() error {
 			}
 		}
 	}
-	// ensure all etcds are running
+	glog.Infof("ensure all etcds are running")
 	err := fa.StartETCD()
 	if err != nil {
 		return err
 	}
-	// ensure all kubelets are running
+	glog.Infof("ensure all kubelets are running")
 	for _, physicalNode := range fa.cfg.Nodes {
 		for _, vNode := range physicalNode.Nodes {
 			err := fa.StartKubelet(vNode)
@@ -87,7 +87,7 @@ func (fa *faultTriggerActions) CheckAndRecoverEnv() error {
 			}
 		}
 	}
-	// ensure all static pods are running
+	glog.Infof("ensure all static pods are running")
 	for _, physicalNode := range fa.cfg.APIServers {
 		for _, vNode := range physicalNode.Nodes {
 			err := fa.StartKubeAPIServer(vNode)

--- a/tests/pkg/fault-trigger/manager/static_pod_service.go
+++ b/tests/pkg/fault-trigger/manager/static_pod_service.go
@@ -15,6 +15,7 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/golang/glog"
@@ -74,6 +75,10 @@ func (m *Manager) StopKubeControllerManager() error {
 
 func (m *Manager) stopStaticPodService(serviceName string, fileName string) error {
 	maniest := fmt.Sprintf("%s/%s", staticPodPath, fileName)
+	if _, err := os.Stat(maniest); os.IsNotExist(err) {
+		glog.Infof("%s had been stopped before", serviceName)
+		return nil
+	}
 	shell := fmt.Sprintf("mkdir -p %s && mv %s %s", staticPodTmpPath, maniest, staticPodTmpPath)
 
 	cmd := exec.Command("/bin/sh", "-c", shell)
@@ -90,6 +95,10 @@ func (m *Manager) stopStaticPodService(serviceName string, fileName string) erro
 
 func (m *Manager) startStaticPodService(serviceName string, fileName string) error {
 	maniest := fmt.Sprintf("%s/%s", staticPodTmpPath, fileName)
+	if _, err := os.Stat(maniest); err == nil {
+		glog.Infof("%s had been started before", serviceName)
+		return nil
+	}
 	shell := fmt.Sprintf("mv %s %s", maniest, staticPodPath)
 
 	cmd := exec.Command("/bin/sh", "-c", shell)

--- a/tests/pkg/fault-trigger/manager/static_pod_service.go
+++ b/tests/pkg/fault-trigger/manager/static_pod_service.go
@@ -95,7 +95,7 @@ func (m *Manager) stopStaticPodService(serviceName string, fileName string) erro
 
 func (m *Manager) startStaticPodService(serviceName string, fileName string) error {
 	maniest := fmt.Sprintf("%s/%s", staticPodTmpPath, fileName)
-	if _, err := os.Stat(maniest); err == nil {
+	if _, err := os.Stat(maniest); os.IsNotExist(err) {
 		glog.Infof("%s had been started before", serviceName)
 		return nil
 	}


### PR DESCRIPTION
currently, stability test directly runs on k8s cluster without the test env check, this may cause invalid test and results. this pr add test env check and recover to ensure it is normal before the stability test cases start running; in the other hand if recover failed, the stability test will be failed,  need to recover  test environment manually.



