### PR TITLE
Correctly uses tidb cluster version var when creating cluster

### DIFF
--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -135,6 +135,7 @@ module "tidb-cluster" {
   tikv_count                 = var.tikv_node_count * local.num_availability_zones
   tidb_count                 = var.tidb_node_count * local.num_availability_zones
   tidb_cluster_chart_version = var.tidb_cluster_chart_version
+  cluster_version            = var.cluster_version
   override_values            = var.override_values
   kubeconfig_filename        = var.kubeconfig_path
   base_values                = file("${path.module}/values/default.yaml")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
GCP terraform was not creating tidb clusters when `tidb_version` was overriden with the right version number

### What is changed and how does it work?
Correctly passes tidb version through the modules

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has terraform changes

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
