### PR TITLE
pdapi: update healthPrefix

### DIFF
--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -246,6 +246,7 @@ func (pc *pdClient) GetHealth() (*HealthInfo, error) {
 	apiURL = fmt.Sprintf("%s/%s", pc.url, healthPrefix)
 	body, err = httputil.GetBodyOK(pc.httpClient, apiURL)
 	if err != nil {
+		// compatible with older versions
 		apiURL = fmt.Sprintf("%s/%s", pc.url, healthPrefixOld)
 		body, err = httputil.GetBodyOK(pc.httpClient, apiURL)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
use `pd/api/v1/health`  url instead of `pd/health` to check pd health 
```
$ curl pdip:2379/pd/health
404 page not found
$ curl pdip:2379/pd/api/v1/health
[
  {
    "name": "tidb-cluster-pd-0",
    "member_id": 17115972119073096751,
    "client_urls": [
      "http://tidb-cluster-pd-0.tidb-cluster-pd-peer.hibernate-regions-exp61-cat0-tidb-cluster.svc:2379"
    ],
    "health": true
  }
]
```
related pr: https://github.com/pingcap/pd/pull/1918