### PR TITLE
Enable configmap rollout by default and quote configmap digest suffix 

### DIFF
--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ template "cluster.name" . }}
 {{- if .Values.enableConfigMapRollout }}
   annotations:
-    pingcap.com/pd.{{ template "cluster.name" . }}-pd.sha: {{ template "pd-configmap.data-digest" . }}
-    pingcap.com/tikv.{{ template "cluster.name" . }}-tikv.sha: {{ template "tikv-configmap.data-digest" . }}
-    pingcap.com/tidb.{{ template "cluster.name" . }}-tidb.sha: {{ template "tidb-configmap.data-digest" . }}
+    pingcap.com/pd.{{ template "cluster.name" . }}-pd.sha: {{ include "pd-configmap.data-digest" . | quote }}
+    pingcap.com/tikv.{{ template "cluster.name" . }}-tikv.sha: {{ include "tikv-configmap.data-digest" . | quote }}
+    pingcap.com/tidb.{{ template "cluster.name" . }}-tidb.sha: {{ include "tidb-configmap.data-digest" . | quote }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -45,7 +45,7 @@ discovery:
 # This feature is only available in tidb-operator v1.0 or higher.
 # Note: Switch this variable against an existing cluster will cause an rolling-update of each component even
 # if the ConfigMap was not changed.
-enableConfigMapRollout: false
+enableConfigMapRollout: true
 
 pd:
   # Please refer to https://github.com/pingcap/pd/blob/master/conf/config.toml for the default


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Enable configmap rollout by default and quote configmap digest suffix
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes

 - Has Helm charts change
 - Has Go code change

Side effects
 - The tidb cluster will perform a rolling update when user upgrade chart from the prior versions.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Configmap rollout is now enabled by default. 
 ```
