### PR TITLE
WIP: Do not set --capacity to tikv-server if resources.limits.storage is absent

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
@@ -37,9 +37,12 @@ ARGS="--pd=${SCHEME}://${CLUSTER_NAME}-pd:2379 \
 --addr=0.0.0.0:20160 \
 --status-addr=0.0.0.0:20180 \
 --data-dir=/var/lib/tikv \
---capacity=${CAPACITY} \
 --config=/etc/tikv/tikv.toml
 "
+
+if [ -n "${CAPACITY:-}" ]; then
+    ARGS="${ARGS} --capacity=${CAPACITY}"
+fi
 
 echo "starting tikv-server ..."
 echo "/tikv-server ${ARGS}"

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -206,8 +206,6 @@ tikv:
   #
   #   # Normally it should be tuned to 30%-50% of `tikv.resources.limits.memory`, for example: 32Gi -> 16GB
   #   capacity = "1GB"
-  # Note that we can't set raftstore.capacity in config because it will be overridden by the command line parameter, 
-  # we can only set capacity in tikv.resources.limits.storage.
 
   replicas: 3
   image: pingcap/tikv:v3.0.1
@@ -222,9 +220,11 @@ tikv:
 
   resources:
     limits: {}
-    #   cpu: 16000m
-    #   memory: 32Gi
-    #   storage: 300Gi # We can set capacity here.
+      # cpu: 16000m
+      # memory: 32Gi
+      # This sets store capacity for tikv-server via --capacity flag. Optionally, you can
+      # set `raftstore.capacity` in TiKV configuration.
+      # storage: 300Gi
     requests:
       # cpu: 12000m
       # memory: 24Gi

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -160,14 +160,11 @@ func GetServiceType(services []v1alpha1.Service, serviceName string) corev1.Serv
 // https://github.com/tikv/tikv/blob/v3.0.3/components/tikv_util/src/config.rs#L155-L168
 // For backward compatibility with old TiKV versions, we should use GB/MB
 // rather than GiB/MiB, see https://github.com/tikv/tikv/blob/v2.1.16/src/util/config.rs#L359.
-func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
+func TiKVCapacity(capacity string) string {
 	defaultArgs := "0"
-	if limits == nil || limits.Storage == "" {
-		return defaultArgs
-	}
-	q, err := resource.ParseQuantity(limits.Storage)
+	q, err := resource.ParseQuantity(capacity)
 	if err != nil {
-		glog.Errorf("failed to parse quantity %s: %v", limits.Storage, err)
+		glog.Errorf("failed to parse quantity %s: %v", capacity, err)
 		return defaultArgs
 	}
 	i, b := q.AsInt64()

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -80,72 +80,46 @@ func TestTiKVCapacity(t *testing.T) {
 
 	type testcase struct {
 		name     string
-		limit    *v1alpha1.ResourceRequirement
+		capacity string
 		expectFn func(*GomegaWithT, string)
 	}
 	testFn := func(test *testcase, t *testing.T) {
 		t.Log(test.name)
-		test.expectFn(g, TiKVCapacity(test.limit))
+		test.expectFn(g, TiKVCapacity(test.capacity))
 	}
 	tests := []testcase{
 		{
-			name:  "limit is nil",
-			limit: nil,
+			name:     "failed to parse quantity",
+			capacity: "100x",
 			expectFn: func(g *GomegaWithT, s string) {
 				g.Expect(s).To(Equal("0"))
 			},
 		},
 		{
-			name: "storage is empty",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "",
-			},
-			expectFn: func(g *GomegaWithT, s string) {
-				g.Expect(s).To(Equal("0"))
-			},
-		},
-		{
-			name: "failed to parse quantity",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "100x",
-			},
-			expectFn: func(g *GomegaWithT, s string) {
-				g.Expect(s).To(Equal("0"))
-			},
-		},
-		{
-			name: "100Gi",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "100Gi",
-			},
+			name:     "100Gi",
+			capacity: "100Gi",
 			expectFn: func(g *GomegaWithT, s string) {
 				g.Expect(s).To(Equal("100GB"))
 			},
 		},
 		{
-			name: "100GiB",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "100GiB",
-			},
+			name:     "100GiB",
+			capacity: "100GiB",
 			expectFn: func(g *GomegaWithT, s string) {
 				// GiB is an invalid suffix
 				g.Expect(s).To(Equal("0"))
 			},
 		},
 		{
-			name: "1G",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "1G",
-			},
+			name:     "1G",
+			capacity: "1G",
 			expectFn: func(g *GomegaWithT, s string) {
 				g.Expect(s).To(Equal("953MB"))
 			},
 		},
 		{
-			name: "1.5G",
-			limit: &v1alpha1.ResourceRequirement{
-				Storage: "1.5G",
-			},
+			name:     "1.5G",
+			capacity: "1.5G",
 			expectFn: func(g *GomegaWithT, s string) {
 				g.Expect(s).To(Equal("1430MB"))
 			},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes #944

This makes it possible for users to set capacity in TiKV configuration.

### What is changed and how does it work?

Do not set --capacity to tikv-server if resources.limits.storage is absent.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix a bug that `raftstore.capacity` is ignored even if  `limits.storage` is absent.
 ```
