### PR TITLE
do not limit failover count when maxFailoverCount not greater than 0

### DIFF
--- a/pkg/manager/member/tidb_failover.go
+++ b/pkg/manager/member/tidb_failover.go
@@ -45,7 +45,7 @@ func (tf *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
 		}
 	}
 
-	if len(tc.Status.TiDB.FailureMembers) >= int(tc.Spec.TiDB.MaxFailoverCount) {
+	if tc.Spec.TiDB.MaxFailoverCount > 0 && len(tc.Status.TiDB.FailureMembers) >= int(tc.Spec.TiDB.MaxFailoverCount) {
 		glog.Warningf("the failure members count reached the limit:%d", tc.Spec.TiDB.MaxFailoverCount)
 		return nil
 	}

--- a/pkg/manager/member/tidb_failover_test.go
+++ b/pkg/manager/member/tidb_failover_test.go
@@ -157,6 +157,52 @@ func TestFakeTiDBFailoverFailover(t *testing.T) {
 				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
 			},
 		},
+		{
+			name: "max failover count but maxFailoverCount = 0",
+			update: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.TiDB.MaxFailoverCount = 0
+				tc.Status.TiDB.Members = map[string]v1alpha1.TiDBMember{
+					"failover-tidb-0": {
+						Name:   "failover-tidb-0",
+						Health: false,
+					},
+					"failover-tidb-1": {
+						Name:   "failover-tidb-1",
+						Health: false,
+					},
+					"failover-tidb-2": {
+						Name:   "failover-tidb-2",
+						Health: false,
+					},
+					"failover-tidb-3": {
+						Name:   "failover-tidb-3",
+						Health: false,
+					},
+					"failover-tidb-4": {
+						Name:   "failover-tidb-4",
+						Health: false,
+					},
+				}
+				tc.Status.TiDB.FailureMembers = map[string]v1alpha1.TiDBFailureMember{
+					"failover-tidb-0": {
+						PodName: "failover-tidb-0",
+					},
+					"failover-tidb-1": {
+						PodName: "failover-tidb-1",
+					},
+					"failover-tidb-2": {
+						PodName: "failover-tidb-2",
+					},
+				}
+			},
+			errExpectFn: func(t *GomegaWithT, err error) {
+				t.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(t *GomegaWithT, tc *v1alpha1.TidbCluster) {
+				t.Expect(len(tc.Status.TiDB.FailureMembers)).To(Equal(4))
+				t.Expect(int(tc.Spec.TiDB.Replicas)).To(Equal(2))
+			},
+		},
 	}
 
 	for i := range tests {

--- a/pkg/manager/member/tikv_failover.go
+++ b/pkg/manager/member/tikv_failover.go
@@ -51,7 +51,7 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 			if tc.Status.TiKV.FailureStores == nil {
 				tc.Status.TiKV.FailureStores = map[string]v1alpha1.TiKVFailureStore{}
 			}
-			if len(tc.Status.TiKV.FailureStores) >= int(tc.Spec.TiKV.MaxFailoverCount) {
+			if tc.Spec.TiKV.MaxFailoverCount > 0 && len(tc.Status.TiKV.FailureStores) >= int(tc.Spec.TiKV.MaxFailoverCount) {
 				glog.Warningf("%s/%s failure stores count reached the limit: %d", ns, tcName, tc.Spec.TiKV.MaxFailoverCount)
 				return nil
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

https://github.com/pingcap/tidb-operator/pull/965, added a `maxFailoverCount ` limit to TiKV, set it to `3` in `values.yaml`. But the old `TidbCluster` object is `0`, it can't failover after upgrade the tidb-operator.

To ensure compatibility, we should keep it no failover count limit if `maxFailoverCount` is `0`.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has Go code change

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
