### PR TITLE
deploy/gcp: omit node_locations argument when it is empty

### DIFF
--- a/deploy/modules/gcp/tidb-operator/main.tf
+++ b/deploy/modules/gcp/tidb-operator/main.tf
@@ -3,7 +3,7 @@ resource "google_container_cluster" "cluster" {
   network        = var.vpc_name
   subnetwork     = var.subnetwork_name
   location       = var.location
-  node_locations = var.node_locations
+  node_locations = length(var.node_locations) == 0 ? null : var.node_locations
   project        = var.gcp_project
 
   master_auth {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

If it's not empty, terraform will try to modify the cluster (empty the locations attribute) in second apply.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
