### PR TITLE
make grafana configuration extensible

### DIFF
--- a/charts/tidb-cluster/templates/monitor-deployment.yaml
+++ b/charts/tidb-cluster/templates/monitor-deployment.yaml
@@ -114,18 +114,6 @@ spec:
           containerPort: 3000
           protocol: TCP
         env:
-        # The following two env (SERVER_ROOT_URL and SERVER_DOMAIN) should be configured in configuration file
-        # but grafana container startup script will chown of configuration directory
-        # this will be failed because configmap is mounted as readonly volume in container
-        # so they're temporarily set here as env
-        {{- if .Values.monitor.grafana.serverRootUrl }}
-        - name: GF_SERVER_ROOT_URL
-          value: {{ .Values.monitor.grafana.serverRootUrl | quote }}
-        {{- end }}
-        {{- if .Values.monitor.grafana.serverRootUrl }}
-        - name: GF_SERVER_DOMAIN
-          value: {{ .Values.monitor.grafana.serverDomain | quote }}
-        {{- end }}
         - name: GF_PATHS_DATA
           value: /data/grafana
         - name: GF_SECURITY_ADMIN_USER
@@ -138,6 +126,12 @@ spec:
             secretKeyRef:
               name: {{ template "cluster.name" . }}-monitor
               key: password
+         {{- if .Values.monitor.grafana.config }}
+         {{- range $key, $value := .Values.monitor.grafana.config }}
+         - name: GF_{{ $key | replace "." "_" | upper }}
+           value: {{ $value | quote }}
+         {{- end }}
+         {{- end }}
         - name: TZ
           value: {{ .Values.timezone | default "UTC" }}
         volumeMounts:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -221,6 +221,15 @@ monitor:
     image: grafana/grafana:6.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
+    # Here you can set any value in grafana.ini
+    # Note that these are set as environment variables
+    # There is a grafana.ini file in the chart mounted as a configmap that you can also customize
+    config:
+      # if grafana is running behind a reverse proxy with subpath http://foo.bar/grafana
+      # config the `serverDomain` and `serverRootUrl` as follows
+      # "server.domain": foo.bar
+      # "server.root_url": "%(protocol)s://%(domain)s/grafana/"
+
     resources:
       limits: {}
       #   cpu: 8000m
@@ -232,10 +241,6 @@ monitor:
     password: admin
     service:
       type: NodePort
-    # if grafana is running behind a reverse proxy with subpath http://foo.bar/grafana
-    # config the `serverDomain` and `serverRootUrl` as follows
-    # serverDomain: foo.bar
-    # serverRootUrl: "%(protocol)s://%(domain)s/grafana/"
   prometheus:
     image: prom/prometheus:v2.2.1
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This way we don't have to do any additional grafana config templating

@tennix this is relevant to changes in #435

I have properly tested this change but not on this version of the charts I just pull-requested to master.