### PR TITLE
Update e2e workflow in CONTRIBUTING.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ e2e-docker-push: e2e-docker
 	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator-e2e:latest"
 
 e2e-docker: e2e-build
-	[[ -d tests/images/e2e/tidb-operator ]] && rm -r tests/images/e2e/tidb-operator || true
-	[[ -d tests/images/e2e/tidb-cluster ]] && rm -r tests/images/e2e/tidb-cluster || true
-	[[ -d tests/images/e2e/tidb-backup ]] && rm -r tests/images/e2e/tidb-backup || true
+	[ -d tests/images/e2e/tidb-operator ] && rm -r tests/images/e2e/tidb-operator || true
+	[ -d tests/images/e2e/tidb-cluster ] && rm -r tests/images/e2e/tidb-cluster || true
+	[ -d tests/images/e2e/tidb-backup ] && rm -r tests/images/e2e/tidb-backup || true
 	cp -r charts/tidb-operator tests/images/e2e
 	cp -r charts/tidb-cluster tests/images/e2e
 	cp -r charts/tidb-backup tests/images/e2e

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -122,7 +122,7 @@ $ make e2e-docker-push
 After Docker images are pushed to the DinD Docker registry, run e2e tests:
 
 ```sh
-$ kubectl apply -f manifests/tidb-operator-e2e.yaml
+$ kubectl apply -f tests/manifests/e2e/e2e.yaml
 ```
 
 You can get the e2e test report from the log of testing pod: 

--- a/tests/manifests/e2e/e2e.yaml
+++ b/tests/manifests/e2e/e2e.yaml
@@ -27,7 +27,7 @@ spec:
   serviceAccount: tidb-operator-e2e
   containers:
   - name: tidb-operator-e2e
-    image: ""
+    image: 127.0.0.1:5000/pingcap/tidb-operator-e2e:latest
     imagePullPolicy: Always
     command:
     - /usr/local/bin/e2e


### PR DESCRIPTION
- use `[` instead of `[[` to be sh-compatible (more portable)
- fix e2e workflow in CONTRIBUTING.md
 
`make e2e-docker` builds e2e image from `tests/images/e2e` instead of `images/tidb-operator-e2e`, we should use new e2e yaml file `tests/manifests/e2e/e2e.yaml`.

xref: #346