### PR TITLE
Upgrade default TiDB version to v3.0.1

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -61,7 +61,7 @@ pd:
     location-labels = ["region", "zone", "rack", "host"]
   
   replicas: 3
-  image: pingcap/pd:v3.0.0-rc.1
+  image: pingcap/pd:v3.0.1
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -203,7 +203,7 @@ tikv:
   # # capacity = "1GB"
 
   replicas: 3
-  image: pingcap/tikv:v3.0.0-rc.1
+  image: pingcap/tikv:v3.0.1
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -260,7 +260,7 @@ tidb:
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v3.0.0-rc.1
+  image: pingcap/tidb:v3.0.1
   # Image pull policy.
   imagePullPolicy: IfNotPresent
 
@@ -385,7 +385,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v3.0.0-rc.1
+    image: pingcap/tidb-binlog:v3.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -403,7 +403,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v3.0.0-rc.1
+    image: pingcap/tidb-binlog:v3.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.

--- a/deploy/aliyun/README-CN.md
+++ b/deploy/aliyun/README-CN.md
@@ -77,7 +77,7 @@ monitor_endpoint = 1.2.3.4:3000
 region = cn-hangzhou
 tidb_port = 4000
 tidb_slb_ip = 192.168.5.53
-tidb_version = v3.0.0-rc.1
+tidb_version = v3.0.1
 vpc_id = vpc-bp16wcbu0xhbg833fymmc
 worker_key_file = /root/tidb-operator/deploy/aliyun/credentials/tidb-cluster-node-key.pem
 ```

--- a/deploy/aliyun/README.md
+++ b/deploy/aliyun/README.md
@@ -83,7 +83,7 @@ monitor_endpoint = 1.2.3.4:3000
 region = cn-hangzhou
 tidb_port = 4000
 tidb_slb_ip = 192.168.5.53
-tidb_version = v3.0.0-rc.1
+tidb_version = v3.0.1
 vpc_id = vpc-bp16wcbu0xhbg833fymmc
 worker_key_file = /root/tidb-operator/deploy/aliyun/credentials/tidb-cluster-node-key.pem
 ```

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -5,7 +5,7 @@ variable "cluster_name_prefix" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v3.0.0-rc.1"
+  default     = "v3.0.1"
 }
 
 variable "pd_count" {

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -76,7 +76,7 @@ monitor_endpoint = http://abd299cc47af411e98aae02938da0762-1989524000.us-east-2.
 region = us-east-2
 tidb_dns = abd2e3f7c7af411e98aae02938da0762-17499b76b312be02.elb.us-east-2.amazonaws.com
 tidb_port = 4000
-tidb_version = v3.0.0
+tidb_version = v3.0.1
 ```
 
 > **Note:** You can use the `terraform output` command to get the output again.
@@ -118,12 +118,12 @@ The initial Grafana login credentials are:
 
 To upgrade the TiDB cluster, edit the `variables.tf` file with your preferred text editor and modify the `tidb_version` variable to a higher version, and then run `terraform apply`.
 
-For example, to upgrade the cluster to version 3.0.0-rc.1, modify the `tidb_version` to `v3.0.0`:
+For example, to upgrade the cluster to version 3.0.1, modify the `tidb_version` to `v3.0.1`:
 
 ```
  variable "tidb_version" {
    description = "tidb cluster version"
-   default = "v3.0.0"
+   default = "v3.0.1"
  }
 ```
 
@@ -198,7 +198,7 @@ module example-cluster {
   # Helm values file
   override_values = file("example-cluster.yaml")
   # TiDB cluster version
-  cluster_version               = "v3.0.0"
+  cluster_version               = "v3.0.1"
   # SSH key of cluster nodes
   ssh_key_name                  = module.key-pair.key_name
   # PD replica number

--- a/deploy/aws/clusters.tf
+++ b/deploy/aws/clusters.tf
@@ -24,7 +24,7 @@ provider "helm" {
 #
 #  # NOTE: cluster_name cannot be changed after creation
 #  cluster_name                  = "demo-cluster"
-#  cluster_version               = "v3.0.0"
+#  cluster_version               = "v3.0.1"
 #  ssh_key_name                  = module.key-pair.key_name
 #  pd_count                      = 1
 #  pd_instance_type              = "t2.xlarge"

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -80,7 +80,7 @@ variable "bastion_instance_type" {
 
 # For aws tutorials compatiablity
 variable "default_cluster_version" {
-  default = "v3.0.0"
+  default = "v3.0.1"
 }
 
 variable "default_cluster_pd_count" {

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -108,7 +108,7 @@ monitor_port = 3000
 region = us-west1
 tidb_ilb_ip = 172.31.252.20
 tidb_port = 4000
-tidb_version = v3.0.0-rc.1
+tidb_version = v3.0.1
 ```
 
 ## Access the database
@@ -142,12 +142,12 @@ helm ls
 
 To upgrade the TiDB cluster, modify the `tidb_version` variable to a higher version in the `variables.tf` file, and run `terraform apply`.
 
-For example, to upgrade the cluster to the 3.0.0-rc.2 version, modify the `tidb_version` to `v3.0.0-rc.2`:
+For example, to upgrade the cluster to the 3.0.1 version, modify the `tidb_version` to `v3.0.1`:
 
 ```
 variable "tidb_version" {
   description = "TiDB version"
-  default     = "v3.0.0-rc.2"
+  default     = "v3.0.1"
 }
 ```
 
@@ -156,7 +156,7 @@ The upgrading does not finish immediately. You can run `kubectl --kubeconfig cre
 ```sql
 MySQL [(none)]> select tidb_version();
 *************************** 1. row ***************************
-tidb_version(): Release Version: v3.0.0-rc.2
+tidb_version(): Release Version: v3.0.1
 Git Commit Hash: 06f3f63d5a87e7f0436c0618cf524fea7172eb93
 Git Branch: HEAD
 UTC Build Time: 2019-05-28 12:48:52

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -5,7 +5,7 @@ variable "cluster_name" {
 
 variable "tidb_version" {
   description = "TiDB version"
-  default     = "v3.0.0-rc.1"
+  default     = "v3.0.1"
 }
 
 variable "tidb_operator_version" {

--- a/deploy/modules/aws/tidb-cluster/variables.tf
+++ b/deploy/modules/aws/tidb-cluster/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v3.0.0-rc.2"
+  default = "v3.0.1"
 }
 
 variable "ssh_key_name" {

--- a/deploy/modules/share/tidb-cluster-release/variables.tf
+++ b/deploy/modules/share/tidb-cluster-release/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v3.0.0"
+  default = "v3.0.1"
 }
 
 variable "pd_count" {

--- a/docs/aws-eks-tutorial.md
+++ b/docs/aws-eks-tutorial.md
@@ -138,7 +138,7 @@ monitor_endpoint = http://a37987df9710211e9b48c0ae40bc8d7b-1847612729.us-east-2.
 region = us-east-2
 tidb_dns = internal-a37a17c22710211e9b48c0ae40bc8d7b-1891023212.us-east-2.elb.amazonaws.com
 tidb_port = 4000
-tidb_version = v3.0.0-rc.1
+tidb_version = v3.0.1
 ```
 
 > *NOTE*: Be careful about changing instance types for PD and TiKV worker groups as they rely on local SSD. Doing so may break user-data and local volume setup.

--- a/docs/cli-manual.md
+++ b/docs/cli-manual.md
@@ -128,9 +128,9 @@ CreationTimestamp:  2019-04-17 17:33:41 +0800 CST
 Overview:
          Phase    Ready  Desired  CPU    Memory  Storage  Version
          -----    -----  -------  ---    ------  -------  -------
-  PD:    Normal   3      3        200m   1Gi     1Gi      pingcap/pd:v3.0.0-rc.1
-  TiKV:  Normal   3      3        1000m  2Gi     10Gi     pingcap/tikv:v3.0.0-rc.1
-  TiDB   Upgrade  1      2        500m   1Gi              pingcap/tidb:v3.0.0-rc.1
+  PD:    Normal   3      3        200m   1Gi     1Gi      pingcap/pd:v3.0.1
+  TiKV:  Normal   3      3        1000m  2Gi     10Gi     pingcap/tikv:v3.0.1
+  TiDB   Upgrade  1      2        500m   1Gi              pingcap/tidb:v3.0.1
 Endpoints(NodePort):
   - 172.16.4.158:31441
   - 172.16.4.155:31441

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -139,7 +139,7 @@ $ kubectl get pods --namespace tidb -l app.kubernetes.io/instance=demo -o wide -
 # Get basic information of the TiDB cluster
 $ kubectl get tidbcluster -n tidb
 NAME   PD                       STORAGE   READY   DESIRE   TIKV                       STORAGE   READY   DESIRE   TIDB                       READY   DESIRE
-demo   pingcap/pd:v3.0.0-rc.1   1Gi       3       3        pingcap/tikv:v3.0.0-rc.1   10Gi      3       3        pingcap/tidb:v3.0.0-rc.1   2       2
+demo   pingcap/pd:v3.0.1        1Gi       3       3        pingcap/tikv:v3.0.1        10Gi      3       3        pingcap/tidb:v3.0.1        2       2
 
 $ kubectl get statefulset -n tidb
 NAME        DESIRED   CURRENT   AGE

--- a/docs/local-dind-tutorial.md
+++ b/docs/local-dind-tutorial.md
@@ -286,7 +286,7 @@ Use `kubectl get pod -n tidb` to verify the number of each compoments equal to v
 
 1. Edit the `charts/tidb-cluster/values.yaml` file with your preferred text editor.
 
-    For example, change the version of PD/TiKV/TiDB `image` to `v3.0.0-rc.2`.
+    For example, change the version of PD/TiKV/TiDB `image` to `v3.0.1`.
 
 2. Run the following command to apply the changes:
 
@@ -299,7 +299,7 @@ Use `kubectl get pod -n tidb` to verify that all pods are in `Running` state. Th
 ```sh
 MySQL [(none)]> select tidb_version();
 *************************** 1. row ***************************
-tidb_version(): Release Version: v3.0.0-rc.2
+tidb_version(): Release Version: v3.0.1
 Git Commit Hash: 06f3f63d5a87e7f0436c0618cf524fea7172eb93
 Git Branch: HEAD
 UTC Build Time: 2019-05-28 12:48:52

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -36,7 +36,7 @@ discovery:
 
 pd:
   replicas: 3
-  image: pingcap/pd:v3.0.0-rc.1
+  image: pingcap/pd:v3.0.1
   imagePullPolicy: IfNotPresent
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -81,7 +81,7 @@ pd:
 
 tikv:
   replicas: 3
-  image: pingcap/tikv:v3.0.0-rc.1
+  image: pingcap/tikv:v3.0.1
   imagePullPolicy: IfNotPresent
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -133,7 +133,7 @@ tidb:
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v3.0.0-rc.1
+  image: pingcap/tidb:v3.0.1
   imagePullPolicy: IfNotPresent
   logLevel: info
   resources:
@@ -221,7 +221,7 @@ monitor:
 
 fullbackup:
   create: false
-  binlogImage: pingcap/tidb-binlog:v3.0.0-rc.1
+  binlogImage: pingcap/tidb-binlog:v3.0.1
   binlogImagePullPolicy: IfNotPresent
   # https://github.com/tennix/tidb-cloud-backup
   mydumperImage: pingcap/tidb-cloud-backup:20190610
@@ -262,7 +262,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v3.0.0-rc.1
+    image: pingcap/tidb-binlog:v3.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -279,7 +279,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v3.0.0-rc.1
+    image: pingcap/tidb-binlog:v3.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.

--- a/tests/config.go
+++ b/tests/config.go
@@ -78,7 +78,7 @@ func NewConfig() (*Config, error) {
 	flag.StringVar(&cfg.configFile, "config", "", "Config file")
 	flag.StringVar(&cfg.LogDir, "log-dir", "/logDir", "log directory")
 	flag.IntVar(&cfg.FaultTriggerPort, "fault-trigger-port", 23332, "the http port of fault trigger service")
-	flag.StringVar(&cfg.TidbVersions, "tidb-versions", "v3.0.0-rc.1,v3.0.0-rc.2,v3.0.0", "tidb versions")
+	flag.StringVar(&cfg.TidbVersions, "tidb-versions", "v3.0.0-rc.1,v3.0.0-rc.2,v3.0.1", "tidb versions")
 	flag.StringVar(&cfg.OperatorTag, "operator-tag", "master", "operator tag used to choose charts")
 	flag.StringVar(&cfg.OperatorImage, "operator-image", "pingcap/tidb-operator:latest", "operator image")
 	flag.StringVar(&cfg.UpgradeOperatorTag, "upgrade-operator-tag", "", "upgrade operator tag used to choose charts")

--- a/tests/manifests/e2e/e2e.yaml
+++ b/tests/manifests/e2e/e2e.yaml
@@ -48,7 +48,7 @@ spec:
     - /usr/local/bin/e2e
     - --operator-tag=e2e
     - --operator-image=pingcap/tidb-operator:latest
-    - --tidb-versions=v3.0.0-beta.1,v3.0.0-rc.1
+    - --tidb-versions=v3.0.0-beta.1,v3.0.1
     - --chart-dir=/charts
     volumeMounts:
     - mountPath: /logDir


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
upgrade default TiDB version to v3.0.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has documents change

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
ACTION REQUIRED: upgrade default TiDB version to v3.0.1
 ```
