### PR TITLE
Unify code-gen and verify-codegen to simplify local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ check-setup:
 	@which retool >/dev/null 2>&1 || GO111MODULE=off go get github.com/twitchtv/retool
 	@GO111MODULE=off retool sync
 
-check: check-setup lint tidy check-static check-crd check-codegen check-terraform
+check: check-setup lint tidy check-static check-codegen check-terraform
 
 check-static:
 	@ # Not running vet and fmt through metalinter becauase it ends up looking at vendor
@@ -156,9 +156,6 @@ check-static:
 	  --enable misspell \
 	  --enable ineffassign \
 	  $$($(PACKAGE_DIRECTORIES))
-
-check-crd:
-	./hack/crd-groups.sh verify
 
 check-codegen:
 	./hack/verify-codegen.sh

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -31,3 +31,5 @@ GO111MODULE=off bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,inform
     github.com/pingcap/tidb-operator/pkg/apis \
     pingcap:v1alpha1 \
     --go-header-file ./hack/boilerplate.go.txt
+
+./hack/crd-groups.sh generate

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -31,3 +31,5 @@ else
   echo "${DIFFROOT} is out of date. Please run hack/codegen.sh"
   exit 1
 fi
+
+${ROOT}/hack/crd-groups.sh verify


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Tired of typing `./hack/codegen` and then `./hack/crd-groups generate`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)

There is no user-facing change introduced in this PR.
