### PR TITLE
Increase the default storage size for pump from 10Gi to 20Gi

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -392,7 +392,7 @@ binlog:
     # or to arbitrary policies determined by the cluster administrators.
     # refer to https://kubernetes.io/docs/concepts/storage/storage-classes
     storageClassName: local-storage
-    storage: 10Gi
+    storage: 20Gi
     syncLog: true
     # a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored.
     # must bigger than 0


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/656

### What is changed and how does it work?
values.yaml from TiDB cluster helm chart is updated

The default storage size for pump services is increased from 10GiB to 20GiB because pump introduced a new configuration `stop-write-at-available-space`, which comes with a default value of 10GiB. Deploying with the old default storage size, 10GiB, immediately results in `no available space` error in pump services.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
1. Deploy TiDB operator and cluster with the updated helm charts to AWS

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
