### PR TITLE
Fix transfer leader before delete member during pd scale in

### DIFF
--- a/pkg/webhook/pod/pd_deleter.go
+++ b/pkg/webhook/pod/pd_deleter.go
@@ -49,7 +49,12 @@ func (pc *PodAdmissionControl) admitDeletePdPods(pod *corev1.Pod, ownerStatefulS
 
 	IsDeferDeleting := IsPodWithPDDeferDeletingAnnotations(pod)
 
-	klog.Infof("receive delete pd pod[%s/%s] of tc[%s/%s],isMember=%v,isInOrdinal=%v,isUpgrading=%v,IsDeferDeleting=%v", namespace, name, namespace, tcName, isMember, isInOrdinal, isUpgrading, IsDeferDeleting)
+	isLeader, err := isPDLeader(pdClient, pod)
+	if err != nil {
+		return util.ARFail(err)
+	}
+
+	klog.Infof("receive delete pd pod[%s/%s] of tc[%s/%s],isMember=%v,isInOrdinal=%v,isUpgrading=%v,isDeferDeleting=%v,isLeader=%v", namespace, name, namespace, tcName, isMember, isInOrdinal, isUpgrading, IsDeferDeleting, isLeader)
 
 	// NotMember represents this pod is deleted from pd cluster or haven't register to pd cluster yet.
 	// We should ensure this pd pod wouldn't be pd member any more.
@@ -59,7 +64,7 @@ func (pc *PodAdmissionControl) admitDeletePdPods(pod *corev1.Pod, ownerStatefulS
 
 	// NotInOrdinal represents this is an scale-in operation, we need to delete this member in pd cluster
 	if !isInOrdinal {
-		return pc.admitDeleteExceedReplicasPDPod(pod, tcName, pdClient)
+		return pc.admitDeleteExceedReplicasPDPod(pod, tc, pdClient, isLeader)
 	}
 
 	// If there is an pd pod deleting operation during upgrading, we should
@@ -72,14 +77,7 @@ func (pc *PodAdmissionControl) admitDeletePdPods(pod *corev1.Pod, ownerStatefulS
 		}
 	}
 
-	leader, err := pdClient.GetPDLeader()
-	if err != nil {
-		klog.Errorf("tc[%s/%s] fail to get pd leader %v,refuse to delete pod[%s/%s]", namespace, tc.Name, err, namespace, name)
-		return util.ARFail(err)
-	}
-
-	klog.Infof("tc[%s/%s]'s pd leader is pod[%s/%s] during deleting pod[%s/%s]", namespace, tc.Name, namespace, leader.Name, namespace, name)
-	if leader.Name == name {
+	if isLeader {
 		return pc.admitDeletePDLeader(pod, tc, pdClient, ordinal)
 	}
 
@@ -129,12 +127,21 @@ func (pc *PodAdmissionControl) admitDeleteNonPDMemberPod(IsDeferDeleting, isInOr
 	}
 }
 
-func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(pod *corev1.Pod, tcName string, pdClient pdapi.PDClient) *v1beta1.AdmissionResponse {
+func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(pod *corev1.Pod, tc *v1alpha1.TidbCluster, pdClient pdapi.PDClient, isPdLeader bool) *v1beta1.AdmissionResponse {
 
 	name := pod.Name
 	namespace := pod.Namespace
+	tcName := tc.Name
+	ordinal, err := operatorUtils.GetOrdinalFromPodName(name)
+	if err != nil {
+		return util.ARFail(err)
+	}
 
-	err := pdClient.DeleteMember(name)
+	if isPdLeader {
+		return pc.admitDeletePDLeader(pod, tc, pdClient, ordinal)
+	}
+
+	err = pdClient.DeleteMember(name)
 	if err != nil {
 		return util.ARFail(err)
 	}

--- a/pkg/webhook/pod/pd_deleter.go
+++ b/pkg/webhook/pod/pd_deleter.go
@@ -78,7 +78,7 @@ func (pc *PodAdmissionControl) admitDeletePdPods(pod *corev1.Pod, ownerStatefulS
 	}
 
 	if isLeader {
-		return pc.admitDeletePDLeader(pod, tc, pdClient, ordinal)
+		return pc.transferPDLeader(pod, tc, pdClient, ordinal)
 	}
 
 	klog.Infof("pod[%s/%s] is not pd-leader,admit to delete", namespace, name)
@@ -138,7 +138,7 @@ func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(pod *corev1.Pod, t
 	}
 
 	if isPdLeader {
-		return pc.admitDeletePDLeader(pod, tc, pdClient, ordinal)
+		return pc.transferPDLeader(pod, tc, pdClient, ordinal)
 	}
 
 	err = pdClient.DeleteMember(name)
@@ -158,7 +158,7 @@ func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(pod *corev1.Pod, t
 }
 
 // this pod is a pd leader, we should transfer pd leader to other pd pod before it gets deleted before.
-func (pc *PodAdmissionControl) admitDeletePDLeader(pod *corev1.Pod, tc *v1alpha1.TidbCluster, pdClient pdapi.PDClient, ordinal int32) *v1beta1.AdmissionResponse {
+func (pc *PodAdmissionControl) transferPDLeader(pod *corev1.Pod, tc *v1alpha1.TidbCluster, pdClient pdapi.PDClient, ordinal int32) *v1beta1.AdmissionResponse {
 
 	name := pod.Name
 	namespace := pod.Namespace

--- a/pkg/webhook/pod/util.go
+++ b/pkg/webhook/pod/util.go
@@ -114,3 +114,11 @@ func addDeferDeletingToPDPod(podAC *PodAdmissionControl, pod *core.Pod) error {
 	_, err := podAC.kubeCli.CoreV1().Pods(pod.Namespace).Update(pod)
 	return err
 }
+
+func isPDLeader(pdClient pdapi.PDClient, pod *core.Pod) (bool, error) {
+	leader, err := pdClient.GetPDLeader()
+	if err != nil {
+		return false, err
+	}
+	return leader.Name == pod.Name, nil
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
According to https://github.com/pingcap/tidb-operator/pull/1101/files#r343496778' comment, it should be transferring pd leader first then deleting pd member during pd scale-in if the target pod was pd leader.

 - Manual test (add detailed scripts or steps below)

Code changes
 - Has Go code change
