### PR TITLE
charts/tidb-lightning: Add adhoc data source for lightning

### DIFF
--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       {{ if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
       nodeName: {{ .Values.dataSource.local.nodeName }}
-      {{ else -}}
+      {{ else if not .Values.dataSource.adhoc.pvcName -}}
       initContainers:
       - name: data-retriever
         image: {{ .Values.dataSource.remote.rcloneImage }}
@@ -78,7 +78,11 @@ spec:
         hostPath:
           path: {{ .Values.dataSource.local.hostPath }}
           type: Directory
-      {{- else -}}
+      {{- else if .Values.dataSource.adhoc.pvcName -}}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Values.dataSource.adhoc.pvcName }}
+      {{ else }}
       - name: credentials
         secret:
           secretName: {{ .Values.dataSource.remote.secretName }}

--- a/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
+++ b/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.dataSource.adhoc.pvcName }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -15,3 +16,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.dataSource.remote.storage }}
+{{ end -}}

--- a/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
+++ b/charts/tidb-lightning/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,5 @@
-{{ if not .Values.dataSource.adhoc.pvcName }}
+{{ if or .Values.dataSource.adhoc.pvcName (and .Values.dataSource.local.nodeName .Values.dataSource.local.hostPath) }}
+{{- else -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -1,5 +1,7 @@
 {{- if and .Values.dataSource.local.hostPath .Values.dataSource.local.nodeName -}}
 data_dir={{ .Values.dataSource.local.hostPath }}
+{{- else if .Values.dataSource.adhoc.pvcName -}}
+data_dir=/var/lib/tidb-lightning/{{ .Values.dataSource.adhoc.backupName | default .Values.dataSource.adhoc.pvcName }}
 {{- else -}}
 data_dir=$(dirname $(find /var/lib/tidb-lightning -name metadata 2>/dev/null) 2>/dev/null)
 if [ -z $data_dir ]; then
@@ -12,12 +14,12 @@ if [ -z $data_dir ]; then
 fi
 {{ end }}
 /tidb-lightning \
-    --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Release.Namespace }}:2379 \
+    --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:2379 \
     --status-addr=0.0.0.0:8289 \
-    --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Release.Namespace }}:8287 \
+    --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:8287 \
     --server-mode=false \
     --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
-    --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Release.Namespace }} \
+    --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }} \
     --d=${data_dir} \
     --config=/etc/tidb-lightning/tidb-lightning.toml
 

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -9,7 +9,7 @@ service:
 
 # failFast causes the lightning pod fails when any error happens.
 # when disabled, the lightning pod will keep running when error happens to allow manual intervention, users have to check logs to see the job status.
-failFast: false
+failFast: true
 
 dataSource:
   local: {}

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -15,6 +15,12 @@ dataSource:
   local: {}
     # nodeName: kind-worker3
     # hostPath: /data/export-20190820
+  # The backup data is on a PVC which is from tidb-backup or scheduled backup, and is not uploaded to cloud storage yet.
+  # Note: when using this mode, the lightning needs to be deployed in the same namespace as the PVC
+  # and the `targetTidbCluster.namespace` needs to be configured explicitly
+  adhoc: {}
+    # pvcName: tidb-cluster-scheduled-backup
+    # backupName: scheduled-backup-20190822-041004
   remote:
     rcloneImage: tynor88/rclone
     storageClassName: local-storage
@@ -24,6 +30,8 @@ dataSource:
 
 targetTidbCluster:
   name: tidb-cluster
+  # namespace is the target tidb cluster namespace, can be omitted if the lightning is deployed in the same namespace of the target tidb cluster
+  namespace: ""
   user: root
 
 resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Allow ad-hoc data to be restored with tidb-lightning.

### What is changed and how does it work?

Add an option to support ad-hoc backup.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test with scheduled backup on AWS.

Code changes

 - Has Helm charts change

Side effects

None

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Support add-hoc data source to be restored with tidb-lightning chart
 ```
