### PR TITLE
Fix TiDB Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TiDB Operator
 
 - [**Stack Overflow**](https://stackoverflow.com/questions/tagged/tidb)
-- [**Community Slack Channel**](http://bit.ly/tidbslack)
+- [**Community Slack Channel**](https://join.slack.com/t/tidbcommunity/shared_invite/enQtNjIyNjA5Njk0NTAxLTVmZDkxOWY1ZGZhMDg3YzcwNGU0YmM4ZjIyODRhOTg4MWEwZjJmMGQzZTJlNjllMGY1YzdlNzIxZGE2NzRlMGY)
 - [**Reddit**](https://www.reddit.com/r/TiDB/)
 - **Mailing list**: [Google Group](https://groups.google.com/forum/#!forum/tidb-user)
 - [**Blog**](https://www.pingcap.com/blog/)


### PR DESCRIPTION
Simple change to README.me to fix broken TiDB Slack link.