### PR TITLE
Support plugin start argument for tidb instance

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
@@ -41,7 +41,7 @@ then
 fi
 
 {{- if .Values.tidb.plugin.enable | default false }}
-ARGS="${ARGS}  --plugin-dir  {{ .Values.tidb.plugin.directory  }} --plugin-load {{ .Values.tidb.plugin.list }}  "
+ARGS="${ARGS}  --plugin-dir  {{ .Values.tidb.plugin.directory  }} --plugin-load {{ .Values.tidb.plugin.list  | join ","  }}  "
 {{- end }}
 
 echo "start tidb-server ..."

--- a/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
@@ -40,6 +40,10 @@ then
     ARGS="${ARGS} --log-slow-query=${SLOW_LOG_FILE:-}"
 fi
 
+{{- if .Values.tidb.plugin.enable | default false }}
+ARGS="${ARGS}  --plugin-dir  {{ .Values.tidb.plugin.directory  }} --plugin-load {{ .Values.tidb.plugin.list }}  "
+{{- end }}
+
 echo "start tidb-server ..."
 echo "/tidb-server ${ARGS}"
 exec /tidb-server ${ARGS}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -194,10 +194,10 @@ tidb:
 
   # tidb plugin configuration
   plugin:
-    # enable pulgin or not
+    # enable plugin or not
     enable: false
     # the start argument to specify the folder containing
-    directory: /pulugins
+    directory: /plugins
     # the start argument to specify the plugin id (name "-" version) that needs to be loaded, e.g. 'conn_limit-1'.
     list: whitelist-1
 

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -199,7 +199,7 @@ tidb:
     # the start argument to specify the folder containing
     directory: /plugins
     # the start argument to specify the plugin id (name "-" version) that needs to be loaded, e.g. 'conn_limit-1'.
-    list: whitelist-1
+    list: ["whitelist-1"]
 
 # mysqlClient is used to set password for TiDB
 # it must has Python MySQL client installed

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -192,6 +192,15 @@ tidb:
         cpu: 20m
         memory: 5Mi
 
+  # tidb plugin configuration
+  plugin:
+    # enable pulgin or not
+    enable: false
+    # the start argument to specify the folder containing
+    directory: /pulugins
+    # the start argument to specify the plugin id (name "-" version) that needs to be loaded, e.g. 'conn_limit-1'.
+    list: whitelist-1
+
 # mysqlClient is used to set password for TiDB
 # it must has Python MySQL client installed
 mysqlClient:


### PR DESCRIPTION
Support plugin start argument for tidb instance. The default value is disabled

Tests
- enable the plugin,  ARGS is appended as expected.
` ARGS="${ARGS}  --plugin-dir  /pulugins --plugin-load whitelist-1  "`
- disable the plugin, no plugin argument is added