### PR TITLE
Refine aliyun and aws cloud tidb configurations

### DIFF
--- a/deploy/aliyun/README-CN.md
+++ b/deploy/aliyun/README-CN.md
@@ -18,7 +18,7 @@
 - 一个新的 VPC；
 - 一台 ECS 实例作为堡垒机；
 - 一个托管版 ACK(阿里云 Kubernetes)集群以及一系列 worker 节点：
-  - 属于一个伸缩组的 2 台 ECS 实例(1核1G), 托管版 Kubernetes 的默认伸缩组中必须至少有两台实例, 用于承载整个的系统服务, 比如 CoreDNS
+  - 属于一个伸缩组的 2 台 ECS 实例(2核2G), 托管版 Kubernetes 的默认伸缩组中必须至少有两台实例, 用于承载整个的系统服务, 比如 CoreDNS
   - 属于一个伸缩组的 3 台 `ecs.i2.xlarge` 实例, 用于部署 PD
   - 属于一个伸缩组的 3 台 `ecs.i2.2xlarge` 实例, 用于部署 TiKV
   - 属于一个伸缩组的 2 台 ECS 实例(16核32G)用于部署 TiDB

--- a/deploy/aliyun/README.md
+++ b/deploy/aliyun/README.md
@@ -20,7 +20,7 @@ The default setup will create:
 - A new VPC 
 - An ECS instance as bastion machine
 - A managed ACK(Alibaba Cloud Kubernetes) cluster with the following ECS instance worker nodes:
-  - An auto-scaling group of 2 * instances(1c1g) as ACK mandatory workers for system service like CoreDNS
+  - An auto-scaling group of 2 * instances(2c2g) as ACK mandatory workers for system service like CoreDNS
   - An auto-scaling group of 3 * `ecs.i2.xlarge` instances for PD
   - An auto-scaling group of 3 * `ecs.i2.2xlarge` instances for TiKV
   - An auto-scaling group of 2 * instances(16c32g) for TiDB

--- a/deploy/aliyun/data.tf
+++ b/deploy/aliyun/data.tf
@@ -15,6 +15,7 @@ data "template_file" "tidb-cluster-values" {
     tikv_writecf_block_cache_size   = "${var.tikv_memory_size * 0.2}GB"
     monitor_reserve_days            = "${var.monitor_reserve_days}"
     monitor_slb_network_type        = "${var.monitor_slb_network_type}"
+    monitor_enable_anonymous_user   = "${var.monitor_enable_anonymous_user}"
   }
 }
 

--- a/deploy/aliyun/main.tf
+++ b/deploy/aliyun/main.tf
@@ -46,6 +46,8 @@ module "ack" {
   vpc_id           = "${var.vpc_id}"
   group_id         = "${var.group_id}"
 
+  default_worker_cpu_core_count = "${var.default_worker_core_count}"
+
   worker_groups = [
     {
       name          = "pd_worker_group"

--- a/deploy/aliyun/outputs.tf
+++ b/deploy/aliyun/outputs.tf
@@ -6,6 +6,10 @@ output "cluster_id" {
   value = "${module.ack.cluster_id}"
 }
 
+output "cluster_name" {
+  value = "${var.cluster_name}"
+}
+
 output "kubeconfig_file" {
   value = "${module.ack.kubeconfig_filename}"
 }

--- a/deploy/aliyun/templates/tidb-cluster-values.yaml.tpl
+++ b/deploy/aliyun/templates/tidb-cluster-values.yaml.tpl
@@ -255,7 +255,7 @@ monitor:
     config:
       # Configure Grafana using environment variables except GF_PATHS_DATA, GF_SECURITY_ADMIN_USER and GF_SECURITY_ADMIN_PASSWORD
       # Ref https://grafana.com/docs/installation/configuration/#using-environment-variables
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: %{ if monitor_enable_anonymous_user }"true"%{ else }"false"%{ endif }
       GF_AUTH_ANONYMOUS_ORG_NAME: "Main Org."
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
       # if grafana is running behind a reverse proxy with subpath http://foo.bar/grafana

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -5,7 +5,7 @@ variable "cluster_name" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v2.1.0"
+  default     = "v2.1.8"
 }
 
 variable "pd_count" {
@@ -25,7 +25,7 @@ variable "pd_instance_memory_size" {
 
 variable "tikv_count" {
   description = "TiKV instance count, ranges: [3, 100]"
-  default     = 4
+  default     = 3
 }
 
 variable "tikv_instance_type_family" {
@@ -40,7 +40,7 @@ variable "tikv_memory_size" {
 
 variable "tidb_count" {
   description = "TiDB instance count, ranges: [1, 100]"
-  default     = 3
+  default     = 2
 }
 
 variable "tidb_instance_type" {
@@ -86,6 +86,11 @@ variable "monitor_reserve_days" {
   default     = 14
 }
 
+variable "default_worker_core_count" {
+  description = "CPU core count of default kubernetes workers"
+  default = 2
+}
+
 variable "create_bastion" {
   description = "Whether create bastion server"
   default     = true
@@ -115,6 +120,11 @@ variable "monitor_slb_network_type" {
   default     = "internet"
 }
 
+variable "monitor_enable_anonymous_user" {
+  description = "Whether enabling anonymous user visiting for monitoring"
+  default = false
+}
+
 variable "vpc_id" {
   description = "VPC id, specify this variable to use an exsiting VPC and the vswitches in the VPC. Note that when using existing vpc, it is recommended to use a existing security group too. Otherwise you have to set vpc_cidr according to the existing VPC settings to get correct in-cluster security rule."
   default     = ""
@@ -142,5 +152,5 @@ variable "k8s_service_cidr" {
 
 variable "vpc_cidr" {
   description = "VPC cidr_block, options: [192.168.0.0.0/16, 172.16.0.0/16, 10.0.0.0/8], cannot collidate with kubernetes service cidr and pod cidr. Cannot change once the vpc created."
-  default     = "192.168.0.0/16"
+  default = "192.168.0.0/16"
 }

--- a/deploy/aws/data.tf
+++ b/deploy/aws/data.tf
@@ -18,6 +18,7 @@ data "template_file" "tidb_cluster_values" {
     pd_replicas = "${var.pd_count}"
     tikv_replicas = "${var.tikv_count}"
     tidb_replicas = "${var.tidb_count}"
+    monitor_enable_anonymous_user = "${var.monitor_enable_anonymous_user}"
   }
 }
 

--- a/deploy/aws/templates/tidb-cluster-values.yaml.tpl
+++ b/deploy/aws/templates/tidb-cluster-values.yaml.tpl
@@ -258,7 +258,7 @@ monitor:
     config:
       # Configure Grafana using environment variables except GF_PATHS_DATA, GF_SECURITY_ADMIN_USER and GF_SECURITY_ADMIN_PASSWORD
       # Ref https://grafana.com/docs/installation/configuration/#using-environment-variables
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: %{ if monitor_enable_anonymous_user }"true"%{ else }"false"%{ endif }
       GF_AUTH_ANONYMOUS_ORG_NAME: "Main Org."
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
       # if grafana is running behind a reverse proxy with subpath http://foo.bar/grafana

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -105,3 +105,7 @@ variable "tikv_root_volume_size" {
   default = "100"
 }
 
+variable "monitor_enable_anonymous_user" {
+  description = "Whether enabling anonymous user visiting for monitoring"
+  default = false
+}


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

### What problem does this PR solve?
Improve the user experience of terraform deployment:

* Use tidb 2.1.8 by default for Aliyun
* Better defaults for Aliyun kubernetes cluster
* Disable Grafana anonymous user by default (both AWS and Aliyun expose Grafana to internet by default)
* Add an option to enable Grafana anonymous user
 
### What is changed and how it works?
Terraform scripts changed, more options are exposed.

### Check List
Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
$ terraform apply
```
@AstroProfundis @jlerche @tennix PTAL