### PR TITLE
Pin Terraform Google provider version to avoid use_ip_aliases error

### DIFF
--- a/deploy/modules/gcp/tidb-operator/versions.tf
+++ b/deploy/modules/gcp/tidb-operator/versions.tf
@@ -2,8 +2,10 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 2.16"
-    google-beta = "~> 2.16"
+    # TODO: remove the restriction of < 2.19 once the `ip_allocation_policy.0.use_ip_aliases` error fixes
+    # https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md#2190-november-05-2019
+    google      = ">= 2.16, < 2.19"
+    google-beta = ">= 2.16, < 2.19"
     external    = "~> 1.2"
     helm        = "~> 0.10"
     null        = "~> 2.1"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR adds a workaround for #1205 

### What is changed and how does it work?

This PR restricts the Google Terraform provider to less than `2.19`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Code changes

None

Side effects

None

Related changes

 - Need to cherry-pick to the release-1.0 branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix google terraform module `use_ip_aliases` error.
 ```
