### PR TITLE
Fix tidb-init-job chart templates timezone bug

### DIFF
--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -28,12 +28,12 @@ spec:
         - -c
         - |
 {{ tuple "scripts/_initialize_tidb_users.py.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
-        volumeMounts:
       {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
         env:
         - name: TZ
           value: {{ .Values.timezone | default "UTC" }}
       {{- end }}
+        volumeMounts:
         - name: password
           mountPath: /etc/tidb/password
           readOnly: true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
set timezone and tidb-init-job not work

### What is changed and how does it work?
fix helm chart template
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)


Code changes

 - Has Helm charts change


Side effects


Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
NONE
 ```
