### PR TITLE
Automated cherry pick of #812: Keep the instance label of drainer same with the TiDB cluster

### DIFF
--- a/charts/tidb-drainer/templates/drainer-configmap.yaml
+++ b/charts/tidb-drainer/templates/drainer-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "drainer-configmap.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
     app.kubernetes.io/component: drainer
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 data:

--- a/charts/tidb-drainer/templates/drainer-service.yaml
+++ b/charts/tidb-drainer/templates/drainer-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "drainer.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
     app.kubernetes.io/component: drainer
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
@@ -15,5 +15,5 @@ spec:
     port: 8249
   selector:
     app.kubernetes.io/name: {{ include "drainer.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
     app.kubernetes.io/component: drainer

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "drainer.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Values.clusterName }}
     app.kubernetes.io/component: drainer
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "drainer.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Values.clusterName }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/component: drainer
   serviceName: {{ include "drainer.name" . }}
@@ -25,7 +25,7 @@ spec:
         prometheus.io/port: "8249"
       labels:
         app.kubernetes.io/name: {{ include "drainer.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Values.clusterName }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: drainer
     spec:


### PR DESCRIPTION
Cherry pick of #812 on release-1.0.

#812: Keep the instance label of drainer same with the TiDB cluster