### PR TITLE
bugfix: get time string from current time instead of pod name

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_scheduled_backup.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_scheduled_backup.sh.tpl
@@ -2,9 +2,7 @@ set -euo pipefail
 
 host=$(getent hosts {{ template "cluster.name" . }}-tidb | head | awk '{print $1}')
 
-timestamp=$(echo ${POD_NAME}|awk -F- '{print $(NF-1)}')
-## use UTC time zone to resolve timestamp, avoiding different parsing results due to different default time zones
-backupName=scheduled-backup-`date -u -d @${timestamp}  "+%Y%m%d-%H%M%S"`
+backupName=scheduled-backup-`date "+%Y%m%d-%H%M%S"`
 backupPath=/data/${backupName}
 
 echo "making dir ${backupPath}"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes #1227 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

 - Has Helm charts change

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
get time string from current time instead of pod name
 ```
