### PR TITLE
support force upgrade when pd cluster is unavailable

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -15,9 +15,10 @@ package label
 
 import (
 	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"strings"
 )
 
 const (
@@ -52,6 +53,11 @@ const (
 	AnnPVCPodScheduling = "tidb.pingcap.com/pod-scheduling"
 	// AnnTiDBPartition is pod annotation which TiDB pod chould upgrade to
 	AnnTiDBPartition string = "tidb.pingcap.com/tidb-partition"
+	// AnnForceUpgradeKey is tc annotation key to indicate whether force upgrade should be done
+	AnnForceUpgradeKey = "tidb.pingcap.com/forceUpgrade"
+
+	// AnnForceUpgradeVal is tc annotation value to indicate whether force upgrade should be done
+	AnnForceUpgradeVal = "true"
 
 	// PDLabelVal is PD label value
 	PDLabelVal string = "pd"

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -54,7 +54,7 @@ const (
 	// AnnTiDBPartition is pod annotation which TiDB pod chould upgrade to
 	AnnTiDBPartition string = "tidb.pingcap.com/tidb-partition"
 	// AnnForceUpgradeKey is tc annotation key to indicate whether force upgrade should be done
-	AnnForceUpgradeKey = "tidb.pingcap.com/forceUpgrade"
+	AnnForceUpgradeKey = "tidb.pingcap.com/force-upgrade"
 
 	// AnnForceUpgradeVal is tc annotation value to indicate whether force upgrade should be done
 	AnnForceUpgradeVal = "true"

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -206,7 +206,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 			tc.Status.PD.Phase = v1alpha1.UpgradePhase
 			setUpgradePartition(newPDSet, 0)
 			errSTS := pmm.updateStatefulSet(tc, newPDSet, oldPDSet)
-			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", tc.GetNamespace(), tc.GetName(), errSTS)
+			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
 		}
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -200,6 +200,16 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		glog.Errorf("failed to sync TidbCluster: [%s/%s]'s status, error: %v", ns, tcName, err)
 	}
 
+	if !tc.Status.PD.Synced {
+		force := needForceUpgrade(tc)
+		if force {
+			tc.Status.PD.Phase = v1alpha1.UpgradePhase
+			setUpgradePartition(newPDSet, 0)
+			errSTS := pmm.updateStatefulSet(tc, newPDSet, oldPDSet)
+			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", tc.GetNamespace(), tc.GetName(), errSTS)
+		}
+	}
+
 	if !templateEqual(newPDSet.Spec.Template, oldPDSet.Spec.Template) || tc.Status.PD.Phase == v1alpha1.UpgradePhase {
 		if err := pmm.pdUpgrader.Upgrade(tc, oldPDSet, newPDSet); err != nil {
 			return err
@@ -227,7 +237,9 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		}
 	}
 
-	// TODO FIXME equal is false every time
+	return pmm.updateStatefulSet(tc, newPDSet, oldPDSet)
+}
+func (pmm *pdMemberManager) updateStatefulSet(tc *v1alpha1.TidbCluster, newPDSet, oldPDSet *apps.StatefulSet) error {
 	if !statefulSetEqual(*newPDSet, *oldPDSet) {
 		set := *oldPDSet
 		set.Spec.Template = newPDSet.Spec.Template

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -704,7 +704,7 @@ func TestPDMemberManagerSyncPDSts(t *testing.T) {
 				cluster.Spec.PD.Image = "pd-test-image:v2"
 				cluster.Spec.PD.Replicas = 1
 				cluster.ObjectMeta.Annotations = make(map[string]string)
-				cluster.ObjectMeta.Annotations["tidb.pingcap.com/forceUpgrade"] = "true"
+				cluster.ObjectMeta.Annotations["tidb.pingcap.com/force-upgrade"] = "true"
 			},
 			pdHealth: &pdapi.HealthInfo{Healths: []pdapi.MemberHealth{
 				{Name: "pd1", MemberID: uint64(1), ClientUrls: []string{"http://pd1:2379"}, Health: false},

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
-	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	apps "k8s.io/api/apps/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -42,14 +41,6 @@ func NewPDUpgrader(pdControl pdapi.PDControlInterface,
 }
 
 func (pu *pdUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	force, err := pu.needForceUpgrade(tc)
-	if err != nil {
-		return err
-	}
-	if force {
-		return pu.forceUpgrade(tc, oldSet, newSet)
-	}
-
 	return pu.gracefulUpgrade(tc, oldSet, newSet)
 }
 
@@ -97,35 +88,6 @@ func (pu *pdUpgrader) gracefulUpgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Sta
 	return nil
 }
 
-func (pu *pdUpgrader) needForceUpgrade(tc *v1alpha1.TidbCluster) (bool, error) {
-	ns := tc.GetNamespace()
-	tcName := tc.GetName()
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
-	selector, err := label.New().Instance(instanceName).PD().Selector()
-	if err != nil {
-		return false, err
-	}
-	pdPods, err := pu.podLister.Pods(ns).List(selector)
-	if err != nil {
-		return false, err
-	}
-
-	imagePullFailedCount := 0
-	for _, pod := range pdPods {
-		revisionHash, exist := pod.Labels[apps.ControllerRevisionHashLabelKey]
-		if !exist {
-			return false, fmt.Errorf("tidbcluster: [%s/%s]'s pod:[%s] doesn't have label: %s", ns, tcName, pod.GetName(), apps.ControllerRevisionHashLabelKey)
-		}
-		if revisionHash == tc.Status.PD.StatefulSet.CurrentRevision {
-			if imagePullFailed(pod) {
-				imagePullFailedCount++
-			}
-		}
-	}
-
-	return imagePullFailedCount >= int(tc.Status.PD.StatefulSet.Replicas)/2+1, nil
-}
-
 func (pu *pdUpgrader) upgradePDPod(tc *v1alpha1.TidbCluster, ordinal int32, newSet *apps.StatefulSet) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
@@ -161,6 +123,9 @@ func NewFakePDUpgrader() Upgrader {
 }
 
 func (fpu *fakePDUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+	if !tc.Status.PD.Synced {
+		return fmt.Errorf("tidbcluster: pd status sync failed,can not to be upgraded")
+	}
 	tc.Status.PD.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -168,36 +168,6 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: "force upgrade",
-			changeFn: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.PD.Synced = false
-			},
-			changePods: func(pods []*corev1.Pod) {
-				pods[1].Status = corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-					{
-						State: corev1.ContainerState{
-							Waiting: &corev1.ContainerStateWaiting{Reason: ErrImagePull},
-						},
-					},
-				}}
-				pods[0].Status = corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-					{
-						State: corev1.ContainerState{
-							Waiting: &corev1.ContainerStateWaiting{Reason: ErrImagePull},
-						},
-					},
-				}}
-			},
-			transferLeaderErr: false,
-			errExpectFn: func(g *GomegaWithT, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-			},
-			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
-				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(func() *int32 { i := int32(0); return &i }()))
-			},
-		},
-		{
 			name: "error when transfer leader",
 			changeFn: func(tc *v1alpha1.TidbCluster) {
 				tc.Status.PD.Synced = true

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -219,7 +219,7 @@ func CombineAnnotations(a, b map[string]string) map[string]string {
 
 // needForceUpgrade check if force upgrade is necessary
 func needForceUpgrade(tc *v1alpha1.TidbCluster) bool {
-	// Check if annotation 'pingcap.com/forceUpgrade: "true"' is set
+	// Check if annotation 'pingcap.com/force-upgrade: "true"' is set
 	if tc.Annotations != nil {
 		forceVal, ok := tc.Annotations[label.AnnForceUpgradeKey]
 		if ok && (forceVal == label.AnnForceUpgradeVal) {

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
 	apps "k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -213,4 +215,16 @@ func CombineAnnotations(a, b map[string]string) map[string]string {
 		a[k] = v
 	}
 	return a
+}
+
+// needForceUpgrade check if force upgrade is necessary
+func needForceUpgrade(tc *v1alpha1.TidbCluster) bool {
+	// Check if annotation 'pingcap.com/forceUpgrade: "true"' is set
+	if tc.Annotations != nil {
+		forceVal, ok := tc.Annotations[label.AnnForceUpgradeKey]
+		if ok && (forceVal == label.AnnForceUpgradeVal) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #609 
### What is changed and how does it work?
Support force upgrade if PD cluster is unavailable
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
    - PD cluster image pull backoff during the creation
    - PD cluster pending due to affinity setting during the creation
    - PD cluster is unavailable after creation
    - PD cluster is running normally
    - PD cluster only has 1 replica

Code changes

 - Has Go code change
 - Has documents change

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
```
Support force upgrade when PD cluster is unavailable.
To enable force upgrade:
kubectl annotate --overwrite tc ${releaseName} -n ${namespace} tidb.pingcap.com/force-upgrade=true
To disable force upgrade:
kubectl annotate tc ${releaseName} -n ${namespace} tidb.pingcap.com/force-upgrade-
Note: Force upgrade must be disabled when PD cluster is recovered.
```
