### PR TITLE
support kubeconfig env

### DIFF
--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/pingcap/tidb-operator/pkg/util"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -13,18 +14,22 @@ import (
 	"github.com/pingcap/tidb-operator/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/logs"
-	"k8s.io/client-go/rest"
 )
 
 var (
 	printVersion bool
 	port         int
+	kubeConfig   string
+	masterURL    string
 )
 
 func init() {
 	flag.BoolVar(&printVersion, "V", false, "Show version and quit")
 	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
 	flag.IntVar(&port, "port", 10261, "The port that the tidb discovery's http service runs on (default 10261)")
+	flag.StringVar(&kubeConfig, "kubeconfig", "", "The path of kubeconfig file, only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "", `The url of the Kubernetes API server,will overrides 
+		any value in kubeconfig, only required if out-of-cluster.`)
 	flag.Parse()
 }
 
@@ -38,10 +43,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		glog.Fatalf("failed to get config: %v", err)
-	}
+	cfg := util.NewClusterConfig(masterURL, kubeConfig)
 	cli, err := versioned.NewForConfig(cfg)
 	if err != nil {
 		glog.Fatalf("failed to create Clientset: %v", err)

--- a/pkg/util/k8s_util.go
+++ b/pkg/util/k8s_util.go
@@ -1,0 +1,43 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const KUBECONFIGENV = "KUBECONFIG"
+
+func NewClusterConfig(masterURL, kubeconfig string) (cfg *rest.Config) {
+	var err error
+	if os.Getenv(KUBECONFIGENV) != "" {
+		kubeconfig = os.Getenv(KUBECONFIGENV)
+	}
+	if kubeconfig != "" {
+		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		if err != nil {
+			glog.Fatalf("failed to create config from file %s, masterURL %s: %v\n", kubeconfig, masterURL, err)
+		}
+		return
+	}
+	cfg, err = rest.InClusterConfig()
+	if err != nil {
+		glog.Fatalf("failed to get in-cluster config: %v", err)
+	}
+	return
+}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?
Add support for KUBECONFIG env when starting components.
This env enables running and debugging this operator in local development environment easier.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Helm charts change
 - Has Go code change yes
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
