### PR TITLE
Fix stability tidb pause case

### DIFF
--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -235,7 +235,7 @@ func main() {
 
 		// only check manual pause for 1 cluster
 		if len(clusterInfos) >= 1 {
-			oa.CheckManualPauseTiDB(clusterInfos[0])
+			oa.CheckManualPauseTiDBOrDie(clusterInfos[0])
 		}
 
 		for _, clusterInfo := range clusterInfos {

--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -232,6 +232,12 @@ func main() {
 				glog.Fatal(err)
 			}
 		}
+
+		// only check manual pause for 1 cluster
+		if len(clusterInfos) >= 1 {
+			oa.CheckManualPauseTiDB(clusterInfos[0])
+		}
+
 		for _, clusterInfo := range clusterInfos {
 			if err = oa.CheckTidbClusterStatus(clusterInfo); err != nil {
 				glog.Fatal(err)

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -254,8 +254,13 @@ func run(oa tests.OperatorActions,
 	cluster2.UpgradeAll(firstUpgradeVersion)
 	oa.UpgradeTidbClusterOrDie(cluster1)
 	oa.UpgradeTidbClusterOrDie(cluster2)
+
+	// check pause upgrade feature in cluster2
+	oa.CheckManualPauseTiDBOrDie(cluster2)
+
 	oa.CheckTidbClusterStatusOrDie(cluster1)
 	oa.CheckTidbClusterStatusOrDie(cluster2)
+
 	oa.CheckTidbMemberAssignedNodesOrDie(cluster1, assignedNodes1)
 	oa.CheckTidbMemberAssignedNodesOrDie(cluster2, assignedNodes2)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Check the pause upgrade feature only when upgrading cluster 2. 
### What is changed and how it works?
Check the pause upgrade feature only once instead of every upgrade time
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Stability test

Code changes

 - Has Go code change


### Does this PR introduce a user-facing change?:

 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```