### PR TITLE
make the script run anywhere correctly

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -24,10 +24,10 @@ export GO111MODULE=on
 
 go mod vendor
 
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${CODEGEN_PKG:-$(ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 GO111MODULE=off bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,informer,lister" \
     github.com/pingcap/tidb-operator/pkg/client \
     github.com/pingcap/tidb-operator/pkg/apis \
     pingcap:v1alpha1 \
-    --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate.go.txt
+    --go-header-file ./hack/boilerplate.go.txt


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
We can only run this script correctly in the tidb-operator directory `./hack/codegen.sh`. If you run it in another directory, there will be problems.

run `./tidb-operator/hack/codegen.sh`
```
F1112 17:27:43.587879    7270 deepcopy.go:131] Failed loading boilerplate: open ./tidb-operator/hack/../hack/boilerplate.go.txt: no such file or directory
```

run `./codegen.sh`
```
bash: ../code-generator/generate-groups.sh: No such file or directory
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
