### PR TITLE
use staticcheck instead of megacheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test:
 	@echo "Run unit tests"
 	@$(GOTEST) ./pkg/... -coverprofile=coverage.txt -covermode=atomic && echo "\nUnit tests run successfully!"
 
-check-all: lint check-static check-shadow check-gosec megacheck errcheck
+check-all: lint check-static check-shadow check-gosec staticcheck errcheck
 
 check-setup:
 	@which retool >/dev/null 2>&1 || go get github.com/twitchtv/retool
@@ -99,11 +99,11 @@ check-static:
 	  --enable ineffassign \
 	  $$($(PACKAGE_DIRECTORIES))
 
-# TODO: megacheck is too slow currently
-megacheck:
-	@echo "gometalinter megacheck"
+# TODO: staticcheck is too slow currently
+staticcheck:
+	@echo "gometalinter staticcheck"
 	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --deadline 120s \
-	  --enable megacheck \
+	  --enable staticcheck \
 	  $$($(PACKAGE_DIRECTORIES))
 
 # TODO: errcheck is too slow currently

--- a/tools.json
+++ b/tools.json
@@ -13,8 +13,8 @@
       "Commit": "7bae11eba15a3285c75e388f77eb6357a2d73ee2"
     },
     {
-      "Repository": "honnef.co/go/tools/cmd/megacheck",
-      "Commit": "88497007e8588ea5b6baee991f74a1607e809487"
+      "Repository": "honnef.co/go/tools/cmd/staticcheck",
+      "Commit": "5a4a2f4a438d01ba03c591f88ef312005a05063b"
     },
     {
       "Repository": "github.com/kisielk/errcheck",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/dominikh/go-tools/blob/5a4a2f4a438d01ba03c591f88ef312005a05063b/doc/2019.1.html
```
At the core of the 2019.1 release lies the grand restructuring of all of the staticcheck tools.
  All of the individual checkers, as well as megacheck, have been merged into a single tool,
  which is simply called staticcheck.
```

So we use `staticcheck` instead of `megacheck`.

This pr fixes: #546


### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has CI related scripts change

Side effects


Related changes

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
