### PR TITLE
ConfigMapRollout should be enabled by default in stability test

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3019,7 +3019,7 @@ func (oa *operatorActions) CheckManualPauseTiDBOrDie(info *TidbClusterConfig) {
 
 func (oa *operatorActions) CheckUpgradeComplete(info *TidbClusterConfig) error {
 	ns, tcName := info.Namespace, info.ClusterName
-	if err := wait.PollImmediate(15*time.Second, DefaultPollTimeout, func() (done bool, err error) {
+	if err := wait.PollImmediate(15*time.Second, 30*time.Minute, func() (done bool, err error) {
 		tc, err := oa.cli.PingcapV1alpha1().TidbClusters(ns).Get(tcName, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("checkUpgradeComplete, [%s/%s] cannot get tidbcluster, %v", ns, tcName, err)

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -180,8 +180,6 @@ func run() {
 
 		// configuration change
 		for _, cluster := range clusters {
-			cluster.EnableConfigMapRollout = true
-
 			// bad conf
 			cluster.TiDBPreStartScript = strconv.Quote("exit 1")
 			cluster.TiKVPreStartScript = strconv.Quote("exit 1")
@@ -436,9 +434,10 @@ func newTidbClusterConfig(ns, clusterName string) *tests.TidbClusterConfig {
 			"binlog.drainer.workerCount": "1024",
 			"binlog.drainer.txnBatch":    "512",
 		},
-		Monitor:          true,
-		BlockWriteConfig: cfg.BlockWriter,
-		TopologyKey:      topologyKey,
-		ClusterVersion:   tidbVersion,
+		Monitor:                true,
+		BlockWriteConfig:       cfg.BlockWriter,
+		TopologyKey:            topologyKey,
+		ClusterVersion:         tidbVersion,
+		EnableConfigMapRollout: true,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #1035 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Stability test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Enable ConfigMapRollout by default in stability test.
 ```
