### PR TITLE
Fix terraform aws operator values

### DIFF
--- a/deploy/aws/main.tf
+++ b/deploy/aws/main.tf
@@ -27,13 +27,14 @@ module "vpc" {
 module "tidb-operator" {
   source = "../modules/aws/tidb-operator"
 
-  eks_name           = var.eks_name
-  eks_version        = var.eks_version
-  operator_version   = var.operator_version
-  config_output_path = "credentials/"
-  subnets            = local.subnets
-  vpc_id             = module.vpc.vpc_id
-  ssh_key_name       = module.key-pair.key_name
+  eks_name             = var.eks_name
+  eks_version          = var.eks_version
+  operator_version     = var.operator_version
+  config_output_path   = "credentials/"
+  subnets              = local.subnets
+  vpc_id               = module.vpc.vpc_id
+  ssh_key_name         = module.key-pair.key_name
+  operator_helm_values = var.operator_values == "" ? "" : file(var.operator_values)
 }
 
 module "bastion" {

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -23,7 +23,7 @@ variable "operator_version" {
 }
 
 variable "operator_values" {
-  description = "The helm values of TiDB Operator, it is recommended to use the 'file()' function call to read the content from a local file, e.g. 'file(\"my-cluster.yaml\")'"
+  description = "The helm values file for TiDB Operator, path is relative to current working dir"
   default     = ""
 }
 


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #925

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
The custom tidb-operator values can be properly set now in terraform script for AWS .
 ```
