### PR TITLE
Update Jenkins links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [**Blog**](https://www.pingcap.com/blog/)
 - [**For support, please contact PingCAP**](http://bit.ly/contact_us_via_github)
 
-[![Build Status](https://internal.pingcap.net/jenkins/job/build_tidb_operator_master/badge/icon)](https://internal.pingcap.net/jenkins/job/build_tidb_operator_master)
+[![Build Status](https://internal.pingcap.net/idc-jenkins/job/operator_ghpr_e2e_test/badge/icon)](https://internal.pingcap.net/idc-jenkins/job/operator_ghpr_e2e_test)
 [![codecov](https://codecov.io/gh/pingcap/tidb-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/tidb-operator)
 
 TiDB Operator manages [TiDB](https://github.com/pingcap/tidb) clusters on [Kubernetes](https://kubernetes.io) and automates tasks related to operating a TiDB cluster. It makes TiDB a truly cloud-native database.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [**Blog**](https://www.pingcap.com/blog/)
 - [**For support, please contact PingCAP**](http://bit.ly/contact_us_via_github)
 
-[![Build Status](https://internal.pingcap.net/idc-jenkins/job/operator_ghpr_e2e_test/badge/icon)](https://internal.pingcap.net/idc-jenkins/job/operator_ghpr_e2e_test)
+[![Build Status](https://internal.pingcap.net/idc-jenkins/job/build_tidb_operator_master/badge/icon)](https://internal.pingcap.net/idc-jenkins/job/build_tidb_operator_master)
 [![codecov](https://codecov.io/gh/pingcap/tidb-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/tidb-operator)
 
 TiDB Operator manages [TiDB](https://github.com/pingcap/tidb) clusters on [Kubernetes](https://kubernetes.io) and automates tasks related to operating a TiDB cluster. It makes TiDB a truly cloud-native database.


### PR DESCRIPTION
- job url: https://internal.pingcap.net/jenkins/job/build_tidb_operator_master -> https://internal.pingcap.net/idc-jenkins/job/build_tidb_operator_master
- badge image: https://internal.pingcap.net/jenkins/job/build_tidb_operator_master/badge/icon -> https://internal.pingcap.net/idc-jenkins/job/build_tidb_operator_master/badge/icon

I guess, we migrated to `https://internal.pingcap.net/idc-jenkins` now.