### PR TITLE
Sets node count for default pool equal to total desired node count to correctly size master

### DIFF
--- a/deploy/gcp/data.tf
+++ b/deploy/gcp/data.tf
@@ -2,16 +2,16 @@ data "template_file" "tidb_cluster_values" {
   template = file("${path.module}/templates/tidb-cluster-values.yaml.tpl")
 
   vars = {
-    cluster_version  = var.tidb_version
-    pd_replicas      = var.pd_replica_count
-    tikv_replicas    = var.tikv_replica_count
-    tidb_replicas    = var.tidb_replica_count
-    operator_version = var.tidb_operator_version
+    cluster_version        = var.tidb_version
+    pd_replicas            = var.pd_replica_count
+    tikv_replicas          = var.tikv_replica_count
+    tidb_replicas          = var.tidb_replica_count
+    operator_version       = var.tidb_operator_version
     tidb_operator_registry = var.tidb_operator_registry
   }
 }
 
-data "google_compute_zones" "available" { }
+data "google_compute_zones" "available" {}
 
 data "external" "tidb_ilb_ip" {
   depends_on = [null_resource.deploy-tidb-cluster]

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -100,7 +100,8 @@ resource "google_container_cluster" "cluster" {
   }
 
   remove_default_node_pool = true
-  initial_node_count       = 1
+  // see https://github.com/terraform-providers/terraform-provider-google/issues/3385 for why initial_node_count is sum of node counts
+  initial_node_count       = var.pd_count + var.tikv_count + var.tidb_count + var.monitor_count
 
   min_master_version = "latest"
 
@@ -126,7 +127,7 @@ resource "google_container_node_pool" "pd_pool" {
   initial_node_count = var.pd_count
 
   management {
-    auto_repair = false
+    auto_repair  = false
     auto_upgrade = false
   }
 
@@ -158,13 +159,13 @@ resource "google_container_node_pool" "tikv_pool" {
   initial_node_count = var.tikv_count
 
   management {
-    auto_repair = false
+    auto_repair  = false
     auto_upgrade = false
   }
 
   node_config {
-    machine_type    = var.tikv_instance_type
-    image_type      = "UBUNTU"
+    machine_type = var.tikv_instance_type
+    image_type   = "UBUNTU"
     // This value cannot be changed (instead a new node pool is needed)
     // 1 SSD is 375 GiB
     local_ssd_count = 1
@@ -195,7 +196,7 @@ resource "google_container_node_pool" "tidb_pool" {
   initial_node_count = var.tidb_count
 
   management {
-    auto_repair = false
+    auto_repair  = false
     auto_upgrade = false
   }
 
@@ -228,7 +229,7 @@ resource "google_container_node_pool" "monitor_pool" {
   initial_node_count = var.monitor_count
 
   management {
-    auto_repair = false
+    auto_repair  = false
     auto_upgrade = false
   }
 
@@ -389,7 +390,7 @@ resource "null_resource" "deploy-tidb-cluster" {
 
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-command = <<EOS
+command         = <<EOS
 set -euo pipefail
 
 helm upgrade --install tidb-cluster ${path.module}/charts/tidb-cluster --namespace=tidb -f ${local.tidb_cluster_values_path}

--- a/deploy/gcp/prod.tfvars
+++ b/deploy/gcp/prod.tfvars
@@ -1,3 +1,3 @@
-pd_instance_type = "n1-standard-4"
+pd_instance_type   = "n1-standard-4"
 tikv_instance_type = "n1-highmem-8"
 tidb_instance_type = "n1-standard-16"

--- a/deploy/gcp/small.tfvars
+++ b/deploy/gcp/small.tfvars
@@ -1,3 +1,3 @@
-pd_instance_type = "n1-standard-2"
+pd_instance_type   = "n1-standard-2"
 tikv_instance_type = "n1-highmem-4"
 tidb_instance_type = "n1-standard-8"

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -49,11 +49,11 @@ variable "monitor_count" {
   description = "Number of monitor nodes per availability zone"
   default     = 1
 }
-variable "pd_instance_type" { }
+variable "pd_instance_type" {}
 
-variable "tikv_instance_type" { }
+variable "tikv_instance_type" {}
 
-variable "tidb_instance_type" { }
+variable "tidb_instance_type" {}
 
 variable "monitor_instance_type" {
   default = "n1-standard-2"


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Closes #615 

### What is changed and how does it work?
GKE master node is sized initially to expect 5 or fewer nodes when first provisioned, or the size of the default node pool. Previously, the initial node count for the default pool was 1 (3 total because one per availability zone), so when the rest of the node pools get provisioned, GKE would then upgrade the master node to accommodate the rest of the nodes. This change sets the initial node count of the default pool to be equal to the sum of the node counts for the other pools (pd, tikv, tidb, monitor). With this, the master node is correctly sized and does not upgrade shortly after creating the cluster, as it did previously.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
* `terraform apply` to GKE
* When all done, wait and see if master node auto upgrades


Code changes

 - Has Terraform changes

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
