### PR TITLE
charts: allow cross namespace metrics scraping

### DIFF
--- a/charts/tidb-cluster/templates/config/_prometheus-config.tpl
+++ b/charts/tidb-cluster/templates/config/_prometheus-config.tpl
@@ -14,9 +14,6 @@ scrape_configs:
     honor_labels: true
     kubernetes_sd_configs:
     - role: pod
-      namespaces:
-        names:
-        - {{ .Release.Namespace }}
     tls_config:
       insecure_skip_verify: true
     relabel_configs:

--- a/charts/tidb-cluster/templates/monitor-rbac.yaml
+++ b/charts/tidb-cluster/templates/monitor-rbac.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.monitor.create }}
 {{- if .Values.rbac.create }}
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
 metadata:
-  name: {{ template "cluster.name" . }}-monitor
+  name: {{ template "cluster.name" . }}:monitor
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,16 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "watch", "list"]
+  resources:
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "cluster.name" . }}-monitor
+  name: {{ template "cluster.name" . }}:monitor
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -32,12 +35,13 @@ subjects:
   {{- else }}
   name: {{ template "cluster.name" . }}-monitor
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
-  name: {{ template "cluster.name" . }}-monitor
+  kind: ClusterRole
+  name: {{ template "cluster.name" . }}:monitor
   apiGroup: rbac.authorization.k8s.io
----
 {{- if not .Values.monitor.serviceAccount }}
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Allow Prometheus to scrape cross namespace pods. The tidb-lightning chart may be deployed in the upstream tidb cluster to use the adhoc backup PVC. So Prometheus needs to scrape metrics cross namespace.

### What is changed and how does it work?

The rbac rule of Prometheus changed to use cluster role and cluster role binding in order scrape cross namespace.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test

Code changes

 - Has Helm charts change

Side effects

None

Related changes

 - Need to cherry-pick to the release branch release-1.1

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
None
 ```
