### PR TITLE
by default, don't give montior any cross-namespace access

### DIFF
--- a/charts/tidb-cluster/templates/config/_prometheus-config.tpl
+++ b/charts/tidb-cluster/templates/config/_prometheus-config.tpl
@@ -14,7 +14,7 @@ scrape_configs:
     honor_labels: true
     kubernetes_sd_configs:
     - role: pod
-    {{- if not .Values.rbac.cross_namespace }}
+    {{- if not .Values.rbac.crossNamespace }}
       namespaces:
         names:
         - {{ .Release.Namespace }}

--- a/charts/tidb-cluster/templates/config/_prometheus-config.tpl
+++ b/charts/tidb-cluster/templates/config/_prometheus-config.tpl
@@ -14,6 +14,11 @@ scrape_configs:
     honor_labels: true
     kubernetes_sd_configs:
     - role: pod
+    {{- if not .Values.rbac.cross_namespace }}
+      namespaces:
+        names:
+        - {{ .Release.Namespace }}
+    {{- end }}
     tls_config:
       insecure_skip_verify: true
     relabel_configs:

--- a/charts/tidb-cluster/templates/monitor-rbac.yaml
+++ b/charts/tidb-cluster/templates/monitor-rbac.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.monitor.create }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
 kind: ClusterRole
   {{- else }}
 kind: Role
   {{- end }}
 metadata:
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
   name: {{ template "cluster.name" . }}:monitor
   {{- else }}
   name: {{ template "cluster.name" . }}-monitor
@@ -23,19 +23,19 @@ rules:
   resources:
   - pods
   verbs: ["get", "list", "watch"]
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
   {{- end }}
 ---
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
 kind: ClusterRoleBinding
   {{- else }}
 kind: RoleBinding
   {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
   name: {{ template "cluster.name" . }}:monitor
   {{- else }}
   name: {{ template "cluster.name" . }}-monitor
@@ -53,18 +53,15 @@ subjects:
   {{- else }}
   name: {{ template "cluster.name" . }}-monitor
   {{- end }}
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
 roleRef:
-  {{- if .Values.rbac.cross_namespace }}
+  {{- if .Values.rbac.crossNamespace }}
   kind: ClusterRole
-  {{- else }}
-  kind: Role
-  {{- end }}
-  {{- if .Values.rbac.cross_namespace }}
   name: {{ template "cluster.name" . }}:monitor
   {{- else }}
+  kind: Role
   name: {{ template "cluster.name" . }}-monitor
   {{- end }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/tidb-cluster/templates/monitor-rbac.yaml
+++ b/charts/tidb-cluster/templates/monitor-rbac.yaml
@@ -1,9 +1,17 @@
 {{- if .Values.monitor.create }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+  {{- if .Values.rbac.cross_namespace }}
 kind: ClusterRole
+  {{- else }}
+kind: Role
+  {{- end }}
 metadata:
+  {{- if .Values.rbac.cross_namespace }}
   name: {{ template "cluster.name" . }}:monitor
+  {{- else }}
+  name: {{ template "cluster.name" . }}-monitor
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -15,13 +23,23 @@ rules:
   resources:
   - pods
   verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.cross_namespace }}
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
+  {{- end }}
 ---
+  {{- if .Values.rbac.cross_namespace }}
 kind: ClusterRoleBinding
+  {{- else }}
+kind: RoleBinding
+  {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  {{- if .Values.rbac.cross_namespace }}
   name: {{ template "cluster.name" . }}:monitor
+  {{- else }}
+  name: {{ template "cluster.name" . }}-monitor
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -35,10 +53,20 @@ subjects:
   {{- else }}
   name: {{ template "cluster.name" . }}-monitor
   {{- end }}
+  {{- if .Values.rbac.cross_namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
+  {{- if .Values.rbac.cross_namespace }}
   kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
+  {{- if .Values.rbac.cross_namespace }}
   name: {{ template "cluster.name" . }}:monitor
+  {{- else }}
+  name: {{ template "cluster.name" . }}-monitor
+  {{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- if not .Values.monitor.serviceAccount }}
 ---

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -6,6 +6,8 @@
 # If you set rbac.create to false, you need to provide a value for monitor.serviceAccount
 rbac:
   create: true
+  # Set to true to enable cross-namespace monitoring
+  cross_namespace: false
 
 # clusterName is the TiDB cluster name, if not specified, the chart release name will be used
 # clusterName: demo

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -7,7 +7,7 @@
 rbac:
   create: true
   # Set to true to enable cross-namespace monitoring
-  cross_namespace: false
+  crossNamespace: false
 
 # clusterName is the TiDB cluster name, if not specified, the chart release name will be used
 # clusterName: demo


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fixes #862. #854 enabled cross-namespace access in the tidb-cluster deployment. 

### What is changed and how does it work?

By default use the previous code. Add an option to use new code.
This maintains backwards compatibility with the previous chart.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 
I deployed both versions to a local kind cluster

Code changes

 - Has Helm charts change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:

This maintains backwards compatibility. Most users won't need to change this setting.

 ```release-note
Add an option to monitor across namespaces
 ```
