### PR TITLE
fix e2e nil point dereference

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -140,7 +140,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 					}
 				}
 
-				if ( BUILD_BRANCH !=~ /[a-z0-9]{40}/) {
+				if ( !(BUILD_BRANCH ==~ /[a-z0-9]{40}/) ) {
 					stage('upload tidb-operator binary and charts'){
 						//upload binary and charts
 						sh """
@@ -177,7 +177,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 			return
 		}
 
-		if ( BUILD_BRANCH !=~ /[a-z0-9]{40}/ ){
+		if ( !(BUILD_BRANCH ==~ /[a-z0-9]{40}/) ){
 			slackmsg = "${slackmsg}" + "\n" +
 			"Binary Download URL:" + "\n" +
 			"${UCLOUD_OSS_URL}/builds/pingcap/operator/${GITHASH}/centos7/tidb-operator.tar.gz"

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1844,7 +1844,7 @@ func (oa *operatorActions) getComponentPVList(tc *v1alpha1.TidbCluster, componen
 
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(
-			label.New().Instance(tcName).Component(component).Labels()).String(),
+			label.New().Instance(tcName).Component(component).Namespace(ns).Labels()).String(),
 	}
 
 	pvList, err := oa.kubeCli.CoreV1().PersistentVolumes().List(listOptions)

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1328,7 +1328,7 @@ func (oa *operatorActions) pdMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, err
 		return false, nil
 	}
 
-	if tc.Spec.TiKV.Image != c.Image {
+	if tc.Spec.PD.Image != c.Image {
 		glog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=pd].image(%s) != %s",
 			ns, pdSetName, c.Image, tc.Spec.PD.Image)
 		return false, nil

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1320,7 +1320,15 @@ func (oa *operatorActions) pdMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, err
 			ns, pdSetName, pdSet.Status.ReadyReplicas, pdSet.Status.Replicas)
 		return false, nil
 	}
-	if c, ok := getMemberContainer(oa.kubeCli, ns, pdSetName); !ok || tc.Spec.PD.Image != c.Image {
+
+	c, found := getMemberContainer(oa.kubeCli, ns, pdSetName)
+	if !found {
+		glog.Infof("statefulset: %s/%s not found containers[name=pd] or pod %s-0",
+			ns, pdSetName, pdSetName)
+		return false, nil
+	}
+
+	if tc.Spec.TiKV.Image != c.Image {
 		glog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=pd].image(%s) != %s",
 			ns, pdSetName, c.Image, tc.Spec.PD.Image)
 		return false, nil
@@ -1385,7 +1393,15 @@ func (oa *operatorActions) tikvMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, e
 			ns, tikvSetName, tikvSet.Status.ReadyReplicas, tikvSet.Status.Replicas)
 		return false, nil
 	}
-	if c, ok := getMemberContainer(oa.kubeCli, ns, tikvSetName); !ok || tc.Spec.TiKV.Image != c.Image {
+
+	c, found := getMemberContainer(oa.kubeCli, ns, tikvSetName)
+	if !found {
+		glog.Infof("statefulset: %s/%s not found containers[name=tikv] or pod %s-0",
+			ns, tikvSetName, tikvSetName)
+		return false, nil
+	}
+
+	if tc.Spec.TiKV.Image != c.Image {
 		glog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=tikv].image(%s) != %s",
 			ns, tikvSetName, c.Image, tc.Spec.TiKV.Image)
 		return false, nil
@@ -1445,7 +1461,14 @@ func (oa *operatorActions) tidbMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, e
 		return false, nil
 	}
 
-	if c, ok := getMemberContainer(oa.kubeCli, ns, tidbSetName); !ok || tc.Spec.TiDB.Image != c.Image {
+	c, found := getMemberContainer(oa.kubeCli, ns, tidbSetName)
+	if !found {
+		glog.Infof("statefulset: %s/%s not found containers[name=tidb] or pod %s-0",
+			ns, tidbSetName, tidbSetName)
+		return false, nil
+	}
+
+	if tc.Spec.TiDB.Image != c.Image {
 		glog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=tidb].image(%s) != %s",
 			ns, tidbSetName, c.Image, tc.Spec.TiDB.Image)
 		return false, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
* Fix e2e nil point dereference when get pod from apiserver failed.
https://internal.pingcap.net/idc-jenkins/view/tidb-operator/job/build_tidb_operator_master_kind/168/console

* Fix reclaim PV failed, this failed job come from PR #1210
https://internal.pingcap.net/idc-jenkins/view/tidb-operator/job/operator_ghpr_e2e_test_kind/1114/console

* Fix the judgment condition of ci script, make not upload build artifact when running PR

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test


Code changes

 - Has Go code change

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
None
 ```
