### PR TITLE
make GO111MODULE=on by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ifeq ($(GO111), 1)
 $(error Please upgrade your Go compiler to 1.11 or higher version)
 endif
 
+# Enable GO111MODULE=on explicitly, disable it with GO111MODULE=off when necessary.
 export GO111MODULE := on
 GOOS := $(if $(GOOS),$(GOOS),linux)
 GOARCH := $(if $(GOARCH),$(GOARCH),amd64)

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ endif
 
 GOOS := $(if $(GOOS),$(GOOS),linux)
 GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
-GOENV  := GO15VENDOREXPERIMENT="1" GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
+GO111MODULE := on
+GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go build
-GOTEST := CGO_ENABLED=0 GO111MODULE=on go test -v -cover
+GOTEST := CGO_ENABLED=0 go test -v -cover
 
 PACKAGE_LIST := go list ./... | grep -vE "pkg/client" | grep -vE "zz_generated"
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'
@@ -54,7 +55,7 @@ backup-docker: backup-manager
 
 e2e-setup:
 	# ginkgo doesn't work with retool for Go 1.11
-	@GO111MODULE=on CGO_ENABLED=0 go get github.com/onsi/ginkgo@v1.6.0
+	@GO_ENABLED=0 go get github.com/onsi/ginkgo@v1.6.0
 
 e2e-docker-push: e2e-docker
 	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator-e2e:latest"
@@ -102,7 +103,7 @@ check-static:
 	@echo "gofmt checking"
 	gofmt -s -l -w $(FILES) 2>&1| $(FAIL_ON_STDOUT)
 	@echo "go vet check"
-	@GO111MODULE=on go vet -all $$($(PACKAGE_LIST)) 2>&1
+	@go vet -all $$($(PACKAGE_LIST)) 2>&1
 	@echo "mispell and ineffassign checking"
 	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all \
 	  --enable misspell \
@@ -127,7 +128,7 @@ errcheck:
 check-shadow:
 	@echo "go vet shadow checking"
 	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-	@GO111MODULE=on go vet -vettool=$(which shadow) $$($(PACKAGE_LIST))
+	@go vet -vettool=$(which shadow) $$($(PACKAGE_LIST))
 
 lint:
 	@echo "linting"
@@ -135,7 +136,7 @@ lint:
 
 tidy:
 	@echo "go mod tidy"
-	GO111MODULE=on go mod tidy
+	go mod tidy
 	git diff --quiet go.mod go.sum
 
 check-gosec:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ ifeq ($(GO111), 1)
 $(error Please upgrade your Go compiler to 1.11 or higher version)
 endif
 
+export GO111MODULE := on
 GOOS := $(if $(GOOS),$(GOOS),linux)
 GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
-GO111MODULE := on
 GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go build
 GOTEST := CGO_ENABLED=0 go test -v -cover
@@ -55,7 +55,7 @@ backup-docker: backup-manager
 
 e2e-setup:
 	# ginkgo doesn't work with retool for Go 1.11
-	@GO_ENABLED=0 go get github.com/onsi/ginkgo@v1.6.0
+	@CGO_ENABLED=0 go get github.com/onsi/ginkgo@v1.6.0
 
 e2e-docker-push: e2e-docker
 	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator-e2e:latest"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

because our projects are using `go mod` now, we can safely make `GO111MODULE=on` by default, use `GO111MODULE=off` when necessary.

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
