### PR TITLE
fix stability test lack argument bug

### DIFF
--- a/tests/cmd/stability/stability.go
+++ b/tests/cmd/stability/stability.go
@@ -70,6 +70,7 @@ func newTidbClusterConfig(ns, clusterName string) *tests.TidbClusterConfig {
 		TiKVGrpcConcurrency: 4,
 		TiDBTokenLimit:      1000,
 		PDLogLevel:          "info",
+		TopologyKey:         topologyKey,
 		SubValues:           tests.GetAffinityConfigOrDie(clusterName, ns, topologyKey, []string{topologyKey}),
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #629 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
