### PR TITLE
skip emitting events for e2e tests

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -179,7 +179,7 @@ type OperatorActions interface {
 	RegisterWebHookAndServiceOrDie(context *apimachinery.CertContext, info *OperatorConfig)
 	CleanWebHookAndService(info *OperatorConfig) error
 	CleanWebHookAndServiceOrDie(info *OperatorConfig)
-	EventWorker()
+	RunEventWorker()
 	EmitEvent(info *TidbClusterConfig, msg string)
 	BackupRestore(from, to *TidbClusterConfig) error
 	BackupRestoreOrDie(from, to *TidbClusterConfig)
@@ -198,14 +198,15 @@ type OperatorActions interface {
 }
 
 type operatorActions struct {
-	cli           versioned.Interface
-	kubeCli       kubernetes.Interface
-	pdControl     pdapi.PDControlInterface
-	tidbControl   controller.TiDBControlInterface
-	pollInterval  time.Duration
-	cfg           *Config
-	clusterEvents map[string]*clusterEvent
-	lock          sync.Mutex
+	cli                versioned.Interface
+	kubeCli            kubernetes.Interface
+	pdControl          pdapi.PDControlInterface
+	tidbControl        controller.TiDBControlInterface
+	pollInterval       time.Duration
+	cfg                *Config
+	clusterEvents      map[string]*clusterEvent
+	lock               sync.Mutex
+	eventWorkerRunning bool
 }
 
 type clusterEvent struct {
@@ -2984,6 +2985,10 @@ func (oa *operatorActions) EmitEvent(info *TidbClusterConfig, message string) {
 	oa.lock.Lock()
 	defer oa.lock.Unlock()
 
+	if !oa.eventWorkerRunning {
+		return
+	}
+
 	if len(oa.clusterEvents) == 0 {
 		return
 	}
@@ -3011,7 +3016,15 @@ func (oa *operatorActions) EmitEvent(info *TidbClusterConfig, message string) {
 	time.Sleep(10 * time.Second)
 }
 
-func (oa *operatorActions) EventWorker() {
+func (oa *operatorActions) RunEventWorker() {
+	oa.lock.Lock()
+	oa.eventWorkerRunning = true
+	oa.lock.Unlock()
+	glog.Infof("Event worker started")
+	wait.Forever(oa.eventWorker, 10*time.Second)
+}
+
+func (oa *operatorActions) eventWorker() {
 	oa.lock.Lock()
 	defer oa.lock.Unlock()
 

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -113,7 +113,7 @@ func run() {
 	oa.CheckK8sAvailableOrDie(nil, nil)
 	oa.LabelNodesOrDie()
 
-	go wait.Forever(oa.EventWorker, 10*time.Second)
+	go oa.RunEventWorker()
 
 	oa.CleanOperatorOrDie(ocfg)
 	oa.DeployOperatorOrDie(ocfg)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

https://github.com/pingcap/tidb-operator/blob/3692c17bf18c8563e2426376ee865c2f0b18af5d/tests/actions.go#L2983-L3012

- EmitEvent sleeps 10 seconds, this slow down the e2e processes
- EmitEvent is used in stability test, no need to run in e2e tests. This is a quick fix to speed up e2e.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Helm charts change
 - Has Go code change
 - Has CI related scripts change
 - Has documents change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
