### PR TITLE
pump: prevent pump progress from an exit with 0 if the pump become `offline`

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_pump.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_pump.sh.tpl
@@ -5,3 +5,8 @@ set -euo pipefail
 -advertise-addr=`echo ${HOSTNAME}`.{{ template "cluster.name" . }}-pump:8250 \
 -config=/etc/pump/pump.toml \
 -log-file=
+
+if [ $? == 0 ]; then
+    echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "pump offline, please delete my pod"
+    tail -f /dev/null
+fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

prevent pump progress from an exit with 0 if the pump become `offline`
, because it will be `online` again if the pod get restarted by `statefulset`.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Code changes

 - Has Helm charts change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
prevent pump progress from an exit with 0 if the pump become `offline`
 ```
