### PR TITLE
manually cherry-pick #1129 to upgrade Go compiler to 1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@ DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
 
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")
-GO111 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 11 ]; echo $$?)
-ifeq ($(GO111), 1)
-$(error Please upgrade your Go compiler to 1.11 or higher version)
+GO113 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 13 ]; echo $$?)
+ifeq ($(GO113), 1)
+$(error Please upgrade your Go compiler to 1.13 or higher version)
 endif
 
 GOOS := $(if $(GOOS),$(GOOS),linux)
 GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
 GOENV  := GO15VENDOREXPERIMENT="1" GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
-GO     := $(GOENV) go build
+GO     := $(GOENV) go build -trimpath
 GOTEST := CGO_ENABLED=0 GO111MODULE=on go test -v -cover
 
 PACKAGE_LIST := go list ./... | grep -vE "pkg/client" | grep -vE "zz_generated"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Go
 TiDB Operator is written in [Go](https://golang.org). If you don't have a Go development environment, [set one up](https://golang.org/doc/code.html).
 
-The version of Go should be 1.9 or later.
+The version of Go should be 1.13 or later.
 
 After Go is installed, you need to define `GOPATH` and modify `PATH` modified to access your Go binaries.
 
@@ -125,7 +125,7 @@ After Docker images are pushed to the DinD Docker registry, run e2e tests:
 $ kubectl apply -f tests/manifests/e2e/e2e.yaml
 ```
 
-You can get the e2e test report from the log of testing pod: 
+You can get the e2e test report from the log of testing pod:
 
 ```sh
 $ kubectl -n=tidb-operator-e2e logs -f tidb-operator-e2e

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	golang.org/x/tools v0.0.0-20190405180640-052fc3cfdbc2 // indirect
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect
 	google.golang.org/genproto v0.0.0-20180731170733-daca94659cb5 // indirect
 	google.golang.org/grpc v1.12.0 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
@@ -119,9 +120,8 @@ require (
 	k8s.io/apimachinery v0.0.0-20181128191346-49ce2735e507
 	k8s.io/apiserver v0.0.0-20190118115647-a748535592ba
 	k8s.io/cli-runtime v0.0.0-20190118125240-caee4253d968
-	k8s.io/client-go v2.0.0-alpha.0.0.20190115164855-701b91367003+incompatible
-	k8s.io/code-generator v0.0.0-20190612125529-c522cb6c26aa
-	k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a // indirect; indirec
+	k8s.io/client-go v0.0.0-20190115164855-701b91367003
+	k8s.io/gengo v0.0.0-20180702041517-fdcf9f9480fd // indirect; indirec
 	k8s.io/klog v0.3.1
 	k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 // indirect
 	k8s.io/kubernetes v1.12.5

--- a/go.mod
+++ b/go.mod
@@ -131,3 +131,5 @@ require (
 )
 
 replace github.com/renstrom/dedent => github.com/lithammer/dedent v1.1.0
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -297,10 +297,14 @@ k8s.io/apiserver v0.0.0-20190118115647-a748535592ba h1:W82rVwBkq6uCzFdR9v/XXN3AO
 k8s.io/apiserver v0.0.0-20190118115647-a748535592ba/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/cli-runtime v0.0.0-20190118125240-caee4253d968 h1:VXLj8aMvJEo14Utv+knJDs0U+i/Atl3/cQRtzq1nbrk=
 k8s.io/cli-runtime v0.0.0-20190118125240-caee4253d968/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
+k8s.io/client-go v0.0.0-20190115164855-701b91367003 h1:gQQC0U1hM6L808TYvGGO/5vhUisGw384axV7rqFUv04=
+k8s.io/client-go v0.0.0-20190115164855-701b91367003/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v2.0.0-alpha.0.0.20190115164855-701b91367003+incompatible h1:Qw/ADzXV2yX+39UUCwNcZmdNS4+sR+V2Jf9NBdZWlQg=
 k8s.io/client-go v2.0.0-alpha.0.0.20190115164855-701b91367003+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/code-generator v0.0.0-20190612125529-c522cb6c26aa h1:R/ZQEUP8jVryCMdJDSiHqx00/u9k2oRt0LEZq/qK+tE=
 k8s.io/code-generator v0.0.0-20190612125529-c522cb6c26aa/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
+k8s.io/gengo v0.0.0-20180702041517-fdcf9f9480fd h1:vrN4VnaCWTfFhsSITN/6ZpiuPw0sc7e59Eo07aQfbEw=
+k8s.io/gengo v0.0.0-20180702041517-fdcf9f9480fd/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a h1:QoHVuRquf80YZ+/bovwxoMO3Q/A3nt3yTgS0/0nejuk=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/tests/cmd/e2e/main.go
+++ b/tests/cmd/e2e/main.go
@@ -67,6 +67,8 @@ func main() {
 	}
 
 	oa := tests.NewOperatorActions(cli, kubeCli, tests.DefaultPollInterval, cfg, nil)
+	oa.CleanCRDOrDie()
+	oa.InstallCRDOrDie()
 	oa.LabelNodesOrDie()
 	oa.CleanOperatorOrDie(ocfg)
 	oa.DeployOperatorOrDie(ocfg)


### PR DESCRIPTION
Cherry-pick #1129 to release-1.0 branch to upgrade the Go compiler to 1.13.