### PR TITLE
Set cache binlog count for drainer to reduce memory footprint

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_drainer.sh.tpl
@@ -31,5 +31,6 @@ done
 -config=/etc/drainer/drainer.toml \
 -disable-detect={{ .Values.binlog.drainer.disableDetect | default false }} \
 -initial-commit-ts={{ .Values.binlog.drainer.initialCommitTs | default 0 }} \
+-cache-binlog-count={{ .Values.binlog.drainer.cacheBinlogCount | default 16 }} \
 -data-dir=/data \
 -log-file=

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -481,6 +481,9 @@ binlog:
       # kafkaAddrs: "127.0.0.1:9092"
       # kafkaVersion: "0.8.2.0"
 
+    # max binlog records that being cached
+    cacheBinlogCount: 16
+
     # Please refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml for the default
     # drainer configurations (change to the tags of your drainer version),
     # just follow the format in the file and configure in the 'config' section

--- a/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
@@ -31,5 +31,6 @@ done
 -config=/etc/drainer/drainer.toml \
 -disable-detect={{ .Values.disableDetect | default false }} \
 -initial-commit-ts={{ .Values.initialCommitTs | default 0 }} \
+-cache-binlog-count={{ .Values.cacheBinlogCount | default 16 }} \
 -data-dir=/data \
 -log-file=""

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -21,6 +21,9 @@ disableDetect: false
 # if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint
 initialCommitTs: 0
 
+# max binlog records that being cached
+cacheBinlogCount: 16
+
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml
 config: |
   detect-interval = 10


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
According to @july2993 , the default cache binlog count of drainer is 64k, which may cause the drainer OOM if the size of each binlog record is large. 

### What is changed and how does it work?
Make the cache binlog count configurable and set it default to 16
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes

 - Has Helm charts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Set cache binlog count for drainer to reduce the memory footprint.
 ```
