### PR TITLE
add option to initSql from Configmap

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
+++ b/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
@@ -16,7 +16,7 @@ for file in os.listdir(password_dir):
     else:
         conn.cursor().execute("create user %s@%s identified by %s;", (user, permit_host, password,))
 {{- end }}
-{{- if .Values.tidb.initSql }}
+{{- if or .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
 with open('/data/init.sql', 'r') as sql:
     for line in sql.readlines():
         conn.cursor().execute(line)

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -43,12 +43,19 @@ spec:
       - name: password
         secret:
           secretName: {{ .Values.tidb.passwordSecretName }}
-      {{- if .Values.tidb.initSql }}
+      {{- if .Values.tidb.initSqlConfigMapName }}
+      - name: init-sql
+        configMap:
+          name: {{ .Values.tidb.initSqlConfigMapName }}
+          items:
+          - key: init-sql
+            path: init.sql
+      {{- else if .Values.tidb.initSql }}
       - name: init-sql
         configMap:
           name: {{ template "cluster.name" . }}-tidb
           items:
-          - key: init-sql
-            path: init.sql
+            - key: init-sql
+              path: init.sql
       {{- end }}
 {{- end }}

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -39,8 +39,7 @@ spec:
           - name: init-sql
             mountPath: /data
             readOnly: true
-          {{- end }}
-          {{- if .Values.tidb.initSql }}
+          {{- else if .Values.tidb.initSql }}
           - name: init-sql
             mountPath: /data
             readOnly: true

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.tidb.passwordSecretName .Values.tidb.permitHost .Values.tidb.initSql }}
+{{- if or .Values.tidb.passwordSecretName .Values.tidb.permitHost .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,11 +28,16 @@ spec:
         - -c
         - |
 {{ tuple "scripts/_initialize_tidb_users.py.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
-        {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
+        {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
         volumeMounts:
           {{- if .Values.tidb.passwordSecretName }}
           - name: password
             mountPath: /etc/tidb/password
+            readOnly: true
+          {{- end }}
+          {{- if .Values.tidb.initSqlConfigMapName }}
+          - name: init-sql
+            mountPath: /data
             readOnly: true
           {{- end }}
           {{- if .Values.tidb.initSql }}
@@ -43,14 +48,21 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.tidb.initializer.resources | indent 10 }}
-      {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
+      {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
       volumes:
         {{- if .Values.tidb.passwordSecretName }}
         - name: password
           secret:
             secretName: {{ .Values.tidb.passwordSecretName }}
         {{- end }}
-        {{- if .Values.tidb.initSql }}
+        {{- if .Values.tidb.initSqlConfigMapName }}
+        - name: init-sql
+          configMap:
+            name: {{ .Values.tidb.initSqlConfigMapName }}
+            items:
+              - key: init-sql
+                path: init.sql
+        {{- else if .Values.tidb.initSql }}
         - name: init-sql
           configMap:
             name: {{ template "cluster.name" . }}-tidb

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -267,6 +267,10 @@ tidb:
   # If unset, defaults to '%' which means allow any host to connect to the TiDB.
   # permitHost: 127.0.0.1
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
+  # The configmap name of init sql, you can create configmap with following command:
+  # kubectl create configmap tidb-initsql --from-file=init-sql --namespace=<namespace>
+  # If both set the initSqlConfigMapName and initSql, the initSqlConfigMapName will have the higher priority and both are mutually exclusive.
+  # initSqlConfigMapName: tidb-initsql
   # initSql: |-
   #   create database app;
   image: pingcap/tidb:v3.0.1

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -267,8 +267,8 @@ tidb:
   # If unset, defaults to '%' which means allow any host to connect to the TiDB.
   # permitHost: 127.0.0.1
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
-  # The configmap name of init sql, you can create configmap with following command:
-  # kubectl create configmap tidb-initsql --from-file=init-sql --namespace=<namespace>
+  # The configmap name of init sql and the name of file must be init-sql with no file extension, you can create configmap with following command:
+  # kubectl create configmap tidb-initsql --from-file=init-sql=/path/to/your/init-sql --namespace=<namespace>
   # If both set the initSqlConfigMapName and initSql, the initSqlConfigMapName will have the higher priority and both are mutually exclusive.
   # initSqlConfigMapName: tidb-initsql
   # initSql: |-

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -269,7 +269,7 @@ tidb:
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
   # The configmap name of init sql and the name of file must be init-sql with no file extension, you can create configmap with following command:
   # kubectl create configmap tidb-initsql --from-file=init-sql=/path/to/your/init-sql --namespace=<namespace>
-  # If both set the initSqlConfigMapName and initSql, the initSqlConfigMapName will have the higher priority and both are mutually exclusive.
+  # If both initSqlConfigMapName and initSql are set, the initSqlConfigMapName will be used.
   # initSqlConfigMapName: tidb-initsql
   # initSql: |-
   #   create database app;


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/899
It will be user-friendly if the sql of tidb initialization is supported to be read from configmap. and the previous way to init sql is still work.

### What is changed and how does it work?
Make initSql from configmap in `tidb-cluster` chart have a higher priority than iniSql in `values.yaml`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
NONE
