### PR TITLE
Fix tkctl version does not work when the release name is un-wan…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ vendor
 tests/e2e/e2e.test
 .orig
 tkc
+/tkctl

--- a/pkg/tkctl/cmd/version/version.go
+++ b/pkg/tkctl/cmd/version/version.go
@@ -80,7 +80,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	controllers, err := kubeCli.AppsV1().
 		Deployments(core.NamespaceAll).
 		List(v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "controller-manager", label.InstanceLabelKey, "operator"),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "controller-manager", label.NameLabelKey, "tidb-operator"),
 		})
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	schedulers, err := kubeCli.AppsV1().
 		Deployments(core.NamespaceAll).
 		List(v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "scheduler", label.InstanceLabelKey, "operator"),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "scheduler", label.NameLabelKey, "tidb-operator"),
 		})
 	if err != nil {
 		return nil
@@ -103,7 +103,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	} else {
 		fmt.Fprintf(o, "TiDB Controller Manager Versions:\n")
 		for _, item := range controllers.Items {
-			fmt.Fprintf(o, "\t%s: %s\n", item.Name, item.Spec.Template.Spec.Containers[0].Image)
+			fmt.Fprintf(o, "\t%s/%s: %s\n", item.Namespace, item.Name, item.Spec.Template.Spec.Containers[0].Image)
 		}
 	}
 	if len(schedulers.Items) == 0 {
@@ -115,7 +115,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 		}
 	} else {
 		// warn for multiple scheduler
-		fmt.Fprintf(o, "WARN: more than one TiDB Scheduler instance found, this is un-supported and may lead to un-expected behavior:\n")
+		fmt.Fprintf(o, "WARN: more than one TiDB Scheduler deployment found, this is un-supported and may lead to un-expected behavior:\n")
 		for _, item := range schedulers.Items {
 			fmt.Fprintf(o, "\t%s\n", item.Name)
 		}


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
#1028 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
./tkctl version
Client Version: v1.1.0-alpha.1.87+461bffe0599abb-dirty
TiDB Controller Manager Version: hub.pingcap.net/schrodinger/tidb-operator:latest
TiDB Scheduler Version:
	tidb-scheduler: hub.pingcap.net/schrodinger/tidb-operator:latest
	kube-scheduler: k8s.gcr.io/kube-scheduler:v1.12.9
```

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix tkctl version does not work when the release name is un-wanted
 ```
