### PR TITLE
make rootpasswordreset optional

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
+++ b/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
@@ -2,8 +2,9 @@ import os, MySQLdb
 host = '{{ template "cluster.name" . }}-tidb'
 permit_host = {{ .Values.tidb.permitHost | default "%" | quote }}
 port = 4000
-password_dir = '/etc/tidb/password'
 conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5)
+{{- if .Values.tidb.passwordSecretName }}
+password_dir = '/etc/tidb/password'
 for file in os.listdir(password_dir):
     if file.startswith('.'):
         continue
@@ -14,6 +15,7 @@ for file in os.listdir(password_dir):
         conn.cursor().execute("set password for 'root'@'%%' = %s;", (password,))
     else:
         conn.cursor().execute("create user %s@%s identified by %s;", (user, permit_host, password,))
+{{- end }}
 {{- if .Values.tidb.initSql }}
 with open('/data/init.sql', 'r') as sql:
     for line in sql.readlines():

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -30,33 +30,33 @@ spec:
 {{ tuple "scripts/_initialize_tidb_users.py.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
         {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
         volumeMounts:
-        {{- if .Values.tidb.passwordSecretName }}
-        - name: password
-          mountPath: /etc/tidb/password
-          readOnly: true
-        {{- end }}
-        {{- if .Values.tidb.initSql }}
-        - name: init-sql
-          mountPath: /data
-          readOnly: true
-        {{- end }}
+          {{- if .Values.tidb.passwordSecretName }}
+          - name: password
+            mountPath: /etc/tidb/password
+            readOnly: true
+          {{- end }}
+          {{- if .Values.tidb.initSql }}
+          - name: init-sql
+            mountPath: /data
+            readOnly: true
+          {{- end }}
         {{- end }}
         resources:
 {{ toYaml .Values.tidb.initializer.resources | indent 10 }}
       {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
       volumes:
-      {{- if .Values.tidb.passwordSecretName }}
-      - name: password
-        secret:
-          secretName: {{ .Values.tidb.passwordSecretName }}
-      {{- end }}
-      {{- if .Values.tidb.initSql }}
-      - name: init-sql
-        configMap:
-          name: {{ template "cluster.name" . }}-tidb
-          items:
-          - key: init-sql
-            path: init.sql
-      {{- end }}
+        {{- if .Values.tidb.passwordSecretName }}
+        - name: password
+          secret:
+            secretName: {{ .Values.tidb.passwordSecretName }}
+        {{- end }}
+        {{- if .Values.tidb.initSql }}
+        - name: init-sql
+          configMap:
+            name: {{ template "cluster.name" . }}-tidb
+            items:
+            - key: init-sql
+              path: init.sql
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -28,21 +28,28 @@ spec:
         - -c
         - |
 {{ tuple "scripts/_initialize_tidb_users.py.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
+        {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
         volumeMounts:
+        {{- if .Values.tidb.passwordSecretName }}
         - name: password
           mountPath: /etc/tidb/password
           readOnly: true
+        {{- end }}
         {{- if .Values.tidb.initSql }}
         - name: init-sql
           mountPath: /data
           readOnly: true
         {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.tidb.initializer.resources | indent 10 }}
+      {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql }}
       volumes:
+      {{- if .Values.tidb.passwordSecretName }}
       - name: password
         secret:
           secretName: {{ .Values.tidb.passwordSecretName }}
+      {{- end }}
       {{- if .Values.tidb.initSql }}
       - name: init-sql
         configMap:
@@ -50,5 +57,6 @@ spec:
           items:
           - key: init-sql
             path: init.sql
+      {{- end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/921
For now, root password reset is not optional during sql intialization.

### What is changed and how does it work?
Editing the job template and python script for sql initialization.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Helm charts change

Side effects

 - N/A

Related changes

 - N/A
### Does this PR introduce a user-facing change?:
NONE
