### PR TITLE
Cleanup scheduled backup data after successful upload

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_scheduled_backup.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_scheduled_backup.sh.tpl
@@ -60,3 +60,11 @@ uploader \
   --bucket={{ .Values.scheduledBackup.s3.bucket }} \
   --backup-dir=${backupPath}
 {{- end }}
+
+{{- if and (.Values.scheduledBackup.cleanupAfterUpload) (or (.Values.scheduledBackup.gcp) (or .Values.scheduledBackup.ceph .Values.scheduledBackup.s3)) }}
+if [ $? -eq 0 ]; then
+    if [ -d "${backupPath}" -a -n "${backupName}" ]; then
+        rm -rf "${backupPath}"
+    fi
+fi
+{{- end }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -561,6 +561,8 @@ scheduledBackup:
   # refer to https://kubernetes.io/docs/concepts/storage/storage-classes
   storageClassName: local-storage
   storage: 100Gi
+  # When set to true, cleans up the backup data on storage upon successful upload to the cloud object storage
+  cleanupAfterUpload: false
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
   schedule: "0 0 * * *"
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#suspend


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/841

### What is changed and how does it work?
Helm chart
Cleans up the backup directory if the last attempt to upload it to the cloud object storage was successful.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Prerequisite: Install tidb-operator and tidb-cluster on AWS with scheduled backup enabled
Cases:
1. cleanupAfterUpload=true and s3 destination configured => directory deleted after upload
2. cleanupAfterUpload=false and s3 destination configured => directory not deleted after upload
3. cleanupAfterUpload=true and s3 destination not configured => directory not deleted after upload

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - Usage is briefly documented as a comment above the parameter

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
