### PR TITLE
bugfix: move initialization logic into leader election onStarted function

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -159,31 +159,32 @@ func main() {
 		},
 	}
 
-	tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
-	backupController := backup.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
-	restoreController := restore.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
-	bsController := backupschedule.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start informer factories after all controller are initialized.
-	informerFactory.Start(controllerCtx.Done())
-	kubeInformerFactory.Start(controllerCtx.Done())
-
-	// Wait for all started informers' cache were synced.
-	for v, synced := range informerFactory.WaitForCacheSync(wait.NeverStop) {
-		if !synced {
-			glog.Fatalf("error syncing informer for %v", v)
-		}
-	}
-	for v, synced := range kubeInformerFactory.WaitForCacheSync(wait.NeverStop) {
-		if !synced {
-			glog.Fatalf("error syncing informer for %v", v)
-		}
-	}
-	glog.Infof("cache of informer factories sync successfully")
-
 	onStarted := func(ctx context.Context) {
+		tcController := tidbcluster.NewController(kubeCli, cli, genericCli, informerFactory, kubeInformerFactory, autoFailover, pdFailoverPeriod, tikvFailoverPeriod, tidbFailoverPeriod)
+		backupController := backup.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
+		restoreController := restore.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
+		bsController := backupschedule.NewController(kubeCli, cli, informerFactory, kubeInformerFactory)
+
+		// Start informer factories after all controller are initialized.
+		informerFactory.Start(ctx.Done())
+		kubeInformerFactory.Start(ctx.Done())
+
+		// Wait for all started informers' cache were synced.
+		for v, synced := range informerFactory.WaitForCacheSync(wait.NeverStop) {
+			if !synced {
+				glog.Fatalf("error syncing informer for %v", v)
+			}
+		}
+		for v, synced := range kubeInformerFactory.WaitForCacheSync(wait.NeverStop) {
+			if !synced {
+				glog.Fatalf("error syncing informer for %v", v)
+			}
+		}
+		glog.Infof("cache of informer factories sync successfully")
+
 		go wait.Forever(func() { backupController.Run(workers, ctx.Done()) }, waitDuration)
 		go wait.Forever(func() { restoreController.Run(workers, ctx.Done()) }, waitDuration)
 		go wait.Forever(func() { bsController.Run(workers, ctx.Done()) }, waitDuration)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

informers are registered and started which is unnecessary. It consumes memory but does nothing in non-leader mode.

### What is changed and how does it work?

move initialization logic into leader election onStarted function

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
