### PR TITLE
tls: fix temp volume configs for controller-manager

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -56,15 +56,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: TZ
             value: {{ .Values.timezone | default "UTC" }}
-        volumeMounts:
-        - mountPath: /var/lib/tls
-          name: tls
-          readOnly: true
-      volumes:
-      - name: tls
-        secret:
-          defaultMode: 420
-          secretName: client-tls
     {{- with .Values.controllerManager.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
This breaks CI and is fixed in later PR, so not necessary to keep in master

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix broken CI on master after #750 is merged

### What is changed and how does it work?
The CI doesn't test TLS enabled cluster yet, so no need to keep that config in master

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has Helm charts change

Side effects

 - Manual added secret for TLS server won't work, but that doesn't matter as later PR fix it

Related changes

 - #750 

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
