### PR TITLE
deploy/gcp: fix apply issue and simplify terraform configuration

### DIFF
--- a/deploy/gcp/tidbclusters.tf
+++ b/deploy/gcp/tidbclusters.tf
@@ -1,14 +1,3 @@
-data "local_file" "kubeconfig" {
-  depends_on = [module.tidb-operator.get_credentials_id]
-  filename   = local.kubeconfig
-}
-
-# local file resource used to delay helm provider initialization
-resource "local_file" "kubeconfig" {
-  content    = data.local_file.kubeconfig.content
-  filename   = local.kubeconfig
-}
-
 provider "helm" {
   alias          = "gke"
   insecure       = true
@@ -20,7 +9,8 @@ provider "helm" {
     # we defer initialization by using load_config_file argument.
     # See https://github.com/pingcap/tidb-operator/pull/819#issuecomment-524547459
     config_path = local.kubeconfig
-    load_config_file = local_file.kubeconfig.filename != "" ? true : false
+    # used to delay helm provisioner initialization in apply phrase
+    load_config_file = module.tidb-operator.get_credentials_id != "" ? true : null
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fix #859 

we should not create the file again with its content. terraform will not
skip creation even if the content does not change. so terraform will
destroy the file and the new file cannot be created anymore
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Steps to test:

- terraform apply -var-file small.tfvars -state small.tfstate
- terraform apply -var-file small.tfvars -var 'tidb_version=v3.0.2' -state small.tfstate
- terraform refresh -var-file small.tfvars -var 'tidb_version=v3.0.2' -state small.tfstate
- terraform destroy -var-file small.tfvars -var 'tidb_version=v3.0.2' -state small.tfstate

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
deploy/gcp: fix an issue that kubeconfig may be destroyed in apply phrase
 ```
