### PR TITLE
Use kube-scheduler image instead of hyperkube

### DIFF
--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -54,6 +54,6 @@ scheduler:
     requests:
       cpu: 80m
       memory: 50Mi
-  kubeSchedulerImageName: gcr.io/google-containers/hyperkube
+  kubeSchedulerImageName: k8s.gcr.io/kube-scheduler
   # This will default to matching your kubernetes version
   # kubeSchedulerImageTag:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Use scheduler image instead of hyperkube which is unnecessary and very large.

```
# docker images | grep v1.12.2
gcr.io/google-containers/hyperkube                               v1.12.2                      3e4497624dd0        7 months ago        635MB
gcr.io/google_containers/kube-scheduler                          v1.12.2                      d6d57c76136c        7 months ago        58.3MB
```

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Scheduler image is updated to use "k8s.gcr.io/kube-scheduler" which is much smaller than "gcr.io/google-containers/hyperkube". You must pre-pull the new scheduler image into your airgap environment before upgrading.
 ```