### PR TITLE
compatible with the old controller manager

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -34,8 +34,12 @@ spec:
         command:
           - /usr/local/bin/tidb-controller-manager
           - -default-storage-class-name={{ .Values.defaultStorageClassName }}
-          - -default-backup-storage-class-name={{ .Values.defaultBackupStorageClassName }}
+          {{- if .Values.tidbBackupManagerImage }}
           - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
+          {{- end }}
+          {{- if .Values.defaultBackupStorageClassName }}
+          - -default-backup-storage-class-name={{ .Values.defaultBackupStorageClassName }}
+          {{- end }}
           - -cluster-scoped={{ .Values.clusterScoped }}
           - -auto-failover={{ .Values.controllerManager.autoFailover | default true }}
           - -pd-failover-period={{ .Values.controllerManager.pdFailoverPeriod | default "5m" }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -15,8 +15,8 @@ imagePullPolicy: IfNotPresent
 defaultStorageClassName: local-storage
 
 # tidbBackupManagerImage is tidb backup manager image
-tidbBackupManagerImage: pingcap/tidb-backup-manager:latest
-defaultBackupStorageClassName: local-storage
+# tidbBackupManagerImage: pingcap/tidb-backup-manager:latest
+# defaultBackupStorageClassName: local-storage
 
 controllerManager:
   # With rbac.create=false, the user is responsible for creating this account


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Make the latest charts compatible with the old controller manager

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test


Code changes

 - Has Helm charts change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
make the latest  charts compatible with the old controller manager
 ```
