### PR TITLE
add GitHub templates for issue reporting and PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: "\U0001F41B Bug Report"
+about: Something isn't working as expected
+
+---
+
+## Bug Report
+
+**What version of Kubernetes are you using?**
+<!-- You can run `kubectl version` -->
+
+**What storage classes exist in the Kubernetes cluster?**
+<!-- You can run `kubectl get sc` -->
+
+**What version of TiDB Operator are you using?**
+<!-- You can run `kubectl exec -n tidb-admin {tidb-controller-manager-pod-name} -- tidb-controller-manager -V` -->
+
+**What storage classes are used for PD and TiKV?**
+<!-- You can run `kubectl get pvc -n {tidb-cluster-namespace}` -->
+
+**What's the status of the TiDB cluster pods?**
+<!-- You can run `kubectl get po -n {tidb-cluster-namespace} -o wide` -->
+
+**What did you do?**
+<!-- If possible, provide a recipe for reproducing the error. A complete runnable program is good. -->
+
+**What did you expect to see?**
+
+**What did you see instead?**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,20 +9,17 @@ about: Something isn't working as expected
 **What version of Kubernetes are you using?**
 <!-- You can run `kubectl version` -->
 
-**What storage classes exist in the Kubernetes cluster?**
-<!-- You can run `kubectl get sc` -->
-
 **What version of TiDB Operator are you using?**
 <!-- You can run `kubectl exec -n tidb-admin {tidb-controller-manager-pod-name} -- tidb-controller-manager -V` -->
 
-**What storage classes are used for PD and TiKV?**
-<!-- You can run `kubectl get pvc -n {tidb-cluster-namespace}` -->
+**What storage classes exist in the Kubernetes cluster and what are used for PD/TiKV pods?**
+<!-- You can run `kubectl get sc` and `kubectl get pvc -n {tidb-cluster-namespace}` -->
 
 **What's the status of the TiDB cluster pods?**
 <!-- You can run `kubectl get po -n {tidb-cluster-namespace} -o wide` -->
 
 **What did you do?**
-<!-- If possible, provide a recipe for reproducing the error. A complete runnable program is good. -->
+<!-- If possible, provide a recipe for reproducing the error. How you installed tidb-operator and tidb-cluster. -->
 
 **What did you expect to see?**
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F680 Feature Request"
+about: I have a suggestion
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe:**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the feature you'd like:**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered:**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Teachability, Documentation, Adoption, Migration Strategy:**
+<!-- If you can, explain some scenarios how users might use this, situations it would be helpful in. Any API designs, mockups, or diagrams are also helpful. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,8 +8,7 @@ about: Usage question that isn't answered in docs or discussion
 
 Before asking a question, make sure you have:
 
-- Searched existing Stack Overflow questions.
-- Googled your question.
+- Reviewed relevant Kubernetes information: Google your error messages and look at K8s docs.
 - Searched open and closed [GitHub issues](https://github.com/pingcap/tidb-operator/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Read the documentation:
   - [TiDB Operator Readme](https://github.com/pingcap/tidb-operator)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: "\U0001F914 Question"
+about: Usage question that isn't answered in docs or discussion
+
+---
+
+## Question
+
+Before asking a question, make sure you have:
+
+- Searched existing Stack Overflow questions.
+- Googled your question.
+- Searched open and closed [GitHub issues](https://github.com/pingcap/tidb-operator/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- Read the documentation:
+  - [TiDB Operator Readme](https://github.com/pingcap/tidb-operator)
+  - [TiDB Operator Doc](https://github.com/pingcap/tidb-operator/tree/master/docs)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
 -->
 
-### What problem does this PR solve? <!--add issue link with summary if exists-->
+### What problem does this PR solve? <!--add and issue link with summary if exists-->
 
 ### What is changed and how it works?
 
@@ -12,6 +12,7 @@ Tests <!-- At least one of them must be included. -->
 
  - Unit test
  - E2E test
+ - Stability test
  - Manual test (add detailed scripts or steps below)
  - No code
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
+-->
+
+### What problem does this PR solve? <!--add issue link with summary if exists-->
+
+### What is changed and how it works?
+
+### Check List <!--REMOVE the items that are not applicable-->
+
+Tests <!-- At least one of them must be included. -->
+
+ - Unit test
+ - E2E test
+ - Manual test (add detailed scripts or steps below)
+ - No code
+
+Code changes
+
+ - Has Helm charts change
+ - Has Go code change
+ - Has CI related scripts change
+
+Side effects
+
+ - Increased code complexity
+ - Breaking backward compatibility
+
+Related changes
+
+ - Need to cherry-pick to the release branch
+ - Need to update the documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,10 +20,10 @@ Code changes
  - Has Helm charts change
  - Has Go code change
  - Has CI related scripts change
+ - Has documents change
 
 Side effects
 
- - Increased code complexity
  - Breaking backward compatibility
 
 Related changes


### PR DESCRIPTION
GitHub allows a repository to [create issue templates and PR template under the `.github` directory](https://help.github.com/en/articles/about-issue-and-pull-request-templates). This PR adds some templates for issue reporting and PR. It should help users, contributors and ourselves to communicate more efficiently.