### PR TITLE
add recommendations options to mydumper

### DIFF
--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -42,7 +42,7 @@ storage:
   size: 100Gi
 
 # backupOptions is the options of mydumper https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options
-backupOptions: "--verbose=3"
+backupOptions: "-t 16 -F 256 --skip-tz-utc --verbose=3"
 # Set the tidb_snapshot to be used for the backup
 # Use `show master status` to get the ts:
 #   MySQL [(none)]> show master status;

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -41,7 +41,10 @@ storage:
   className: local-storage
   size: 100Gi
 
-# backupOptions is the options of mydumper https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options
+# -t is thread count, larger thread count will speed up the backup, but may impact the performance of the upstream TiDB.
+# -F is the chunk size, a big table is partitioned into many chunks.
+# Other useful options are -B for database, and -T for tables.
+# See https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options for more options.
 backupOptions: "-t 16 -F 256 --skip-tz-utc --verbose=3"
 # Set the tidb_snapshot to be used for the backup
 # Use `show master status` to get the ts:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -520,7 +520,7 @@ scheduledBackup:
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#starting-deadline
   startingDeadlineSeconds: 3600
   # https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options
-  options: "--verbose=3"
+  options: "-t 16 -F 256 --skip-tz-utc --verbose=3"
   # secretName is the name of the secret which stores user and password used for backup
   # Note: you must give the user enough privilege to do the backup
   # you can create the secret by:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -519,7 +519,10 @@ scheduledBackup:
   failedJobsHistoryLimit: 1
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#starting-deadline
   startingDeadlineSeconds: 3600
-  # https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options
+  # -t is thread count, larger thread count will speed up the backup, but may impact the performance of the upstream TiDB.
+  # -F is the chunk size, a big table is partitioned into many chunks.
+  # Other useful options are -B for database, and -T for tables.
+  # See https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options for more options.
   options: "-t 16 -F 256 --skip-tz-utc --verbose=3"
   # secretName is the name of the secret which stores user and password used for backup
   # Note: you must give the user enough privilege to do the backup

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1818,7 +1818,6 @@ func (oa *operatorActions) DeployAdHocBackup(info *TidbClusterConfig) error {
 		"user":            "root",
 		"password":        info.Password,
 		"storage.size":    "10Gi",
-		"backupOptions":   "\"--verbose=3\"",
 		"initialCommitTs": strings.TrimSpace(tsStr),
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

add recommendations options to `mydumper`:

https://pingcap.com/docs/v3.0/how-to/maintain/backup-and-restore/#best-practices-of-full-backup-and-restoration-using-mydumper-loader

- `-t 16`: means 16 threads are used to export the data.
- `-F 64`: means a table is partitioned into chunks and one chunk is 64MB.
- `--skip-tz-utc`: the purpose of adding this parameter is to ignore the inconsistency of time zone setting between MySQL and the data exporting machine and to disable automatic conversion.


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

 - Has Helm charts change

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
add recommendations options to mydumper: `-t 16 -F 64 --skip-tz-utc`
 ```
