### PR TITLE
Fix the pump/drainer data dir to avoid data loss caused by bad configuration

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_drainer.sh.tpl
@@ -31,4 +31,5 @@ done
 -config=/etc/drainer/drainer.toml \
 -disable-detect={{ .Values.binlog.drainer.disableDetect | default false }} \
 -initial-commit-ts={{ .Values.binlog.drainer.initialCommitTs | default 0 }} \
+-data-dir=/data \
 -log-file=

--- a/charts/tidb-cluster/templates/scripts/_start_pump.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_pump.sh.tpl
@@ -4,6 +4,7 @@ set -euo pipefail
 -L={{ .Values.binlog.pump.logLevel | default "info" }} \
 -advertise-addr=`echo ${HOSTNAME}`.{{ template "cluster.name" . }}-pump:8250 \
 -config=/etc/pump/pump.toml \
+-data-dir=/data \
 -log-file=
 
 if [ $? == 0 ]; then

--- a/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
@@ -31,4 +31,5 @@ done
 -config=/etc/drainer/drainer.toml \
 -disable-detect={{ .Values.disableDetect | default false }} \
 -initial-commit-ts={{ .Values.initialCommitTs | default 0 }} \
+-data-dir=/data \
 -log-file=""


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
We allow users to specify a customized configuration file for `pump` and `drainer`, but if the user forget to configure the `data-dir` in config file or configure it wrongly, there are potential data loss risk.

This PR fix this problem.
### What is changed and how does it work?
Fix the `data-dir` via command line arguments.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes

 - Has Helm charts change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix the pump/drainer data dir to avoid potential data loss.
 ```
