### PR TITLE
fix error importer config

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -768,7 +768,7 @@ importer:
   pushgatewayImagePullPolicy: IfNotPresent
   config: |
     log-level = "info"
-    [metrics]
+    [metric]
     job = "tikv-importer"
     interval = "15s"
     address = "localhost:9091"


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Cannot start tikv-importer using the default config
```
thread 'main' panicked at 'invalid auto generated configuration file /etc/tikv-importer/tikv-importer.toml, err unknown field `metrics`, expected one of `log-level`, `log-file`, `log-rotation-timespan`, `storage`, `server`, `metric`, `rocksdb`, `security`, `import`', src/import/config.rs:134:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

Reference: https://github.com/tikv/importer/blob/master/etc/tikv-importer.toml
### What is changed and how does it work?
A typo is fixed
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
Fix the default tikv-importer configuration
 ```
