### PR TITLE
fix e2e: do not print headers in `kubectl get pv`

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -797,7 +797,7 @@ func (oa *operatorActions) CleanTidbCluster(info *TidbClusterConfig) error {
 		return fmt.Errorf("failed to delete configmaps: %v, %s", err, string(res))
 	}
 
-	patchPVCmd := fmt.Sprintf("kubectl get pv -l %s=%s,%s=%s,%s=%s | awk '{print $1}' | "+
+	patchPVCmd := fmt.Sprintf("kubectl get pv --no-headers -l %s=%s,%s=%s,%s=%s | awk '{print $1}' | "+
 		"xargs -I {} kubectl patch pv {} -p '{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Delete\"}}'",
 		label.ManagedByLabelKey, "tidb-operator",
 		label.NamespaceLabelKey, info.Namespace,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/operator_ghpr_e2e_test_kind/detail/operator_ghpr_e2e_test_kind/1033/

```
[2019-11-19T11:08:35.109Z] I1119 11:08:33.833151       1 actions.go:805] kubectl get pv -l app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/namespace=e2e,app.kubernetes.io/instance=cluster1 | awk '{print $1}' | xargs -I {} kubectl patch pv {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
[2019-11-19T11:08:37.624Z] panic: failed to patch pv: exit status 123, Error from server (NotFound): persistentvolumes "NAME" not found
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-4ee4259 patched
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-644a88ec patched
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-9212c973 patched
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-b00790fa patched
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-b7ee9f63 patched
[2019-11-19T11:08:37.624Z] persistentvolume/local-pv-d2bcc268 patched
[2019-11-19T11:08:37.624Z] 
[2019-11-19T11:08:37.624Z] 
[2019-11-19T11:08:37.624Z] goroutine 276 [running]:
[2019-11-19T11:08:37.624Z] github.com/pingcap/tidb-operator/tests/slack.NotifyAndPanic(0x20df340, 0xc000c574d0)
[2019-11-19T11:08:37.624Z] 	github.com/pingcap/tidb-operator@/tests/slack/slack.go:156 +0x270
[2019-11-19T11:08:37.624Z] github.com/pingcap/tidb-operator/tests.(*operatorActions).CleanTidbClusterOrDie(0xc0003902d0, 0xc00000a5a0)
[2019-11-19T11:08:37.624Z] 	github.com/pingcap/tidb-operator@/tests/actions.go:835 +0x5c
[2019-11-19T11:08:37.624Z] main.main.func3(0xc0002924a0, 0xc00000a5a0)
[2019-11-19T11:08:37.624Z] 	github.com/pingcap/tidb-operator@/tests/cmd/e2e/main.go:134 +0x64
[2019-11-19T11:08:37.624Z] main.main.func10(0xc0002924a0, 0xc000152300, 0xc00000a5a0, 0x218a140, 0xc0003902d0)
[2019-11-19T11:08:37.624Z] 	github.com/pingcap/tidb-operator@/tests/cmd/e2e/main.go:240 +0x6e
[2019-11-19T11:08:37.624Z] created by main.main
[2019-11-19T11:08:37.624Z] 	github.com/pingcap/tidb-operator@/tests/cmd/e2e/main.go:238 +0xa3e
```


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
