### PR TITLE
chart/tidb-operator: Use HOSTNAME if POD_NAME is unset for backward compatibility.

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_pd.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_pd.sh.tpl
@@ -28,6 +28,8 @@ then
     tail -f /dev/null
 fi
 
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
 # the general form of variable PEER_SERVICE_NAME is: "<clusterName>-pd-peer"
 cluster_name=`echo ${PEER_SERVICE_NAME} | sed 's/-pd-peer//'`
 domain="${POD_NAME}.${PEER_SERVICE_NAME}.${NAMESPACE}.svc"

--- a/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
@@ -28,6 +28,8 @@ then
 	tail -f /dev/null
 fi
 
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--pd=${CLUSTER_NAME}-pd:2379 \
 --advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20160 \
 --addr=0.0.0.0:20160 \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

See https://github.com/pingcap/tidb-operator/pull/774/files#r316750805.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
