### PR TITLE
Gke terraform upgrade to 0.12 and fix bastion instance zone to be region agnostic

### DIFF
--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -7,7 +7,7 @@ This document describes how to deploy TiDB Operator and a TiDB cluster on GCP GK
 First of all, make sure the following items are installed on your machine:
 
 * [Google Cloud SDK](https://cloud.google.com/sdk/install)
-* [terraform](https://www.terraform.io/downloads.html)
+* [terraform](https://www.terraform.io/downloads.html) >= 0.12
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) >= 1.11
 * [helm](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client) >= 2.9.0
 * [jq](https://stedolan.github.io/jq/download/)

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -236,5 +236,3 @@ terraform destroy
 You have to manually delete disks in the Google Cloud Console, or with `gcloud` after running `terraform destroy` if you do not need the data anymore.
 
 > *Note*: When `terraform destroy` is running, an error with the following message might occur: `Error reading Container Cluster "my-cluster": Cluster "my-cluster" has status "RECONCILING" with message""`. This happens when GCP is upgrading the kubernetes master node, which it does automatically at times. While this is happening, it is not possible to delete the cluster. When it is done, run `terraform destroy` again.
-
-> *Note*: When `terraform destroy` is running, an error with the following message might occur: `Error deleting NodePool: googleapi: Error 400: Operation operation-1558952543255-89695179 is currently deleting a node pool for cluster my-cluster. Please wait and try again once it is done., failedPrecondition`. This happens when terraform issues delete requests to cluster resources concurrently. To resolve, wait a little bit and then run `terraform destroy` again.

--- a/deploy/gcp/data.tf
+++ b/deploy/gcp/data.tf
@@ -1,31 +1,32 @@
 data "template_file" "tidb_cluster_values" {
-  template = "${file("${path.module}/templates/tidb-cluster-values.yaml.tpl")}"
+  template = file("${path.module}/templates/tidb-cluster-values.yaml.tpl")
 
-  vars {
-    cluster_version  = "${var.tidb_version}"
-    pd_replicas      = "${var.pd_replica_count}"
-    tikv_replicas    = "${var.tikv_replica_count}"
-    tidb_replicas    = "${var.tidb_replica_count}"
-    operator_version = "${var.tidb_operator_version}"
+  vars = {
+    cluster_version  = var.tidb_version
+    pd_replicas      = var.pd_replica_count
+    tikv_replicas    = var.tikv_replica_count
+    tidb_replicas    = var.tidb_replica_count
+    operator_version = var.tidb_operator_version
   }
 }
 
 data "external" "tidb_ilb_ip" {
-  depends_on = ["null_resource.deploy-tidb-cluster"]
+  depends_on = [null_resource.deploy-tidb-cluster]
   program    = ["bash", "-c", "kubectl --kubeconfig ${local.kubeconfig} get svc -n tidb tidb-cluster-tidb -o json | jq '.status.loadBalancer.ingress[0]'"]
 }
 
 data "external" "monitor_ilb_ip" {
-  depends_on = ["null_resource.deploy-tidb-cluster"]
+  depends_on = [null_resource.deploy-tidb-cluster]
   program    = ["bash", "-c", "kubectl --kubeconfig ${local.kubeconfig} get svc -n tidb tidb-cluster-grafana -o json | jq '.status.loadBalancer.ingress[0]'"]
 }
 
 data "external" "tidb_port" {
-  depends_on = ["null_resource.deploy-tidb-cluster"]
+  depends_on = [null_resource.deploy-tidb-cluster]
   program    = ["bash", "-c", "kubectl --kubeconfig ${local.kubeconfig} get svc -n tidb tidb-cluster-tidb -o json | jq '.spec.ports | .[] | select( .name == \"mysql-client\") | {port: .port|tostring}'"]
 }
 
 data "external" "monitor_port" {
-  depends_on = ["null_resource.deploy-tidb-cluster"]
+  depends_on = [null_resource.deploy-tidb-cluster]
   program    = ["bash", "-c", "kubectl --kubeconfig ${local.kubeconfig} get svc -n tidb tidb-cluster-grafana -o json | jq '.spec.ports | .[] | select( .name == \"grafana\") | {port: .port|tostring}'"]
 }
+

--- a/deploy/gcp/data.tf
+++ b/deploy/gcp/data.tf
@@ -10,6 +10,11 @@ data "template_file" "tidb_cluster_values" {
   }
 }
 
+data external "available_zones_in_region" {
+  depends_on = [null_resource.prepare-dir]
+  program = ["bash", "-c", "gcloud compute regions describe ${var.GCP_REGION} --format=json | jq -r '.\"zones\" | .[0]' | grep -o '[^/]*$'"]
+}
+
 data "external" "tidb_ilb_ip" {
   depends_on = [null_resource.deploy-tidb-cluster]
   program    = ["bash", "-c", "kubectl --kubeconfig ${local.kubeconfig} get svc -n tidb tidb-cluster-tidb -o json | jq '.status.loadBalancer.ingress[0]'"]

--- a/deploy/gcp/data.tf
+++ b/deploy/gcp/data.tf
@@ -12,7 +12,7 @@ data "template_file" "tidb_cluster_values" {
 
 data external "available_zones_in_region" {
   depends_on = [null_resource.prepare-dir]
-  program = ["bash", "-c", "gcloud compute regions describe ${var.GCP_REGION} --format=json | jq -r '.\"zones\" | .[0]' | grep -o '[^/]*$'"]
+  program    = ["bash", "-c", "gcloud compute regions describe ${var.GCP_REGION} --format=json | jq '{zone: .zones|.[0]|match(\"[^/]*$\"; \"g\")|.string}'"]
 }
 
 data "external" "tidb_ilb_ip" {

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -110,7 +110,7 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "pd_pool" {
-  depends_on = [google_container_cluster.cluster]
+  depends_on         = [google_container_cluster.cluster]
   provider           = google-beta
   project            = var.GCP_PROJECT
   cluster            = google_container_cluster.cluster.name
@@ -139,7 +139,7 @@ resource "google_container_node_pool" "pd_pool" {
 }
 
 resource "google_container_node_pool" "tikv_pool" {
-  depends_on = [google_container_node_pool.pd_pool]
+  depends_on         = [google_container_node_pool.pd_pool]
   provider           = google-beta
   project            = var.GCP_PROJECT
   cluster            = google_container_cluster.cluster.name
@@ -168,7 +168,7 @@ resource "google_container_node_pool" "tikv_pool" {
 }
 
 resource "google_container_node_pool" "tidb_pool" {
-  depends_on = [google_container_node_pool.tikv_pool]
+  depends_on         = [google_container_node_pool.tikv_pool]
   provider           = google-beta
   project            = var.GCP_PROJECT
   cluster            = google_container_cluster.cluster.name
@@ -195,7 +195,7 @@ resource "google_container_node_pool" "tidb_pool" {
 }
 
 resource "google_container_node_pool" "monitor_pool" {
-  depends_on = [google_container_node_pool.tidb_pool]
+  depends_on         = [google_container_node_pool.tidb_pool]
   project            = var.GCP_PROJECT
   cluster            = google_container_cluster.cluster.name
   location           = google_container_cluster.cluster.location
@@ -253,7 +253,7 @@ resource "google_compute_firewall" "allow_ssh_from_bastion" {
 
 resource "google_compute_instance" "bastion" {
   project      = var.GCP_PROJECT
-  zone         = "${var.GCP_REGION}-a"
+  zone         = data.external.available_zones_in_region.result["zone"]
   machine_type = var.bastion_instance_type
   name         = "bastion"
 

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -1,18 +1,23 @@
-variable "GCP_CREDENTIALS_PATH" {}
-variable "GCP_REGION" {}
-variable "GCP_PROJECT" {}
+variable "GCP_CREDENTIALS_PATH" {
+}
+
+variable "GCP_REGION" {
+}
+
+variable "GCP_PROJECT" {
+}
 
 provider "google" {
-  credentials = "${file("${var.GCP_CREDENTIALS_PATH}")}"
-  region      = "${var.GCP_REGION}"
-  project     = "${var.GCP_PROJECT}"
+  credentials = file(var.GCP_CREDENTIALS_PATH)
+  region      = var.GCP_REGION
+  project     = var.GCP_PROJECT
 }
 
 // required for taints on node pools
 provider "google-beta" {
-  credentials = "${file("${var.GCP_CREDENTIALS_PATH}")}"
-  region      = "${var.GCP_REGION}"
-  project     = "${var.GCP_PROJECT}"
+  credentials = file(var.GCP_CREDENTIALS_PATH)
+  region      = var.GCP_REGION
+  project     = var.GCP_PROJECT
 }
 
 locals {
@@ -30,14 +35,14 @@ resource "null_resource" "prepare-dir" {
 resource "google_compute_network" "vpc_network" {
   name                    = "vpc-network"
   auto_create_subnetworks = false
-  project                 = "${var.GCP_PROJECT}"
+  project                 = var.GCP_PROJECT
 }
 
 resource "google_compute_subnetwork" "private_subnet" {
   ip_cidr_range = "172.31.252.0/22"
   name          = "private-subnet"
-  network       = "${google_compute_network.vpc_network.name}"
-  project       = "${var.GCP_PROJECT}"
+  network       = google_compute_network.vpc_network.name
+  project       = var.GCP_PROJECT
 
   secondary_ip_range {
     ip_cidr_range = "172.30.0.0/16"
@@ -50,23 +55,23 @@ resource "google_compute_subnetwork" "private_subnet" {
   }
 
   lifecycle {
-    ignore_changes = ["secondary_ip_range"]
+    ignore_changes = [secondary_ip_range]
   }
 }
 
 resource "google_compute_subnetwork" "public_subnet" {
   ip_cidr_range = "172.29.252.0/22"
   name          = "public-subnet"
-  network       = "${google_compute_network.vpc_network.name}"
-  project       = "${var.GCP_PROJECT}"
+  network       = google_compute_network.vpc_network.name
+  project       = var.GCP_PROJECT
 }
 
 resource "google_container_cluster" "cluster" {
-  name       = "${var.cluster_name}"
-  network    = "${google_compute_network.vpc_network.name}"
-  subnetwork = "${google_compute_subnetwork.private_subnet.name}"
-  location   = "${var.GCP_REGION}"
-  project    = "${var.GCP_PROJECT}"
+  name       = var.cluster_name
+  network    = google_compute_network.vpc_network.name
+  subnetwork = google_compute_subnetwork.private_subnet.name
+  location   = var.GCP_REGION
+  project    = var.GCP_PROJECT
 
   master_auth {
     username = ""
@@ -94,20 +99,20 @@ resource "google_container_cluster" "cluster" {
   min_master_version = "latest"
 
   lifecycle {
-    ignore_changes = ["master_auth"] // see above linked issue
+    ignore_changes = [master_auth] // see above linked issue
   }
 }
 
 resource "google_container_node_pool" "pd_pool" {
-  provider           = "google-beta"
-  project            = "${var.GCP_PROJECT}"
-  cluster            = "${google_container_cluster.cluster.name}"
-  location           = "${google_container_cluster.cluster.location}"
+  provider           = google-beta
+  project            = var.GCP_PROJECT
+  cluster            = google_container_cluster.cluster.name
+  location           = google_container_cluster.cluster.location
   name               = "pd-pool"
-  initial_node_count = "${var.pd_count}"
+  initial_node_count = var.pd_count
 
   node_config {
-    machine_type    = "${var.pd_instance_type}"
+    machine_type    = var.pd_instance_type
     image_type      = "UBUNTU"
     local_ssd_count = 1
 
@@ -117,7 +122,7 @@ resource "google_container_node_pool" "pd_pool" {
       value  = "pd"
     }
 
-    labels {
+    labels = {
       dedicated = "pd"
     }
 
@@ -127,15 +132,15 @@ resource "google_container_node_pool" "pd_pool" {
 }
 
 resource "google_container_node_pool" "tikv_pool" {
-  provider           = "google-beta"
-  project            = "${var.GCP_PROJECT}"
-  cluster            = "${google_container_cluster.cluster.name}"
-  location           = "${google_container_cluster.cluster.location}"
+  provider           = google-beta
+  project            = var.GCP_PROJECT
+  cluster            = google_container_cluster.cluster.name
+  location           = google_container_cluster.cluster.location
   name               = "tikv-pool"
-  initial_node_count = "${var.tikv_count}"
+  initial_node_count = var.tikv_count
 
   node_config {
-    machine_type    = "${var.tikv_instance_type}"
+    machine_type    = var.tikv_instance_type
     image_type      = "UBUNTU"
     local_ssd_count = 1
 
@@ -145,7 +150,7 @@ resource "google_container_node_pool" "tikv_pool" {
       value  = "tikv"
     }
 
-    labels {
+    labels = {
       dedicated = "tikv"
     }
 
@@ -155,15 +160,15 @@ resource "google_container_node_pool" "tikv_pool" {
 }
 
 resource "google_container_node_pool" "tidb_pool" {
-  provider           = "google-beta"
-  project            = "${var.GCP_PROJECT}"
-  cluster            = "${google_container_cluster.cluster.name}"
-  location           = "${google_container_cluster.cluster.location}"
+  provider           = google-beta
+  project            = var.GCP_PROJECT
+  cluster            = google_container_cluster.cluster.name
+  location           = google_container_cluster.cluster.location
   name               = "tidb-pool"
-  initial_node_count = "${var.tidb_count}"
+  initial_node_count = var.tidb_count
 
   node_config {
-    machine_type = "${var.tidb_instance_type}"
+    machine_type = var.tidb_instance_type
 
     taint {
       effect = "NO_SCHEDULE"
@@ -171,7 +176,7 @@ resource "google_container_node_pool" "tidb_pool" {
       value  = "tidb"
     }
 
-    labels {
+    labels = {
       dedicated = "tidb"
     }
 
@@ -181,14 +186,14 @@ resource "google_container_node_pool" "tidb_pool" {
 }
 
 resource "google_container_node_pool" "monitor_pool" {
-  project            = "${var.GCP_PROJECT}"
-  cluster            = "${google_container_cluster.cluster.name}"
-  location           = "${google_container_cluster.cluster.location}"
+  project            = var.GCP_PROJECT
+  cluster            = google_container_cluster.cluster.name
+  location           = google_container_cluster.cluster.location
   name               = "monitor-pool"
-  initial_node_count = "${var.monitor_count}"
+  initial_node_count = var.monitor_count
 
   node_config {
-    machine_type = "${var.monitor_instance_type}"
+    machine_type = var.monitor_instance_type
     tags         = ["monitor"]
     oauth_scopes = ["storage-ro", "logging-write", "monitoring"]
   }
@@ -196,8 +201,8 @@ resource "google_container_node_pool" "monitor_pool" {
 
 resource "google_compute_firewall" "allow_ssh_bastion" {
   name    = "allow-ssh-bastion"
-  network = "${google_compute_network.vpc_network.self_link}"
-  project = "${var.GCP_PROJECT}"
+  network = google_compute_network.vpc_network.self_link
+  project = var.GCP_PROJECT
 
   allow {
     protocol = "tcp"
@@ -210,8 +215,8 @@ resource "google_compute_firewall" "allow_ssh_bastion" {
 
 resource "google_compute_firewall" "allow_mysql_from_bastion" {
   name    = "allow-mysql-from-bastion"
-  network = "${google_compute_network.vpc_network.self_link}"
-  project = "${var.GCP_PROJECT}"
+  network = google_compute_network.vpc_network.self_link
+  project = var.GCP_PROJECT
 
   allow {
     protocol = "tcp"
@@ -224,8 +229,8 @@ resource "google_compute_firewall" "allow_mysql_from_bastion" {
 
 resource "google_compute_firewall" "allow_ssh_from_bastion" {
   name    = "allow-ssh-from-bastion"
-  network = "${google_compute_network.vpc_network.self_link}"
-  project = "${var.GCP_PROJECT}"
+  network = google_compute_network.vpc_network.self_link
+  project = var.GCP_PROJECT
 
   allow {
     protocol = "tcp"
@@ -237,20 +242,21 @@ resource "google_compute_firewall" "allow_ssh_from_bastion" {
 }
 
 resource "google_compute_instance" "bastion" {
-  project      = "${var.GCP_PROJECT}"
+  project      = var.GCP_PROJECT
   zone         = "${var.GCP_REGION}-a"
-  machine_type = "${var.bastion_instance_type}"
+  machine_type = var.bastion_instance_type
   name         = "bastion"
 
-  "boot_disk" {
+  boot_disk {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-1804-lts"
     }
   }
 
-  "network_interface" {
-    subnetwork    = "${google_compute_subnetwork.public_subnet.self_link}"
-    access_config = {}
+  network_interface {
+    subnetwork = google_compute_subnetwork.public_subnet.self_link
+    access_config {
+    }
   }
 
   tags = ["bastion"]
@@ -262,38 +268,42 @@ resource "null_resource" "get-credentials" {
   provisioner "local-exec" {
     command = "gcloud container clusters get-credentials ${google_container_cluster.cluster.name} --region ${var.GCP_REGION}"
 
-    environment {
-      KUBECONFIG = "${local.kubeconfig}"
+    environment = {
+      KUBECONFIG = local.kubeconfig
     }
   }
 
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
 
     command = <<EOS
 kubectl get pvc -n tidb -o jsonpath='{.items[*].spec.volumeName}'|fmt -1 | xargs -I {} kubectl patch pv {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
 EOS
 
-    environment {
-      KUBECONFIG = "${local.kubeconfig}"
+
+    environment = {
+      KUBECONFIG = local.kubeconfig
     }
   }
 }
 
 resource "local_file" "tidb-cluster-values" {
-  depends_on = ["data.template_file.tidb_cluster_values"]
-  filename   = "${local.tidb_cluster_values_path}"
-  content    = "${data.template_file.tidb_cluster_values.rendered}"
+  depends_on = [data.template_file.tidb_cluster_values]
+  filename = local.tidb_cluster_values_path
+  content = data.template_file.tidb_cluster_values.rendered
 }
 
 resource "null_resource" "setup-env" {
-  depends_on = ["google_container_cluster.cluster", "null_resource.get-credentials"]
+  depends_on = [
+    google_container_cluster.cluster,
+    null_resource.get-credentials,
+  ]
 
   provisioner "local-exec" {
-    working_dir = "${path.module}"
+    working_dir = path.module
 
     command = <<EOS
-kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $$(gcloud config get-value account)
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
 kubectl create serviceaccount --namespace kube-system tiller
 kubectl apply -f manifests/crd.yaml
 kubectl apply -f manifests/startup-script.yaml
@@ -307,21 +317,28 @@ done
 helm install --namespace tidb-admin --name tidb-operator ${path.module}/charts/tidb-operator
 EOS
 
-    environment {
-      KUBECONFIG = "${local.kubeconfig}"
-    }
-  }
+
+environment = {
+KUBECONFIG = local.kubeconfig
+}
+}
 }
 
 resource "null_resource" "deploy-tidb-cluster" {
-  depends_on = ["null_resource.setup-env", "local_file.tidb-cluster-values", "google_container_node_pool.pd_pool", "google_container_node_pool.tikv_pool", "google_container_node_pool.tidb_pool"]
+depends_on = [
+null_resource.setup-env,
+local_file.tidb-cluster-values,
+google_container_node_pool.pd_pool,
+google_container_node_pool.tikv_pool,
+google_container_node_pool.tidb_pool,
+]
 
-  triggers {
-    values = "${data.template_file.tidb_cluster_values.rendered}"
-  }
+triggers = {
+values = data.template_file.tidb_cluster_values.rendered
+}
 
-  provisioner "local-exec" {
-    command = <<EOS
+provisioner "local-exec" {
+command = <<EOS
 helm upgrade --install tidb-cluster ${path.module}/charts/tidb-cluster --namespace=tidb -f ${local.tidb_cluster_values_path}
 until kubectl get po -n tidb -lapp.kubernetes.io/component=tidb | grep Running; do
   echo "Wait for TiDB pod running"
@@ -333,8 +350,10 @@ until kubectl get svc -n tidb tidb-cluster-tidb -o json | jq '.status.loadBalanc
 done
 EOS
 
-    environment {
-      KUBECONFIG = "${local.kubeconfig}"
-    }
-  }
+
+environment = {
+KUBECONFIG = local.kubeconfig
 }
+}
+}
+

--- a/deploy/gcp/outputs.tf
+++ b/deploy/gcp/outputs.tf
@@ -1,37 +1,37 @@
 output "region" {
-  value = "${var.GCP_REGION}"
+  value = var.GCP_REGION
 }
 
 output "cluster_id" {
-  value = "${google_container_cluster.cluster.id}"
+  value = google_container_cluster.cluster.id
 }
 
 output "cluster_name" {
-  value = "${google_container_cluster.cluster.name}"
+  value = google_container_cluster.cluster.name
 }
 
 output "kubeconfig_file" {
-  value = "${local.kubeconfig}"
+  value = local.kubeconfig
 }
 
 output "tidb_version" {
-  value = "${var.tidb_version}"
+  value = var.tidb_version
 }
 
 output "tidb_ilb_ip" {
-  value = "${data.external.tidb_ilb_ip.result["ip"]}"
+  value = data.external.tidb_ilb_ip.result["ip"]
 }
 
 output "tidb_port" {
-  value = "${data.external.tidb_port.result["port"]}"
+  value = data.external.tidb_port.result["port"]
 }
 
 output "monitor_ilb_ip" {
-  value = "${data.external.monitor_ilb_ip.result["ip"]}"
+  value = data.external.monitor_ilb_ip.result["ip"]
 }
 
 output "monitor_port" {
-  value = "${data.external.monitor_port.result["port"]}"
+  value = data.external.monitor_port.result["port"]
 }
 
 output "how_to_ssh_to_bastion" {
@@ -41,3 +41,4 @@ output "how_to_ssh_to_bastion" {
 output "how_to_connect_to_mysql_from_bastion" {
   value = "mysql -h ${data.external.tidb_ilb_ip.result["ip"]} -P ${data.external.tidb_port.result["port"]} -u root"
 }
+

--- a/deploy/gcp/outputs.tf
+++ b/deploy/gcp/outputs.tf
@@ -35,7 +35,7 @@ output "monitor_port" {
 }
 
 output "how_to_ssh_to_bastion" {
-  value = "gcloud compute ssh bastion --zone ${var.GCP_REGION}-a"
+  value = "gcloud compute ssh bastion --zone ${google_compute_instance.bastion.zone}"
 }
 
 output "how_to_connect_to_mysql_from_bastion" {

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -64,3 +64,4 @@ variable "monitor_instance_type" {
 variable "bastion_instance_type" {
   default = "f1-micro"
 }
+

--- a/deploy/gcp/versions.tf
+++ b/deploy/gcp/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
This PR fixes #522 as well as upgrading the GCP terraform script to 0.12 compatibility. It will break backwards compatibility, but terraform will not run until upgraded

### What is changed and how it works?
- Previously, bastion instance zone was hardcoded, script now checks `gcloud compute regions describe name-of-region` to see what zones are available in the region, and grabs the first one in the result
- Upgraded to be compatible with terraform 0.12
- Usability: Previously, when doing `terraform destroy` it would frequently abort because GCP does not allow deleting simultaneous node pools. The user would then have to re-run the command. This no longer happens, the downside is that `terraform apply` will run a little slower as the node pools are now created and destroyed sequentially.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
`terraform apply`
`terraform destroy`

Code changes

 - Has Terraform changes

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
