### PR TITLE
Update mount options in local volume provisioner

### DIFF
--- a/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
+++ b/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
@@ -66,6 +66,11 @@ spec:
                 set -euo pipefail
                 set -x
 
+                # discard,nobarrier are required to optimize local SSD
+                # performance in GCP, see
+                # https://cloud.google.com/compute/docs/disks/performance#optimize_local_ssd
+                mnt_opts="defaults,nodelalloc,noatime,discard,nobarrier"
+
                 # use /var because it is writeable on COS
                 if ! findmnt -n -a -l | grep /mnt/disks/ssd ; then
                   if test -f /var/ssd_mounts ; then
@@ -128,9 +133,9 @@ spec:
                         mnt_dir="/mnt/disks/$uuid"
                         mkdir -p "$mnt_dir"
                         if ! grep "$uuid" /etc/fstab ; then
-                          echo "UUID=$uuid $mnt_dir ext4 rw,relatime,discard,nobarrier,data=ordered" >> /etc/fstab
+                          echo "UUID=$uuid $mnt_dir ext4 $mnt_opts" >> /etc/fstab
                         fi
-                        mount -U "$uuid" -t ext4 --target "$mnt_dir" --options 'rw,relatime,discard,nobarrier,data=ordered'
+                        mount -U "$uuid" -t ext4 --target "$mnt_dir" --options "$mnt_opts"
                         chmod a+w "$mnt_dir"
                       fi
                     done
@@ -173,9 +178,9 @@ spec:
                 mkdir -p "$mnt_dir"
 
                 if ! grep "$uuid" /etc/fstab ; then
-                  echo "UUID=$uuid $mnt_dir ext4 rw,relatime,discard,nobarrier,data=ordered" >> /etc/fstab
+                  echo "UUID=$uuid $mnt_dir ext4 $mnt_opts" >> /etc/fstab
                 fi
-                mount -U "$uuid" -t ext4 --target "$mnt_dir" --options 'rw,relatime,discard,nobarrier,data=ordered'
+                mount -U "$uuid" -t ext4 --target "$mnt_dir" --options "$mnt_opts"
                 chmod a+w "$mnt_dir"
       containers:
         - image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

- `defaults` includes `rw,data=ordered`
- `noatime` and `nodelalloc` are recommneded in https://pingcap.com/docs/v3.0/how-to/deploy/orchestrated/ansible/
- share mount options by using a variable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
