### PR TITLE
Update READMEs to point to correct docs URLs

### DIFF
--- a/deploy/aliyun/README.md
+++ b/deploy/aliyun/README.md
@@ -1,3 +1,4 @@
 # Deploy TiDB Operator and TiDB Cluster on Alibaba Cloud Kubernetes
 
-This document has been moved to [https://pingcap.com/docs/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/alibaba-cloud/](https://pingcap.com/docs/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/alibaba-cloud/).
+This document has been moved to [https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/](https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/).
+简体中文 [https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/](https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/).

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,3 +1,4 @@
 # Deploy TiDB Operator and TiDB cluster on AWS EKS
 
-This document has been moved to [https://pingcap.com/docs-cn/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/aws-eks/](https://pingcap.com/docs-cn/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/aws-eks/).
+This document has been moved to [https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/aws-eks/](https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/aws-eks/).
+简体中文 [https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/aws-eks/](https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/aws-eks/).

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,3 +1,4 @@
 # Deploy TiDB Operator and TiDB cluster on GCP GKE
 
 This document has been moved to [https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/gcp-gke/](https://pingcap.com/docs/v3.0/tidb-in-kubernetes/deploy/gcp-gke/).
+简体中文 [https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/gcp-gke/](https://pingcap.com/docs-cn/v3.0/tidb-in-kubernetes/deploy/gcp-gke/).


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

README.md had a number of outdated (404) links to pingcap.com/docs. This resolves that.
