### PR TITLE
Limit the service accounts from pod request for webhook

### DIFF
--- a/cmd/admission-controller/main.go
+++ b/cmd/admission-controller/main.go
@@ -48,7 +48,7 @@ func init() {
 	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
 	flag.StringVar(&certFile, "tlsCertFile", "/etc/webhook/certs/cert.pem", "File containing the x509 Certificate for HTTPS.")
 	flag.StringVar(&keyFile, "tlsKeyFile", "/etc/webhook/certs/key.pem", "File containing the x509 private key to --tlsCertFile.")
-	flag.StringVar(&extraServiceAccounts, "extraServiceAccounts", "", "extra Service Accounts the Webhook should control")
+	flag.StringVar(&extraServiceAccounts, "extraServiceAccounts", "", "comma-separated, extra Service Accounts the Webhook should control. The full pattern for each common service account is system:serviceaccount:<namespace>:<serviceaccount-name>")
 	features.DefaultFeatureGate.AddFlag(flag.CommandLine)
 	flag.Parse()
 }

--- a/pkg/manager/member/scaler.go
+++ b/pkg/manager/member/scaler.go
@@ -84,15 +84,17 @@ func (gs *generalScaler) deleteDeferDeletingPVC(tc *v1alpha1.TidbCluster,
 func resetReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
 	*newSet.Spec.Replicas = *oldSet.Spec.Replicas
 }
+
 func increaseReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
 	*newSet.Spec.Replicas = *oldSet.Spec.Replicas + 1
 	glog.Infof("pd scale out: increase pd statefulset: %s/%s replicas to %d",
-		newSet.GetNamespace(), newSet.GetName(), newSet.Spec.Replicas)
+		newSet.GetNamespace(), newSet.GetName(), *newSet.Spec.Replicas)
 }
+
 func decreaseReplicas(newSet *apps.StatefulSet, oldSet *apps.StatefulSet) {
 	*newSet.Spec.Replicas = *oldSet.Spec.Replicas - 1
 	glog.Infof("pd scale in: decrease pd statefulset: %s/%s replicas to %d",
-		newSet.GetNamespace(), newSet.GetName(), newSet.Spec.Replicas)
+		newSet.GetNamespace(), newSet.GetName(), *newSet.Spec.Replicas)
 }
 
 func ordinalPVCName(memberType v1alpha1.MemberType, setName string, ordinal int32) string {

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -92,12 +92,12 @@ func (pc *PodAdmissionControl) AdmitPods(ar v1beta1.AdmissionReview) *v1beta1.Ad
 	skippableSA := true
 	for _, sa := range pc.serviceAccounts {
 		if sa == serviceAccount {
-			isUnknownServiceAccounts = false
+			skippableSA = false
 			break
 		}
 	}
 
-	if isUnknownServiceAccounts {
+	if skippableSA {
 		klog.Infof("Request was not sent by Knowing Controlled ServiceAccounts,Admit to %s pod[%s/%s]", operation, namespace, name)
 		return util.ARSuccess()
 	}

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -52,7 +52,7 @@ type PodAdmissionControl struct {
 	tcLister listers.TidbClusterLister
 	// sts Lister
 	stsLister appslisters.StatefulSetLister
-	// the list of the service account from the request which should be checked by webhook
+	// the map of the service account from the request which should be checked by webhook
 	serviceAccounts sets.String
 }
 

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -89,7 +89,7 @@ func (pc *PodAdmissionControl) AdmitPods(ar v1beta1.AdmissionReview) *v1beta1.Ad
 	serviceAccount := ar.Request.UserInfo.Username
 	klog.Infof("receive %s pod[%s/%s] by sa[%s]", operation, namespace, name, serviceAccount)
 
-	isUnknownServiceAccounts := true
+	skippableSA := true
 	for _, sa := range pc.serviceAccounts {
 		if sa == serviceAccount {
 			isUnknownServiceAccounts = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Currently pod delete webhook would affect each delete request for pd/tikv pod. This requests limit the service account from admission request to avoid affecting other client requests ( like kubectl )

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - N/A

### Does this PR introduce a user-facing change?:

 None
