### PR TITLE
Add tidb-backup job reource limits

### DIFF
--- a/charts/tidb-backup/templates/backup-job.yaml
+++ b/charts/tidb-backup/templates/backup-job.yaml
@@ -26,6 +26,10 @@ spec:
       - name: backup
         image: {{ .Values.image.backup }}
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+    {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- end }}
         command:
         - /bin/sh
         - -c

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -23,6 +23,14 @@ extraLabels: {}
 # kubectl create secret generic backup-secret --namespace=<namespace> --from-literal=user=root --from-literal=password=<password>
 secretName: backup-secret
 
+resources:
+  limits:
+    cpu: 4000m
+    memory: 8Gi
+  requests:
+    cpu: 2000m
+    memory: 4Gi
+
 storage:
   className: local-storage
   size: 100Gi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
#284
### What is changed and how does it work?
Add Tidb-backup helm chart job resource limits and requests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes

 - Has Helm charts change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
