### PR TITLE
Add Pod Restarter Controller

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -50,7 +50,6 @@ var (
 	printVersion       bool
 	workers            int
 	autoFailover       bool
-	webhookEnabled     bool
 	pdFailoverPeriod   time.Duration
 	tikvFailoverPeriod time.Duration
 	tidbFailoverPeriod time.Duration
@@ -76,7 +75,6 @@ func init() {
 	flag.StringVar(&controller.TidbBackupManagerImage, "tidb-backup-manager-image", "pingcap/tidb-backup-manager:latest", "The image of backup manager tool")
 	// TODO: actually we just want to use the same image with tidb-controller-manager, but DownwardAPI cannot get image ID, see if there is any better solution
 	flag.StringVar(&controller.TidbDiscoveryImage, "tidb-discovery-image", "pingcap/tidb-operator:latest", "The image of the tidb discovery service")
-	flag.BoolVar(&webhookEnabled, "webhook-enabled", false, "whether tidb-operator admission webhook is enabled")
 	features.DefaultFeatureGate.AddFlag(flag.CommandLine)
 
 	flag.Parse()
@@ -161,7 +159,7 @@ func main() {
 		},
 	}
 
-	tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, webhookEnabled, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
+	tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
 	backupController := backup.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
 	restoreController := restore.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
 	bsController := backupschedule.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -50,6 +50,7 @@ var (
 	printVersion       bool
 	workers            int
 	autoFailover       bool
+	webhookEnabled     bool
 	pdFailoverPeriod   time.Duration
 	tikvFailoverPeriod time.Duration
 	tidbFailoverPeriod time.Duration
@@ -75,6 +76,7 @@ func init() {
 	flag.StringVar(&controller.TidbBackupManagerImage, "tidb-backup-manager-image", "pingcap/tidb-backup-manager:latest", "The image of backup manager tool")
 	// TODO: actually we just want to use the same image with tidb-controller-manager, but DownwardAPI cannot get image ID, see if there is any better solution
 	flag.StringVar(&controller.TidbDiscoveryImage, "tidb-discovery-image", "pingcap/tidb-operator:latest", "The image of the tidb discovery service")
+	flag.BoolVar(&webhookEnabled, "webhook-enabled", false, "whether tidb-operator admission webhook is enabled")
 	features.DefaultFeatureGate.AddFlag(flag.CommandLine)
 
 	flag.Parse()
@@ -159,7 +161,7 @@ func main() {
 		},
 	}
 
-	tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
+	tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, webhookEnabled, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
 	backupController := backup.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
 	restoreController := restore.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
 	bsController := backupschedule.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)

--- a/pkg/controller/tidbcluster/tidb_cluster_control_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control_test.go
@@ -317,6 +317,7 @@ func newFakeTidbClusterControl() (
 	pvcCleaner := mm.NewFakePVCCleaner()
 	pumpMemberManager := mm.NewFakePumpMemberManager()
 	discoveryManager := mm.NewFakeDiscoveryManger()
+	podRestarter := mm.NewFakePodRestarter()
 	control := NewDefaultTidbClusterControl(
 		tcUpdater,
 		pdMemberManager,
@@ -328,6 +329,7 @@ func newFakeTidbClusterControl() (
 		pvcCleaner,
 		pumpMemberManager,
 		discoveryManager,
+		podRestarter,
 		recorder,
 	)
 

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -72,6 +72,7 @@ func NewController(
 	informerFactory informers.SharedInformerFactory,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	autoFailover bool,
+	webhookEnabled bool,
 	pdFailoverPeriod time.Duration,
 	tikvFailoverPeriod time.Duration,
 	tidbFailoverPeriod time.Duration,
@@ -113,6 +114,7 @@ func NewController(
 	pdUpgrader := mm.NewPDUpgrader(pdControl, podControl, podInformer.Lister())
 	tikvUpgrader := mm.NewTiKVUpgrader(pdControl, podControl, podInformer.Lister())
 	tidbUpgrader := mm.NewTiDBUpgrader(tidbControl, podInformer.Lister())
+	podRestarter := mm.NewPodRestarter(kubeCli, podInformer.Lister(), webhookEnabled)
 
 	tcc := &Controller{
 		kubeClient: kubeCli,
@@ -201,6 +203,7 @@ func NewController(
 				cmInformer.Lister(),
 			),
 			mm.NewTidbDiscoveryManager(typedControl),
+			podRestarter,
 			recorder,
 		),
 		queue: workqueue.NewNamedRateLimitingQueue(

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -72,7 +72,6 @@ func NewController(
 	informerFactory informers.SharedInformerFactory,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	autoFailover bool,
-	webhookEnabled bool,
 	pdFailoverPeriod time.Duration,
 	tikvFailoverPeriod time.Duration,
 	tidbFailoverPeriod time.Duration,
@@ -114,7 +113,7 @@ func NewController(
 	pdUpgrader := mm.NewPDUpgrader(pdControl, podControl, podInformer.Lister())
 	tikvUpgrader := mm.NewTiKVUpgrader(pdControl, podControl, podInformer.Lister())
 	tidbUpgrader := mm.NewTiDBUpgrader(tidbControl, podInformer.Lister())
-	podRestarter := mm.NewPodRestarter(kubeCli, podInformer.Lister(), webhookEnabled)
+	podRestarter := mm.NewPodRestarter(kubeCli, podInformer.Lister())
 
 	tcc := &Controller{
 		kubeClient: kubeCli,

--- a/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
@@ -269,7 +269,6 @@ func newFakeTidbClusterController() (*Controller, cache.Indexer, *FakeTidbCluste
 
 	tcInformer := informerFactory.Pingcap().V1alpha1().TidbClusters()
 	autoFailover := true
-	webhookEnabled := false
 	tcControl := NewFakeTidbClusterControlInterface()
 
 	tcc := NewController(
@@ -279,7 +278,6 @@ func newFakeTidbClusterController() (*Controller, cache.Indexer, *FakeTidbCluste
 		informerFactory,
 		kubeInformerFactory,
 		autoFailover,
-		webhookEnabled,
 		5*time.Minute,
 		5*time.Minute,
 		5*time.Minute,

--- a/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
@@ -269,7 +269,7 @@ func newFakeTidbClusterController() (*Controller, cache.Indexer, *FakeTidbCluste
 
 	tcInformer := informerFactory.Pingcap().V1alpha1().TidbClusters()
 	autoFailover := true
-
+	webhookEnabled := false
 	tcControl := NewFakeTidbClusterControlInterface()
 
 	tcc := NewController(
@@ -279,6 +279,7 @@ func newFakeTidbClusterController() (*Controller, cache.Indexer, *FakeTidbCluste
 		informerFactory,
 		kubeInformerFactory,
 		autoFailover,
+		webhookEnabled,
 		5*time.Minute,
 		5*time.Minute,
 		5*time.Minute,

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -79,6 +79,8 @@ const (
 	AnnSysctlInit = "tidb.pingcap.com/sysctl-init"
 	// AnnEvictLeaderBeginTime is pod annotation key to indicate the begin time for evicting region leader
 	AnnEvictLeaderBeginTime = "tidb.pingcap.com/evictLeaderBeginTime"
+	// AnnPodDeferDeleting is pod annotation key to indicate the pod which need to be restarted
+	AnnPodDeferDeleting = "tidb.pingcap.com/pod-defer-deleting"
 
 	// AnnForceUpgradeVal is tc annotation value to indicate whether force upgrade should be done
 	AnnForceUpgradeVal = "true"

--- a/pkg/manager/member/pod_restarter.go
+++ b/pkg/manager/member/pod_restarter.go
@@ -32,10 +32,7 @@ type podRestarter struct {
 	podLister corelisters.PodLister
 }
 
-func NewPodRestarter(kubeCli kubernetes.Interface, podLister corelisters.PodLister, webhookEnabled bool) *podRestarter {
-	if !webhookEnabled {
-		return nil
-	}
+func NewPodRestarter(kubeCli kubernetes.Interface, podLister corelisters.PodLister) *podRestarter {
 	return &podRestarter{kubeCli: kubeCli, podLister: podLister}
 }
 

--- a/pkg/manager/member/pod_restarter.go
+++ b/pkg/manager/member/pod_restarter.go
@@ -1,0 +1,86 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+)
+
+type PodRestarter interface {
+	Sync(tc *v1alpha1.TidbCluster) error
+}
+
+type podRestarter struct {
+	kubeCli   kubernetes.Interface
+	podLister corelisters.PodLister
+}
+
+func NewPodRestarter(kubeCli kubernetes.Interface, podLister corelisters.PodLister, webhookEnabled bool) *podRestarter {
+	if !webhookEnabled {
+		return nil
+	}
+	return &podRestarter{kubeCli: kubeCli, podLister: podLister}
+}
+
+func (gr *podRestarter) Sync(tc *v1alpha1.TidbCluster) error {
+
+	namespace := tc.Namespace
+	selector, err := label.New().Instance(tc.Name).Selector()
+	if err != nil {
+		return err
+	}
+	tcPods, err := gr.podLister.Pods(namespace).List(selector)
+	if err != nil {
+		return err
+	}
+	requeue := false
+	for _, pod := range tcPods {
+		if _, existed := pod.Annotations[label.AnnPodDeferDeleting]; existed {
+			requeue = true
+			err = gr.restart(pod.Name, pod.Namespace)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if requeue {
+		return controller.RequeueErrorf("tc[%s/%s] is under restarting", namespace, tc.Name)
+	}
+	return nil
+}
+
+// pod deleting webhook ensured each tc pod would be deleted safely
+func (gr *podRestarter) restart(podName, namespace string) error {
+	err := gr.kubeCli.CoreV1().Pods(namespace).Delete(podName, &meta.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type FakeRestarter struct {
+}
+
+func NewFakePodRestarter() *FakeRestarter {
+	return &FakeRestarter{}
+}
+
+func (fsr *FakeRestarter) Sync(tc *v1alpha1.TidbCluster) error {
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -119,3 +119,7 @@ func IsSubMapOf(first map[string]string, second map[string]string) bool {
 	}
 	return true
 }
+
+func GetPodName(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType, ordinal int32) string {
+	return fmt.Sprintf("%s-%s-%d", tc.Name, memberType.String(), ordinal)
+}

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/tidb-operator/pkg/label"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	asclientset "github.com/pingcap/advanced-statefulset/pkg/client/clientset/versioned"
@@ -30,6 +32,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/features"
 	"github.com/pingcap/tidb-operator/pkg/manager/member"
 	"github.com/pingcap/tidb-operator/pkg/scheme"
+	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	tcconfig "github.com/pingcap/tidb-operator/pkg/util/config"
 	"github.com/pingcap/tidb-operator/tests"
 	"github.com/pingcap/tidb-operator/tests/apiserver"
@@ -584,6 +587,60 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		})
 
 		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("Restarter: Testing restarting by annotations", func() {
+		cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, "restarter", "admin", "")
+		cluster.Resources["pd.replicas"] = "1"
+		cluster.Resources["tikv.replicas"] = "1"
+		cluster.Resources["tidb.replicas"] = "1"
+		oa.DeployTidbClusterOrDie(&cluster)
+		oa.CheckTidbClusterStatusOrDie(&cluster)
+
+		tc, err := cli.PingcapV1alpha1().TidbClusters(cluster.Namespace).Get(cluster.ClusterName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected get tidbcluster")
+		pd_0, err := c.CoreV1().Pods(ns).Get(operatorUtils.GetPodName(tc, v1alpha1.PDMemberType, 0), metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected get pd-0")
+		tikv_0, err := c.CoreV1().Pods(ns).Get(operatorUtils.GetPodName(tc, v1alpha1.TiKVMemberType, 0), metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected get tikv-0")
+		tidb_0, err := c.CoreV1().Pods(ns).Get(operatorUtils.GetPodName(tc, v1alpha1.TiDBMemberType, 0), metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected get tidb-0")
+		pd_0.Annotations[label.AnnPodDeferDeleting] = "true"
+		tikv_0.Annotations[label.AnnPodDeferDeleting] = "true"
+		tidb_0.Annotations[label.AnnPodDeferDeleting] = "true"
+		_, err = c.CoreV1().Pods(ns).Update(pd_0)
+		framework.ExpectNoError(err, "Expected update pd-0 restarting ann")
+		_, err = c.CoreV1().Pods(ns).Update(tikv_0)
+		framework.ExpectNoError(err, "Expected update tikv-0 restarting ann")
+		_, err = c.CoreV1().Pods(ns).Update(tidb_0)
+		framework.ExpectNoError(err, "Expected update tidb-0 restarting ann")
+
+		f := func(name, namespace string) (bool, error) {
+			pod, err := c.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if _, existed := pod.Annotations[label.AnnPodDeferDeleting]; existed {
+				return false, nil
+			}
+			return true, nil
+		}
+		err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+			isPdRestarted, err := f(pd_0.Name, ns)
+			if !(isPdRestarted && err == nil) {
+				return isPdRestarted, err
+			}
+			isTiKVRestarted, err := f(tikv_0.Name, ns)
+			if !(isTiKVRestarted && err == nil) {
+				return isTiKVRestarted, err
+			}
+			isTiDBRestarted, err := f(tidb_0.Name, ns)
+			if !(isTiDBRestarted && err == nil) {
+				return isTiDBRestarted, err
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "Expected tidbcluster pod restarted")
 	})
 })
 

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -629,7 +629,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 			}
 			return true, nil
 		}
-		
+
 		err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
 			isPdRestarted, err := f(pd_0.Name, ns, pd_0.UID)
 			if !(isPdRestarted && err == nil) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This request added a pod restarter controller. The controller would fetch all the pods of `tidbcluster` and restart them if they have specific annotations.

### What is changed and how does it work?

Add one controller into `tidbcluster` controller.

Code changes

 - Has Go code change

Tests:

- e2e test



