### PR TITLE
Stability: only expect upgrade complete when rollback bad conf

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3019,19 +3019,19 @@ func (oa *operatorActions) CheckManualPauseTiDBOrDie(info *TidbClusterConfig) {
 
 func (oa *operatorActions) CheckUpgradeComplete(info *TidbClusterConfig) error {
 	ns, tcName := info.Namespace, info.ClusterName
-	if err := wait.PollImmediate(15 * time.Second, DefaultPollTimeout, func() (done bool, err error) {
+	if err := wait.PollImmediate(15*time.Second, DefaultPollTimeout, func() (done bool, err error) {
 		tc, err := oa.cli.PingcapV1alpha1().TidbClusters(ns).Get(tcName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 		if tc.Status.PD.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] PD is still upgrading")
+			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] PD is still upgrading", ns, tcName)
 		}
 		if tc.Status.TiKV.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiKV is still upgrading")
+			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiKV is still upgrading", ns, tcName)
 		}
 		if tc.Status.TiDB.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiDB is still upgrading")
+			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiDB is still upgrading", ns, tcName)
 		}
 		return true, nil
 	}); err != nil {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3022,16 +3022,20 @@ func (oa *operatorActions) CheckUpgradeComplete(info *TidbClusterConfig) error {
 	if err := wait.PollImmediate(15*time.Second, DefaultPollTimeout, func() (done bool, err error) {
 		tc, err := oa.cli.PingcapV1alpha1().TidbClusters(ns).Get(tcName, metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			glog.Errorf("checkUpgradeComplete, [%s/%s] cannot get tidbcluster, %v", ns, tcName, err)
+			return false, nil
 		}
 		if tc.Status.PD.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] PD is still upgrading", ns, tcName)
+			glog.Errorf("checkUpgradeComplete, [%s/%s] PD is still upgrading", ns, tcName)
+			return false, nil
 		}
 		if tc.Status.TiKV.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiKV is still upgrading", ns, tcName)
+			glog.Errorf("checkUpgradeComplete, [%s/%s] TiKV is still upgrading", ns, tcName)
+			return false, nil
 		}
 		if tc.Status.TiDB.Phase == v1alpha1.UpgradePhase {
-			return false, fmt.Errorf("checkUpgradeComplete, [%s/%s] TiDB is still upgrading", ns, tcName)
+			glog.Errorf("checkUpgradeComplete, [%s/%s] TiDB is still upgrading", ns, tcName)
+			return false, nil
 		}
 		return true, nil
 	}); err != nil {

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -190,12 +190,12 @@ func run() {
 			time.Sleep(30 * time.Second)
 			oa.CheckTidbClustersAvailableOrDie([]*tests.TidbClusterConfig{cluster})
 			// rollback conf
-			cluster.PDPreStartScript = strconv.Quote("# noop")
-			cluster.TiKVPreStartScript = strconv.Quote("# noop")
-			cluster.TiDBPreStartScript = strconv.Quote("# noop")
+			cluster.PDPreStartScript = strconv.Quote("")
+			cluster.TiKVPreStartScript = strconv.Quote("")
+			cluster.TiDBPreStartScript = strconv.Quote("")
 			oa.UpgradeTidbClusterOrDie(cluster)
 			// wait upgrade complete
-			oa.CheckUpgradeOrDie(ctx, cluster)
+			oa.CheckUpgradeCompleteOrDie(cluster)
 			oa.CheckTidbClusterStatusOrDie(cluster)
 
 			cluster.UpdatePdMaxReplicas(cfg.PDMaxReplicas).


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #1029 
### What is changed and how does it work?
Only expect upgrade complete when rollback bad conf.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [x] E2E test
 - [x] Stability test, passed

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release-1.0 branch
 - Need to cherry-pick to the release-1.1 branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Stability: only expect upgrade complete when rollback bad configuration.
 ```
