### PR TITLE
e2e: free resources on successful runs

### DIFF
--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -188,22 +188,27 @@ func main() {
 		testBasic(&wg, cluster1)
 		testHostNetwork(&wg, cluster1)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster1)
+		oa.CleanTidbClusterOrDie(cluster1)
 	}()
 	go func() {
 		defer wg.Done()
 		testBasic(&wg, cluster5)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster5)
+		oa.CleanTidbClusterOrDie(cluster5)
 	}()
 	go func() {
 		defer wg.Done()
 		testUpgrade(&wg, cluster2)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster2)
+		oa.CleanTidbClusterOrDie(cluster2)
 	}()
 	go func() {
 		defer wg.Done()
 		testBackupAndRestore(&wg, cluster3, cluster4)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster3)
 		oa.CheckDataRegionDisasterToleranceOrDie(cluster4)
+		oa.CleanTidbClusterOrDie(cluster3)
+		oa.CleanTidbClusterOrDie(cluster4)
 	}()
 	wg.Wait()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

because we share a machine to run e2e tests, if we don't free resources, a lot of processes will run in the machine even if no e2e tests are running.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
