### PR TITLE
Terraform gke scale out fix

### DIFF
--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -99,7 +99,7 @@ resource "google_container_cluster" "cluster" {
     use_ip_aliases = true
   }
 
-  // see https://github.com/terraform-providers/terraform-provider-google/issues/3385 for why initial_node_count is sum of node counts
+  // See https://kubernetes.io/docs/setup/best-practices/cluster-large/#size-of-master-and-master-components for why initial_node_count is 5. The master node should accommodate up to 100 nodes like this
   remove_default_node_pool = true
   initial_node_count       = 5
 
@@ -118,12 +118,12 @@ resource "google_container_cluster" "cluster" {
 
 resource "google_container_node_pool" "pd_pool" {
   // The monitor pool is where tiller must first be deployed to.
-  depends_on         = [google_container_node_pool.monitor_pool]
-  provider           = google-beta
-  project            = var.GCP_PROJECT
-  cluster            = google_container_cluster.cluster.name
-  location           = google_container_cluster.cluster.location
-  name               = "pd-pool"
+  depends_on = [google_container_node_pool.monitor_pool]
+  provider   = google-beta
+  project    = var.GCP_PROJECT
+  cluster    = google_container_cluster.cluster.name
+  location   = google_container_cluster.cluster.location
+  name       = "pd-pool"
   node_count = var.pd_count
 
   management {
@@ -151,11 +151,11 @@ resource "google_container_node_pool" "pd_pool" {
 }
 
 resource "google_container_node_pool" "tikv_pool" {
-  provider           = google-beta
-  project            = var.GCP_PROJECT
-  cluster            = google_container_cluster.cluster.name
-  location           = google_container_cluster.cluster.location
-  name               = "tikv-pool"
+  provider   = google-beta
+  project    = var.GCP_PROJECT
+  cluster    = google_container_cluster.cluster.name
+  location   = google_container_cluster.cluster.location
+  name       = "tikv-pool"
   node_count = var.tikv_count
 
   management {
@@ -187,12 +187,12 @@ resource "google_container_node_pool" "tikv_pool" {
 
 resource "google_container_node_pool" "tidb_pool" {
   // The pool order is tikv -> monitor -> pd -> tidb
-  depends_on         = [google_container_node_pool.pd_pool]
-  provider           = google-beta
-  project            = var.GCP_PROJECT
-  cluster            = google_container_cluster.cluster.name
-  location           = google_container_cluster.cluster.location
-  name               = "tidb-pool"
+  depends_on = [google_container_node_pool.pd_pool]
+  provider   = google-beta
+  project    = var.GCP_PROJECT
+  cluster    = google_container_cluster.cluster.name
+  location   = google_container_cluster.cluster.location
+  name       = "tidb-pool"
   node_count = var.tidb_count
 
   management {
@@ -221,11 +221,11 @@ resource "google_container_node_pool" "tidb_pool" {
 resource "google_container_node_pool" "monitor_pool" {
   // Setup local SSD on TiKV nodes first (this can take some time)
   // Create the monitor pool next because that is where tiller will be deployed to
-  depends_on         = [google_container_node_pool.tikv_pool]
-  project            = var.GCP_PROJECT
-  cluster            = google_container_cluster.cluster.name
-  location           = google_container_cluster.cluster.location
-  name               = "monitor-pool"
+  depends_on = [google_container_node_pool.tikv_pool]
+  project    = var.GCP_PROJECT
+  cluster    = google_container_cluster.cluster.name
+  location   = google_container_cluster.cluster.location
+  name       = "monitor-pool"
   node_count = var.monitor_count
 
   management {

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -99,9 +99,9 @@ resource "google_container_cluster" "cluster" {
     use_ip_aliases = true
   }
 
-  remove_default_node_pool = true
   // see https://github.com/terraform-providers/terraform-provider-google/issues/3385 for why initial_node_count is sum of node counts
-  initial_node_count       = var.pd_count + var.tikv_count + var.tidb_count + var.monitor_count
+  remove_default_node_pool = true
+  initial_node_count       = 5
 
   min_master_version = "latest"
 
@@ -340,6 +340,7 @@ resource "null_resource" "setup-env" {
     null_resource.get-credentials,
     var.tidb_operator_registry,
     var.tidb_operator_version,
+    google_container_node_pool.monitor_pool
   ]
 
   provisioner "local-exec" {
@@ -382,6 +383,8 @@ resource "null_resource" "deploy-tidb-cluster" {
     null_resource.setup-env,
     local_file.tidb-cluster-values,
     google_container_node_pool.pd_pool,
+    google_container_node_pool.tikv_pool,
+    google_container_node_pool.tidb_pool
   ]
 
   triggers = {

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -384,7 +384,8 @@ resource "null_resource" "deploy-tidb-cluster" {
     local_file.tidb-cluster-values,
     google_container_node_pool.pd_pool,
     google_container_node_pool.tikv_pool,
-    google_container_node_pool.tidb_pool
+    google_container_node_pool.tidb_pool,
+    google_container_node_pool.monitor_pool
   ]
 
   triggers = {

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -39,14 +39,14 @@ resource "null_resource" "set-gcloud-project" {
 }
 
 resource "google_compute_network" "vpc_network" {
-  name                    = "vpc-network"
+  name                    = "${var.cluster_name}-vpc-network"
   auto_create_subnetworks = false
   project                 = var.GCP_PROJECT
 }
 
 resource "google_compute_subnetwork" "private_subnet" {
   ip_cidr_range = "172.31.252.0/22"
-  name          = "private-subnet"
+  name          = "${var.cluster_name}-private-subnet"
   network       = google_compute_network.vpc_network.name
   project       = var.GCP_PROJECT
 
@@ -67,7 +67,7 @@ resource "google_compute_subnetwork" "private_subnet" {
 
 resource "google_compute_subnetwork" "public_subnet" {
   ip_cidr_range = "172.29.252.0/22"
-  name          = "public-subnet"
+  name          = "${var.cluster_name}-public-subnet"
   network       = google_compute_network.vpc_network.name
   project       = var.GCP_PROJECT
 }
@@ -124,7 +124,7 @@ resource "google_container_node_pool" "pd_pool" {
   cluster            = google_container_cluster.cluster.name
   location           = google_container_cluster.cluster.location
   name               = "pd-pool"
-  initial_node_count = var.pd_count
+  node_count = var.pd_count
 
   management {
     auto_repair  = false
@@ -156,7 +156,7 @@ resource "google_container_node_pool" "tikv_pool" {
   cluster            = google_container_cluster.cluster.name
   location           = google_container_cluster.cluster.location
   name               = "tikv-pool"
-  initial_node_count = var.tikv_count
+  node_count = var.tikv_count
 
   management {
     auto_repair  = false
@@ -193,7 +193,7 @@ resource "google_container_node_pool" "tidb_pool" {
   cluster            = google_container_cluster.cluster.name
   location           = google_container_cluster.cluster.location
   name               = "tidb-pool"
-  initial_node_count = var.tidb_count
+  node_count = var.tidb_count
 
   management {
     auto_repair  = false
@@ -226,7 +226,7 @@ resource "google_container_node_pool" "monitor_pool" {
   cluster            = google_container_cluster.cluster.name
   location           = google_container_cluster.cluster.location
   name               = "monitor-pool"
-  initial_node_count = var.monitor_count
+  node_count = var.monitor_count
 
   management {
     auto_repair  = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Closes #708 

### What is changed and how does it work?
This incorporates changes from @aylei's' commit https://github.com/aylei/tidb-operator/commit/47be0a7b388b5023f926571446b9a3390a98ff7c in his fork. This prevents node pools from being recreated.

In #673 the `initial_node_count` variable in the cluster resource was changed to depend on the tidb/monitor/tikv/pd count variables. Because of this, when a count variable is changed to scale out, the cluster resource is recreated by terraform. To get around this, a literal value of `5` is used. According to https://kubernetes.io/docs/setup/best-practices/cluster-large/#size-of-master-and-master-components this will cause a master node to be created that can accommodate up to 100 nodes.

Additional ordering in the resource creation to ensure that the tidb-cluster helm release is installed/upgraded only after the node pools are created/updated to prevent an issue where pods might be scheduled on old nodes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
* terraform apply
* wait for finish
* check master node is not upgrading
* increase `tikv_count` `tikv_replica_count` (availabillity zones means `tikv_count=1` will have 3 nodes, 2 -> 6, etc)
* terraform apply
* check plan to make sure cluster is not recreated
* type `yes`
* check that cluster is not recreated, tidb node pool is created, then tidb-cluster release is upgraded
* check tidb pods are running properly
* terraform destroy


Code changes

 - Terraform changes

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
