### PR TITLE
Adds workaround for data.google_compute_zones.available weirdness

### DIFF
--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -125,7 +125,7 @@ resource "google_container_node_pool" "monitor_pool" {
 }
 
 locals {
-  num_availability_zones = length(data.google_compute_zones.available)
+  num_availability_zones = length(data.google_compute_zones.available.names)
 }
 
 module "tidb-cluster" {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
```hcl
length(data.google_compute_zones.available)
```
returns `5` for `us-west1`.

### What is changed and how does it work?
In `deploy/modules/gcp/tidb-cluster/main.tf` switches to 
```hcl
length(data.google_compute_zones.available.names)
```
which correctly reteurns `3`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below):

    - `terraform apply`
    - When complete, note that number of pods is equal to the number of availability zones in the region (3 for us-west1).
    - `terraform destroy`

Code changes

 - Has Terraform changes

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
