### PR TITLE
Automated cherry pick of #1065: Fix tkctl version does not work when the release name is

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ vendor
 tests/e2e/e2e.test
 .orig
 tkc
-
+/tkctl

--- a/pkg/tkctl/cmd/version/version.go
+++ b/pkg/tkctl/cmd/version/version.go
@@ -80,7 +80,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	controllers, err := kubeCli.AppsV1().
 		Deployments(core.NamespaceAll).
 		List(v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "controller-manager", label.InstanceLabelKey, "tidb-operator"),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "controller-manager", label.NameLabelKey, "tidb-operator"),
 		})
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	schedulers, err := kubeCli.AppsV1().
 		Deployments(core.NamespaceAll).
 		List(v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "scheduler", label.InstanceLabelKey, "tidb-operator"),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", label.ComponentLabelKey, "scheduler", label.NameLabelKey, "tidb-operator"),
 		})
 	if err != nil {
 		return nil
@@ -103,7 +103,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 	} else {
 		fmt.Fprintf(o, "TiDB Controller Manager Versions:\n")
 		for _, item := range controllers.Items {
-			fmt.Fprintf(o, "\t%s: %s\n", item.Name, item.Spec.Template.Spec.Containers[0].Image)
+			fmt.Fprintf(o, "\t%s/%s: %s\n", item.Namespace, item.Name, item.Spec.Template.Spec.Containers[0].Image)
 		}
 	}
 	if len(schedulers.Items) == 0 {
@@ -115,7 +115,7 @@ func (o *VersionOptions) runVersion(tkcContext *config.TkcContext) error {
 		}
 	} else {
 		// warn for multiple scheduler
-		fmt.Fprintf(o, "WARN: more than one TiDB Scheduler instance found, this is un-supported and may lead to un-expected behavior:\n")
+		fmt.Fprintf(o, "WARN: more than one TiDB Scheduler deployment found, this is un-supported and may lead to un-expected behavior:\n")
 		for _, item := range schedulers.Items {
 			fmt.Fprintf(o, "\t%s\n", item.Name)
 		}


### PR DESCRIPTION
Cherry pick of #1065 on release-1.0.

#1065: Fix tkctl version does not work when the release name is