### PR TITLE
e2e:extend the wating time of CheckManualPauseTiDB process

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -2693,7 +2693,7 @@ func (oa *operatorActions) CheckManualPauseTiDB(info *TidbClusterConfig) error {
 	}
 
 	// wait for the tidb statefulset is upgrade to the protect one
-	if err = wait.Poll(DefaultPollInterval, DefaultPollTimeout, fn); err != nil {
+	if err = wait.Poll(DefaultPollInterval, 30*time.Minute, fn); err != nil {
 		return fmt.Errorf("fail to upgrade to annotation TiDB pod : %v", err)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
e2e:extend the wating time of CheckManualPauseTiDB process
### What is changed and how does it work?
Extends the wait time of the CheckManualPauseTiDB process to avoid test timeouts in extreme cases.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Stability test


Code changes

 - Has Go code change