### PR TITLE
Support adding additional pod annotations for PD/TiKV/TiDB

### DIFF
--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -42,6 +42,10 @@ spec:
     tolerations:
 {{ toYaml .Values.pd.tolerations | indent 4 }}
   {{- end }}
+  {{- if .Values.pd.annotations }}
+    annotations:
+{{ toYaml .Values.pd.annotations | indent 6 }}
+  {{- end }}
   tikv:
     replicas: {{ .Values.tikv.replicas }}
     image: {{ .Values.tikv.image }}
@@ -61,6 +65,10 @@ spec:
     tolerations:
 {{ toYaml .Values.tikv.tolerations | indent 4 }}
   {{- end }}
+  {{- if .Values.tikv.annotations }}
+    annotations:
+{{ toYaml .Values.tikv.annotations | indent 6 }}
+  {{- end }}
   tidb:
     replicas: {{ .Values.tidb.replicas }}
     image: {{ .Values.tidb.image }}
@@ -76,6 +84,10 @@ spec:
   {{- if .Values.tidb.tolerations }}
     tolerations:
 {{ toYaml .Values.tidb.tolerations | indent 4 }}
+  {{- end }}
+  {{- if .Values.tidb.annotations }}
+    annotations:
+{{ toYaml .Values.tidb.annotations | indent 6 }}
   {{- end }}
     binlogEnabled: {{ .Values.binlog.pump.create | default false }}
     maxFailoverCount: {{ .Values.tidb.maxFailoverCount | default 3 }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -88,6 +88,7 @@ pd:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
 
 tikv:
   replicas: 3
@@ -125,6 +126,7 @@ tikv:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
 
   # block-cache used to cache uncompressed blocks, big block-cache can speed up read.
   # in normal cases should tune to 30%-50% tikv.resources.limits.memory
@@ -203,6 +205,7 @@ tidb:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
   maxFailoverCount: 3
   service:
     type: NodePort

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -73,6 +73,7 @@ pd:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
 
 tikv:
   replicas: 3
@@ -106,6 +107,7 @@ tikv:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
 
 tikvPromGateway:
   image: prom/pushgateway:v0.3.1
@@ -146,6 +148,7 @@ tidb:
   #   operator: Equal
   #   value: tidb
   #   effect: "NoSchedule"
+  annotations: {}
   maxFailoverCount: 3
   service:
     type: NodePort

--- a/pkg/apis/pingcap.com/v1alpha1/types.go
+++ b/pkg/apis/pingcap.com/v1alpha1/types.go
@@ -112,6 +112,7 @@ type PDSpec struct {
 	NodeSelectorRequired bool                `json:"nodeSelectorRequired,omitempty"`
 	StorageClassName     string              `json:"storageClassName,omitempty"`
 	Tolerations          []corev1.Toleration `json:"tolerations,omitempty"`
+	Annotations          map[string]string   `json:"annotations,omitempty"`
 }
 
 // TiDBSpec contains details of PD member
@@ -122,6 +123,7 @@ type TiDBSpec struct {
 	NodeSelectorRequired bool                  `json:"nodeSelectorRequired,omitempty"`
 	StorageClassName     string                `json:"storageClassName,omitempty"`
 	Tolerations          []corev1.Toleration   `json:"tolerations,omitempty"`
+	Annotations          map[string]string     `json:"annotations,omitempty"`
 	BinlogEnabled        bool                  `json:"binlogEnabled,omitempty"`
 	MaxFailoverCount     int32                 `json:"maxFailoverCount,omitempty"`
 	SeparateSlowLog      bool                  `json:"separateSlowLog,omitempty"`
@@ -141,6 +143,7 @@ type TiKVSpec struct {
 	NodeSelectorRequired bool                `json:"nodeSelectorRequired,omitempty"`
 	StorageClassName     string              `json:"storageClassName,omitempty"`
 	Tolerations          []corev1.Toleration `json:"tolerations,omitempty"`
+	Annotations          map[string]string   `json:"annotations,omitempty"`
 }
 
 // TiKVPromGatewaySpec runs as a sidecar with TiKVSpec

--- a/pkg/apis/pingcap.com/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap.com/v1alpha1/zz_generated.deepcopy.go
@@ -103,6 +103,13 @@ func (in *PDSpec) DeepCopyInto(out *PDSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -252,6 +259,13 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.SlowLogTailer.DeepCopyInto(&out.SlowLogTailer)
 	return
 }
@@ -350,6 +364,13 @@ func (in *TiKVSpec) DeepCopyInto(out *TiKVSpec) {
 		*out = make([]v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -448,6 +448,7 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 	}
 	pdLabel := label.New().Instance(instanceName).PD()
 	setName := controller.PDMemberName(tcName)
+	podAnnotations := CombineAnnotations(controller.AnnProm(2379), tc.Spec.PD.Annotations)
 	storageClassName := tc.Spec.PD.StorageClassName
 	if storageClassName == "" {
 		storageClassName = controller.DefaultStorageClassName
@@ -472,7 +473,7 @@ func (pmm *pdMemberManager) getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster) 
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      pdLabel.Labels(),
-					Annotations: controller.AnnProm(2379),
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					SchedulerName: tc.Spec.SchedulerName,

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -330,6 +330,7 @@ func (tmm *tidbMemberManager) getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbClust
 	})
 
 	tidbLabel := label.New().Instance(instanceName).TiDB()
+	podAnnotations := CombineAnnotations(controller.AnnProm(10080), tc.Spec.TiDB.Annotations)
 	tidbSet := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            controller.TiDBMemberName(tcName),
@@ -343,7 +344,7 @@ func (tmm *tidbMemberManager) getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbClust
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      tidbLabel.Labels(),
-					Annotations: controller.AnnProm(10080),
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					SchedulerName: tc.Spec.SchedulerName,

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -311,6 +311,7 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 
 	tikvLabel := tkmm.labelTiKV(tc)
 	setName := controller.TiKVMemberName(tcName)
+	podAnnotations := CombineAnnotations(controller.AnnProm(20180), tc.Spec.TiKV.Annotations)
 	capacity := controller.TiKVCapacity(tc.Spec.TiKV.Limits)
 	headlessSvcName := controller.TiKVPeerMemberName(tcName)
 	storageClassName := tc.Spec.TiKV.StorageClassName
@@ -331,7 +332,7 @@ func (tkmm *tikvMemberManager) getNewSetForTidbCluster(tc *v1alpha1.TidbCluster)
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      tikvLabel.Labels(),
-					Annotations: controller.AnnProm(20180),
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					SchedulerName: tc.Spec.SchedulerName,

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -206,12 +206,11 @@ func tidbPodName(tcName string, ordinal int32) string {
 
 // CombineAnnotations merges two annotations maps
 func CombineAnnotations(a, b map[string]string) map[string]string {
-	m := make(map[string]string)
-	for k, v := range a {
-		m[k] = v
+	if a == nil {
+		a = make(map[string]string)
 	}
 	for k, v := range b {
-		m[k] = v
+		a[k] = v
 	}
-	return m
+	return a
 }

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -203,3 +203,11 @@ func pdPodName(tcName string, ordinal int32) string {
 func tidbPodName(tcName string, ordinal int32) string {
 	return fmt.Sprintf("%s-%d", controller.TiDBMemberName(tcName), ordinal)
 }
+
+// CombineAnnotations merges two annotations maps
+func CombineAnnotations(a map[string]string, b map[string]string) map[string]string {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -205,9 +205,13 @@ func tidbPodName(tcName string, ordinal int32) string {
 }
 
 // CombineAnnotations merges two annotations maps
-func CombineAnnotations(a map[string]string, b map[string]string) map[string]string {
-	for k, v := range b {
-		a[k] = v
+func CombineAnnotations(a, b map[string]string) map[string]string {
+	m := make(map[string]string)
+	for k, v := range a {
+		m[k] = v
 	}
-	return a
+	for k, v := range b {
+		m[k] = v
+	}
+	return m
 }


### PR DESCRIPTION
### What problem does this PR solve?

Support adding additional pod annotations for PD/TiKV/TiDB.
We could add pod annotation `fluentbit.io/parser: pingcap_log` for PD/TiKV/TiDB pod, so fluentbit knows that  the pod log should be processed using the pre-defined parser called `pingcap_log `.
refer: https://docs.fluentbit.io/manual/filter/kubernetes#kubernetes-annotations

### What is changed and how it works?

At the server side, `Annotations` field was added in TidbClusterSpec's Pod Spec (PDSpec, TiKVSpec and TiDBSpec). If Annotations field is not empty, the PD/TiKV/TiDB statefulset will add the annotation to PodTemplateSpec's Annotations field.

At the client side, you could add additional annotations in Helm values file `charts/tidb-cluster/values.yaml`. 

### Check List

Tests

 - [] Unit test
 - [] E2E test

The Unit and E2E test cases will be tracked in  issue https://github.com/pingcap/tidb-operator/issues/505.

Code changes

 - Has Helm charts change ✔️
 - Has Go code change ✔️

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Support adding additional pod annotations for PD/TiKV/TiDB,  e.g. [fluentbit.io/parser](https://docs.fluentbit.io/manual/filter/kubernetes#kubernetes-annotations).
 ```

