### PR TITLE
set net.ipv4.tcp_keepalive_time and net.core.somaxconn for tidb and tikv in init container

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -177,10 +177,6 @@ pd:
     # # when the kubelet is configured to allow unsafe sysctls
     # - name: net.core.somaxconn
     #   value: "32768"
-    # - name: net.ipv4.tcp_syncookies
-    #   value: "0"
-    # - name: net.ipv4.tcp_tw_recycle
-    #   value: "0"
 
   # Specify the priorityClassName for PD Pod.
   # refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#how-to-use-priority-and-preemption
@@ -275,10 +271,6 @@ tikv:
     # # when the kubelet is configured to allow unsafe sysctls
     # - name: net.core.somaxconn
     #   value: "32768"
-    # - name: net.ipv4.tcp_syncookies
-    #   value: "0"
-    # - name: net.ipv4.tcp_tw_recycle
-    #   value: "0"
 
   # Specify the priorityClassName for TiKV Pod.
   # refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#how-to-use-priority-and-preemption
@@ -362,10 +354,6 @@ tidb:
     # # when the kubelet is configured to allow unsafe sysctls
     # - name: net.core.somaxconn
     #   value: "32768"
-    # - name: net.ipv4.tcp_syncookies
-    #   value: "0"
-    # - name: net.ipv4.tcp_tw_recycle
-    #   value: "0"
 
     # # Load balancers usually have an idle timeout (eg. AWS NLB idle timeout is 350),
     # # the tcp_keepalive_time must be set to lower than LB idle timeout.

--- a/deploy/modules/aliyun/tidb-cluster/values/default.yaml
+++ b/deploy/modules/aliyun/tidb-cluster/values/default.yaml
@@ -8,10 +8,26 @@ pd:
       storage: 20Gi
   storageClassName: alicloud-disk
 tikv:
+  annotations:
+    tidb.pingcap.com/sysctl-init: "true"
+  podSecurityContext:
+    sysctls:
+    - name: net.core.somaxconn
+      value: "32768"
   logLevel: info
   storageClassName: local-volume
   syncLog: true
 tidb:
+  annotations:
+    tidb.pingcap.com/sysctl-init: "true"
+  podSecurityContext:
+    sysctls:
+    - name: net.core.somaxconn
+      value: "32768"
+    - name: net.ipv4.tcp_keepalive_intvl
+      value: "75"
+    - name: net.ipv4.tcp_keepalive_time
+      value: "300"
   logLevel: info
   service:
     type: LoadBalancer

--- a/deploy/modules/gcp/tidb-cluster/values/default.yaml
+++ b/deploy/modules/gcp/tidb-cluster/values/default.yaml
@@ -4,8 +4,24 @@ timezone: UTC
 pd:
   storageClassName: pd-ssd
 tikv:
+  annotations:
+    tidb.pingcap.com/sysctl-init: "true"
+  podSecurityContext:
+    sysctls:
+    - name: net.core.somaxconn
+      value: "32768"
   storageClassName: local-storage
 tidb:
+  annotations:
+    tidb.pingcap.com/sysctl-init: "true"
+  podSecurityContext:
+    sysctls:
+    - name: net.core.somaxconn
+      value: "32768"
+    - name: net.ipv4.tcp_keepalive_intvl
+      value: "75"
+    - name: net.ipv4.tcp_keepalive_time
+      value: "300"
   service:
     type: LoadBalancer
     externalTrafficPolicy: Local

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -203,10 +203,10 @@ func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 
 // Reuse the SlowLogTailer image for TiDB
 func GetUtilImage(cluster *v1alpha1.TidbCluster) string {
-        if img := cluster.Spec.TiDB.SlowLogTailer.Image; img != "" {
-                return img
-        }
-        return defaultTiDBLogTailerImage
+	if img := cluster.Spec.TiDB.SlowLogTailer.Image; img != "" {
+		return img
+	}
+	return defaultTiDBLogTailerImage
 }
 
 func GetSlowLogTailerImage(cluster *v1alpha1.TidbCluster) string {

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -201,6 +201,14 @@ func TiKVCapacity(limits *v1alpha1.ResourceRequirement) string {
 	return fmt.Sprintf("%dMB", i/humanize.MiByte)
 }
 
+// Reuse the SlowLogTailer image for TiDB
+func GetUtilImage(cluster *v1alpha1.TidbCluster) string {
+        if img := cluster.Spec.TiDB.SlowLogTailer.Image; img != "" {
+                return img
+        }
+        return defaultTiDBLogTailerImage
+}
+
 func GetSlowLogTailerImage(cluster *v1alpha1.TidbCluster) string {
 	if img := cluster.Spec.TiDB.SlowLogTailer.Image; img != "" {
 		return img

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -75,9 +75,13 @@ const (
 	AnnForceUpgradeKey = "tidb.pingcap.com/force-upgrade"
 	// AnnPDDeferDeleting is pd pod annotation key  in pod for defer for deleting pod
 	AnnPDDeferDeleting = "tidb.pingcap.com/pd-defer-deleting"
+	// AnnSysctlInit is pod annotation key to indicate whether configuring sysctls with init container
+	AnnSysctlInit = "tidb.pingcap.com/sysctl-init"
 
 	// AnnForceUpgradeVal is tc annotation value to indicate whether force upgrade should be done
 	AnnForceUpgradeVal = "true"
+	// AnnSysctlInitVal is pod annotation value to indicate whether configuring sysctls with init container
+	AnnSysctlInitVal = "true"
 
 	// PDLabelVal is PD label value
 	PDLabelVal string = "pd"

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -278,7 +278,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster) *apps.StatefulSet {
 				privileged := true
 				initContainers = append(initContainers, corev1.Container{
 					Name:  "init",
-					Image: controller.GetSlowLogTailerImage(tc),
+					Image: controller.GetUtilImage(tc),
 					Command: []string{
 						"sh",
 						"-c",

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -266,6 +266,36 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster) *apps.StatefulSet {
 		})
 	}
 
+	sysctls := "sysctl -w"
+	var initContainers []corev1.Container
+	if tc.Spec.TiDB.Annotations != nil {
+		init, ok := tc.Spec.TiDB.Annotations[label.AnnSysctlInit]
+		if ok && (init == label.AnnSysctlInitVal) {
+			if tc.Spec.TiDB.PodSecurityContext != nil && len(tc.Spec.TiDB.PodSecurityContext.Sysctls) > 0 {
+				for _, sysctl := range tc.Spec.TiDB.PodSecurityContext.Sysctls {
+					sysctls = sysctls + fmt.Sprintf(" %s=%s", sysctl.Name, sysctl.Value)
+				}
+				privileged := true
+				initContainers = append(initContainers, corev1.Container{
+					Name:  "init",
+					Image: controller.GetSlowLogTailerImage(tc),
+					Command: []string{
+						"sh",
+						"-c",
+						sysctls,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+				})
+			}
+		}
+	}
+	podSecurityContext := tc.Spec.TiDB.PodSecurityContext.DeepCopy()
+	if len(initContainers) > 0 {
+		podSecurityContext.Sysctls = []corev1.Sysctl{}
+	}
+
 	var containers []corev1.Container
 	if tc.Spec.TiDB.SeparateSlowLog {
 		// mount a shared volume and tail the slow log to STDOUT using a sidecar.
@@ -383,8 +413,9 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster) *apps.StatefulSet {
 					RestartPolicy:     corev1.RestartPolicyAlways,
 					Tolerations:       tc.Spec.TiDB.Tolerations,
 					Volumes:           vols,
-					SecurityContext:   tc.Spec.TiDB.PodSecurityContext,
+					SecurityContext:   podSecurityContext,
 					PriorityClassName: tc.Spec.TiDB.PriorityClassName,
+					InitContainers:    initContainers,
 				},
 			},
 			ServiceName:         controller.TiDBPeerMemberName(tcName),

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -291,6 +291,9 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster) *apps.StatefulSet {
 			}
 		}
 	}
+	// Init container is only used for the case where allowed-unsafe-sysctls
+	// cannot be enabled for kubelet, so clean the sysctl in statefulset
+	// SecurityContext if init container is enabled
 	podSecurityContext := tc.Spec.TiDB.PodSecurityContext.DeepCopy()
 	if len(initContainers) > 0 {
 		podSecurityContext.Sysctls = []corev1.Sysctl{}

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -728,3 +728,266 @@ func TestGetNewTiDBSetForTidbCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestTiDBInitContainers(t *testing.T) {
+	privileged := true
+	asRoot := false
+	tests := []struct {
+		name             string
+		tc               v1alpha1.TidbCluster
+		expectedInit     []corev1.Container
+		expectedSecurity *corev1.PodSecurityContext
+	}{
+		{
+			name: "no init container",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: v1alpha1.TiDBSpec{
+						PodAttributesSpec: v1alpha1.PodAttributesSpec{
+							PodSecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: &asRoot,
+								Sysctls: []corev1.Sysctl{
+									{
+										Name:  "net.core.somaxconn",
+										Value: "32768",
+									},
+									{
+										Name:  "net.ipv4.tcp_syncookies",
+										Value: "0",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_time",
+										Value: "300",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_intvl",
+										Value: "75",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedInit: nil,
+			expectedSecurity: &corev1.PodSecurityContext{
+				RunAsNonRoot: &asRoot,
+				Sysctls: []corev1.Sysctl{
+					{
+						Name:  "net.core.somaxconn",
+						Value: "32768",
+					},
+					{
+						Name:  "net.ipv4.tcp_syncookies",
+						Value: "0",
+					},
+					{
+						Name:  "net.ipv4.tcp_keepalive_time",
+						Value: "300",
+					},
+					{
+						Name:  "net.ipv4.tcp_keepalive_intvl",
+						Value: "75",
+					},
+				},
+			},
+		},
+		{
+			name: "sysctl with init container",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: v1alpha1.TiDBSpec{
+						PodAttributesSpec: v1alpha1.PodAttributesSpec{
+							Annotations: map[string]string{
+								"tidb.pingcap.com/sysctl-init": "true",
+							},
+							PodSecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: &asRoot,
+								Sysctls: []corev1.Sysctl{
+									{
+										Name:  "net.core.somaxconn",
+										Value: "32768",
+									},
+									{
+										Name:  "net.ipv4.tcp_syncookies",
+										Value: "0",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_time",
+										Value: "300",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_intvl",
+										Value: "75",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedInit: []corev1.Container{
+				{
+					Name:  "init",
+					Image: "busybox:1.26.2",
+					Command: []string{
+						"sh",
+						"-c",
+						"sysctl -w net.core.somaxconn=32768 net.ipv4.tcp_syncookies=0 net.ipv4.tcp_keepalive_time=300 net.ipv4.tcp_keepalive_intvl=75",
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+				},
+			},
+			expectedSecurity: &corev1.PodSecurityContext{
+				RunAsNonRoot: &asRoot,
+				Sysctls:      []corev1.Sysctl{},
+			},
+		},
+		{
+			name: "sysctl with init container",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: v1alpha1.TiDBSpec{
+						PodAttributesSpec: v1alpha1.PodAttributesSpec{
+							Annotations: map[string]string{
+								"tidb.pingcap.com/sysctl-init": "true",
+							},
+							PodSecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: &asRoot,
+							},
+						},
+					},
+				},
+			},
+			expectedInit: nil,
+			expectedSecurity: &corev1.PodSecurityContext{
+				RunAsNonRoot: &asRoot,
+			},
+		},
+		{
+			name: "sysctl with init container",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: v1alpha1.TiDBSpec{
+						PodAttributesSpec: v1alpha1.PodAttributesSpec{
+							Annotations: map[string]string{
+								"tidb.pingcap.com/sysctl-init": "true",
+							},
+							PodSecurityContext: nil,
+						},
+					},
+				},
+			},
+			expectedInit:     nil,
+			expectedSecurity: nil,
+		},
+		{
+			name: "sysctl without init container due to invalid annotation",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: v1alpha1.TiDBSpec{
+						PodAttributesSpec: v1alpha1.PodAttributesSpec{
+							Annotations: map[string]string{
+								"tidb.pingcap.com/sysctl-init": "false",
+							},
+							PodSecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: &asRoot,
+								Sysctls: []corev1.Sysctl{
+									{
+										Name:  "net.core.somaxconn",
+										Value: "32768",
+									},
+									{
+										Name:  "net.ipv4.tcp_syncookies",
+										Value: "0",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_time",
+										Value: "300",
+									},
+									{
+										Name:  "net.ipv4.tcp_keepalive_intvl",
+										Value: "75",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedInit: nil,
+			expectedSecurity: &corev1.PodSecurityContext{
+				RunAsNonRoot: &asRoot,
+				Sysctls: []corev1.Sysctl{
+					{
+						Name:  "net.core.somaxconn",
+						Value: "32768",
+					},
+					{
+						Name:  "net.ipv4.tcp_syncookies",
+						Value: "0",
+					},
+					{
+						Name:  "net.ipv4.tcp_keepalive_time",
+						Value: "300",
+					},
+					{
+						Name:  "net.ipv4.tcp_keepalive_intvl",
+						Value: "75",
+					},
+				},
+			},
+		},
+		{
+			name: "no init container no securityContext",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+			},
+			expectedInit:     nil,
+			expectedSecurity: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := getNewTiDBSetForTidbCluster(&tt.tc)
+			if diff := cmp.Diff(tt.expectedInit, sts.Spec.Template.Spec.InitContainers); diff != "" {
+				t.Errorf("unexpected InitContainers in Statefulset (-want, +got): %s", diff)
+			}
+			if tt.expectedSecurity == nil {
+				if sts.Spec.Template.Spec.SecurityContext != nil {
+					t.Errorf("unexpected SecurityContext in Statefulset (want nil, got %#v)", *sts.Spec.Template.Spec.SecurityContext)
+				}
+			} else if sts.Spec.Template.Spec.SecurityContext == nil {
+				t.Errorf("unexpected SecurityContext in Statefulset (want %#v, got nil)", *tt.expectedSecurity)
+			} else if diff := cmp.Diff(*(tt.expectedSecurity), *(sts.Spec.Template.Spec.SecurityContext)); diff != "" {
+				t.Errorf("unexpected SecurityContext in Statefulset (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -327,7 +327,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster) (*apps.StatefulSet, e
 				privileged := true
 				initContainers = append(initContainers, corev1.Container{
 					Name:  "init",
-					Image: controller.GetSlowLogTailerImage(tc),
+					Image: controller.GetUtilImage(tc),
 					Command: []string{
 						"sh",
 						"-c",

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -340,6 +340,9 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster) (*apps.StatefulSet, e
 			}
 		}
 	}
+	// Init container is only used for the case where allowed-unsafe-sysctls
+	// cannot be enabled for kubelet, so clean the sysctl in statefulset
+	// SecurityContext if init container is enabled
 	podSecurityContext := tc.Spec.TiKV.PodSecurityContext.DeepCopy()
 	if len(initContainers) > 0 {
 		podSecurityContext.Sysctls = []corev1.Sysctl{}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -315,6 +315,36 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster) (*apps.StatefulSet, e
 		})
 	}
 
+	sysctls := "sysctl -w"
+	var initContainers []corev1.Container
+	if tc.Spec.TiKV.Annotations != nil {
+		init, ok := tc.Spec.TiKV.Annotations[label.AnnSysctlInit]
+		if ok && (init == label.AnnSysctlInitVal) {
+			if tc.Spec.TiKV.PodSecurityContext != nil && len(tc.Spec.TiKV.PodSecurityContext.Sysctls) > 0 {
+				for _, sysctl := range tc.Spec.TiKV.PodSecurityContext.Sysctls {
+					sysctls = sysctls + fmt.Sprintf(" %s=%s", sysctl.Name, sysctl.Value)
+				}
+				privileged := true
+				initContainers = append(initContainers, corev1.Container{
+					Name:  "init",
+					Image: controller.GetSlowLogTailerImage(tc),
+					Command: []string{
+						"sh",
+						"-c",
+						sysctls,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+				})
+			}
+		}
+	}
+	podSecurityContext := tc.Spec.TiKV.PodSecurityContext.DeepCopy()
+	if len(initContainers) > 0 {
+		podSecurityContext.Sysctls = []corev1.Sysctl{}
+	}
+
 	var q resource.Quantity
 	var err error
 
@@ -419,8 +449,9 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster) (*apps.StatefulSet, e
 					RestartPolicy:     corev1.RestartPolicyAlways,
 					Tolerations:       tc.Spec.TiKV.Tolerations,
 					Volumes:           vols,
-					SecurityContext:   tc.Spec.TiKV.PodSecurityContext,
+					SecurityContext:   podSecurityContext,
 					PriorityClassName: tc.Spec.TiKV.PriorityClassName,
+					InitContainers:    initContainers,
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix https://github.com/pingcap/tidb-operator/issues/880 for GCP  and Alibaba
### What is changed and how does it work?
Set net.ipv4.tcp_keepalive_time and net.core.somaxconn for tidb in init container
Set net.core.somaxconn for tikv in init container
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has documents change

Related changes
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Support configuring net.ipv4.tcp_keepalive_time and net.core.somaxconn for TiDB and configuring net.core.somaxconn for TiKV.
 ```
