### PR TITLE
Specify tikv status address to fix monitoring

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -161,6 +161,8 @@ tikv:
   # (choose the version matching your tikv) for detailed explanation of each parameter.
   config: |
     log-level = "info"
+    [server]
+    status-addr = "0.0.0.0:20180"
   
   # Here are some parameters you may want to customize (Please configure in the above 'config' section):
   # [readpool.storage]


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
TiKV metrics port cannot be accessed from Prometheus by default.

Also, we have to notice users to keep this configuration when they customize the `tikv.config`

### What is changed and how does it work?
Specify the tikv metrics listen address as `0.0.0.0`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Helm charts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix TiKV metrics monitoring in default setup.
 ```
@tennix @DanielZhangQD @weekface PTAL