### PR TITLE
terraform/gcp: Able to configure image type

### DIFF
--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -15,6 +15,7 @@ resource "google_container_node_pool" "pd_pool" {
 
   node_config {
     machine_type    = var.pd_instance_type
+    image_type      = var.pd_image_type
     local_ssd_count = 0
 
     taint {
@@ -47,6 +48,7 @@ resource "google_container_node_pool" "tikv_pool" {
 
   node_config {
     machine_type = var.tikv_instance_type
+    image_type   = var.tikv_image_type
     // This value cannot be changed (instead a new node pool is needed)
     // 1 SSD is 375 GiB
     local_ssd_count = 1
@@ -83,6 +85,7 @@ resource "google_container_node_pool" "tidb_pool" {
 
   node_config {
     machine_type = var.tidb_instance_type
+    image_type   = var.tidb_image_type
 
     taint {
       effect = "NO_SCHEDULE"

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -44,3 +44,18 @@ variable "tidb_instance_type" {}
 variable "monitor_instance_type" {
   default = "n1-standard-2"
 }
+
+variable "pd_image_type" {
+  description = "PD image type, avaiable: UBUNTU/COS"
+  default = "COS"
+}
+
+variable "tidb_image_type" {
+  description = "TiDB image type, avaiable: UBUNTU/COS"
+  default = "COS"
+}
+
+variable "tikv_image_type" {
+  description = "TiKV image type, avaiable: UBUNTU/COS"
+  default = "COS"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Sometimes users may favor non-COS node images. This adds variables to configure image type for TiDB node pools.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
terraform/gcp: Able to configure node image types for PD/TiDB/TiKV node pools.
 ```
