### PR TITLE
Fix default tidb-drainer config

### DIFF
--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -24,7 +24,7 @@ initialCommitTs: 0
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml
 config: |
   detect-interval = 10
-  compressor = "gzip"
+  compressor = ""
   [syncer]
   worker-count = 16
   disable-dispatch = false

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -23,17 +23,17 @@ initialCommitTs: 0
 
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml
 config: |
+  detect-interval = 10
+  compressor = "gzip"
   [syncer]
   worker-count = 16
-  detect-interval = 10
   disable-dispatch = false
   ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
   safe-mode = false
   txn-batch = 20
-  db-type = "pb"
+  db-type = "file"
   [syncer.to]
   dir = "/data/pb"
-  compression = "gzip"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/792

### What is changed and how does it work?
Default tidb-drainer config is adjusted to be compatible with the latest drainer config format.
To be more specific:
detect-interval is moved out from [syncer]
db-type value is changed from pb to file
compression is moved out from [syncer] and renamed to compressor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Deploy tidb-drainer chart out-of-box to AWS
2. Drainer is successfully deployed and running

Code changes

 - Has Helm charts change

Side effects

 - Breaking backward compatibility

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
