### PR TITLE
Set the default externalTrafficPolicy to be Local for TiDB service

### DIFF
--- a/deploy/modules/aliyun/tidb-cluster/values/default.yaml
+++ b/deploy/modules/aliyun/tidb-cluster/values/default.yaml
@@ -15,6 +15,7 @@ tidb:
   logLevel: info
   service:
     type: LoadBalancer
+    externalTrafficPolicy: Local
     exposeStatus: true
     annotations:
       service.beta.kubernetes.io/alicloud-loadbalancer-address-type: intranet

--- a/deploy/modules/aws/tidb-cluster/values/default.yaml
+++ b/deploy/modules/aws/tidb-cluster/values/default.yaml
@@ -9,6 +9,7 @@ tikv:
 tidb:
   service:
     type: LoadBalancer
+    externalTrafficPolicy: Local
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-internal: '0.0.0.0/0'
       service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/deploy/modules/gcp/tidb-cluster/values/default.yaml
+++ b/deploy/modules/gcp/tidb-cluster/values/default.yaml
@@ -8,6 +8,7 @@ tikv:
 tidb:
   service:
     type: LoadBalancer
+    externalTrafficPolicy: Local
     annotations:
       cloud.google.com/load-balancer-type: "Internal"
   separateSlowLog: true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/879

### What is changed and how does it work?
The default externalTrafficPolicy is now set to be Local

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Deploy to AWS from /tidb-operator/deploy/aws out-of-box
2. Run `kubectl describe service my-cluster-tidb -n my-cluster` and verify the value of externalTrafficPolicy.

Code changes

 - Has Helm charts change

Side effects

 - Breaking backward compatibility

Related changes

 - N/A

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
