### PR TITLE
config: add openapi-gen in tikv cofigurations

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1490,7 +1490,51 @@ spec:
                     concurrent-send-snap-limit:
                       format: int32
                       type: integer
-                    coprocessor: {}
+                    coprocessor:
+                      description: TiKVCoprocessorConfig is the configuration of TiKV
+                        Coprocessor component.
+                      properties:
+                        batch-split-limit:
+                          description: One split check produces several split keys
+                            in batch. This config limits the number of produced split
+                            keys in one batch. optional
+                          format: int64
+                          type: integer
+                        region-max-keys:
+                          description: 'When the number of keys in Region [a,e) exceeds
+                            the `region_max_keys`, it will be split into several Regions
+                            [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b),
+                            [b,c), [c,d) will be `region_split_keys`. See also: region-split-keys
+                            optional'
+                          format: int64
+                          type: integer
+                        region-max-size:
+                          description: 'When Region [a,e) size exceeds `region_max_size`,
+                            it will be split into several Regions [a,b), [b,c), [c,d),
+                            [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size`
+                            (or a little larger). See also: region-split-size optional'
+                          type: string
+                        region-split-keys:
+                          description: 'When the number of keys in Region [a,e) exceeds
+                            the `region_max_keys`, it will be split into several Regions
+                            [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b),
+                            [b,c), [c,d) will be `region_split_keys`. See also: region-max-keys
+                            optional'
+                          format: int64
+                          type: integer
+                        region-split-size:
+                          description: 'When Region [a,e) size exceeds `region_max_size`,
+                            it will be split into several Regions [a,b), [b,c), [c,d),
+                            [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size`
+                            (or a little larger). See also: region-max-size optional'
+                          type: string
+                        split-region-on-table:
+                          description: When it is set to `true`, TiKV will try to
+                            split a Region with table prefix if that Region crosses
+                            tables. It is recommended to turn off this option if there
+                            will be a large number of tables created. optional
+                          type: boolean
+                      type: object
                     end-point-batch-row-limit:
                       format: int32
                       type: integer
@@ -1662,7 +1706,30 @@ spec:
                               type: string
                             target-file-size-base:
                               type: string
-                            titan: {}
+                            titan:
+                              description: TiKVTitanCfConfig is the titian config.
+                              properties:
+                                blob-cache-size:
+                                  type: string
+                                blob-file-compression:
+                                  type: string
+                                blob-run-mode:
+                                  type: string
+                                discardable-ratio:
+                                  format: double
+                                  type: number
+                                max-gc-batch-size:
+                                  type: string
+                                merge-small-file-threshold:
+                                  type: string
+                                min-blob-size:
+                                  type: string
+                                min-gc-batch-size:
+                                  type: string
+                                sample-ratio:
+                                  format: double
+                                  type: number
+                              type: object
                             use-bloom-filter:
                               type: boolean
                             whole-key-filtering:
@@ -2016,7 +2083,30 @@ spec:
                               type: string
                             target-file-size-base:
                               type: string
-                            titan: {}
+                            titan:
+                              description: TiKVTitanCfConfig is the titian config.
+                              properties:
+                                blob-cache-size:
+                                  type: string
+                                blob-file-compression:
+                                  type: string
+                                blob-run-mode:
+                                  type: string
+                                discardable-ratio:
+                                  format: double
+                                  type: number
+                                max-gc-batch-size:
+                                  type: string
+                                merge-small-file-threshold:
+                                  type: string
+                                min-blob-size:
+                                  type: string
+                                min-gc-batch-size:
+                                  type: string
+                                sample-ratio:
+                                  format: double
+                                  type: number
+                              type: object
                             use-bloom-filter:
                               type: boolean
                             whole-key-filtering:
@@ -2120,7 +2210,30 @@ spec:
                               type: string
                             target-file-size-base:
                               type: string
-                            titan: {}
+                            titan:
+                              description: TiKVTitanCfConfig is the titian config.
+                              properties:
+                                blob-cache-size:
+                                  type: string
+                                blob-file-compression:
+                                  type: string
+                                blob-run-mode:
+                                  type: string
+                                discardable-ratio:
+                                  format: double
+                                  type: number
+                                max-gc-batch-size:
+                                  type: string
+                                merge-small-file-threshold:
+                                  type: string
+                                min-blob-size:
+                                  type: string
+                                min-gc-batch-size:
+                                  type: string
+                                sample-ratio:
+                                  format: double
+                                  type: number
+                              type: object
                             use-bloom-filter:
                               type: boolean
                             whole-key-filtering:
@@ -2224,7 +2337,30 @@ spec:
                               type: string
                             target-file-size-base:
                               type: string
-                            titan: {}
+                            titan:
+                              description: TiKVTitanCfConfig is the titian config.
+                              properties:
+                                blob-cache-size:
+                                  type: string
+                                blob-file-compression:
+                                  type: string
+                                blob-run-mode:
+                                  type: string
+                                discardable-ratio:
+                                  format: double
+                                  type: number
+                                max-gc-batch-size:
+                                  type: string
+                                merge-small-file-threshold:
+                                  type: string
+                                min-blob-size:
+                                  type: string
+                                min-gc-batch-size:
+                                  type: string
+                                sample-ratio:
+                                  format: double
+                                  type: number
+                              type: object
                             use-bloom-filter:
                               type: boolean
                             whole-key-filtering:
@@ -2355,7 +2491,30 @@ spec:
                               type: string
                             target-file-size-base:
                               type: string
-                            titan: {}
+                            titan:
+                              description: TiKVTitanCfConfig is the titian config.
+                              properties:
+                                blob-cache-size:
+                                  type: string
+                                blob-file-compression:
+                                  type: string
+                                blob-run-mode:
+                                  type: string
+                                discardable-ratio:
+                                  format: double
+                                  type: number
+                                max-gc-batch-size:
+                                  type: string
+                                merge-small-file-threshold:
+                                  type: string
+                                min-blob-size:
+                                  type: string
+                                min-gc-batch-size:
+                                  type: string
+                                sample-ratio:
+                                  format: double
+                                  type: number
+                              type: object
                             use-bloom-filter:
                               type: boolean
                             whole-key-filtering:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -83,6 +83,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVClient":                  schema_pkg_apis_pingcap_v1alpha1_TiKVClient(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVComponentReadPoolConfig": schema_pkg_apis_pingcap_v1alpha1_TiKVComponentReadPoolConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVConfig":                  schema_pkg_apis_pingcap_v1alpha1_TiKVConfig(ref),
+		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVCoprocessorConfig":       schema_pkg_apis_pingcap_v1alpha1_TiKVCoprocessorConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVDbConfig":                schema_pkg_apis_pingcap_v1alpha1_TiKVDbConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVGCConfig":                schema_pkg_apis_pingcap_v1alpha1_TiKVGCConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVImportConfig":            schema_pkg_apis_pingcap_v1alpha1_TiKVImportConfig(ref),
@@ -94,6 +95,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVServerConfig":            schema_pkg_apis_pingcap_v1alpha1_TiKVServerConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVSpec":                    schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVStorageConfig":           schema_pkg_apis_pingcap_v1alpha1_TiKVStorageConfig(ref),
+		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVTitanCfConfig":           schema_pkg_apis_pingcap_v1alpha1_TiKVTitanCfConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVTitanDBConfig":           schema_pkg_apis_pingcap_v1alpha1_TiKVTitanDBConfig(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TidbCluster":                 schema_pkg_apis_pingcap_v1alpha1_TidbCluster(ref),
 		"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TidbClusterList":             schema_pkg_apis_pingcap_v1alpha1_TidbClusterList(ref),
@@ -3731,6 +3733,61 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVConfig(ref common.ReferenceCallback) c
 	}
 }
 
+func schema_pkg_apis_pingcap_v1alpha1_TiKVCoprocessorConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TiKVCoprocessorConfig is the configuration of TiKV Coprocessor component.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"split-region-on-table": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When it is set to `true`, TiKV will try to split a Region with table prefix if that Region crosses tables. It is recommended to turn off this option if there will be a large number of tables created. optional",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"batch-split-limit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "One split check produces several split keys in batch. This config limits the number of produced split keys in one batch. optional",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"region-max-size": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When Region [a,e) size exceeds `region_max_size`, it will be split into several Regions [a,b), [b,c), [c,d), [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size` (or a little larger). See also: region-split-size optional",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"region-split-size": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When Region [a,e) size exceeds `region_max_size`, it will be split into several Regions [a,b), [b,c), [c,d), [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size` (or a little larger). See also: region-max-size optional",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"region-max-keys": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When the number of keys in Region [a,e) exceeds the `region_max_keys`, it will be split into several Regions [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b), [b,c), [c,d) will be `region_split_keys`. See also: region-split-keys optional",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"region-split-keys": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When the number of keys in Region [a,e) exceeds the `region_max_keys`, it will be split into several Regions [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b), [b,c), [c,d) will be `region_split_keys`. See also: region-max-keys optional",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func schema_pkg_apis_pingcap_v1alpha1_TiKVDbConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -4846,6 +4903,73 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVStorageConfig(ref common.ReferenceCall
 		},
 		Dependencies: []string{
 			"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVBlockCacheConfig"},
+	}
+}
+
+func schema_pkg_apis_pingcap_v1alpha1_TiKVTitanCfConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TiKVTitanCfConfig is the titian config.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"min-blob-size": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"blob-file-compression": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"blob-cache-size": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"min-gc-batch-size": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"max-gc-batch-size": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"discardable-ratio": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"number"},
+							Format: "double",
+						},
+					},
+					"sample-ratio": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"number"},
+							Format: "double",
+						},
+					},
+					"merge-small-file-threshold": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"blob-run-mode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/apis/pingcap/v1alpha1/tikv_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tikv_config.go
@@ -380,6 +380,7 @@ type TiKVCfConfig struct {
 }
 
 // TiKVTitanCfConfig is the titian config.
+// +k8s:openapi-gen=true
 type TiKVTitanCfConfig struct {
 	// +optional
 	MinBlobSize string `json:"min-blob-size,omitempty" toml:"min-blob-size,omitempty"`
@@ -646,6 +647,8 @@ type TiKVRaftstoreConfig struct {
 	HibernateRegions *bool `json:"hibernate-regions,omitempty" toml:"hibernate-regions,omitempty"`
 }
 
+// TiKVCoprocessorConfig is the configuration of TiKV Coprocessor component.
+// +k8s:openapi-gen=true
 type TiKVCoprocessorConfig struct {
 	// When it is set to `true`, TiKV will try to split a Region with table prefix if that Region
 	// crosses tables.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Added some code-gen tag for tikv configuration
### What is changed and how does it work?
The schema will generate for tep swagger ui

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes
 - Has Go code change