### PR TITLE
fix apiVersion for DaemonSet

### DIFF
--- a/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
+++ b/manifests/gke/local-ssd-provision/local-ssd-provision.yaml
@@ -25,7 +25,7 @@ data:
 # This will combine all disks with mdadm or LVM.
 # If you don't want to combine disks, you can set NO_COMBINE_LOCAL_SSD=1
 # mdadm is preferred over LVM, to use LVM set USE_LVM=1
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-volume-provisioner


### PR DESCRIPTION
# What problem does this PR solve? <!--add and issue link with summary if exists-->

`apiVersion: extensions/v1beta1` has marked DaemonSet as obsolete, switching to `apps/v1`

### What is changed and how does it work?

`apiVersion: extensions/v1beta1` has marked DaemonSet as obsolete

### Check List <!--REMOVE the items that are not applicable-->

?

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
