### PR TITLE
Wait rolling-update complete in configmap rollout case to workaround #901

### DIFF
--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -177,7 +177,6 @@ func run() {
 			oa.CheckTidbClusterStatusOrDie(cluster)
 			oa.CheckTidbMemberAssignedNodesOrDie(cluster, assignedNodes)
 		}
-		cancel()
 
 		// configuration change
 		for _, cluster := range clusters {
@@ -196,13 +195,18 @@ func run() {
 			cluster.TiDBPreStartScript = strconv.Quote("")
 			oa.UpgradeTidbClusterOrDie(cluster)
 			oa.CheckTidbClusterStatusOrDie(cluster)
+			// wait upgrade complete
+			oa.CheckUpgradeOrDie(ctx, cluster)
 
 			cluster.UpdatePdMaxReplicas(cfg.PDMaxReplicas).
 				UpdateTiKVGrpcConcurrency(cfg.TiKVGrpcConcurrency).
 				UpdateTiDBTokenLimit(cfg.TiDBTokenLimit)
 			oa.UpgradeTidbClusterOrDie(cluster)
 			oa.CheckTidbClusterStatusOrDie(cluster)
+			// wait upgrade complete
+			oa.CheckUpgradeOrDie(ctx, cluster)
 		}
+		cancel()
 		oa.CleanWebHookAndServiceOrDie(ocfg)
 
 		for _, cluster := range clusters {


### PR DESCRIPTION
close #923 
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
#901 
### What is changed and how does it work?
check upgrade after configmap rollout to avoid rollover

Related changes

 - Need to cherry-pick to the release branch
