### PR TITLE
Enable useNodeNameOnly in local-volume-provisioner deployment

### DIFF
--- a/deploy/modules/aliyun/tidb-operator/templates/local-volume-provisioner.yaml.tpl
+++ b/deploy/modules/aliyun/tidb-operator/templates/local-volume-provisioner.yaml.tpl
@@ -4,6 +4,9 @@ metadata:
   name: local-provisioner-config
   namespace: kube-system
 data:
+  useNodeNameOnly: "true"
+  nodeLabelsForPV: |
+    - kubernetes.io/hostname
   storageClassMap: |
     local-volume:
        vendor: alibabacloud

--- a/deploy/modules/aws/tidb-operator/manifests/local-volume-provisioner.yaml
+++ b/deploy/modules/aws/tidb-operator/manifests/local-volume-provisioner.yaml
@@ -12,6 +12,9 @@ metadata:
   name: local-provisioner-config
   namespace: kube-system
 data:
+  useNodeNameOnly: "true"
+  nodeLabelsForPV: |
+    - kubernetes.io/hostname
   storageClassMap: |
     local-storage:
       hostDir: /mnt/local-ssd

--- a/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
+++ b/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
@@ -12,6 +12,9 @@ metadata:
   name: local-provisioner-config
   namespace: kube-system
 data:
+  useNodeNameOnly: "true"
+  nodeLabelsForPV: |
+    - kubernetes.io/hostname
   storageClassMap: |
     local-storage:
       hostDir: /mnt/disks

--- a/manifests/local-dind/local-volume-provisioner.yaml
+++ b/manifests/local-dind/local-volume-provisioner.yaml
@@ -12,6 +12,7 @@ metadata:
   name: local-provisioner-config
   namespace: kube-system
 data:
+  useNodeNameOnly: "true"
   nodeLabelsForPV: |
     - kubernetes.io/hostname
   storageClassMap: |


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fix #421

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
ACTION REQUIRED: In cloud platforms, a node may be recreated with the same name but different UID, we enable `useNodeNameOnly` in local-volume-provisioner to avoid issues. However, you must fix existing PVs by removing UUID suffixes in annotation `pv.kubernetes.io/provisioned-by` when you upgrade your current local-volume-provisioner.
 ```