### PR TITLE
Make scheduled backup more configurable

### DIFF
--- a/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
+++ b/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: scheduled-backup
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
     spec:
+      backoffLimit: {{ .Values.scheduledBackup.backoffLimit | default 6 }}
+    {{- if .Values.scheduledBackup.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.scheduledBackup.activeDeadlineSeconds }}
+    {{- end }}
       template:
         metadata:
           labels:
@@ -88,7 +92,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scheduledBackup.secretName }}
                   key: password
-          restartPolicy: OnFailure
+          restartPolicy: {{ .Values.scheduledBackup.restartPolicy | default "OnFailure" }}
           volumes:
           - name: data
             persistentVolumeClaim:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -570,6 +570,12 @@ scheduledBackup:
   failedJobsHistoryLimit: 1
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#starting-deadline
   startingDeadlineSeconds: 3600
+  # https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#pod-backoff-failure-policy
+  backoffLimit: 6
+  # https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#job-termination-and-cleanup
+  # activeDeadlineSeconds: 10800
+  # https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#handling-pod-and-container-failures
+  restartPolicy: OnFailure
   # -t is thread count, larger thread count will speed up the backup, but may impact the performance of the upstream TiDB.
   # -F is the chunk size, a big table is partitioned into many chunks.
   # Other useful options are -B for database, and -T for tables.


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/903

### What is changed and how does it work?
Make backoffLimit, activeDeadlineSeconds and restartPolicy for the scheduled backup configurable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Prerequisite: Install tidb-operator and tidb-cluster on AWS with scheduled backup enabled.
Cases:
1. Set backoffLimit only => observe that it takes effect
2. Set activeDeadlineSeconds only => observe that it takes effect
3. Set restartPolicy=Never => observe that it takes effect

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
