### PR TITLE
pdapi: only read secret for PD client cert (on TLS enabled clusters) …

### DIFF
--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -83,7 +83,7 @@ func (pdc *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tls
 
 			rootCAs, tlsCert, err := certutil.LoadCerts(secret.Data["cert"], secret.Data["key"])
 			if err != nil {
-				glog.Errorf("unable to load certificates from secret %s/%s, PDClient may not work: %v", namespace, err)
+				glog.Errorf("unable to load certificates from secret %s/%s, PDClient may not work: %v", namespace, secretName, err)
 				return &pdClient{url: PdClientURL(namespace, tcName, scheme), httpClient: &http.Client{Timeout: timeout}}
 			}
 			tlsConfig = &tls.Config{

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -83,7 +83,7 @@ func (pdc *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tls
 
 			rootCAs, tlsCert, err := certutil.LoadCerts(secret.Data["cert"], secret.Data["key"])
 			if err != nil {
-				glog.Errorf("unable to load certificates for %s discovery, PDClient may not work: %v", namespace, err)
+				glog.Errorf("unable to load certificates from secret %s/%s, PDClient may not work: %v", namespace, err)
 				return &pdClient{url: PdClientURL(namespace, tcName, scheme), httpClient: &http.Client{Timeout: timeout}}
 			}
 			tlsConfig = &tls.Config{


### PR DESCRIPTION
…when needed

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
`pdapi.GetPDClient()` reads `Secret` for PD client cert every time it is called for TLS enabled clusters, but that's not necessary.

The `pdapi.GetPDClient()` already implements a simple cache for PD clients it handled, so only read `Secret` at the first time it is called for a TLS enabled cluster could improve the performance a little.

### What is changed and how does it work?
Read `Secret` only when the PD client is not in cache (for TLS enabled clusters)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test

Code changes

 - Has Go code change

Side effects

- None

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note

 ```
