### PR TITLE
register e2e webhook for tidb clusters in upgrading only

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3210,13 +3210,14 @@ func (oa *operatorActions) CheckUpgradeCompleteOrDie(info *TidbClusterConfig) {
 	}
 }
 
-func StartValidatingAdmissionWebhookServerOrDie(context *apimachinery.CertContext) {
+func StartValidatingAdmissionWebhookServerOrDie(context *apimachinery.CertContext, tidbClusters ...string) {
 	sCert, err := tls.X509KeyPair(context.Cert, context.Key)
 	if err != nil {
 		panic(err)
 	}
 
-	http.HandleFunc("/pods", webhook.ServePods)
+	wh := webhook.NewWebhook(tidbClusters)
+	http.HandleFunc("/pods", wh.ServePods)
 	server := &http.Server{
 		Addr: ":443",
 		TLSConfig: &tls.Config{

--- a/tests/pkg/webhook/pods.go
+++ b/tests/pkg/webhook/pods.go
@@ -15,13 +15,14 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	"github.com/pingcap/tidb-operator/tests/pkg/client"
+
 	"k8s.io/api/admission/v1beta1"
 	glog "k8s.io/klog"
 )
 
 // only allow pods to be delete when it is not ddlowner of tidb, not leader of pd and not
 // master of tikv.
-func admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+func (wh *webhook) admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	glog.V(4).Infof("admitting pods")
 
 	podResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
@@ -50,6 +51,13 @@ func admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	tc, err := versionCli.PingcapV1alpha1().TidbClusters(namespace).Get(pod.Labels[label.InstanceLabelKey], metav1.GetOptions{})
 	if err != nil {
 		glog.Infof("fail to fetch tidbcluster info namespace %s clustername(instance) %s err %v", namespace, pod.Labels[label.InstanceLabelKey], err)
+		return &reviewResponse
+	}
+
+	tcKey := fmt.Sprintf("%s/%s", tc.Namespace, tc.Name)
+	if !wh.tidbClusters.Has(tcKey) {
+		glog.V(4).Infof("%q is not in tidb clusters %v, skip", tcKey, wh.tidbClusters.List())
+		reviewResponse.Allowed = true
 		return &reviewResponse
 	}
 

--- a/tests/pkg/webhook/route.go
+++ b/tests/pkg/webhook/route.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"net/http"
+
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	glog "k8s.io/klog"
-	"net/http"
 )
 
 // toAdmissionResponse is a helper function to create an AdmissionResponse
@@ -76,6 +77,6 @@ returnData:
 	}
 }
 
-func ServePods(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, admitPods)
+func (wh *webhook) ServePods(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, wh.admitPods)
 }

--- a/tests/pkg/webhook/webhook.go
+++ b/tests/pkg/webhook/webhook.go
@@ -1,0 +1,21 @@
+package webhook
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type Interface interface {
+	ServePods(w http.ResponseWriter, r *http.Request)
+}
+
+type webhook struct {
+	tidbClusters sets.String
+}
+
+func NewWebhook(tidbClusters []string) Interface {
+	return &webhook{
+		tidbClusters: sets.NewString(tidbClusters...),
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes #1180

### What is changed and how does it work?

e2e webhook is used to verify pods in upgrading
however because we run e2e tests parallelly, the e2e webhook will reject pods in scaling in test
now, so we should update it to take effect for tidb clusters in ugprading only

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
