### PR TITLE
tidb loadbalancer output is empty after terraform apply

### DIFF
--- a/deploy/modules/aliyun/tidb-operator/operator.tf
+++ b/deploy/modules/aliyun/tidb-operator/operator.tf
@@ -59,6 +59,6 @@ resource "helm_release" "tidb-operator" {
 
   set {
     name = "scheduler.kubeSchedulerImageName"
-    value = "gcr.akscn.io/google_containers/hyperkube"
+    value = "registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler-amd64"
   }
 }

--- a/deploy/modules/gcp/tidb-cluster/main.tf
+++ b/deploy/modules/gcp/tidb-cluster/main.tf
@@ -145,6 +145,7 @@ module "tidb-cluster" {
   kubeconfig_filename        = var.kubeconfig_path
   base_values                = file("${path.module}/values/default.yaml")
   wait_on_resource           = [google_container_node_pool.tidb_pool, var.tidb_operator_id]
+  service_ingress_key        = "ip"
 }
 
 resource "null_resource" "wait-lb-ip" {

--- a/deploy/modules/share/tidb-cluster-release/data.tf
+++ b/deploy/modules/share/tidb-cluster-release/data.tf
@@ -1,5 +1,5 @@
 data "external" "tidb_hostname" {
-  depends_on  = [helm_release.tidb-cluster]
+  depends_on  = [helm_release.tidb-cluster, null_resource.wait-lb-ip]
   working_dir = path.cwd
   program     = ["bash", "-c", "kubectl --kubeconfig ${var.kubeconfig_filename} get svc -n ${var.cluster_name} ${var.cluster_name}-tidb -o json | jq '.status.loadBalancer.ingress[0]'"]
 }

--- a/deploy/modules/share/tidb-cluster-release/data.tf
+++ b/deploy/modules/share/tidb-cluster-release/data.tf
@@ -5,7 +5,7 @@ data "external" "tidb_hostname" {
 }
 
 data "external" "monitor_hostname" {
-  depends_on  = [helm_release.tidb-cluster]
+  depends_on  = [helm_release.tidb-cluster, null_resource.wait-mlb-ip]
   working_dir = path.cwd
   program     = ["bash", "-c", "kubectl --kubeconfig ${var.kubeconfig_filename} get svc -n ${var.cluster_name} ${var.cluster_name}-grafana -o json | jq '.status.loadBalancer.ingress[0]'"]
 }

--- a/deploy/modules/share/tidb-cluster-release/main.tf
+++ b/deploy/modules/share/tidb-cluster-release/main.tf
@@ -161,3 +161,25 @@ EOS
     }
   }
 }
+
+resource "null_resource" "wait-mlb-ip" {
+  depends_on = [
+    helm_release.tidb-cluster
+  ]
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    working_dir = path.cwd
+    command     = <<EOS
+set -euo pipefail
+
+until kubectl get svc -n ${var.cluster_name} ${var.cluster_name}-grafana -o json | jq '.status.loadBalancer.ingress[0]' | grep "${var.service_ingress_key}"; do
+  echo "Wait for TiDB monitoring internal loadbalancer IP"
+  sleep 5
+done
+EOS
+
+    environment = {
+      KUBECONFIG = var.kubeconfig_filename
+    }
+  }
+}

--- a/deploy/modules/share/tidb-cluster-release/main.tf
+++ b/deploy/modules/share/tidb-cluster-release/main.tf
@@ -139,3 +139,25 @@ EOS
     }
   }
 }
+
+resource "null_resource" "wait-lb-ip" {
+  depends_on = [
+    helm_release.tidb-cluster
+  ]
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    working_dir = path.cwd
+    command     = <<EOS
+set -euo pipefail
+
+until kubectl get svc -n ${var.cluster_name} ${var.cluster_name}-tidb -o json | jq '.status.loadBalancer.ingress[0]' | grep "${var.service_ingress_key}"; do
+  echo "Wait for TiDB internal loadbalancer IP"
+  sleep 5
+done
+EOS
+
+    environment = {
+      KUBECONFIG = var.kubeconfig_filename
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix https://github.com/pingcap/tidb-operator/issues/1043
### What is changed and how does it work?
Wait for LB ready before computing output data
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
   - AWS test

Outputs:

bastion_ip = [
  "54.184.41.97",
]
default-cluster_monitor-dns = aeb62d185f56d11e9aeb70ae67ff0b7e-1988083749.us-west-2.elb.amazonaws.com
default-cluster_tidb-dns = aeb748195f56d11e9aeb70ae67ff0b7e-25bbd4125f96646b.elb.us-west-2.amazonaws.com
eks_endpoint = https://3A07AB19D3A05BD1BF7B170A276FE317.yl4.us-west-2.eks.amazonaws.com
eks_version = 1.12
kubeconfig_filename = credentials/kubeconfig_dan-eks
region = us-west-2
     - GKE test
Outputs:

how_to_connect_to_default_cluster_tidb_from_bastion = mysql -h 172.31.252.29 -P 4000 -u root
how_to_set_reclaim_policy_of_pv_for_default_tidb_cluster_to_delete = kubectl --kubeconfig /tmp/tidb-operator/deploy/gcp/credentials/kubeconfig_gke-dan get pvc -n tidb-cluster -o jsonpath='{.items[*].spec.volumeName}'|fmt -1 | xargs -I {} kubectl --kubeconfig /tmp/tidb-operator/deploy/gcp/credentials/kubeconfig_gke-dan patch pv {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
how_to_ssh_to_bastion = gcloud --project smooth-tendril-207212 compute ssh gke-dan-tidb-bastion --zone us-west1-a
kubeconfig_file = /tmp/tidb-operator/deploy/gcp/credentials/kubeconfig_gke-dan
monitor_ilb_ip = 34.83.244.11
monitor_port = 3000
region = us-west1
tidb_version = v3.0.4
     - ACK test
Outputs:

bastion_ip = 47.93.233.109
cluster_id = c0b39f3a352e445c98ac1ddddd5ad1643
kubeconfig_file = /tmp/tidb-operator/deploy/aliyun/credentials/kubeconfig
monitor_endpoint = 39.105.218.153:3000
region = cn-beijing
ssh_key_file = /tmp/tidb-operator/deploy/aliyun/credentials/my-cluster-key.pem
tidb_endpoint = 192.168.0.216:4000
tidb_version = v3.0.4
vpc_id = vpc-2zeluubd9sc8upj5qkrjb

Code changes

 - Has terraform scripts change


Side effects



Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix the issue that TiDB Loadbalancer is empty in terraform output.
 ```
