### PR TITLE
add store state for tkctl get tikv

### DIFF
--- a/pkg/tkctl/alias/alias.go
+++ b/pkg/tkctl/alias/alias.go
@@ -31,5 +31,15 @@ func (t TikvList) GetObjectKind() schema.ObjectKind {
 }
 
 func (t TikvList) DeepCopyObject() runtime.Object {
-	return t.PodList.DeepCopyObject()
+	out := TikvList{
+		PodList:    nil,
+		TikvStatus: nil,
+	}
+	if t.PodList != nil {
+		out.PodList = t.PodList.DeepCopy()
+	}
+	if t.TikvStatus != nil {
+		out.TikvStatus = t.TikvStatus.DeepCopy()
+	}
+	return out
 }

--- a/pkg/tkctl/alias/alias.go
+++ b/pkg/tkctl/alias/alias.go
@@ -14,29 +14,22 @@
 package alias
 
 import (
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap.com/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type Tikv v1.Pod
-
-type TikvList v1.PodList
-
-// implement type Object interface
-func (t Tikv) GetObjectKind() schema.ObjectKind {
-	return t.GetObjectKind()
-}
-
-func (t Tikv) DeepCopyObject() runtime.Object {
-	return t.DeepCopyObject()
+type TikvList struct {
+	PodList    *v1.PodList
+	TikvStatus *v1alpha1.TiKVStatus
 }
 
 // implement type Object interface
 func (t TikvList) GetObjectKind() schema.ObjectKind {
-	return t.GetObjectKind()
+	return t.PodList.GetObjectKind()
 }
 
 func (t TikvList) DeepCopyObject() runtime.Object {
-	return t.DeepCopyObject()
+	return t.PodList.DeepCopyObject()
 }

--- a/pkg/tkctl/cmd/get/get.go
+++ b/pkg/tkctl/cmd/get/get.go
@@ -285,13 +285,13 @@ func (o *GetOptions) PrintOutput(tc *v1alpha1.TidbCluster, resourceType string, 
 			tc, err := o.tcCli.PingcapV1alpha1().
 				TidbClusters(o.Namespace).
 				Get(o.TidbClusterName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			tikvStatus := tc.Status.TiKV
 			tikvList := alias.TikvList{
 				PodList:    podList,
-				TikvStatus: &tikvStatus,
+				TikvStatus: nil,
+			}
+			if err == nil {
+				tikvStatus := tc.Status.TiKV
+				tikvList.TikvStatus = &tikvStatus
 			}
 			return printer.PrintObj(&tikvList, o.Out)
 		default:

--- a/pkg/tkctl/cmd/get/get.go
+++ b/pkg/tkctl/cmd/get/get.go
@@ -282,7 +282,17 @@ func (o *GetOptions) PrintOutput(tc *v1alpha1.TidbCluster, resourceType string, 
 		}
 		switch resourceType {
 		case kindTiKV:
-			tikvList := alias.TikvList(*podList)
+			tc, err := o.tcCli.PingcapV1alpha1().
+				TidbClusters(o.Namespace).
+				Get(o.TidbClusterName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			tikvStatus := tc.Status.TiKV
+			tikvList := alias.TikvList{
+				PodList:    podList,
+				TikvStatus: &tikvStatus,
+			}
 			return printer.PrintObj(&tikvList, o.Out)
 		default:
 			break

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -187,7 +187,11 @@ func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]m
 				break
 			}
 		}
-		row.Cells = append(row.Cells, storeId, tikvList.TikvStatus.Stores[storeId].State)
+		if tikvList.TikvStatus != nil {
+			row.Cells = append(row.Cells, storeId, tikvList.TikvStatus.Stores[storeId].State)
+		} else {
+			row.Cells = append(row.Cells, storeId, unset)
+		}
 		metaTableRows[id] = row
 	}
 	return metaTableRows, nil

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -171,7 +171,7 @@ func printPod(pod *v1.Pod, options printers.PrintOptions) ([]metav1beta1.TableRo
 	return []metav1beta1.TableRow{row}, nil
 }
 
-// add more columns for tikv column
+// add more columns for tikv info
 func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	podList := tikvList.PodList
 	metaTableRows, err := printPodList(podList, options)
@@ -187,10 +187,15 @@ func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]m
 				break
 			}
 		}
-		if tikvList.TikvStatus != nil {
-			row.Cells = append(row.Cells, storeId, tikvList.TikvStatus.Stores[storeId].State)
+		if len(storeId) > 0 {
+			row.Cells = append(row.Cells, storeId)
+			if tikvList.TikvStatus != nil {
+				row.Cells = append(row.Cells, tikvList.TikvStatus.Stores[storeId].State)
+			} else {
+				row.Cells = append(row.Cells, unset)
+			}
 		} else {
-			row.Cells = append(row.Cells, storeId, unset)
+			row.Cells = append(row.Cells, unset, unset)
 		}
 		metaTableRows[id] = row
 	}

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -187,22 +187,18 @@ func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]m
 				break
 			}
 		}
-		// judge if storeID exists
+		viewStoreId := unset
+		viewStoreState := unset
+		// set storeId and tikv Store State if existed
 		if len(storeId) > 0 {
-			row.Cells = append(row.Cells, storeId)
-			// judge if tikv Store State exists
+			viewStoreId = storeId
 			if tikvList.TikvStatus != nil && tikvList.TikvStatus.Stores != nil {
 				if _, ok := tikvList.TikvStatus.Stores[storeId]; ok {
-					row.Cells = append(row.Cells, tikvList.TikvStatus.Stores[storeId].State)
-				} else {
-					row.Cells = append(row.Cells, unset)
+					viewStoreState = tikvList.TikvStatus.Stores[storeId].State
 				}
-			} else {
-				row.Cells = append(row.Cells, unset)
 			}
-		} else {
-			row.Cells = append(row.Cells, unset, unset)
 		}
+		row.Cells = append(row.Cells, viewStoreId, viewStoreState)
 		metaTableRows[id] = row
 	}
 	return metaTableRows, nil

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -189,7 +189,7 @@ func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]m
 		}
 		if len(storeId) > 0 {
 			row.Cells = append(row.Cells, storeId)
-			if tikvList.TikvStatus != nil {
+			if tikvList.TikvStatus != nil && tikvList.TikvStatus.Stores != nil {
 				row.Cells = append(row.Cells, tikvList.TikvStatus.Stores[storeId].State)
 			} else {
 				row.Cells = append(row.Cells, unset)

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -187,10 +187,16 @@ func printTikvList(tikvList *alias.TikvList, options printers.PrintOptions) ([]m
 				break
 			}
 		}
+		// judge if storeID exists
 		if len(storeId) > 0 {
 			row.Cells = append(row.Cells, storeId)
+			// judge if tikv Store State exists
 			if tikvList.TikvStatus != nil && tikvList.TikvStatus.Stores != nil {
-				row.Cells = append(row.Cells, tikvList.TikvStatus.Stores[storeId].State)
+				if _, ok := tikvList.TikvStatus.Stores[storeId]; ok {
+					row.Cells = append(row.Cells, tikvList.TikvStatus.Stores[storeId].State)
+				} else {
+					row.Cells = append(row.Cells, unset)
+				}
 			} else {
 				row.Cells = append(row.Cells, unset)
 			}

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -83,12 +83,12 @@ func AddHandlers(h printers.PrintHandler) {
 		Type:        "string",
 		Description: "TiKV StoreID",
 	}
-	storeStatus := metav1beta1.TableColumnDefinition{
-		Name:        "Store Status",
+	storeState := metav1beta1.TableColumnDefinition{
+		Name:        "Store State",
 		Type:        "string",
-		Description: "TiKV Store Status",
+		Description: "TiKV Store State",
 	}
-	tikvPodColumns = append(tikvPodColumns, storeId, storeStatus)
+	tikvPodColumns = append(tikvPodColumns, storeId, storeState)
 	h.TableHandler(tikvPodColumns, printTikvList)
 	// TODO: add available space for volume
 	volumeColumns := []metav1beta1.TableColumnDefinition{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/564
Adding one more column to show store state for each tikv by tkctl get and removing `printTikv` handler cause printing single tikv pod is not supported for tkctl now.

example:
```bash
$ ./tkctl get tikv -t tidb --namespace tidb
NAME          READY   STATUS    MEMORY          CPU             RESTARTS   AGE     STOREID   STORE STATE
tidb-tikv-0   1/1     Running   <none>/<none>   <none>/<none>   0          3d21h   4         Up
tidb-tikv-1   1/1     Running   <none>/<none>   <none>/<none>   0          3d21h   5         Up
tidb-tikv-2   1/1     Running   <none>/<none>   <none>/<none>   0          3d21h   1         Up

```

### What is changed and how does it work?
Moving the steps which printed the extra columns for tikv Into `printTikvList` function in `/pkg/tkctl/readable` from `printPod` function, including `StoreID` and `Store State`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - N/A

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
`tkctl get tikv` now can show store state for each tikv pod
 ```
