### PR TITLE
Add a github actions job to run CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+    - master
+    - release-*
+
+jobs:
+
+  verify:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Basic checks
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin # workaround for https://github.com/actions/setup-go/issues/14
+        make check-setup check
+    - name: Build binaries and images
+      run: make docker e2e-docker cli
+    - name: Unit Tests
+      run: make test


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes https://github.com/pingcap/tidb-operator/issues/1004

### What is changed and how does it work?

Add a github actions job to run CI checks

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Unit test
E2E test

Code changes

 - Has CI related scripts change

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
