### PR TITLE
fix e2e test compatible with v1.0.0

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -2347,13 +2347,22 @@ func (oa *operatorActions) CheckIncrementalBackup(info *TidbClusterConfig, withD
 			return false, nil
 		}
 
+		// v1.0.0 don't have affinity test case
+		// https://github.com/pingcap/tidb-operator/pull/746
+		isv1 := info.OperatorTag == "v1.0.0"
+
 		for _, pod := range pods.Items {
 			if !oa.pumpHealth(info, pod.Spec.Hostname) {
 				glog.Errorf("some pods is not health %s", pumpStatefulSetName)
 				// return false, nil
 			}
+
+			if isv1 {
+				continue
+			}
+
 			glog.Info(pod.Spec.Affinity)
-			if len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+			if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil || len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
 				return true, fmt.Errorf("pump pod %s/%s should have affinity set", pod.Namespace, pod.Name)
 			}
 			glog.Info(pod.Spec.Tolerations)
@@ -2403,8 +2412,13 @@ func (oa *operatorActions) CheckIncrementalBackup(info *TidbClusterConfig, withD
 				glog.Errorf("some pods is not health %s", drainerStatefulSetName)
 				// return false, nil
 			}
+
+			if isv1 {
+				continue
+			}
+
 			glog.Info(pod.Spec.Affinity)
-			if len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+			if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil || len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
 				return true, fmt.Errorf("drainer pod %s/%s should have spec.affinity set", pod.Namespace, pod.Name)
 			}
 			glog.Info(pod.Spec.Tolerations)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

v1.0.0 did't have [`affinity`](https://github.com/pingcap/tidb-operator/pull/746
) test case, we should't run the `affinity` case in v1.0.0

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Stability test

Code changes

 - Has Go code change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
