### PR TITLE
Disable verbose logging and coverage by default and enable -race in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,4 @@ jobs:
     - name: Build binaries and images
       run: make docker e2e-docker cli
     - name: Unit Tests
-      run: make test
+      run: make test GOFLAGS='-race'

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ GOOS := $(if $(GOOS),$(GOOS),linux)
 GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
 GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go build
-GOTEST := CGO_ENABLED=0 go test -v -cover
 
 PACKAGE_LIST := go list ./... | grep -vE "pkg/client" | grep -vE "zz_generated"
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'
@@ -86,14 +85,27 @@ stability-test-push: stability-test-docker
 fault-trigger:
 	$(GO) -ldflags '$(LDFLAGS)' -o tests/images/fault-trigger/bin/fault-trigger tests/cmd/fault-trigger/*.go
 
+# ARGS:
+#
+# GOFLAGS: Extra flags to pass to 'go' when building, e.g.
+# 		`-v` for verbose logging.
+# 		`-race` for race detector.
+# GO_COVER: Whether to run tests with code coverage. Set to 'y' to enable coverage collection.
+#
+ifeq ($(GO_COVER),y)
 test:
 	@echo "Run unit tests"
-	@$(GOTEST) ./pkg/... -coverpkg=$$($(TEST_COVER_PACKAGES)) -coverprofile=coverage.txt -covermode=atomic && echo "\nUnit tests run successfully!"
+	@go test -cover ./pkg/... -coverpkg=$$($(TEST_COVER_PACKAGES)) -coverprofile=coverage.txt -covermode=atomic && echo "\nUnit tests run successfully!"
+else
+test:
+	@echo "Run unit tests"
+	@go test ./pkg/... && echo "\nUnit tests run successfully!"
+endif
 
 check-all: lint check-static check-shadow check-gosec staticcheck errcheck
 
 check-setup:
-	@which retool >/dev/null 2>&1 || go get github.com/twitchtv/retool
+	@which retool >/dev/null 2>&1 || GO111MODULE=off go get github.com/twitchtv/retool
 	@GO111MODULE=off retool sync
 
 check: check-setup lint tidy check-static check-crd check-codegen


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Github action treats `go test` logs as errors.

Note that even if we disabled verbose logging, logs will be printed when the test fails.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Code changes

 - Has Go code change
 - Has CI related scripts change

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
