### PR TITLE
Should use GB/MB rather than GiB/MiB for backward compatibility with old TiKV versions

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -158,6 +158,8 @@ func GetServiceType(services []v1alpha1.Service, serviceName string) corev1.Serv
 // equal to MiB/GiB/TiB, so we cannot use resource.String() directly.
 // Minimum unit we use is MiB, capacity less than 1MiB is ignored.
 // https://github.com/tikv/tikv/blob/v3.0.3/components/tikv_util/src/config.rs#L155-L168
+// For backward compatibility with old TiKV versions, we should use GB/MB
+// rather than GiB/MiB, see https://github.com/tikv/tikv/blob/v2.1.16/src/util/config.rs#L359.
 func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 	defaultArgs := "0"
 	if limits == nil || limits.Storage == "" {
@@ -174,9 +176,9 @@ func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 		return defaultArgs
 	}
 	if i%humanize.GiByte == 0 {
-		return fmt.Sprintf("%dGiB", i/humanize.GiByte)
+		return fmt.Sprintf("%dGB", i/humanize.GiByte)
 	}
-	return fmt.Sprintf("%dMiB", i/humanize.MiByte)
+	return fmt.Sprintf("%dMB", i/humanize.MiByte)
 }
 
 func GetSlowLogTailerImage(cluster *v1alpha1.TidbCluster) string {

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -119,7 +119,7 @@ func TestTiKVCapacity(t *testing.T) {
 				Storage: "100Gi",
 			},
 			expectFn: func(g *GomegaWithT, s string) {
-				g.Expect(s).To(Equal("100GiB"))
+				g.Expect(s).To(Equal("100GB"))
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestTiKVCapacity(t *testing.T) {
 				Storage: "1G",
 			},
 			expectFn: func(g *GomegaWithT, s string) {
-				g.Expect(s).To(Equal("953MiB"))
+				g.Expect(s).To(Equal("953MB"))
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestTiKVCapacity(t *testing.T) {
 				Storage: "1.5G",
 			},
 			expectFn: func(g *GomegaWithT, s string) {
-				g.Expect(s).To(Equal("1430MiB"))
+				g.Expect(s).To(Equal("1430MB"))
 			},
 		},
 	}

--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -55,15 +55,20 @@ func main() {
 	cli, kubeCli := client.NewCliOrDie()
 	ocfg := newOperatorConfig()
 
-	cluster1 := newTidbClusterConfig(ns, "cluster1", "")
-	cluster2 := newTidbClusterConfig(ns, "cluster2", "admin")
+	cluster1 := newTidbClusterConfig(ns, "cluster1", "", "")
+	cluster2 := newTidbClusterConfig(ns, "cluster2", "admin", "")
 	cluster2.Resources["pd.replicas"] = "1"
-	cluster3 := newTidbClusterConfig(ns, "cluster3", "admin")
-	cluster4 := newTidbClusterConfig(ns, "cluster4", "admin")
+	cluster3 := newTidbClusterConfig(ns, "cluster3", "admin", "")
+	cluster4 := newTidbClusterConfig(ns, "cluster4", "admin", "")
+	cluster5 := newTidbClusterConfig(ns, "cluster5", "", "v2.1.16") // for v2.1.x series
+	cluster5.Resources["tikv.resources.limits.storage"] = "1G"
 
 	allClusters := []*tests.TidbClusterConfig{
 		cluster1,
 		cluster2,
+		cluster3,
+		cluster4,
+		cluster5,
 	}
 
 	oa := tests.NewOperatorActions(cli, kubeCli, tests.DefaultPollInterval, cfg, nil)
@@ -71,103 +76,119 @@ func main() {
 	oa.CleanOperatorOrDie(ocfg)
 	oa.DeployOperatorOrDie(ocfg)
 
-	fn1 := func(wg *sync.WaitGroup) {
+	/**
+	 * This test case covers basic operators of a single cluster.
+	 * - deployment
+	 * - scaling
+	 * - update configuration
+	 * - switch back and forth between pod network and host network
+	 */
+	fn1 := func(wg *sync.WaitGroup, cluster *tests.TidbClusterConfig) {
 		defer wg.Done()
-		oa.CleanTidbClusterOrDie(cluster1)
-		oa.DeployTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
-		oa.CheckDisasterToleranceOrDie(cluster1)
+		oa.CleanTidbClusterOrDie(cluster)
+		oa.DeployTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
+		oa.CheckDisasterToleranceOrDie(cluster)
 
 		// scale
-		cluster1.ScaleTiDB(3).ScaleTiKV(5).ScalePD(5)
-		oa.ScaleTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
-		oa.CheckDisasterToleranceOrDie(cluster1)
+		cluster.ScaleTiDB(3).ScaleTiKV(5).ScalePD(5)
+		oa.ScaleTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
+		oa.CheckDisasterToleranceOrDie(cluster)
 
-		cluster1.ScaleTiDB(2).ScaleTiKV(4).ScalePD(3)
-		oa.ScaleTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
-		oa.CheckDisasterToleranceOrDie(cluster1)
+		cluster.ScaleTiDB(2).ScaleTiKV(4).ScalePD(3)
+		oa.ScaleTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
+		oa.CheckDisasterToleranceOrDie(cluster)
 
 		// configuration change
-		cluster1.EnableConfigMapRollout = true
+		cluster.EnableConfigMapRollout = true
 		// moved to stability test because these two cases need too many times
 		// bad conf
-		//cluster1.TiDBPreStartScript = strconv.Quote("exit 1")
-		//cluster1.TiKVPreStartScript = strconv.Quote("exit 1")
-		//cluster1.PDPreStartScript = strconv.Quote("exit 1")
-		//oa.UpgradeTidbClusterOrDie(cluster1)
+		//cluster.TiDBPreStartScript = strconv.Quote("exit 1")
+		//cluster.TiKVPreStartScript = strconv.Quote("exit 1")
+		//cluster.PDPreStartScript = strconv.Quote("exit 1")
+		//oa.UpgradeTidbClusterOrDie(cluster)
 		//time.Sleep(30 * time.Second)
-		//oa.CheckTidbClustersAvailableOrDie([]*tests.TidbClusterConfig{cluster1})
+		//oa.CheckTidbClustersAvailableOrDie([]*tests.TidbClusterConfig{cluster})
 		// rollback conf
-		//cluster1.PDPreStartScript = strconv.Quote("")
-		//cluster1.TiKVPreStartScript = strconv.Quote("")
-		//cluster1.TiDBPreStartScript = strconv.Quote("")
-		//oa.UpgradeTidbClusterOrDie(cluster1)
-		//oa.CheckTidbClusterStatusOrDie(cluster1)
+		//cluster.PDPreStartScript = strconv.Quote("")
+		//cluster.TiKVPreStartScript = strconv.Quote("")
+		//cluster.TiDBPreStartScript = strconv.Quote("")
+		//oa.UpgradeTidbClusterOrDie(cluster)
+		//oa.CheckTidbClusterStatusOrDie(cluster)
 		// correct conf
-		cluster1.UpdatePdMaxReplicas(cfg.PDMaxReplicas).
+		cluster.UpdatePdMaxReplicas(cfg.PDMaxReplicas).
 			UpdateTiKVGrpcConcurrency(cfg.TiKVGrpcConcurrency).
 			UpdateTiDBTokenLimit(cfg.TiDBTokenLimit)
-		oa.UpgradeTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
+		oa.UpgradeTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
 
 		// switch to host network
-		cluster1.RunInHost(true)
-		oa.UpgradeTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
+		cluster.RunInHost(true)
+		oa.UpgradeTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
 
 		// switch to pod network
-		cluster1.RunInHost(false)
-		oa.UpgradeTidbClusterOrDie(cluster1)
-		oa.CheckTidbClusterStatusOrDie(cluster1)
+		cluster.RunInHost(false)
+		oa.UpgradeTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
 	}
-	fn2 := func(wg *sync.WaitGroup) {
+
+	/**
+	 * This test case covers upgrading TiDB version.
+	 */
+	fn2 := func(wg *sync.WaitGroup, cluster *tests.TidbClusterConfig) {
 		defer wg.Done()
 
 		// deploy
-		oa.CleanTidbClusterOrDie(cluster2)
-		oa.DeployTidbClusterOrDie(cluster2)
-		oa.CheckTidbClusterStatusOrDie(cluster2)
-		oa.CheckDisasterToleranceOrDie(cluster2)
+		oa.CleanTidbClusterOrDie(cluster)
+		oa.DeployTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
+		oa.CheckDisasterToleranceOrDie(cluster)
 
-		cluster2.ScalePD(3)
-		oa.ScaleTidbClusterOrDie(cluster2)
-		oa.CheckTidbClusterStatusOrDie(cluster2)
+		cluster.ScalePD(3)
+		oa.ScaleTidbClusterOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
 
 		// upgrade
 		oa.RegisterWebHookAndServiceOrDie(certCtx, ocfg)
 		ctx, cancel := context.WithCancel(context.Background())
-		assignedNodes := oa.GetTidbMemberAssignedNodesOrDie(cluster2)
-		cluster2.UpgradeAll(upgradeVersions[0])
-		oa.UpgradeTidbClusterOrDie(cluster2)
-		oa.CheckUpgradeOrDie(ctx, cluster2)
-		oa.CheckManualPauseTiDBOrDie(cluster2)
-		oa.CheckTidbClusterStatusOrDie(cluster2)
-		oa.CheckTidbMemberAssignedNodesOrDie(cluster2, assignedNodes)
+		assignedNodes := oa.GetTidbMemberAssignedNodesOrDie(cluster)
+		cluster.UpgradeAll(upgradeVersions[0])
+		oa.UpgradeTidbClusterOrDie(cluster)
+		oa.CheckUpgradeOrDie(ctx, cluster)
+		oa.CheckManualPauseTiDBOrDie(cluster)
+		oa.CheckTidbClusterStatusOrDie(cluster)
+		oa.CheckTidbMemberAssignedNodesOrDie(cluster, assignedNodes)
 		cancel()
 
 		oa.CleanWebHookAndServiceOrDie(ocfg)
 	}
-	fn3 := func(wg *sync.WaitGroup) {
+
+	/**
+	 * This test case covers backup and restore between two clusters.
+	 */
+	fn3 := func(wg *sync.WaitGroup, clusterA, clusterB *tests.TidbClusterConfig) {
 		defer wg.Done()
-		oa.CleanTidbClusterOrDie(cluster3)
-		oa.CleanTidbClusterOrDie(cluster4)
-		oa.DeployTidbClusterOrDie(cluster3)
-		oa.DeployTidbClusterOrDie(cluster4)
-		oa.CheckTidbClusterStatusOrDie(cluster3)
-		oa.CheckTidbClusterStatusOrDie(cluster4)
-		go oa.BeginInsertDataToOrDie(cluster3)
+		oa.CleanTidbClusterOrDie(clusterA)
+		oa.CleanTidbClusterOrDie(clusterB)
+		oa.DeployTidbClusterOrDie(clusterA)
+		oa.DeployTidbClusterOrDie(clusterB)
+		oa.CheckTidbClusterStatusOrDie(clusterA)
+		oa.CheckTidbClusterStatusOrDie(clusterB)
+		go oa.BeginInsertDataToOrDie(clusterA)
 
 		// backup and restore
-		oa.BackupRestoreOrDie(cluster3, cluster4)
+		oa.BackupRestoreOrDie(clusterA, clusterB)
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(3)
-	go fn1(&wg)
-	go fn2(&wg)
-	go fn3(&wg)
+	wg.Add(4)
+	go fn1(&wg, cluster1)
+	go fn1(&wg, cluster5)
+	go fn2(&wg, cluster2)
+	go fn3(&wg, cluster3, cluster4)
 	wg.Wait()
 
 	// check data regions disaster tolerance
@@ -198,8 +219,10 @@ func newOperatorConfig() *tests.OperatorConfig {
 	}
 }
 
-func newTidbClusterConfig(ns, clusterName, password string) *tests.TidbClusterConfig {
-	tidbVersion := cfg.GetTiDBVersionOrDie()
+func newTidbClusterConfig(ns, clusterName, password, tidbVersion string) *tests.TidbClusterConfig {
+	if tidbVersion == "" {
+		tidbVersion = cfg.GetTiDBVersionOrDie()
+	}
 	topologyKey := "rack"
 	return &tests.TidbClusterConfig{
 		Namespace:        ns,

--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -168,11 +168,6 @@ func main() {
 	 * Note that only one cluster can run in host network mode at the same time.
 	 */
 	testHostNetwork := func(wg *sync.WaitGroup, cluster *tests.TidbClusterConfig) {
-		oa.CleanTidbClusterOrDie(cluster)
-		oa.DeployTidbClusterOrDie(cluster)
-		oa.CheckTidbClusterStatusOrDie(cluster)
-		oa.CheckDisasterToleranceOrDie(cluster)
-
 		// switch to host network
 		cluster.RunInHost(true)
 		oa.UpgradeTidbClusterOrDie(cluster)
@@ -191,27 +186,22 @@ func main() {
 		testBasic(&wg, cluster1)
 		testHostNetwork(&wg, cluster1)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster1)
-		oa.CleanTidbClusterOrDie(cluster1)
 	}()
 	go func() {
 		defer wg.Done()
 		testBasic(&wg, cluster5)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster5)
-		oa.CleanTidbClusterOrDie(cluster5)
 	}()
 	go func() {
 		defer wg.Done()
 		testUpgrade(&wg, cluster2)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster2)
-		oa.CleanTidbClusterOrDie(cluster2)
 	}()
 	go func() {
 		defer wg.Done()
 		testBackupAndRestore(&wg, cluster3, cluster4)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster3)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster4)
-		oa.CleanTidbClusterOrDie(cluster3)
-		oa.CleanTidbClusterOrDie(cluster4)
 	}()
 	wg.Wait()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fix bug in https://github.com/pingcap/tidb-operator/pull/942.

We should use GB/MB rather than GiB/MiB for backward compatibility with old TiKV versions.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Unit test
E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
