### PR TITLE
fix ad-hoc full backup failure due to incorrect claimName

### DIFF
--- a/charts/tidb-backup/templates/backup-job.yaml
+++ b/charts/tidb-backup/templates/backup-job.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
         env:
         - name: BACKUP_NAME
-          value: {{ .Values.name | quote }}
+          value: {{ tpl .Values.name . | quote }}
       {{- if .Values.gcp }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /gcp/credentials.json
@@ -76,7 +76,7 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
-          claimName: {{ .Values.name }}
+          claimName: {{ tpl .Values.name . }}
     {{- if .Values.gcp }}
       - name: gcp-credentials
         secret:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
ad-hoc backup will fail if use default backup name which is not rendered during helm install in backup-job.yaml.
### What is changed and how does it work?
Make helm render the backup name.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - ad-hoc backup with the default name
   - ad-hoc backup with the specified name

Code changes

 - Has Helm charts change




Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
The ad-hoc backup will fail if use default backup name which is not rendered during helm install in backup-job.yaml.
 ```
