### PR TITLE
[DNM]set pd config strictly-match-label to false

### DIFF
--- a/charts/tidb-cluster/templates/config/_pd-config.tpl
+++ b/charts/tidb-cluster/templates/config/_pd-config.tpl
@@ -83,6 +83,7 @@ max-replicas = {{ .Values.pd.maxReplicas }}
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = ["region", "zone", "rack", "host"]
+strictly-match-label = false
 
 [label-property]
 # Do not assign region leaders to stores that have these tags.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
pd's default location-labels config in tidb-operator  is  `["region", "zone", "rack", "host"]`. If k8s nodes don't have four corresponding labels, tikv pods can't start. 
e.g.:
```
label configuration is incorrect, need to specify the key: region
```

### What is changed and how it works?
set pd's config `strictly-match-label` to `false`.（strictlyMatchLabel strictly checks if the label of TiKV is matched with LocaltionLabels.）
refer: https://github.com/pingcap/pd/blob/0a361b90a6acd86abdd75d13bc21d13744b294ed/server/config.go#L686

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test 
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code ☑️

Code changes

 - Has Helm charts change ☑️
 - Has Go code change
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
set pd config strictly-match-label to false
 ```