### PR TITLE
improve tkctl get command output

### DIFF
--- a/pkg/tkctl/cmd/cmd.go
+++ b/pkg/tkctl/cmd/cmd.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"flag"
-	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/version"
 	"io"
 
 	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/completion"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/list"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/upinfo"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/use"
+	"github.com/pingcap/tidb-operator/pkg/tkctl/cmd/version"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/pkg/tkctl/cmd/ctop/ctop.go
+++ b/pkg/tkctl/cmd/ctop/ctop.go
@@ -15,6 +15,8 @@ package ctop
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/executor"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
@@ -26,16 +28,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"strings"
 )
 
 const (
 	ctopExample = `
 	# ctop the specified pod
-	tkc ctop POD_NAME
+	tkctl ctop POD_NAME
 
 	# ctop the specified node
-	tkc ctop node/NODE_NAME
+	tkctl ctop node/NODE_NAME
 `
 	ctopUsage    = "expected 'ctop POD_NAME' or 'ctop node/NODE_NAME' for the ctop command"
 	defaultImage = "quay.io/vektorlab/ctop:0.7.2"

--- a/pkg/tkctl/cmd/debug/debug.go
+++ b/pkg/tkctl/cmd/debug/debug.go
@@ -15,6 +15,7 @@ package debug
 
 import (
 	"fmt"
+
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/executor"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
@@ -31,16 +32,16 @@ import (
 const (
 	debugExample = `
 	# debug a container in the running pod, the first container will be picked by default
-	tkc debug POD_NAME
+	tkctl debug POD_NAME
 
 	# specify namespace or container
-	tkc debug --namespace foo POD_NAME -c CONTAINER_NAME
+	tkctl debug --namespace foo POD_NAME -c CONTAINER_NAME
 
 	# override the default troubleshooting image
-	tkc debug POD_NAME --image aylei/debug-jvm
+	tkctl debug POD_NAME --image aylei/debug-jvm
 
 	# override entrypoint of debug container
-	tkc debug POD_NAME --image aylei/debug-jvm /bin/bash
+	tkctl debug POD_NAME --image aylei/debug-jvm /bin/bash
 
 `
 	debugLongDesc = `

--- a/pkg/tkctl/cmd/get/get.go
+++ b/pkg/tkctl/cmd/get/get.go
@@ -14,7 +14,10 @@
 package get
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -22,12 +25,15 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/readable"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
+	apicore "k8s.io/kubernetes/pkg/apis/core"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	kubeprinters "k8s.io/kubernetes/pkg/printers"
-	"strings"
 )
 
 const (
@@ -35,20 +41,20 @@ const (
 		Get tidb component detail.
 
 		Available components include: all, pd, tidb, tikv, volume
-		You can omit --tidbcluster=<name> option by running 'tkc use <name>',
+		You can omit --tidbcluster=<name> option by running 'tkctl use <name>',
 `
 	getExample = `
 		# get PD details 
-		tkc get pd
+		tkctl get pd
 
 		# get multiple kinds of resources
-		tkc get tikv,tidb,volume
+		tkctl get tikv,tidb,volume
 
 		# get volume details and choose different format
-		tkc get volume -o yaml
+		tkctl get volume -o yaml
 
 		# get all components
-		tkc get all
+		tkctl get all
 `
 	getUsage = "expect 'get -t=CLUSTER_NAME kind | get -A kind' for get command or set tidb cluster by 'use' first"
 )
@@ -67,12 +73,14 @@ type GetOptions struct {
 	AllClusters     bool
 	Namespace       string
 	TidbClusterName string
+	ResourceName    string
 	GetPD           bool
 	GetTiKV         bool
 	GetTiDB         bool
 	GetVolume       bool
 
-	PrintFlags *readable.PrintFlags
+	IsHumanReadablePrinter bool
+	PrintFlags             *readable.PrintFlags
 
 	tcCli   *versioned.Clientset
 	kubeCli *kubernetes.Clientset
@@ -83,7 +91,6 @@ type GetOptions struct {
 // NewCmdGet creates the get command which get the tidb component detail
 func NewCmdGet(tkcContext *config.TkcContext, streams genericclioptions.IOStreams) *cobra.Command {
 	options := NewGetOptions(streams)
-
 	cmd := &cobra.Command{
 		Use:     "get",
 		Short:   "get pd|tikv|tidb|volume|all",
@@ -147,6 +154,11 @@ func (o *GetOptions) Complete(tkcContext *config.TkcContext, cmd *cobra.Command,
 	}
 	o.kubeCli = kubeClient
 
+	// human readable printers have special conversion rules, so we determine if we're using one.
+	if len(o.PrintFlags.OutputFormat) == 0 || o.PrintFlags.OutputFormat == "wide" {
+		o.IsHumanReadablePrinter = true
+	}
+
 	resources := args[0]
 	for _, resource := range strings.Split(resources, ",") {
 		switch resource {
@@ -165,6 +177,10 @@ func (o *GetOptions) Complete(tkcContext *config.TkcContext, cmd *cobra.Command,
 		case kindVolume:
 			o.GetVolume = true
 		}
+	}
+
+	if len(args) > 1 {
+		o.ResourceName = args[1]
 	}
 	return nil
 }
@@ -190,50 +206,177 @@ func (o *GetOptions) Run(tkcContext *config.TkcContext, cmd *cobra.Command, args
 		tcs = []v1alpha1.TidbCluster{*tc}
 	}
 
-	printer, err := o.PrintFlags.ToPrinter(false, o.AllClusters)
+	multiTidbCluster := len(tcs) > 1
+	var errs []error
+	for i, tc := range tcs {
+		if multiTidbCluster {
+			o.Out.Write([]byte(fmt.Sprintf("Cluster: %s/%s\n", tc.Namespace, tc.Name)))
+		}
+
+		// TODO: do a big batch or steadily print parts in minor step?
+		if err := o.PrintOutput(&tc, kindPD, o.GetPD); err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := o.PrintOutput(&tc, kindTiKV, o.GetTiKV); err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := o.PrintOutput(&tc, kindTiDB, o.GetTiDB); err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := o.PrintOutput(&tc, kindVolume, o.GetVolume); err != nil {
+			errs = append(errs, err)
+		}
+
+		if multiTidbCluster && i != len(tcs)-1 {
+			o.Out.Write([]byte("\n"))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *GetOptions) PrintOutput(tc *v1alpha1.TidbCluster, resourceType string, needPrint bool) error {
+	if !needPrint {
+		return nil
+	}
+
+	switch resourceType {
+	case kindPD, kindTiDB, kindTiKV:
+		var objs []runtime.Object
+		var listOptions metav1.ListOptions
+		if len(o.ResourceName) == 0 {
+			listOptions = metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.InstanceLabelKey, tc.Name, label.ComponentLabelKey, resourceType),
+			}
+		} else {
+			listOptions = metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("metadata.name=%s", o.ResourceName),
+			}
+		}
+
+		podList, err := o.kubeCli.CoreV1().Pods(tc.Namespace).List(listOptions)
+		if err != nil {
+			return err
+		}
+		for _, pod := range podList.Items {
+			pod.GetObjectKind().SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Pod"))
+			objs = append(objs, &pod)
+		}
+
+		if !o.IsHumanReadablePrinter {
+			return o.printGeneric(objs)
+		}
+
+		printer, err := o.PrintFlags.ToPrinter(false, o.AllClusters)
+		if err != nil {
+			return err
+		}
+
+		return printer.PrintObj(podList, o.Out)
+	case kindVolume:
+		var objs []runtime.Object
+		var listOptions metav1.ListOptions
+		if len(o.ResourceName) == 0 {
+			listOptions = metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.InstanceLabelKey, tc.Name, label.NamespaceLabelKey, tc.Namespace),
+			}
+		} else {
+			listOptions = metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("metadata.name=%s", o.ResourceName),
+			}
+		}
+
+		volumeList, err := o.kubeCli.CoreV1().PersistentVolumes().List(listOptions)
+		if err != nil {
+			return err
+		}
+		for _, volume := range volumeList.Items {
+			volume.GetObjectKind().SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("PersistentVolume"))
+			objs = append(objs, &volume)
+		}
+
+		if !o.IsHumanReadablePrinter {
+			return o.printGeneric(objs)
+		}
+
+		// PersistentVolume without namespace concept
+		printer, err := o.PrintFlags.ToPrinter(false, false)
+		if err != nil {
+			return err
+		}
+
+		return printer.PrintObj(volumeList, o.Out)
+	}
+	return fmt.Errorf("Unknow resource type %s", resourceType)
+}
+
+func (o *GetOptions) printGeneric(objs []runtime.Object) error {
+	printer, err := o.PrintFlags.ToPrinter(false, false)
 	if err != nil {
 		return err
 	}
-	w := kubeprinters.GetNewTabWriter(o.Out)
-	printTidbInfo := len(tcs) > 1
-	var errs []error
-	for i := range tcs {
-		tc := tcs[i]
-		if printTidbInfo {
-			w.Write([]byte(fmt.Sprintf("Cluster: %s/%s\n", tc.Namespace, tc.Name)))
-			w.Flush()
+
+	if len(objs) == 0 {
+		return nil
+	}
+
+	var allObj runtime.Object
+	if len(objs) > 1 {
+		list := apicore.List{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "List",
+				APIVersion: "v1",
+			},
+			ListMeta: metav1.ListMeta{},
 		}
-		flushPods := func(kind string) {
-			podList, err := o.kubeCli.CoreV1().Pods(tc.Namespace).List(metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.InstanceLabelKey, tc.Name, label.ComponentLabelKey, kind),
-			})
-			if err != nil {
-				errs = append(errs, err)
-			}
-			printer.PrintObj(podList, w)
-			w.Flush()
+		for _, obj := range objs {
+			list.Items = append(list.Items, obj)
 		}
-		// TODO: do a big batch or steadily print parts in minor step?
-		if o.GetPD {
-			flushPods(kindPD)
+
+		listData, err := json.Marshal(list)
+		if err != nil {
+			return err
 		}
-		if o.GetTiKV {
-			flushPods(kindTiKV)
+
+		converted, err := runtime.Decode(unstructured.UnstructuredJSONScheme, listData)
+		if err != nil {
+			return err
 		}
-		if o.GetTiDB {
-			flushPods(kindTiDB)
-		}
-		if o.GetVolume {
-			volumeList, err := o.kubeCli.CoreV1().PersistentVolumes().List(metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.InstanceLabelKey, tc.Name,
-					label.NamespaceLabelKey, tc.Namespace),
-			})
-			if err != nil {
-				return err
-			}
-			printer.PrintObj(volumeList, w)
-			w.Flush()
+
+		allObj = converted
+	} else {
+		allObj = objs[0]
+	}
+
+	isList := meta.IsListType(allObj)
+	if !isList {
+		return printer.PrintObj(allObj, o.Out)
+	}
+
+	items, err := meta.ExtractList(allObj)
+	if err != nil {
+		return err
+	}
+
+	// take the items and create a new list for display
+	list := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"kind":       "List",
+			"apiVersion": "v1",
+			"metadata":   map[string]interface{}{},
+		},
+	}
+	if listMeta, err := meta.ListAccessor(allObj); err == nil {
+		list.Object["metadata"] = map[string]interface{}{
+			"selfLink":        listMeta.GetSelfLink(),
+			"resourceVersion": listMeta.GetResourceVersion(),
 		}
 	}
-	return nil
+
+	for _, item := range items {
+		list.Items = append(list.Items, *item.(*unstructured.Unstructured))
+	}
+	return printer.PrintObj(list, o.Out)
 }

--- a/pkg/tkctl/cmd/get/get.go
+++ b/pkg/tkctl/cmd/get/get.go
@@ -53,6 +53,12 @@ const (
 		# get volume details and choose different format
 		tkctl get volume -o yaml
 
+		# get details of a specific pd/tikv/tidb/volume
+		tkctl get volume <volume-name> -oyaml
+
+		# output all columns, including omitted columns
+		tkctl get pd,volume -owide
+
 		# get all components
 		tkctl get all
 `

--- a/pkg/tkctl/cmd/info/info.go
+++ b/pkg/tkctl/cmd/info/info.go
@@ -15,6 +15,8 @@ package info
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -22,7 +24,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/readable"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
 	"github.com/spf13/cobra"
-	"io"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -38,13 +39,13 @@ const (
 `
 	infoExample = `
 		# get current tidb cluster info (set by tkc use)
-		tkc info
+		tkctl info
 
 		# get specified tidb cluster info
-		tkc info -t another-cluster
+		tkctl info -t another-cluster
 `
 	infoUsage = `expected 'info -t CLUSTER_NAME' for the info command or 
-using 'tkc use' to set tidb cluster first.
+using 'tkctl use' to set tidb cluster first.
 `
 )
 

--- a/pkg/tkctl/cmd/list/list.go
+++ b/pkg/tkctl/cmd/list/list.go
@@ -33,13 +33,13 @@ const (
 `
 	listExample = `
 		# list all clusters and sync to local config
-		tkc list
+		tkctl list
 
 		# filter by namespace
-		tkc list --namespace=foo
+		tkctl list --namespace=foo
 
 		# get tidb cluster in all namespaces
-		tkc list -A
+		tkctl list -A
 `
 )
 

--- a/pkg/tkctl/cmd/upinfo/upinfo.go
+++ b/pkg/tkctl/cmd/upinfo/upinfo.go
@@ -42,13 +42,13 @@ const (
 `
 	upinfoExample = `
 		# get current tidb cluster info (set by tkc user)
-		tkc upinfo
+		tkctl upinfo
 
 		# get specified tidb cluster component upgrade info
-		tkc upinfo -t another-cluster
+		tkctl upinfo -t another-cluster
 `
 	infoUsage = `expected 'upinfo -t CLUSTER_NAME' for the upinfo command or 
-using 'tkc use' to set tidb cluster first.
+using 'tkctl use' to set tidb cluster first.
 `
 	UPDATED  = "updated"
 	UPDATING = "updating"

--- a/pkg/tkctl/cmd/use/use.go
+++ b/pkg/tkctl/cmd/use/use.go
@@ -15,6 +15,7 @@ package use
 
 import (
 	"fmt"
+
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/spf13/cobra"
@@ -32,10 +33,10 @@ const (
 `
 	useExample = `
 		# specify a tidb cluster to use
-		tkc use demo-cluster
+		tkctl use demo-cluster
 
 		# specify kubernetes context and namespace
-		tkc use --context=demo-ctx --namespace=demo-ns demo-cluster
+		tkctl use --context=demo-ctx --namespace=demo-ns demo-cluster
 `
 	useUsage = "expected 'use CLUSTER_NAME' for the use command"
 )

--- a/pkg/tkctl/readable/print_flags.go
+++ b/pkg/tkctl/readable/print_flags.go
@@ -34,9 +34,15 @@ func NewPrintFlags() *PrintFlags {
 	}
 }
 
+// Copy returns a copy of PrintFlags for mutation
+func (p *PrintFlags) Copy() PrintFlags {
+	printFlags := *p
+	return printFlags
+}
+
 func (p *PrintFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.OutputFormat, "output", "o", p.OutputFormat,
-		"Output format. json|yaml|default.")
+		"Output format. json|yaml|wide")
 	p.JSONYamlPrintFlags.AddFlags(cmd)
 }
 
@@ -53,6 +59,7 @@ func (p *PrintFlags) ToPrinter(withKind, withNamespace bool) (printers.ResourceP
 	printer := kubeprinters.NewHumanReadablePrinter(scheme.Codecs.UniversalDecoder(),
 		kubeprinters.PrintOptions{
 			WithNamespace: withNamespace,
+			Wide:          p.OutputFormat == "wide",
 			WithKind:      withKind,
 		})
 	// Add custom handlers

--- a/pkg/tkctl/readable/print_flags.go
+++ b/pkg/tkctl/readable/print_flags.go
@@ -34,12 +34,6 @@ func NewPrintFlags() *PrintFlags {
 	}
 }
 
-// Copy returns a copy of PrintFlags for mutation
-func (p *PrintFlags) Copy() PrintFlags {
-	printFlags := *p
-	return printFlags
-}
-
 func (p *PrintFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.OutputFormat, "output", "o", p.OutputFormat,
 		"Output format. json|yaml|wide")

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -15,8 +15,11 @@ package readable
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	"k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -24,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/kubernetes/pkg/printers"
 	"k8s.io/kubernetes/pkg/util/node"
-	"time"
 )
 
 const (
@@ -40,7 +42,7 @@ type PodBasicColumns struct {
 	Memory   string
 	Age      string
 	PodIP    string
-	HostIP   string
+	NodeName string
 
 	MemInfo string
 	CPUInfo string
@@ -66,7 +68,8 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "CPU", Type: "string", Description: "The Pod total cpu request and limit."},
 		{Name: "Restarts", Type: "integer", Description: "The number of times the containers in this pod have been restarted."},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
-		{Name: "Node", Type: "string", Description: "Node IP"},
+		{Name: "IP", Type: "string", Priority: 1, Description: apiv1.PodStatus{}.SwaggerDoc()["podIP"]},
+		{Name: "Node", Type: "string", Priority: 1, Description: apiv1.PodSpec{}.SwaggerDoc()["nodeName"]},
 	}
 	h.TableHandler(commonPodColumns, printPod)
 	h.TableHandler(commonPodColumns, printPodList)
@@ -76,8 +79,9 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Claim", Type: "string", Format: "name", Description: "Volume claim"},
 		{Name: "Status", Type: "string", Description: "Volume status"},
 		{Name: "Capacity", Type: "string", Description: "Volume capacity"},
-		{Name: "Node", Type: "string", Description: "Mounted node"},
-		{Name: "Local", Type: "string", Description: "Local path"},
+		{Name: "StorageClass", Type: "string", Description: "Storage class of volume"},
+		{Name: "Node", Type: "string", Priority: 1, Description: "Mounted node"},
+		{Name: "Local", Type: "string", Priority: 1, Description: "Local path"},
 	}
 	h.TableHandler(volumeColumns, printVolume)
 	h.TableHandler(volumeColumns, printVolumeList)
@@ -142,8 +146,11 @@ func printPod(pod *v1.Pod, options printers.PrintOptions) ([]metav1beta1.TableRo
 		columns.MemInfo,
 		columns.CPUInfo,
 		columns.Restarts,
-		columns.Age,
-		columns.HostIP)
+		columns.Age)
+
+	if options.Wide {
+		row.Cells = append(row.Cells, columns.PodIP, columns.NodeName)
+	}
 	return []metav1beta1.TableRow{row}, nil
 }
 
@@ -166,7 +173,7 @@ func printVolume(volume *v1.PersistentVolume, options printers.PrintOptions) ([]
 
 	claim := unset
 	if volume.Spec.ClaimRef != nil {
-		claim = volume.Spec.ClaimRef.Name
+		claim = fmt.Sprintf("%s/%s", volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name)
 	}
 	local := unset
 	if volume.Spec.Local != nil {
@@ -194,7 +201,11 @@ func printVolume(volume *v1.PersistentVolume, options printers.PrintOptions) ([]
 			capacity = val.String()
 		}
 	}
-	row.Cells = append(row.Cells, volume.Name, claim, volume.Status.Phase, capacity, host, local)
+	row.Cells = append(row.Cells, volume.Name, claim, volume.Status.Phase, capacity, volume.Spec.StorageClassName)
+
+	if options.Wide {
+		row.Cells = append(row.Cells, host, local)
+	}
 
 	return []metav1beta1.TableRow{row}, nil
 }
@@ -273,10 +284,10 @@ func basicPodColumns(pod *v1.Pod) *PodBasicColumns {
 		reason = "Terminating"
 	}
 
-	hostIP := pod.Status.HostIP
+	nodeName := pod.Spec.NodeName
 	podIP := pod.Status.PodIP
-	if hostIP == "" {
-		hostIP = unset
+	if nodeName == "" {
+		nodeName = unset
 	}
 	if podIP == "" {
 		podIP = unset
@@ -325,7 +336,7 @@ func basicPodColumns(pod *v1.Pod) *PodBasicColumns {
 		Reason:   reason,
 		Restarts: int64(restarts),
 		Age:      translateTimestampSince(pod.CreationTimestamp),
-		HostIP:   hostIP,
+		NodeName: nodeName,
 		PodIP:    podIP,
 		MemInfo:  memInfo,
 		CPUInfo:  cpuInfo,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #821 and support for viewing details of a specific pod or PV


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
1. Unify the output format of multiple clusters, remove the `NAMESPACE` column of PV. Change CLAIM colume of PV from `<pvc_name>` to `<namespace>/<pvc_name>`
```
$ tkctl get pd,tidb,volume -A
Cluster: test1/demo1
NAMESPACE   NAME         READY   STATUS    MEMORY          CPU             RESTARTS   AGE
test1       demo1-pd-0   1/1     Running   <none>/<none>   <none>/<none>   0          14d
test1       demo1-pd-1   1/1     Running   <none>/<none>   <none>/<none>   0          14d
test1       demo1-pd-2   1/1     Running   <none>/<none>   <none>/<none>   0          14d
NAMESPACE   NAME           READY   STATUS    MEMORY     CPU        RESTARTS   AGE
test1       demo1-tidb-0   2/2     Running   5Mi/50Mi   20m/100m   0          14d
test1       demo1-tidb-1   2/2     Running   5Mi/50Mi   20m/100m   0          14d
VOLUME                                     CLAIM                     STATUS   CAPACITY   STORAGECLASS
pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-0       Bound    1Gi        rook-ceph-block
pvc-a90f9c1b-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-1       Bound    1Gi        rook-ceph-block
pvc-a911506a-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-2       Bound    1Gi        rook-ceph-block
pvc-d4031d35-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-0   Bound    10Gi       rook-ceph-block
pvc-d404a72e-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-1   Bound    10Gi       rook-ceph-block
pvc-d4065414-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-2   Bound    10Gi       rook-ceph-block

Cluster: test2/demo2
NAMESPACE   NAME         READY   STATUS    MEMORY          CPU             RESTARTS   AGE
test2       demo2-pd-0   1/1     Running   <none>/<none>   <none>/<none>   0          11d
test2       demo2-pd-1   1/1     Running   <none>/<none>   <none>/<none>   1          11d
test2       demo2-pd-2   1/1     Running   <none>/<none>   <none>/<none>   0          11d
NAMESPACE   NAME           READY   STATUS    MEMORY     CPU        RESTARTS   AGE
test2       demo2-tidb-0   2/2     Running   5Mi/50Mi   20m/100m   0          11d
test2       demo2-tidb-1   2/2     Running   5Mi/50Mi   20m/100m   0          11d
VOLUME                                     CLAIM                     STATUS   CAPACITY   STORAGECLASS
pvc-3c8b98cc-bcef-11e9-9002-525400d6f2a6   test2/pd-demo2-pd-0       Bound    1Gi        rook-ceph-block
pvc-3c8cda85-bcef-11e9-9002-525400d6f2a6   test2/pd-demo2-pd-1       Bound    1Gi        rook-ceph-block
pvc-3c8e10d0-bcef-11e9-9002-525400d6f2a6   test2/pd-demo2-pd-2       Bound    1Gi        rook-ceph-block
pvc-5669b2b9-bcef-11e9-9002-525400d6f2a6   test2/tikv-demo2-tikv-0   Bound    10Gi       rook-ceph-block
pvc-566b0da6-bcef-11e9-9002-525400d6f2a6   test2/tikv-demo2-tikv-1   Bound    10Gi       rook-ceph-block
pvc-566ca86f-bcef-11e9-9002-525400d6f2a6   test2/tikv-demo2-tikv-2   Bound    10Gi       rook-ceph-block
```
2. Support use `-owide` to see the omitted columns, add `IP` colume for pd/tikv/tidb, and `STOAGECLASS` colume for PV
```
$ tkctl get pd,volume
NAME         READY   STATUS    MEMORY          CPU             RESTARTS   AGE
demo1-pd-0   1/1     Running   <none>/<none>   <none>/<none>   0          14d
demo1-pd-1   1/1     Running   <none>/<none>   <none>/<none>   0          14d
demo1-pd-2   1/1     Running   <none>/<none>   <none>/<none>   0          14d
VOLUME                                     CLAIM                     STATUS   CAPACITY   STORAGECLASS
pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-0       Bound    1Gi        rook-ceph-block
pvc-a90f9c1b-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-1       Bound    1Gi        rook-ceph-block
pvc-a911506a-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-2       Bound    1Gi        rook-ceph-block
pvc-d4031d35-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-0   Bound    10Gi       rook-ceph-block
pvc-d404a72e-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-1   Bound    10Gi       rook-ceph-block
pvc-d4065414-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-2   Bound    10Gi       rook-ceph-block

$ tkctl get pd,volume -owide
NAME         READY   STATUS    MEMORY          CPU             RESTARTS   AGE   IP               NODE
demo1-pd-0   1/1     Running   <none>/<none>   <none>/<none>   0          14d   10.233.89.12     172.16.5.164
demo1-pd-1   1/1     Running   <none>/<none>   <none>/<none>   0          14d   10.233.69.70     172.16.5.165
demo1-pd-2   1/1     Running   <none>/<none>   <none>/<none>   0          14d   10.233.109.198   172.16.5.163
VOLUME                                     CLAIM                     STATUS   CAPACITY   STORAGECLASS      NODE     LOCAL
pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-0       Bound    1Gi        rook-ceph-block   <none>   <none>
pvc-a90f9c1b-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-1       Bound    1Gi        rook-ceph-block   <none>   <none>
pvc-a911506a-ba97-11e9-8a21-525400d6f2a6   test1/pd-demo1-pd-2       Bound    1Gi        rook-ceph-block   <none>   <none>
pvc-d4031d35-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-0   Bound    10Gi       rook-ceph-block   <none>   <none>
pvc-d404a72e-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-1   Bound    10Gi       rook-ceph-block   <none>   <none>
pvc-d4065414-ba97-11e9-8a21-525400d6f2a6   test1/tikv-demo1-tikv-2   Bound    10Gi       rook-ceph-block   <none>   <none>
```
3. fix output nothing with `-oyaml` or `-ojson` option
```
$ tkctl get volume -oyaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: ceph.rook.io/block
      tidb.pingcap.com/pod-name: demo1-tikv-2
    creationTimestamp: "2019-08-09T11:21:27Z"
...
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""

$ tkctl get volume -ojson
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "v1",
            "kind": "PersistentVolume",
            "metadata": {
                "annotations": {
                    "pv.kubernetes.io/provisioned-by": "ceph.rook.io/block",
                    "tidb.pingcap.com/pod-name": "demo1-tikv-2"
                },
                "creationTimestamp": "2019-08-09T11:21:27Z",
...
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
``` 
4. Support for viewing details of a specific pod or PV
```
$ tkctl get pd demo1-pd-0 -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
...
status:
...
  hostIP: 172.16.5.164
  phase: Running
  podIP: 10.233.89.12
  qosClass: BestEffort
  startTime: "2019-08-09T11:20:30Z"

$ tkctl get volume pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6 -ojson
{
    "kind": "PersistentVolume",
    "apiVersion": "v1",
    "metadata": {
        "name": "pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6",
        "selfLink": "/api/v1/persistentvolumes/pvc-a90d84c1-ba97-11e9-8a21-525400d6f2a6",
        "uid": "b1ccca8a-ba97-11e9-8a21-525400d6f2a6",
        "resourceVersion": "177259",
        "creationTimestamp": "2019-08-09T11:20:29Z",
...
    "status": {
        "phase": "Bound"
    }
}
```

Code changes

 - Has Go code change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
fix ouput nothing with -oyaml or -ojson option and support for viewing details of a specific pod or PV,  also improve get comand output
 ```
