### PR TITLE
build without debugger symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Set DEBUGGER=1 to build debug symbols
+LDFLAGS = $(if $(DEBUGGER),,-s -w) $(shell ./hack/version.sh)
+
+# SET DOCKER_REGISTRY to change the docker registry
+DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
+
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")
 GO111 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 11 ]; echo $$?)
@@ -10,10 +16,6 @@ GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
 GOENV  := GO15VENDOREXPERIMENT="1" GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go build
 GOTEST := CGO_ENABLED=0 GO111MODULE=on go test -v -cover
-
-LDFLAGS = $(shell ./hack/version.sh)
-
-DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
 
 PACKAGE_LIST := go list ./... | grep -vE "pkg/client" | grep -vE "zz_generated"
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'


### PR DESCRIPTION
This makes the binaries significantly smaller

before:
30M     images/tidb-operator/bin/tidb-admission-controller
47M     images/tidb-operator/bin/tidb-controller-manager
42M     images/tidb-operator/bin/tidb-discovery
32M     images/tidb-operator/bin/tidb-scheduler

after:
30M     images/tidb-operator/bin/tidb-admission-controller
36M     images/tidb-operator/bin/tidb-controller-manager
32M     images/tidb-operator/bin/tidb-discovery
24M     images/tidb-operator/bin/tidb-scheduler

Note that stack traces still work, this information is just for the debugger. Set DEBUGGER=1 to build for debuggers. Eventually we may need to distribute both of these.

This issue came up when I was adding a new binary and it was initially 40M in size! After some changes I made, even after adding that binary the total binary size of all binaries will be smaller

## Testing

I ran these binaries on GKE. I did see proper stack information from a panic.