### PR TITLE
Support file and tidb destDBType for drainer

### DIFF
--- a/charts/tidb-cluster/templates/config/_drainer-config.tpl
+++ b/charts/tidb-cluster/templates/config/_drainer-config.tpl
@@ -46,7 +46,7 @@ disable-dispatch = {{ .Values.binlog.drainer.disableDispatch | default false }}
 safe-mode = {{ .Values.binlog.drainer.safeMode | default false }}
 
 # downstream storage, equal to --dest-db-type
-# valid values are "mysql", "pb", "tidb", "flash", "kafka"
+# valid values are "mysql", "file", "tidb", "flash", "kafka"
 db-type = "{{ .Values.binlog.drainer.destDBType }}"
 
 # disable sync these schema
@@ -70,7 +70,7 @@ ignore-schemas = {{ .Values.binlog.drainer.ignoreSchemas | default "INFORMATION_
 #db-name = "test"
 #tbl-name = "log"
 
-{{- if eq .Values.binlog.drainer.destDBType "mysql" }}
+{{- if or (eq .Values.binlog.drainer.destDBType "mysql") (eq .Values.binlog.drainer.destDBType "tidb") }}
 # the downstream mysql protocol database
 [syncer.to]
 host = {{ .Values.binlog.drainer.mysql.host | quote }}
@@ -83,14 +83,11 @@ port = {{ .Values.binlog.drainer.mysql.port | default 3306 }}
 #schema = "tidb_binlog"
 {{- end }}
 
-{{- if eq .Values.binlog.drainer.destDBType "pb" }}
-# Uncomment this if you want to use pb or sql as db-type.
-# Compress compresses output file, like pb and sql file. Now it supports "gzip" algorithm only.
-# Values can be "gzip". Leave it empty to disable compression.
+{{- if or (eq .Values.binlog.drainer.destDBType "pb") (eq .Values.binlog.drainer.destDBType "file") }}
+# Uncomment this if you want to use file as db-type.
 [syncer.to]
-# directory to save pb file, default same as data-dir(save checkpoint file) if this is not configured.
+# directory to save binlog file, default same as data-dir(save checkpoint file) if this is not configured.
 dir = "/data/pb"
-compression = "gzip"
 {{- end }}
 
 {{- if eq .Values.binlog.drainer.destDBType "kafka" }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -465,8 +465,8 @@ binlog:
     # the number of SQL statements of a transaction that are output to the downstream database (20 by default)
     txnBatch: 20
     # downstream storage, equal to --dest-db-type
-    # valid values are "mysql", "pb", "kafka"
-    destDBType: pb
+    # valid values are "mysql", "file", "tidb", "kafka"
+    destDBType: file
     mysql: {}
       # host: "127.0.0.1"
       # user: "root"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/838

### What is changed and how does it work?
drainer config template from the tidb-cluster helm chart is changed to accept tidb and file as new drainer destDBType.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Deploy drainer with `destDBType = "tidb"` -> replication is functional, and checkpoint table contains tso mapping
2. Deploy drainer with `destDBType = "mysql"` -> replication is functional, and checkpoint table doesn't contain tso mapping
3. Deploy drainer with `destDBType = "pb"` -> incremental backup is functional
4. Deploy drainer with `destDBType = "file"` -> incremental backup is functional

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
