### PR TITLE
support restore tidb cluster from a specified scheduled backup dir

### DIFF
--- a/charts/tidb-backup/templates/restore-job.yaml
+++ b/charts/tidb-backup/templates/restore-job.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
         env:
         - name: BACKUP_NAME
-          value: {{ .Values.name | quote }}
+          value: {{ .Values.scheduledBackupName | default .Values.name | quote }}
       {{- if .Values.gcp }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /gcp/credentials.json
@@ -69,10 +69,14 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
+    {{- if .Values.scheduledBackupName }}
+          claimName: {{ .Values.clusterName }}-scheduled-backup
+    {{- else }}
           claimName: {{ .Values.name }}
+    {{- end }}
     {{- if .Values.gcp }}
       - name: gcp-credentials
         secret:
           secretName: {{ .Values.gcp.secretName }}
     {{- end }}
-{{- end }}
+{{- end -}}

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -6,8 +6,14 @@
 clusterName: demo
 
 mode: backup # backup | restore | scheduled-restore
-# name is the backup name
+
+# name is the backup dir name and pvc name for ad-hoc backup and restore
 name: fullbackup-{{ date "200601021504" .Release.Time }}
+
+# scheduledBackupName is the name of a scheduled backup directory,
+# used to restore the tidb cluster from scheduled backup.
+# scheduledBackupName: scheduled-backup-20190822-041004
+
 image:
   pullPolicy: IfNotPresent
   # https://github.com/pingcap/tidb-cloud-backup


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Make tidb-backup to support  restore tidb clusters from a specified scheduled backup directory, while compatible with previous ad-hoc backup and restore method

### What is changed and how does it work?
Work as before

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 

Code changes

 - Has Helm charts change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
 support restore tidb cluster from a specified scheduled backup directory
 ```
