### PR TITLE
bugfix: registry mirrors is an array in daemon.json

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -172,7 +172,7 @@ function e2e::up() {
         echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
 cat <<EOF > /etc/docker/daemon.json
 {
-    "registry-mirror": "$DOCKER_IO_MIRROR"
+    "registry-mirrors": ["$DOCKER_IO_MIRROR"]
 }
 EOF
         e2e::__restart_docker


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

https://docs.docker.com/v17.12/registry/recipes/mirror/#configure-the-docker-daemon

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test