### PR TITLE
Update DinD image to make it possible to configure HTTP proxies

### DIFF
--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -43,6 +43,15 @@ $ manifests/local-dind/dind-cluster-v1.12.sh up
 $ KUBE_REPO_PREFIX=uhub.ucloud.cn/pingcap manifests/local-dind/dind-cluster-v1.12.sh up
 ```
 
+> **Note:** An alternative solution is to configure HTTP proxies in DinD.
+
+```
+$ export DIND_HTTP_PROXY=http://<ip>:<port>
+$ export DIND_HTTPS_PROXY=http://<ip>:<port>
+$ export DIND_NO_PROXY=.svc,.local,127.0.0.1,0,1,2,3,4,5,6,7,8,9 # whitelist internal domains and IP addresses
+$ manifests/local-dind/dind-cluster-v1.12.sh up
+```
+
 ## Step 2: Install TiDB Operator in the DinD Kubernetes cluster
 
 ```sh

--- a/manifests/local-dind/dind-cluster-v1.10.sh
+++ b/manifests/local-dind/dind-cluster-v1.10.sh
@@ -52,7 +52,7 @@ if [[ $(uname) == Linux && -z ${DOCKER_HOST:-} ]]; then
     using_local_linuxdocker=1
 fi
 
-EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster@sha256:ba1b61973fb4761f209580c599c17eab7c2e1bead5dfe496aab47c5ff672b05f
+EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster@sha256:0a68bdc682af3e102bafb9efa304a1b50aec0b2c64c086c34004d4d289e5b173
 
 KUBE_REPO_PREFIX="${KUBE_REPO_PREFIX:-}"
 if [[ -n ${KUBE_REPO_PREFIX} ]];then

--- a/manifests/local-dind/dind-cluster-v1.12.sh
+++ b/manifests/local-dind/dind-cluster-v1.12.sh
@@ -52,7 +52,7 @@ if [[ $(uname) == Linux && -z ${DOCKER_HOST:-} ]]; then
     using_local_linuxdocker=1
 fi
 
-EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster@sha256:8e679951101f3f2030e77a1146cc514631f21f424027fcc003fc78a0337eb730
+EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster@sha256:48782c23bedd3f9c3d42af0ab0417eeff7d7884eac20a67adcb0c8534a97fce1
 
 KUBE_REPO_PREFIX="${KUBE_REPO_PREFIX:-}"
 if [[ -n ${KUBE_REPO_PREFIX} ]];then


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes https://github.com/pingcap/tidb-operator/issues/461

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test (add detailed scripts or steps below)

configure http proxies in docker config.json

```
    "proxies": {
        "default": {
            "httpProxy": "http://192.168.90.1:1087",
            "httpsProxy": "http://192.168.90.1:1087",
            "noProxy": ".svc,.local,127.0.0.1,0,1,2,3,4,5,6,7,8,9"
        }   
    }
```

propagate http proxies to dind containers

```
export DIND_PROPAGATE_HTTP_PROXY=true
manifests/local-dind/dind-cluster-v1.12.sh up
```