### PR TITLE
discovery: use port 2379 for cmdline parameters

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -105,7 +105,8 @@ func (td *tidbDiscovery) Discover(advertisePeerUrl string) (string, error) {
 
 	membersArr := make([]string, 0)
 	for _, member := range membersInfo.Members {
-		membersArr = append(membersArr, member.PeerUrls[0])
+		memberURL := strings.ReplaceAll(member.PeerUrls[0], ":2380", ":2379")
+		membersArr = append(membersArr, fmt.Sprintf("%s", memberURL))
 	}
 	delete(currentCluster.peers, podName)
 	return fmt.Sprintf("--join=%s", strings.Join(membersArr, ",")), nil

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -106,7 +106,7 @@ func (td *tidbDiscovery) Discover(advertisePeerUrl string) (string, error) {
 	membersArr := make([]string, 0)
 	for _, member := range membersInfo.Members {
 		memberURL := strings.ReplaceAll(member.PeerUrls[0], ":2380", ":2379")
-		membersArr = append(membersArr, memberURL))
+		membersArr = append(membersArr, memberURL)
 	}
 	delete(currentCluster.peers, podName)
 	return fmt.Sprintf("--join=%s", strings.Join(membersArr, ",")), nil

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -106,7 +106,7 @@ func (td *tidbDiscovery) Discover(advertisePeerUrl string) (string, error) {
 	membersArr := make([]string, 0)
 	for _, member := range membersInfo.Members {
 		memberURL := strings.ReplaceAll(member.PeerUrls[0], ":2380", ":2379")
-		membersArr = append(membersArr, fmt.Sprintf("%s", memberURL))
+		membersArr = append(membersArr, memberURL))
 	}
 	delete(currentCluster.peers, podName)
 	return fmt.Sprintf("--join=%s", strings.Join(membersArr, ",")), nil

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -274,7 +274,7 @@ func TestDiscoveryDiscovery(t *testing.T) {
 				g.Expect(len(td.clusters)).To(Equal(1))
 				g.Expect(len(td.clusters["default/demo"].peers)).To(Equal(1))
 				g.Expect(td.clusters["default/demo"].peers["demo-pd-1"]).To(Equal(struct{}{}))
-				g.Expect(s).To(Equal("--join=demo-pd-2.demo-pd-peer.default.svc:2380"))
+				g.Expect(s).To(Equal("--join=demo-pd-2.demo-pd-peer.default.svc:2379"))
 			},
 		},
 		{
@@ -306,7 +306,7 @@ func TestDiscoveryDiscovery(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(td.clusters)).To(Equal(1))
 				g.Expect(len(td.clusters["default/demo"].peers)).To(Equal(0))
-				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2380,demo-pd-2.demo-pd-peer.default.svc:2380"))
+				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2379,demo-pd-2.demo-pd-peer.default.svc:2379"))
 			},
 		},
 		{
@@ -343,7 +343,7 @@ func TestDiscoveryDiscovery(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(td.clusters)).To(Equal(1))
 				g.Expect(len(td.clusters["default/demo"].peers)).To(Equal(0))
-				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2380,demo-pd-1.demo-pd-peer.default.svc:2380,demo-pd-2.demo-pd-peer.default.svc:2380"))
+				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2379,demo-pd-1.demo-pd-peer.default.svc:2379,demo-pd-2.demo-pd-peer.default.svc:2379"))
 			},
 		},
 		{
@@ -391,7 +391,7 @@ func TestDiscoveryDiscovery(t *testing.T) {
 				g.Expect(len(td.clusters)).To(Equal(2))
 				g.Expect(len(td.clusters["default/demo"].peers)).To(Equal(0))
 				g.Expect(len(td.clusters["default/demo-1"].peers)).To(Equal(3))
-				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2380,demo-pd-1.demo-pd-peer.default.svc:2380,demo-pd-2.demo-pd-peer.default.svc:2380,demo-pd-3.demo-pd-peer.default.svc:2380"))
+				g.Expect(s).To(Equal("--join=demo-pd-0.demo-pd-peer.default.svc:2379,demo-pd-1.demo-pd-peer.default.svc:2379,demo-pd-2.demo-pd-peer.default.svc:2379,demo-pd-3.demo-pd-peer.default.svc:2379"))
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Change port in the URL returned by discovery for `--join` parameters from `2380` to `2379`.

As per comment in [#1682](https://github.com/pingcap/pd/issues/1682), `2379` is the correct port for `--join`.

### What is changed and how does it work?

While `--init-cluster` uses `2380` as the port, and discovery reads member list from PD, which also uses port `2380`, the only change is to replace port `2380` with `2379` when building `--join` parameters for PD instances trying to join the cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Related changes

The current approach of using `2380` for `--join` works when PD instances use plain connections, but when enable TLS encrypted connections, it fails to start etcd server. See comments in [#1682](https://github.com/pingcap/pd/issues/1682) for details.

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
