### PR TITLE
[WIP] add tkctl e2e test

### DIFF
--- a/tests/actions_tkctl.go
+++ b/tests/actions_tkctl.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"text/template"
+
+	"github.com/pingcap/tidb-operator/tests/slack"
+	"k8s.io/kubernetes/test/e2e/framework/job"
+)
+
+var waitCheckArgsTemplate = `
+use {{ .clustername }}
+list --namespace={{- .namespace }}
+info -t {{ .clustername }}
+get all
+`
+
+func Int32Ptr(i int32) *int32 { return &i }
+
+func (oa *operatorActions) waitOnceJobComplete(index int, args []string, info *TidbClusterConfig) error {
+	name := fmt.Sprintf("tkctl-check%d", index)
+	batchjob := batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Job",
+			APIVersion: "batch/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: info.Namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism: Int32Ptr(1),
+			Completions: Int32Ptr(1),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name:    name,
+							Image:   info.TiDBImage,
+							Command: []string{"tkctl"},
+							Args:    args,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+	job.CreateJob(oa.kubeCli, info.Namespace, &batchjob)
+	err := job.WaitForJobFinish(oa.kubeCli, info.Namespace, name)
+	if err != nil {
+		return err
+	}
+	jobstat, err := job.GetJob(oa.kubeCli, info.Namespace, name)
+	if err != nil {
+		return err
+	}
+	for _, c := range jobstat.Status.Conditions {
+		if c.Status == corev1.ConditionTrue && c.Type == batchv1.JobFailed {
+			return fmt.Errorf("%s", c.Reason)
+		}
+	}
+	return nil
+}
+
+func RunPlan(reader io.Reader, info *TidbClusterConfig, fn func(index int, args []string, info *TidbClusterConfig) error) error {
+	var (
+		count     int
+		bufreader = bufio.NewReader(reader)
+	)
+	for {
+		line, err := bufreader.ReadString('\n')
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		err = fn(count, strings.Fields(line), info)
+		if err != nil {
+			return err
+		}
+		count++
+	}
+}
+
+func (oa *operatorActions) CheckTkctlOrDie(ctx context.Context, info *TidbClusterConfig) error {
+	var (
+		tmpmaps = map[string]interface{}{}
+		buf     = new(bytes.Buffer)
+	)
+	tmpmaps["clustername"] = info.ClusterName
+	tmpmaps["namespace"] = info.Namespace
+
+	tmp, err := template.New("").Parse(waitCheckArgsTemplate)
+	if err != nil {
+		return err
+	}
+	err = tmp.Execute(buf, tmpmaps)
+	if err != nil {
+		return err
+	}
+
+	if err := RunPlan(buf, info, oa.waitOnceJobComplete); err != nil {
+		slack.NotifyAndPanic(err)
+	}
+	return nil
+}
+


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #1067

- [ ] add tkctl-build into Makefile 

- [ ] add testFunc in e2e/main.go

### What is changed and how does it work?

I am not sure it's right or not ?

- separate actions_tkctl.go from actions.go

- use template to execute tkctl e2e test 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change


Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
