### PR TITLE
deploy/gcp: fix issues in refreshing state

### DIFF
--- a/deploy/gcp/tidbclusters.tf
+++ b/deploy/gcp/tidbclusters.tf
@@ -13,6 +13,7 @@ module "default-tidb-cluster" {
   }
   source                     = "../modules/gcp/tidb-cluster"
   cluster_id                 = module.tidb-operator.cluster_id
+  tidb_operator_id           = module.tidb-operator.tidb_operator_id
   gcp_project                = var.GCP_PROJECT
   gke_cluster_location       = var.GCP_REGION
   gke_cluster_name           = var.gke_name

--- a/deploy/gcp/tidbclusters.tf
+++ b/deploy/gcp/tidbclusters.tf
@@ -32,7 +32,7 @@ module "default-tidb-cluster" {
   cluster_id                 = module.tidb-operator.cluster_id
   tidb_operator_id           = module.tidb-operator.tidb_operator_id
   gcp_project                = var.GCP_PROJECT
-  gke_cluster_location       = var.GCP_REGION
+  gke_cluster_location       = local.location
   gke_cluster_name           = var.gke_name
   cluster_name               = var.default_tidb_cluster_name
   cluster_version            = var.tidb_version

--- a/deploy/modules/gcp/tidb-cluster/data.tf
+++ b/deploy/modules/gcp/tidb-cluster/data.tf
@@ -24,6 +24,8 @@ locals {
   # TODO Update related code when node locations is avaiable in attributes of cluster resource.
   cmd_get_cluster_locations = <<EOT
 gcloud --project ${var.gcp_project} container clusters list --filter='name=${var.gke_cluster_name}' --format='json[no-heading](locations)' ${local.cluster_location_args} | jq '.[0] | .locations |= join(",")'
+=======
+gcloud --project ${var.gcp_project} container clusters list --filter='name=${var.gke_cluster_name}' --format='json[no-heading](locations)' ${local.cluster_location_args} | jq '{"locations": (if (. | length) > 0 then .[0].locations | join(",") else "" end) }'
 EOT
 }
 

--- a/deploy/modules/gcp/tidb-cluster/data.tf
+++ b/deploy/modules/gcp/tidb-cluster/data.tf
@@ -23,8 +23,6 @@ locals {
   cluster_location_args = "%{if length(split("-", var.gke_cluster_location)) == 3}--zone ${var.gke_cluster_location} %{else}--region ${var.gke_cluster_location} %{endif}"
   # TODO Update related code when node locations is avaiable in attributes of cluster resource.
   cmd_get_cluster_locations = <<EOT
-gcloud --project ${var.gcp_project} container clusters list --filter='name=${var.gke_cluster_name}' --format='json[no-heading](locations)' ${local.cluster_location_args} | jq '.[0] | .locations |= join(",")'
-=======
 gcloud --project ${var.gcp_project} container clusters list --filter='name=${var.gke_cluster_name}' --format='json[no-heading](locations)' ${local.cluster_location_args} | jq '{"locations": (if (. | length) > 0 then .[0].locations | join(",") else "" end) }'
 EOT
 }

--- a/deploy/modules/gcp/tidb-cluster/data.tf
+++ b/deploy/modules/gcp/tidb-cluster/data.tf
@@ -30,5 +30,6 @@ EOT
 }
 
 data "external" "cluster_locations" {
+  depends_on = [var.cluster_id]
   program = ["bash", "-c", local.cmd_get_cluster_locations]
 }

--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -41,6 +41,7 @@ resource "google_container_node_pool" "tikv_pool" {
   name       = "${var.cluster_name}-tikv-pool"
   node_count = var.tikv_node_count
 
+  # tikv_pool is the first resource of node pools to create in this module, wait for the cluster to be ready
   depends_on = [
     var.cluster_id
   ]
@@ -143,7 +144,7 @@ module "tidb-cluster" {
   override_values            = var.override_values
   kubeconfig_filename        = var.kubeconfig_path
   base_values                = file("${path.module}/values/default.yaml")
-  wait_on_resource           = [var.tidb_operator_id]
+  wait_on_resource           = [google_container_node_pool.tidb_pool, var.tidb_operator_id]
 }
 
 resource "null_resource" "wait-lb-ip" {

--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -41,6 +41,10 @@ resource "google_container_node_pool" "tikv_pool" {
   name       = "${var.cluster_name}-tikv-pool"
   node_count = var.tikv_node_count
 
+  depends_on = [
+    var.cluster_id
+  ]
+
   management {
     auto_repair  = false
     auto_upgrade = false

--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -143,7 +143,7 @@ module "tidb-cluster" {
   override_values            = var.override_values
   kubeconfig_filename        = var.kubeconfig_path
   base_values                = file("${path.module}/values/default.yaml")
-  wait_on_resource           = [google_container_node_pool.tidb_pool]
+  wait_on_resource           = [var.tidb_operator_id]
 }
 
 resource "null_resource" "wait-lb-ip" {

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -1,6 +1,11 @@
 variable "cluster_id" {
-  description = "GKE cluster ID. This depends on a running cluster. Please create a cluster first and pass ID here."
+  description = "GKE cluster ID. This module depends on a running cluster. Please create a cluster first and pass ID here."
 }
+
+variable "tidb_operator_id" {
+  description = "TiDB Operator ID. We must wait for tidb-operator is ready before creating TiDB clusters."
+}
+
 variable "cluster_name" {}
 variable "cluster_version" {
   description = "The TiDB cluster version"

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -1,3 +1,6 @@
+variable "cluster_id" {
+  description = "GKE cluster ID. This depends on a running cluster. Please create a cluster first and pass ID here."
+}
 variable "cluster_name" {}
 variable "cluster_version" {
   description = "The TiDB cluster version"

--- a/deploy/modules/gcp/tidb-operator/main.tf
+++ b/deploy/modules/gcp/tidb-operator/main.tf
@@ -65,13 +65,30 @@ resource "null_resource" "get-credentials" {
   }
 }
 
+data "local_file" "kubeconfig" {
+  depends_on = [null_resource.get-credentials]
+  filename   = var.kubeconfig_path
+}
+
+# local file resource used to delay helm provider initialization
+resource "local_file" "kubeconfig" {
+  content    = data.local_file.kubeconfig.content
+  filename   = var.kubeconfig_path
+}
+
 provider "helm" {
   alias    = "initial"
   insecure = true
   # service_account = "tiller"
   install_tiller = false # currently this doesn't work, so we install tiller in the local-exec provisioner. See https://github.com/terraform-providers/terraform-provider-helm/issues/148
   kubernetes {
+    # helm provider loads the file when it's initialized, we must wait for it to be created.
+    # However we cannot use resource here, because in refresh phrase, it will
+    # not be resolved and argument default value is used. To work around this,
+    # we defer initialization by using load_config_file argument.
+    # See https://github.com/pingcap/tidb-operator/pull/819#issuecomment-524547459
     config_path = var.kubeconfig_path
+    load_config_file = local_file.kubeconfig.filename != "" ? true : false
   }
 }
 

--- a/deploy/modules/gcp/tidb-operator/main.tf
+++ b/deploy/modules/gcp/tidb-operator/main.tf
@@ -65,24 +65,13 @@ resource "null_resource" "get-credentials" {
   }
 }
 
-data "local_file" "kubeconfig" {
-  depends_on = [google_container_cluster.cluster, null_resource.get-credentials]
-  filename   = var.kubeconfig_path
-}
-
-resource "local_file" "kubeconfig" {
-  depends_on = [google_container_cluster.cluster, null_resource.get-credentials]
-  content    = data.local_file.kubeconfig.content
-  filename   = var.kubeconfig_path
-}
-
 provider "helm" {
   alias    = "initial"
   insecure = true
   # service_account = "tiller"
   install_tiller = false # currently this doesn't work, so we install tiller in the local-exec provisioner. See https://github.com/terraform-providers/terraform-provider-helm/issues/148
   kubernetes {
-    config_path = local_file.kubeconfig.filename
+    config_path = var.kubeconfig_path
   }
 }
 

--- a/deploy/modules/gcp/tidb-operator/outputs.tf
+++ b/deploy/modules/gcp/tidb-operator/outputs.tf
@@ -13,7 +13,3 @@ output "gcp_project" {
 output "gke_cluster_location" {
   value = google_container_cluster.cluster.location
 }
-
-output "kubeconfig_path" {
-  value = local_file.kubeconfig.filename
-}

--- a/deploy/modules/gcp/tidb-operator/outputs.tf
+++ b/deploy/modules/gcp/tidb-operator/outputs.tf
@@ -2,14 +2,6 @@ output "cluster_id" {
   value = google_container_cluster.cluster.id
 }
 
-output "gke_cluster_name" {
-  value = google_container_cluster.cluster.name
-}
-
-output "gcp_project" {
-  value = google_container_cluster.cluster.project
-}
-
-output "gke_cluster_location" {
-  value = google_container_cluster.cluster.location
+output "tidb_operator_id" {
+  value = helm_release.tidb-operator.id
 }

--- a/deploy/modules/gcp/tidb-operator/outputs.tf
+++ b/deploy/modules/gcp/tidb-operator/outputs.tf
@@ -5,3 +5,7 @@ output "cluster_id" {
 output "tidb_operator_id" {
   value = helm_release.tidb-operator.id
 }
+
+output "get_credentials_id" {
+  value = null_resource.get-credentials.id
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes #815 and other issues in refresh phrase.

For example, when `terraform apply` failed to create GKE cluster. In refreshing state, `jq` command will fail with this error:

```
Error: failed to execute "bash": jq: error (at <stdin>:1): Cannot iterate over null (null)


  on ../modules/gcp/tidb-cluster/data.tf line 28, in data "external" "cluster_locations":
  28: data "external" "cluster_locations" {
```

### What is changed and how does it work?

- module output variables are not available in refresh state, we can use them to set up dependencies or as creation arguments but should not use them as the ID of the resource or refreshing arguments (e.g. cluster name of node pool , kubeconfig file path of helm)
 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
