### PR TITLE
turn on automatic failover

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - /usr/local/bin/tidb-controller-manager
           - -default-storage-class-name={{ .Values.defaultStorageClassName }}
           - -cluster-scoped={{ .Values.clusterScoped }}
-          - -auto-failover={{ .Values.controllerManager.autoFailover | default false }}
+          - -auto-failover={{ .Values.controllerManager.autoFailover | default true }}
           - -pd-failover-period={{ .Values.controllerManager.pdFailoverPeriod | default "5m" }}
           - -tikv-failover-period={{ .Values.controllerManager.tikvFailoverPeriod | default "5m" }}
           - -tidb-failover-period={{ .Values.controllerManager.tidbFailoverPeriod | default "5m" }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -29,7 +29,7 @@ controllerManager:
       cpu: 80m
       memory: 50Mi
   # autoFailover is whether tidb-operator should auto failover when failure occurs
-  autoFailover: false
+  autoFailover: true
   # pd failover period default(5m)
   pdFailoverPeriod: 5m
   # tikv failover period default(5m)

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -58,7 +58,7 @@ func init() {
 	flag.IntVar(&workers, "workers", 5, "The number of workers that are allowed to sync concurrently. Larger number = more responsive management, but more CPU (and network) load")
 	flag.BoolVar(&controller.ClusterScoped, "cluster-scoped", true, "Whether tidb-operator should manage kubernetes cluster wide TiDB Clusters")
 	flag.StringVar(&controller.DefaultStorageClassName, "default-storage-class-name", "standard", "Default storage class name")
-	flag.BoolVar(&autoFailover, "auto-failover", false, "Auto failover")
+	flag.BoolVar(&autoFailover, "auto-failover", true, "Auto failover")
 	flag.DurationVar(&pdFailoverPeriod, "pd-failover-period", time.Duration(5*time.Minute), "PD failover period default(5m)")
 	flag.DurationVar(&tikvFailoverPeriod, "tikv-failover-period", time.Duration(5*time.Minute), "TiKV failover period default(5m)")
 	flag.DurationVar(&tidbFailoverPeriod, "tidb-failover-period", time.Duration(5*time.Minute), "TiDB failover period")

--- a/images/tidb-operator-e2e/tidb-operator-values.yaml
+++ b/images/tidb-operator-e2e/tidb-operator-values.yaml
@@ -29,7 +29,7 @@ controllerManager:
       cpu: 80m
       memory: 50Mi
   # autoFailover is whether tidb-operator should auto failover when failure occurs
-  autoFailover: false
+  autoFailover: true
   # pd failover period default(5m)
   pdFailoverPeriod: 5m
   # tidb failover period default(5m)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Automatic failover has been verified by a large number of stability tests, so we should turn it on by default.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has Helm charts change
 - Has Go code change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
turn on automatic failover feature by default
```
