### PR TITLE
charts: Add tidb-lightning support

### DIFF
--- a/charts/tidb-cluster/templates/_helpers.tpl
+++ b/charts/tidb-cluster/templates/_helpers.tpl
@@ -110,3 +110,18 @@ drainer-config: |-
 {{- define "drainer-configmap.data-digest" -}}
 {{ include "drainer-configmap.data" . | sha256sum | trunc 8 }}
 {{- end -}}
+
+
+{{/*
+Encapsulate tikv-importer configmap data for consistent digest calculation
+*/}}
+{{- define "importer-configmap.data" -}}
+config-file: |-
+    {{- if .Values.importer.config }}
+{{ .Values.importer.config | indent 2 }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "importer-configmap.data-digest" -}}
+{{ include "importer-configmap.data" . | sha256sum | trunc 8 }}
+{{- end -}}

--- a/charts/tidb-cluster/templates/_helpers.tpl
+++ b/charts/tidb-cluster/templates/_helpers.tpl
@@ -111,7 +111,6 @@ drainer-config: |-
 {{ include "drainer-configmap.data" . | sha256sum | trunc 8 }}
 {{- end -}}
 
-
 {{/*
 Encapsulate tikv-importer configmap data for consistent digest calculation
 */}}

--- a/charts/tidb-cluster/templates/tikv-importer-configmap.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cluster.name" . }}-importer-{{ template "importer-configmap.data-digest" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: importer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+data:
+{{ include "importer-configmap.data" . | indent 2 }}

--- a/charts/tidb-cluster/templates/tikv-importer-configmap.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.importer.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 data:
 {{ include "importer-configmap.data" . | indent 2 }}
+{{- end }}

--- a/charts/tidb-cluster/templates/tikv-importer-service.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.importer.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cluster.name" . }}-importer
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: importer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  clusterIP: None
+  ports:
+  - name: importer
+    port: 20170
+  selector:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: importer
+{{- end }}

--- a/charts/tidb-cluster/templates/tikv-importer-service.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-service.yaml
@@ -13,7 +13,7 @@ spec:
   clusterIP: None
   ports:
   - name: importer
-    port: 20170
+    port: 8287
   selector:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "chart.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: tidb-operator
       app.kubernetes.io/component: importer
   serviceName: {{ template "cluster.name" . }}-importer
   replicas: {{ .Values.importer.replicas }}
@@ -23,20 +22,19 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "20170"
+        prometheus.io/port: "9091"
       labels:
         app.kubernetes.io/name: {{ template "chart.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: tidb-operator
         app.kubernetes.io/component: importer
     spec:
     {{- if .Values.importer.affinity }}
       affinity:
-{{ toYaml .Values.importer.affinity | indent 8 }}
+{{ toYaml .Values.importer.affinity | indent 6 }}
     {{- end }}
     {{- if .Values.importer.tolerations }}
       tolerations:
-{{ toYaml .Values.importer.tolerations | indent 8 }}
+{{ toYaml .Values.importer.tolerations | indent 6 }}
     {{- end }}
       containers:
       - name: importer
@@ -45,8 +43,8 @@ spec:
         command:
         - /tikv-importer
         # tikv-importer does not support domain name: https://github.com/tikv/importer/issues/16
-        # - --addr=${MY_POD_NAME}.tikv-importer:20170
-        - --addr=$(MY_POD_IP):20170
+        # - --addr=${MY_POD_NAME}.tikv-importer:8287
+        - --addr=$(MY_POD_IP):8287
         - --config=/etc/tikv-importer/tikv-importer.toml
         - --import-dir=/var/lib/tikv-importer
         env:
@@ -65,6 +63,13 @@ spec:
           mountPath: /var/lib/tikv-importer
         - name: config
           mountPath: /etc/tikv-importer
+        {{- if .Values.importer.resources }}
+        resources:
+{{ toYaml .Values.importer.resources | indent 10 }}
+        {{- end }}
+      - name: pushgateway
+        image: {{ .Values.importer.pushgatewayImage }}
+        imagePullPolicy: {{ .Values.importer.pushgatewayImagePullPolicy | default "IfNotPresent" }}
       volumes:
       - name: config
         configMap:

--- a/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.importer.create }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "cluster.name" . }}-importer
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: importer
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "chart.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: tidb-operator
+      app.kubernetes.io/component: importer
+  serviceName: {{ template "cluster.name" . }}-importer
+  replicas: {{ .Values.importer.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "20170"
+      labels:
+        app.kubernetes.io/name: {{ template "chart.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: tidb-operator
+        app.kubernetes.io/component: importer
+    spec:
+    {{- if .Values.importer.affinity }}
+      affinity:
+{{ toYaml .Values.importer.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.importer.tolerations }}
+      tolerations:
+{{ toYaml .Values.importer.tolerations | indent 8 }}
+    {{- end }}
+      containers:
+      - name: importer
+        image: {{ .Values.importer.image }}
+        imagePullPolicy: {{ .Values.importer.imagePullPolicy | default "IfNotPresent"}}
+        command:
+        - /tikv-importer
+        # tikv-importer does not support domain name: https://github.com/tikv/importer/issues/16
+        # - --addr=${MY_POD_NAME}.tikv-importer:20170
+        - --addr=$(MY_POD_IP):20170
+        - --config=/etc/tikv-importer/tikv-importer.toml
+        - --import-dir=/var/lib/tikv-importer
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/tikv-importer
+        - name: config
+          mountPath: /etc/tikv-importer
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "cluster.name" . }}-importer-{{ template "importer-configmap.data-digest" . }}
+          items:
+          - key: config-file
+            path: tikv-importer.toml
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.importer.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.importer.storage }}
+{{- end }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -49,7 +49,7 @@ enableConfigMapRollout: true
 
 pd:
   # Please refer to https://github.com/pingcap/pd/blob/master/conf/config.toml for the default
-  # pd configurations (change to the tags of your pd version), 
+  # pd configurations (change to the tags of your pd version),
   # just follow the format in the file and configure in the 'config' section
   # as below if you want to customize any configuration.
   # Please refer to https://pingcap.com/docs-cn/v3.0/reference/configuration/pd-server/configuration-file/
@@ -59,7 +59,7 @@ pd:
     level = "info"
     [replication]
     location-labels = ["region", "zone", "rack", "host"]
-  
+
   replicas: 3
   image: pingcap/pd:v3.0.1
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -553,6 +553,17 @@ scheduledBackup:
   # You can create the secret by:
   # kubectl create secret generic s3-backup-secret --from-literal=access_key=<access-key> --from-literal=secret_key=<secret-key>
   # secretName: s3-backup-secret
+
+importer:
+  create: false
+  image: pingcap/tidb-lightning:v3.0.1
+  imagePullPolicy: IfNotPresent
+  storageClassName: local-storage
+  storage: 20Gi
+  affinity: {}
+  tolerations: []
+  config: |
+    log-level = "info"
 
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -559,11 +559,24 @@ importer:
   image: pingcap/tidb-lightning:v3.0.1
   imagePullPolicy: IfNotPresent
   storageClassName: local-storage
-  storage: 20Gi
+  storage: 200Gi
+  resources: {}
+    # limits:
+    #   cpu: 16000m
+    #   memory: 8Gi
+    # requests:
+    #   cpu: 16000m
+    #   memory: 8Gi
   affinity: {}
   tolerations: []
+  pushgatewayImage: prom/pushgateway:v0.3.1
+  pushgatewayImagePullPolicy: IfNotPresent
   config: |
     log-level = "info"
+    [metrics]
+    job = "tikv-importer"
+    interval = "15s"
+    address = "localhost:9091"
 
 metaInstance: "{{ $labels.instance }}"
 metaType: "{{ $labels.type }}"

--- a/charts/tidb-lightning/.helmignore
+++ b/charts/tidb-lightning/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/tidb-lightning/Chart.yaml
+++ b/charts/tidb-lightning/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: tidb-lightning
+version: 0.1.0

--- a/charts/tidb-lightning/Chart.yaml
+++ b/charts/tidb-lightning/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: A Helm chart for TiDB Lightning
 name: tidb-lightning
-version: 0.1.0
+version: dev
+home: https://github.com/pingcap/tidb-lightning
+sources:
+  - https://github.com/pingcap/tidb-operator
+keywords:
+  - newsql
+  - database
+  - backup

--- a/charts/tidb-lightning/secret.yaml
+++ b/charts/tidb-lightning/secret.yaml
@@ -17,15 +17,13 @@ stringData:
     type = s3
     provider = Ceph
     env_auth = false
-    access_key_id = <my-access-key
+    access_key_id = <my-access-key>
     secret_access_key = <my-secret-key>
     endpoint = <ceph-object-store-endpoint>
+    region = :default-placement
 
     [gcs]
     type = google cloud storage
-    client_id =
-    client_secret =
-    token = {"AccessToken":"xxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","RefreshToken":"x/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxx","Expiry":"2014-07-17T20:49:14.929208288+01:00","Extra":null}
-    project_number = 12345678
-    object_acl = private
-    bucket_acl = private
+    # The service account must include Storage Object Viewer role
+    # The content can be retrieved by `cat <service-account-file.json> | jq -c .`
+    service_account_credentials = <service-account-json-file-content>

--- a/charts/tidb-lightning/secret.yaml
+++ b/charts/tidb-lightning/secret.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-storage-secret
+type: Opaque
+stringData:
+  rclone.conf: |
+    [s3]
+    type = s3
+    provider = AWS
+    env_auth = false
+    access_key_id = <my-access-key>
+    secret_access_key = <my-secret-key>
+    region = us-east-1
+
+    [ceph]
+    type = s3
+    provider = Ceph
+    env_auth = false
+    access_key_id = <my-access-key
+    secret_access_key = <my-secret-key>
+    endpoint = <ceph-object-store-endpoint>
+
+    [gcs]
+    type = google cloud storage
+    client_id =
+    client_secret =
+    token = {"AccessToken":"xxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","RefreshToken":"x/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxx","Expiry":"2014-07-17T20:49:14.929208288+01:00","Extra":null}
+    project_number = 12345678
+    object_acl = private
+    bucket_acl = private

--- a/charts/tidb-lightning/templates/NOTES.txt
+++ b/charts/tidb-lightning/templates/NOTES.txt
@@ -2,7 +2,7 @@
   kubectl get job -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
   kubectl get po -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
 2. Check tidb-lightning logs
-  kubectl logs -f -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
 3. View tidb-lightning status page
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "tidb-lightning.name" . }} 8289:8289
   View http://localhost:8289 in web browser

--- a/charts/tidb-lightning/templates/NOTES.txt
+++ b/charts/tidb-lightning/templates/NOTES.txt
@@ -1,0 +1,7 @@
+1. Check tidb-lightning status
+  kubectl get job -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
+  kubectl get po -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
+2. Check tidb-lightning logs
+  kubectl logs -f -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
+3. View tidb-lightning status page
+  kubectl port-forward -n {{ .Release.Namespace }} svc/

--- a/charts/tidb-lightning/templates/NOTES.txt
+++ b/charts/tidb-lightning/templates/NOTES.txt
@@ -4,4 +4,5 @@
 2. Check tidb-lightning logs
   kubectl logs -f -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "tidb-lightning.name" . }}
 3. View tidb-lightning status page
-  kubectl port-forward -n {{ .Release.Namespace }} svc/
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "tidb-lightning.name" . }} 8289:8289
+  View http://localhost:8289 in web browser

--- a/charts/tidb-lightning/templates/_helpers.tpl
+++ b/charts/tidb-lightning/templates/_helpers.tpl
@@ -6,6 +6,14 @@ Expand the name of the chart.
 {{ .Release.Name }}-tidb-lightning
 {{- end -}}
 
+{{- define "helm-toolkit.utils.template" -}}
+{{- $name := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $last := base $context.Template.Name }}
+{{- $wtf := $context.Template.Name | replace $last $name -}}
+{{ include $wtf $context }}
+{{- end -}}
+
 {{/*
 Encapsulate config data for consistent digest calculation
 */}}

--- a/charts/tidb-lightning/templates/_helpers.tpl
+++ b/charts/tidb-lightning/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tidb-lightning.name" -}}
+{{ .Release.Name }}-tidb-lightning
+{{- end -}}
+
+{{/*
+Encapsulate config data for consistent digest calculation
+*/}}
+{{- define "lightning-configmap.data" -}}
+config-file: |-
+    {{- if .Values.config }}
+{{ .Values.config | indent 2 }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "lightning-configmap.data-digest" -}}
+{{ include "lightning-configmap.data" . | sha256sum | trunc 8 }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tidb-lightning.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/tidb-lightning/templates/configmap.yaml
+++ b/charts/tidb-lightning/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tidb-lightning.name" . }}-{{ template "lightning-configmap.data-digest" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb-lightning
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+data:
+{{ include "lightning-configmap.data" . | indent 2 }}

--- a/charts/tidb-lightning/templates/configmap.yaml
+++ b/charts/tidb-lightning/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.targetTidbCluster.name }}
     app.kubernetes.io/component: tidb-lightning
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 data:

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -51,6 +51,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
+        {{- if .Values.failFast }}
+        env:
+        - name: FAIL_FAST
+          value: "true"
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/tidb-lightning

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/component: tidb-lightning
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
+  backoffLimit: 0               # disable job retry when fails
   template:
     metadata:
       labels:

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.targetTidbCluster.name }}
     app.kubernetes.io/component: tidb-lightning
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
@@ -51,12 +51,12 @@ spec:
         - |
           data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
           /tidb-lightning \
-          --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Values.targetTidbCluster.namespace}}:2379 \
+          --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
           --status-addr=0.0.0.0:8289 \
-          --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Values.targetTidbCluster.namespace }}:20170 \
+          --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Release.Namespace }}:8287 \
           --server-mode=false \
-          --tidb-user=root \
-          --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Values.targetTidbCluster.namespace }} \
+          --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
+          --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Release.Namespace }} \
           {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
           --d={{ .Values.dataSource.local.hostPath }} \
           {{ else -}}

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -13,14 +13,14 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
-        app.kubernetes.io/instance:  {{ .Release.Name }}
+        app.kubernetes.io/instance:  {{ .Values.targetTidbCluster.name }}
         app.kubernetes.io/component: tidb-lightning
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8289"
     spec:
-      {{ if .Values.dataSource.local.nodeName -}}
+      {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
       nodeName: {{ .Values.dataSource.local.nodeName }}
       {{ else -}}
       initContainers:
@@ -67,6 +67,10 @@ spec:
               echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
               tail -f /dev/null
           fi
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/tidb-lightning
@@ -96,3 +100,11 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "tidb-lightning.name" . }}
       {{ end -}}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 6 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+    {{- end }}

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tidb-lightning.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb-lightning
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+        app.kubernetes.io/instance:  {{ .Release.Name }}
+        app.kubernetes.io/component: tidb-lightning
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8289"
+    spec:
+      {{ if .Values.dataSource.local.nodeName -}}
+      nodeName: {{ .Values.dataSource.local.nodeName }}
+      {{ else -}}
+      initContainers:
+      - name: data-retriever
+        image: {{ .Values.dataSource.remote.rcloneImage }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          filename=$(basename {{ .Values.dataSource.remote.path }})
+          rclone --config /etc/rclone/rclone.conf copy -P {{ .Values.dataSource.remote.path }} /data
+          cd /data && tar xzvf ${filename}
+        volumeMounts:
+        - name: credentials
+          mountPath: /etc/rclone
+        - name: data
+          mountPath: /data
+      {{ end -}}
+      restartPolicy: Never      # if lightning fails, manual intervention is required so no restart
+      containers:
+      - name: tidb-lightning
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
+          /tidb-lightning \
+          --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Values.targetTidbCluster.namespace}}:2379 \
+          --status-addr=0.0.0.0:8289 \
+          --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Values.targetTidbCluster.namespace }}:20170 \
+          --server-mode=false \
+          --tidb-user=root \
+          --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Values.targetTidbCluster.namespace }} \
+          {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
+          --d={{ .Values.dataSource.local.hostPath }} \
+          {{ else -}}
+          --d=${data_dir} \
+          {{ end -}}
+          --config=/etc/tidb-lightning/tidb-lightning.toml
+          if [ $? != 0 ]; then
+              echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
+              tail -f /dev/null
+          fi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/tidb-lightning
+        - name: data
+          {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName }}
+          mountPath: {{ .Values.dataSource.local.hostPath }}
+          {{ else -}}
+          mountPath: /var/lib/tidb-lightning
+          {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "tidb-lightning.name" . }}-{{ template "lightning-configmap.data-digest" . }}
+          items:
+          - key: config-file
+            path: tidb-lightning.toml
+      {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
+      - name: data
+        hostPath:
+          path: {{ .Values.dataSource.local.hostPath }}
+          type: Directory
+      {{ else -}}
+      - name: credentials
+        secret:
+          secretName: {{ .Values.dataSource.remote.secretName }}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "tidb-lightning.name" . }}
+      {{ end -}}

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -32,8 +32,13 @@ spec:
         - |
           set -euo pipefail
           filename=$(basename {{ .Values.dataSource.remote.path }})
-          rclone --config /etc/rclone/rclone.conf copy -P {{ .Values.dataSource.remote.path }} /data
-          cd /data && tar xzvf ${filename}
+          if find /data -name metadata; then
+              echo "data already exist"
+              exit 0
+          else
+              rclone --config /etc/rclone/rclone.conf copy -P {{ .Values.dataSource.remote.path }} /data
+              cd /data && tar xzvf ${filename}
+          fi
         volumeMounts:
         - name: credentials
           mountPath: /etc/rclone

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -30,15 +30,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          set -euo pipefail
-          filename=$(basename {{ .Values.dataSource.remote.path }})
-          if find /data -name metadata; then
-              echo "data already exist"
-              exit 0
-          else
-              rclone --config /etc/rclone/rclone.conf copy -P {{ .Values.dataSource.remote.path }} /data
-              cd /data && tar xzvf ${filename}
-          fi
+{{ tuple "scripts/_start_data_retriever.sh.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
         volumeMounts:
         - name: credentials
           mountPath: /etc/rclone
@@ -54,24 +46,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
-          /tidb-lightning \
-          --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
-          --status-addr=0.0.0.0:8289 \
-          --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Release.Namespace }}:8287 \
-          --server-mode=false \
-          --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
-          --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Release.Namespace }} \
-          {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
-          --d={{ .Values.dataSource.local.hostPath }} \
-          {{ else -}}
-          --d=${data_dir} \
-          {{ end -}}
-          --config=/etc/tidb-lightning/tidb-lightning.toml
-          if [ $? != 0 ]; then
-              echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
-              tail -f /dev/null
-          fi
+{{ tuple "scripts/_start_lightning.sh.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -82,7 +57,7 @@ spec:
         - name: data
           {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName }}
           mountPath: {{ .Values.dataSource.local.hostPath }}
-          {{ else -}}
+          {{- else -}}
           mountPath: /var/lib/tidb-lightning
           {{- end }}
       volumes:
@@ -97,7 +72,7 @@ spec:
         hostPath:
           path: {{ .Values.dataSource.local.hostPath }}
           type: Directory
-      {{ else -}}
+      {{- else -}}
       - name: credentials
         secret:
           secretName: {{ .Values.dataSource.remote.secretName }}
@@ -112,4 +87,4 @@ spec:
     {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
-    {{- end }}
+    {{- end -}}

--- a/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
+++ b/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tidb-lightning.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb-lightning
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  storageClassName: {{ .Values.dataSource.remote.storageClassName }}
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.dataSource.remote.storage }}

--- a/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
+++ b/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.targetTidbCluster.name }}
     app.kubernetes.io/component: tidb-lightning
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:

--- a/charts/tidb-lightning/templates/scripts/_start_data_retriever.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_data_retriever.sh.tpl
@@ -1,0 +1,9 @@
+set -euo pipefail
+filename=$(basename {{ .Values.dataSource.remote.path }})
+if find /data -name metadata; then
+    echo "data already exist"
+    exit 0
+else
+    rclone --config /etc/rclone/rclone.conf copy -P {{ .Values.dataSource.remote.path }} /data
+    cd /data && tar xzvf ${filename}
+fi

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -1,3 +1,6 @@
+{{- if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
+data_dir={{ .Values.dataSource.local.hostPath }}
+{{- else -}}
 data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
 if [ -z $data_dir ]; then
     if [ ! -z ${FAIL_FAST} ]; then
@@ -7,6 +10,7 @@ if [ -z $data_dir ]; then
         tail -f /dev/null
     fi
 fi
+{{ end }}
 /tidb-lightning \
     --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
     --status-addr=0.0.0.0:8289 \
@@ -14,11 +18,7 @@ fi
     --server-mode=false \
     --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
     --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Release.Namespace }} \
-    {{- if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName }}
-    --d={{ .Values.dataSource.local.hostPath }} \
-    {{ else -}}
     --d=${data_dir} \
-    {{ end -}}
     --config=/etc/tidb-lightning/tidb-lightning.toml
 
 if [ $? != 0 ]; then

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -1,0 +1,18 @@
+data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
+/tidb-lightning \
+    --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
+    --status-addr=0.0.0.0:8289 \
+    --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Release.Namespace }}:8287 \
+    --server-mode=false \
+    --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
+    --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Release.Namespace }} \
+    {{- if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName }}
+    --d={{ .Values.dataSource.local.hostPath }} \
+    {{ else -}}
+    --d=${data_dir} \
+    {{ end -}}
+    --config=/etc/tidb-lightning/tidb-lightning.toml
+if [ $? != 0 ]; then
+    echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
+    tail -f /dev/null
+fi

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -1,4 +1,8 @@
 data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
+if [ -z $data_dir]; then
+    echo "No mydumper files are found, please exec into my container to diagnose"
+    tail -f /dev/null
+fi
 /tidb-lightning \
     --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
     --status-addr=0.0.0.0:8289 \

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -1,7 +1,11 @@
 data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
-if [ -z $data_dir]; then
-    echo "No mydumper files are found, please exec into my container to diagnose"
-    tail -f /dev/null
+if [ -z $data_dir ]; then
+    if [ ! -z ${FAIL_FAST} ]; then
+        exit 1
+    else
+        echo "No mydumper files are found, please exec into my container to diagnose"
+        tail -f /dev/null
+    fi
 fi
 /tidb-lightning \
     --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
@@ -16,7 +20,12 @@ fi
     --d=${data_dir} \
     {{ end -}}
     --config=/etc/tidb-lightning/tidb-lightning.toml
+
 if [ $? != 0 ]; then
-    echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
-    tail -f /dev/null
+    if [ ! -z ${FAIL_FAST} ]; then
+        exit 1
+    else
+        echo $(date -u +"[%Y/%m/%d %H:%M:%S.%3N %:z]") "tidb-lightning exits abnormally, please exec into my container to do manual intervention"
+        tail -f /dev/null
+    fi
 fi

--- a/charts/tidb-lightning/templates/service.yaml
+++ b/charts/tidb-lightning/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tidb-lightning.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb-lightning
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 8289
+      targetPort: 8289
+      protocol: TCP
+      name: lightning
+  selector:
+    app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb-lightning

--- a/charts/tidb-lightning/templates/service.yaml
+++ b/charts/tidb-lightning/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   ports:
     - port: 8289
       targetPort: 8289
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: lightning
   selector:

--- a/charts/tidb-lightning/templates/service.yaml
+++ b/charts/tidb-lightning/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.targetTidbCluster.name }}
     app.kubernetes.io/component: tidb-lightning
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
@@ -17,5 +17,5 @@ spec:
       name: lightning
   selector:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.targetTidbCluster.name }}
     app.kubernetes.io/component: tidb-lightning

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -24,16 +24,15 @@ targetTidbCluster:
 
 resources: {}
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #  cpu: 16000m
+  #  memory: 8Gi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #  cpu: 16000m
+  #  memory: 8Gi
 
 nodeSelector: {}
 
 tolerations: []
-
 affinity: {}
 
 config: |

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -20,7 +20,7 @@ dataSource:
 
 targetTidbCluster:
   name: tidb-cluster
-  namespace: tidb
+  user: root
 
 resources: {}
   # limits:

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -7,6 +7,10 @@ imagePullPolicy: IfNotPresent
 service:
   type: NodePort
 
+# failFast causes the lightning pod fails when any error happens.
+# when disabled, the lightning pod will keep running when error happens to allow manual intervention, users have to check logs to see the job status.
+failFast: false
+
 dataSource:
   local: {}
     # nodeName: kind-worker3

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -1,0 +1,41 @@
+# Default values for tidb-lightning.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image: pingcap/tidb-lightning:v3.0.1
+imagePullPolicy: IfNotPresent
+service:
+  type: NodePort
+
+dataSource:
+  local:
+    # nodeName: kind-worker3
+    hostPath: /data/export-20190820
+  remote:
+    rcloneImage: tynor88/rclone
+    storageClassName: local-storage
+    storage: 100Gi
+    secretName: cloud-storage-secret
+    path: s3:bench-data-us/sysbench/sbtest_16_1e7.tar.gz
+
+targetTidbCluster:
+  name: tidb-cluster
+  namespace: tidb
+
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config: |
+  [lightning]
+  level = "info"

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -8,9 +8,9 @@ service:
   type: NodePort
 
 dataSource:
-  local:
+  local: {}
     # nodeName: kind-worker3
-    hostPath: /data/export-20190820
+    # hostPath: /data/export-20190820
   remote:
     rcloneImage: tynor88/rclone
     storageClassName: local-storage


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Integrate tidb-lightning on k8s, this closes https://github.com/pingcap/tidb-operator/issues/347

### What is changed and how does it work?

Add tidb-lightning chart. The tikv-importer is inside the tidb-cluster chart and tidb-lightning is in a separate chart.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test (add detailed scripts or steps below)
Both the local and remote (S3) data sources are tested. The compressed sysbench dataset is 15GB, and the uncompressed dataset is 31GB. The restore time is `18m` while the sysbench prepare average time is `1h`

Code changes

 - Has Helm charts change

Side effects

 No

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Add tidb-lightning support
 ```
