### PR TITLE
e2e: able to configure replicas of tidb-controller-mananger and tidb-scheduler

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -258,24 +258,26 @@ type event struct {
 var _ = OperatorActions(&operatorActions{})
 
 type OperatorConfig struct {
-	Namespace          string
-	ReleaseName        string
-	Image              string
-	Tag                string
-	SchedulerImage     string
-	SchedulerTag       string
-	Features           []string
-	LogLevel           string
-	WebhookServiceName string
-	WebhookSecretName  string
-	WebhookConfigName  string
-	Context            *apimachinery.CertContext
-	ImagePullPolicy    corev1.PullPolicy
-	TestMode           bool
-	WebhookEnabled     bool
-	PodWebhookEnabled  bool
-	StsWebhookEnabled  bool
-	Cabundle           string
+	Namespace                 string
+	ReleaseName               string
+	Image                     string
+	Tag                       string
+	ControllerManagerReplicas int
+	SchedulerImage            string
+	SchedulerTag              string
+	SchedulerReplicas         int
+	Features                  []string
+	LogLevel                  string
+	WebhookServiceName        string
+	WebhookSecretName         string
+	WebhookConfigName         string
+	Context                   *apimachinery.CertContext
+	ImagePullPolicy           corev1.PullPolicy
+	TestMode                  bool
+	WebhookEnabled            bool
+	PodWebhookEnabled         bool
+	StsWebhookEnabled         bool
+	Cabundle                  string
 }
 
 type TidbClusterConfig struct {
@@ -393,14 +395,18 @@ func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {
 		"scheduler.kubeSchedulerImageName":           oi.SchedulerImage,
 		"controllerManager.logLevel":                 oi.LogLevel,
 		"scheduler.logLevel":                         "4",
-		"controllerManager.replicas":                 "2",
-		"scheduler.replicas":                         "2",
 		"imagePullPolicy":                            string(oi.ImagePullPolicy),
 		"testMode":                                   strconv.FormatBool(oi.TestMode),
 		"admissionWebhook.cabundle":                  oi.Cabundle,
 		"admissionWebhook.create":                    strconv.FormatBool(oi.WebhookEnabled),
 		"admissionWebhook.hooksEnabled.pods":         strconv.FormatBool(oi.PodWebhookEnabled),
 		"admissionWebhook.hooksEnabled.statefulSets": strconv.FormatBool(oi.StsWebhookEnabled),
+	}
+	if oi.ControllerManagerReplicas > 0 {
+		set["controllerManager.replicas"] = strconv.Itoa(oi.ControllerManagerReplicas)
+	}
+	if oi.SchedulerReplicas > 0 {
+		set["scheduler.replicas"] = strconv.Itoa(oi.SchedulerReplicas)
 	}
 	if oi.SchedulerTag != "" {
 		set["scheduler.kubeSchedulerImageTag"] = oi.SchedulerTag

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -383,11 +383,13 @@ func run() {
 
 func newOperatorConfig() *tests.OperatorConfig {
 	return &tests.OperatorConfig{
-		Namespace:      "pingcap",
-		ReleaseName:    "operator",
-		Image:          cfg.OperatorImage,
-		Tag:            cfg.OperatorTag,
-		SchedulerImage: "gcr.io/google-containers/hyperkube",
+		Namespace:                 "pingcap",
+		ReleaseName:               "operator",
+		Image:                     cfg.OperatorImage,
+		Tag:                       cfg.OperatorTag,
+		ControllerManagerReplicas: 2,
+		SchedulerImage:            "gcr.io/google-containers/hyperkube",
+		SchedulerReplicas:         2,
 		Features: []string{
 			"StableScheduling=true",
 		},

--- a/tests/dt.go
+++ b/tests/dt.go
@@ -63,7 +63,7 @@ func (oa *operatorActions) LabelNodes() error {
 	}
 
 	for i, node := range nodes.Items {
-		err := wait.Poll(3*time.Second, time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(3*time.Second, time.Minute, func() (bool, error) {
 			n, err := oa.kubeCli.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 			if err != nil {
 				glog.Errorf("get node:[%s] failed! error: %v", node.Name, err)

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -74,11 +74,13 @@ func AfterReadingAllFlags() error {
 // NewDefaultOperatorConfig creates default operator configuration.
 func NewDefaultOperatorConfig(cfg *tests.Config) *tests.OperatorConfig {
 	return &tests.OperatorConfig{
-		Namespace:      "pingcap",
-		ReleaseName:    "operator",
-		Image:          cfg.OperatorImage,
-		Tag:            cfg.OperatorTag,
-		SchedulerImage: "k8s.gcr.io/kube-scheduler",
+		Namespace:                 "pingcap",
+		ReleaseName:               "operator",
+		Image:                     cfg.OperatorImage,
+		Tag:                       cfg.OperatorTag,
+		ControllerManagerReplicas: 2,
+		SchedulerImage:            "k8s.gcr.io/kube-scheduler",
+		SchedulerReplicas:         2,
 		Features: []string{
 			"StableScheduling=true",
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

- unable to change replicas of tidb-controller-mananger and tidb-scheduler
- LabelNodes is slow because it has unnecessary wait time

### What is changed and how does it work?

- able to configure replicas of tidb-controller-mananger and tidb-scheduler
- speed up LabelNodes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test