### PR TITLE
Fix e2e hyperkube image

### DIFF
--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -42,8 +42,7 @@ func main() {
 		ReleaseName:    "operator",
 		Image:          conf.OperatorImage,
 		Tag:            conf.OperatorTag,
-		SchedulerImage: "mirantis/hypokube",
-		SchedulerTag:   "final",
+		SchedulerImage: "gcr.akscn.io/google_containers/hyperkube",
 		SchedulerFeatures: []string{
 			"StableScheduling",
 		},


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix e2e hyperkube image, the original image has been deleted, the new image site is a mirror of gcr
