### PR TITLE
deploy/gcp: Retrieve real number of node locations of the cluster

### DIFF
--- a/deploy/modules/gcp/tidb-cluster/data.tf
+++ b/deploy/modules/gcp/tidb-cluster/data.tf
@@ -18,4 +18,13 @@ data "external" "monitor_port" {
   program    = ["bash", "-c", "kubectl --kubeconfig ${var.kubeconfig_path} get svc -n ${var.cluster_name} ${var.cluster_name}-grafana -o json | jq '.spec.ports | .[] | select( .name == \"grafana\") | {port: .port|tostring}'"]
 }
 
-data "google_compute_zones" "available" {}
+locals {
+  # TODO Update related code when node locations is avaiable in attributes of cluster resource.
+  cmd_get_cluster_locations = <<EOT
+gcloud --project ${var.gcp_project} container clusters list --filter='name=${var.gke_cluster_name}' --format='json[no-heading](locations)' --region ${var.gke_cluster_location} | jq '.[0] | .locations |= join(",")'
+EOT
+}
+
+data "external" "cluster_locations" {
+  program = ["bash", "-c", local.cmd_get_cluster_locations]
+}

--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -125,7 +125,7 @@ resource "google_container_node_pool" "monitor_pool" {
 }
 
 locals {
-  num_availability_zones = length(data.google_compute_zones.available.names)
+  num_availability_zones = length(split(",", data.external.cluster_locations.result["locations"]))
 }
 
 module "tidb-cluster" {
@@ -143,7 +143,7 @@ module "tidb-cluster" {
 
 resource "null_resource" "wait-lb-ip" {
   depends_on = [
-    google_container_node_pool.tidb_pool,
+    module.tidb-cluster
   ]
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

by default, the regional cluster will [choose 3 from all available zones]((https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters#overview)). However, there are 4 zones in `us-central1` region.

Currently, we need to use `gcloud` command to retrieve the real number of node locations of the cluster.

See discussion: https://github.com/pingcap/tidb-operator/pull/788#issuecomment-523334689

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
