### PR TITLE
charts: add timezone support

### DIFF
--- a/charts/tidb-backup/templates/backup-job.yaml
+++ b/charts/tidb-backup/templates/backup-job.yaml
@@ -46,6 +46,10 @@ spec:
         env:
         - name: BACKUP_NAME
           value: {{ tpl .Values.name . | quote }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       {{- if .Values.gcp }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /gcp/credentials.json

--- a/charts/tidb-backup/templates/restore-job.yaml
+++ b/charts/tidb-backup/templates/restore-job.yaml
@@ -40,6 +40,10 @@ spec:
         env:
         - name: BACKUP_NAME
           value: {{ .Values.scheduledBackupName | default .Values.name | quote }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       {{- if .Values.gcp }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /gcp/credentials.json

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -5,6 +5,9 @@
 # clusterName is the TiDB cluster name that should backup from or restore to.
 clusterName: demo
 
+# timezone is the default system timzone
+timezone: UTC
+
 mode: backup # backup | restore | scheduled-restore
 
 # name is the backup dir name and pvc name for ad-hoc backup and restore

--- a/charts/tidb-cluster/templates/discovery-deployment.yaml
+++ b/charts/tidb-cluster/templates/discovery-deployment.yaml
@@ -45,6 +45,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+          - name: TZ
+            value: {{ .Values.timezone | default "UTC" }}
+        {{- end }}
 {{- if .Values.enableTLSCluster }}
         volumeMounts:
         - mountPath: /var/lib/tls

--- a/charts/tidb-cluster/templates/drainer-statefulset.yaml
+++ b/charts/tidb-cluster/templates/drainer-statefulset.yaml
@@ -57,6 +57,11 @@ spec:
           mountPath: /etc/drainer
         resources:
 {{ toYaml .Values.binlog.drainer.resources | indent 10 }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/tidb-cluster/templates/monitor-deployment.yaml
+++ b/charts/tidb-cluster/templates/monitor-deployment.yaml
@@ -74,6 +74,10 @@ spec:
           value: http://127.0.0.1:9090
         - name: TIDB_CLUSTER_NAMESPACE
           value: {{ .Release.Namespace }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
         command:
         - /bin/sh
         - -c
@@ -152,6 +156,11 @@ spec:
             mountPath: /data
         resources:
 {{ toYaml .Values.monitor.reloader.resources | indent 10 }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       {{- end }}
       {{- if .Values.monitor.grafana.create }}
       - name: grafana

--- a/charts/tidb-cluster/templates/pump-statefulset.yaml
+++ b/charts/tidb-cluster/templates/pump-statefulset.yaml
@@ -57,6 +57,11 @@ spec:
           mountPath: /etc/pump
         resources:
 {{ toYaml .Values.binlog.pump.resources | indent 10 }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
+++ b/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
@@ -66,6 +66,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" }}
+          {{- end }}
           {{- if .Values.scheduledBackup.gcp }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /gcp/credentials.json

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -45,6 +45,11 @@ spec:
             readOnly: true
           {{- end }}
         {{- end }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
         resources:
 {{ toYaml .Values.tidb.initializer.resources | indent 10 }}
       {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}

--- a/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
+++ b/charts/tidb-cluster/templates/tikv-importer-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/tikv-importer

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -46,6 +46,11 @@ spec:
           mountPath: /data
         - name: config
           mountPath: /etc/drainer
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       volumes:

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates
 
+# timezone is the default system timzone
+timezone: UTC
+
 # clusterName is the TiDB cluster name that should backup from or restore to.
 clusterName: demo
 clusterVersion: v3.0.4

--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -37,6 +37,11 @@ spec:
           mountPath: /etc/rclone
         - name: data
           mountPath: /data
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{ end -}}
       {{ end -}}
       restartPolicy: Never      # if lightning fails, manual intervention is required so no restart
       containers:
@@ -52,8 +57,12 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
-        {{- if .Values.failFast }}
         env:
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
+        {{- if .Values.failFast }}
         - name: FAIL_FAST
           value: "true"
         {{- end }}

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# timezone is the default system timzone
+timezone: UTC
+
 image: pingcap/tidb-lightning:v3.0.4
 imagePullPolicy: IfNotPresent
 service:

--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -38,6 +38,11 @@ spec:
         {{- if .Values.scheduler.features }}
           - -features={{ join "," .Values.scheduler.features }}
         {{- end }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
       - name: kube-scheduler
         image: {{ required "scheduler.kubeSchedulerImageName is required" .Values.scheduler.kubeSchedulerImageName }}:{{ .Values.scheduler.kubeSchedulerImageTag | default (split "-" .Capabilities.KubeVersion.GitVersion)._0 }}
         imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
@@ -53,6 +58,11 @@ spec:
         - --v={{ .Values.scheduler.logLevel }}
         - --policy-configmap={{ .Values.scheduler.schedulerName }}-policy
         - --policy-configmap-namespace={{ .Release.Namespace }}
+      {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
+        env:
+        - name: TZ
+          value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
     {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -8,6 +8,9 @@ clusterScoped: true
 rbac:
   create: true
 
+# timezone is the default system timzone
+timezone: UTC
+
 # operatorImage is TiDB Operator image
 operatorImage: pingcap/tidb-operator:v1.0.2
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR adds `timezone` support for [all charts](https://github.com/pingcap/tidb-operator/tree/master/charts), closes: #1123 

For the `tidb-cluster` chart, we already have the `timezone` option(default `UTC`). If the user does not change it to a different value(for example: `Aisa/Shanghai`), all pods will not be recreated.
If the user changes it to other value(for example: `Aisa/Shanghai`), all the related pods (add a `TZ` env) will be recreated(rolling update).

Regard other charts, we don't have a `timezone` option in their `values.yaml`. We add the `timezone` option in this PR. Whether the user uses the old `values.yaml` or the new `values.yaml`, all the related pods (add a `TZ` env) will not be recreated(rolling update).

The related pods include `pump`, `drainer`, `dicovery`, `monitor`, `scheduled backup`, `tidb-initializer`, `tikv-importer`.

All images' time zone maintained by `tidb-operator` are `UTC`. You need to make sure that the time zone inside your images are `UTC` if you use your own images.


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Helm charts change

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
ACTION REQUIRED: 

This PR adds `timezone` support for [all charts](https://github.com/pingcap/tidb-operator/tree/master/charts).

For the `tidb-cluster` chart, we already have the `timezone` option(default `UTC`). If the user does not change it to a different value(for example: `Aisa/Shanghai`), all pods will not be recreated.
If the user changes it to other value(for example: `Aisa/Shanghai`), all the related pods (add a `TZ` env) will be recreated(rolling update).

Regard other charts, we don't have a `timezone` option in their `values.yaml`. We add the `timezone` option in this PR. Whether the user uses the old `values.yaml` or the new `values.yaml`, all the related pods (add a `TZ` env) will not be recreated(rolling update).

The related pods include `pump`, `drainer`, `dicovery`, `monitor`, `scheduled backup`, `tidb-initializer`, `tikv-importer`.

All images' time zone maintained by `tidb-operator` are `UTC`. You need to make sure that the time zone inside your images are `UTC` if you use your own images.
 ```