### PR TITLE
make controller logic independable with certain tidbcluster label

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -409,7 +409,7 @@ func (tc *TidbCluster) GetInstanceName() string {
 	labels := tc.ObjectMeta.GetLabels()
 	// Keep backward compatibility for helm.
 	// This introduce a hidden danger that change this label will trigger rolling-update of most of the components
-	// TODO: disallow mutation of this label or adding this label with value other than the cluster name in ValidateUpdate()
+	// TODO(aylei): disallow mutation of this label or adding this label with value other than the cluster name in ValidateUpdate()
 	if inst, ok := labels[label.InstanceLabelKey]; ok {
 		return inst
 	}

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -402,4 +403,15 @@ func (tc *TidbCluster) Timezone() string {
 		tz = "UTC"
 	}
 	return tz
+}
+
+func (tc *TidbCluster) GetInstanceName() string {
+	labels := tc.ObjectMeta.GetLabels()
+	// Keep backward compatibility for helm.
+	// This introduce a hidden danger that change this label will trigger rolling-update of most of the components
+	// TODO: disallow mutation of this label or adding this label with value other than the cluster name in ValidateUpdate()
+	if inst, ok := labels[label.InstanceLabelKey]; ok {
+		return inst
+	}
+	return tc.Name
 }

--- a/pkg/manager/member/orphan_pods_cleaner.go
+++ b/pkg/manager/member/orphan_pods_cleaner.go
@@ -71,7 +71,7 @@ func (opc *orphanPodsCleaner) Clean(tc *v1alpha1.TidbCluster) (map[string]string
 	// for unit test
 	skipReason := map[string]string{}
 
-	selector, err := label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).Selector()
+	selector, err := label.New().Instance(tc.GetInstanceName()).Selector()
 	if err != nil {
 		return skipReason, err
 	}

--- a/pkg/manager/member/orphan_pods_cleaner_test.go
+++ b/pkg/manager/member/orphan_pods_cleaner_test.go
@@ -86,7 +86,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiDB().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiDB().Labels(),
 					},
 				},
 			},
@@ -104,7 +104,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodPending,
@@ -125,7 +125,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -158,7 +158,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -198,7 +198,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -233,7 +233,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -268,7 +268,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 						UID:             "pod-1-uid",
 						ResourceVersion: "1",
 						Namespace:       metav1.NamespaceDefault,
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -294,7 +294,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 						UID:             "pod-1-uid",
 						ResourceVersion: "2",
 						Namespace:       metav1.NamespaceDefault,
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -327,7 +327,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -361,7 +361,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-1",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -383,7 +383,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-2",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiKV().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiKV().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -405,7 +405,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-3",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiKV().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiKV().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
@@ -427,7 +427,7 @@ func TestOrphanPodsCleanerClean(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod-4",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiDB().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiDB().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -438,7 +438,7 @@ func (pmm *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbClust
 	ns := tc.Namespace
 	tcName := tc.Name
 	svcName := controller.PDMemberName(tcName)
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	pdLabel := label.New().Instance(instanceName).PD().Labels()
 
 	return &corev1.Service{
@@ -467,7 +467,7 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 	ns := tc.Namespace
 	tcName := tc.Name
 	svcName := controller.PDPeerMemberName(tcName)
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	pdLabel := label.New().Instance(instanceName).PD().Labels()
 
 	return &corev1.Service{
@@ -498,7 +498,7 @@ func (pmm *pdMemberManager) pdStatefulSetIsUpgrading(set *apps.StatefulSet, tc *
 		return true, nil
 	}
 	selector, err := label.New().
-		Instance(tc.GetLabels()[label.InstanceLabelKey]).
+		Instance(tc.GetInstanceName()).
 		PD().
 		Selector()
 	if err != nil {
@@ -523,7 +523,7 @@ func (pmm *pdMemberManager) pdStatefulSetIsUpgrading(set *apps.StatefulSet, tc *
 func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.StatefulSet, error) {
 	ns := tc.Namespace
 	tcName := tc.Name
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	pdConfigMap := controller.MemberConfigMapName(tc, v1alpha1.PDMemberType)
 	if cm != nil {
 		pdConfigMap = cm.Name
@@ -728,7 +728,7 @@ func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	pdLabel := label.New().Instance(instanceName).PD().Labels()
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -447,7 +447,7 @@ func TestPDMemberManagerPdStatefulSetIsUpgrading(t *testing.T) {
 					Name:        ordinalPodName(v1alpha1.PDMemberType, tc.GetName(), 0),
 					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{},
-					Labels:      label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+					Labels:      label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 				},
 			}
 			if test.updatePod != nil {
@@ -849,7 +849,7 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -880,7 +880,7 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 					},
 					PublishNotReadyAddresses: true,
@@ -1088,7 +1088,7 @@ func TestGetPDConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -402,7 +402,7 @@ func getNewPumpStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*app
 }
 
 func getPumpMeta(tc *v1alpha1.TidbCluster, nameFunc func(string) string) (metav1.ObjectMeta, label.Label) {
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	pumpLabel := label.New().Instance(instanceName).Pump()
 
 	objMeta := metav1.ObjectMeta{
@@ -453,7 +453,7 @@ func (pmm *pumpMemberManager) pumpStatefulSetIsUpgrading(set *apps.StatefulSet, 
 		return true, nil
 	}
 	selector, err := label.New().
-		Instance(tc.GetLabels()[label.InstanceLabelKey]).
+		Instance(tc.GetInstanceName()).
 		Pump().
 		Selector()
 	if err != nil {

--- a/pkg/manager/member/pump_member_manager_test.go
+++ b/pkg/manager/member/pump_member_manager_test.go
@@ -548,7 +548,7 @@ func TestGetNewPumpHeadlessService(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pump",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -579,7 +579,7 @@ func TestGetNewPumpHeadlessService(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pump",
 					},
 					PublishNotReadyAddresses: true,
@@ -627,7 +627,7 @@ func TestGetNewPumpConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pump",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -676,7 +676,7 @@ func TestGetNewPumpConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pump",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/pvc_cleaner.go
+++ b/pkg/manager/member/pvc_cleaner.go
@@ -273,7 +273,7 @@ func (rpc *realPVCCleaner) listAllPVCs(tc *v1alpha1.TidbCluster) ([]*corev1.Pers
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	selector, err := label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).Selector()
+	selector, err := label.New().Instance(tc.GetInstanceName()).Selector()
 	if err != nil {
 		return nil, fmt.Errorf("cluster %s/%s assemble label selector failed, err: %v", ns, tcName, err)
 	}

--- a/pkg/manager/member/pvc_cleaner_test.go
+++ b/pkg/manager/member/pvc_cleaner_test.go
@@ -126,7 +126,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "tidb-test-tidb-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiDB().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiDB().Labels(),
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -155,7 +155,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "tidb-test-tidb-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -185,7 +185,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Namespace:         metav1.NamespaceDefault,
 						Name:              "tidb-test-tidb-0",
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
-						Labels:            label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:            label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -213,7 +213,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -241,7 +241,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 						},
@@ -270,7 +270,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 				},
 			},
@@ -281,7 +281,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -312,7 +312,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 				},
 			},
@@ -322,7 +322,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -353,7 +353,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 				},
 			},
@@ -363,7 +363,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -396,7 +396,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -432,7 +432,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -479,7 +479,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -528,7 +528,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -550,7 +550,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -598,7 +598,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -620,7 +620,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "2",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -668,7 +668,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -690,7 +690,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -740,7 +740,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -762,7 +762,7 @@ func TestPVCCleanerReclaimPV(t *testing.T) {
 						Name:            "pd-test-pd-0",
 						UID:             types.UID("pd-test"),
 						ResourceVersion: "1",
-						Labels:          label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:          label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: time.Now().Format(time.RFC3339),
 							label.AnnPodNameKey:       "test-pd-0",
@@ -859,7 +859,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "tidb-test-tidb-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiDB().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).TiDB().Labels(),
 					},
 				},
 			},
@@ -878,7 +878,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   metav1.NamespaceDefault,
 						Name:        "pd-test-pd-0",
-						Labels:      label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:      label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{label.AnnPVCDeferDeleting: "true"},
 					},
 				},
@@ -898,7 +898,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: "true",
 							label.AnnPVCPodScheduling: "true",
@@ -922,7 +922,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCDeferDeleting: "true",
 							label.AnnPVCPodScheduling: "true",
@@ -948,7 +948,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCPodScheduling: "true",
 						},
@@ -970,7 +970,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCPodScheduling: "true",
 							label.AnnPodNameKey:       "test-pd-0",
@@ -991,7 +991,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 				},
 			},
@@ -1001,7 +1001,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPodNameKey: "test-pd-0",
 						},
@@ -1022,7 +1022,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 				},
 			},
@@ -1032,7 +1032,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCPodScheduling: "true",
 							label.AnnPodNameKey:       "test-pd-0",
@@ -1054,7 +1054,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						NodeName: "node-1",
@@ -1067,7 +1067,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCPodScheduling: "true",
 							label.AnnPodNameKey:       "test-pd-0",
@@ -1090,7 +1090,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-pd-0",
 						Namespace: metav1.NamespaceDefault,
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 					},
 					Spec: corev1.PodSpec{
 						NodeName: "node-1",
@@ -1103,7 +1103,7 @@ func TestPVCCleanerCleanScheduleLock(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "pd-test-pd-0",
-						Labels:    label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).PD().Labels(),
+						Labels:    label.New().Instance(tc.GetInstanceName()).PD().Labels(),
 						Annotations: map[string]string{
 							label.AnnPVCPodScheduling: "true",
 							label.AnnPodNameKey:       "test-pd-0",

--- a/pkg/manager/member/tidb_discovery_manager.go
+++ b/pkg/manager/member/tidb_discovery_manager.go
@@ -153,7 +153,7 @@ func getTidbDiscoveryDeployment(tc *v1alpha1.TidbCluster) *appsv1.Deployment {
 }
 
 func getDiscoveryMeta(tc *v1alpha1.TidbCluster, nameFunc func(string) string) (metav1.ObjectMeta, label.Label) {
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	discoveryLabel := label.New().Instance(instanceName).Discovery()
 
 	objMeta := metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -446,7 +446,7 @@ func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		"startup-script": startScript,
 	}
 	name := controller.TiDBMemberName(tc.Name)
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	tidbLabels := label.New().Instance(instanceName).TiDB().Labels()
 
 	cm := &corev1.ConfigMap{
@@ -477,7 +477,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 
 	ns := tc.Namespace
 	tcName := tc.Name
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	tidbLabels := label.New().Instance(instanceName).TiDB().Labels()
 	svcName := controller.TiDBMemberName(tcName)
 
@@ -519,7 +519,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Service {
 	ns := tc.Namespace
 	tcName := tc.Name
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	svcName := controller.TiDBPeerMemberName(tcName)
 	tidbLabel := label.New().Instance(instanceName).TiDB().Labels()
 
@@ -549,7 +549,7 @@ func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.S
 func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) *apps.StatefulSet {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	tidbConfigMap := controller.MemberConfigMapName(tc, v1alpha1.TiDBMemberType)
 	if cm != nil {
 		tidbConfigMap = cm.Name
@@ -824,7 +824,7 @@ func tidbStatefulSetIsUpgrading(podLister corelisters.PodLister, set *apps.State
 		return true, nil
 	}
 	selector, err := label.New().
-		Instance(tc.GetLabels()[label.InstanceLabelKey]).
+		Instance(tc.GetInstanceName()).
 		TiDB().
 		Selector()
 	if err != nil {

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -265,7 +265,7 @@ func TestTiDBMemberManagerTiDBStatefulSetIsUpgrading(t *testing.T) {
 					Name:        ordinalPodName(v1alpha1.TiDBMemberType, tc.GetName(), 0),
 					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{},
-					Labels:      label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiDB().Labels(),
+					Labels:      label.New().Instance(tc.GetInstanceName()).TiDB().Labels(),
 				},
 			}
 			if test.updatePod != nil {
@@ -828,7 +828,7 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -859,7 +859,7 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					PublishNotReadyAddresses: true,
@@ -1329,7 +1329,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1359,7 +1359,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 				},
@@ -1387,7 +1387,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1423,7 +1423,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 				},
@@ -1458,7 +1458,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					Annotations: map[string]string{
@@ -1499,7 +1499,7 @@ func TestGetNewTiDBService(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 				},
@@ -1561,7 +1561,7 @@ func TestGetTiDBConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1609,7 +1609,7 @@ func TestGetTiDBConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -301,7 +301,7 @@ func (tkmm *tikvMemberManager) syncTiKVConfigMap(tc *v1alpha1.TidbCluster, set *
 func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) *corev1.Service {
 	ns := tc.Namespace
 	tcName := tc.Name
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	svcName := svcConfig.MemberName(tcName)
 	svcLabel := svcConfig.SvcLabel(label.New().Instance(instanceName)).Labels()
 
@@ -566,7 +566,7 @@ func getTikVConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	if err != nil {
 		return nil, err
 	}
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	tikvLabel := label.New().Instance(instanceName).TiKV().Labels()
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -591,7 +591,7 @@ func getTikVConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 }
 
 func labelTiKV(tc *v1alpha1.TidbCluster) label.Label {
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	return label.New().Instance(instanceName).TiKV()
 }
 
@@ -778,7 +778,7 @@ func tikvStatefulSetIsUpgrading(podLister corelisters.PodLister, pdControl pdapi
 	if statefulSetIsUpgrading(set) {
 		return true, nil
 	}
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 	selector, err := label.New().Instance(instanceName).TiKV().Selector()
 	if err != nil {
 		return false, err

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -398,7 +398,7 @@ func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
 					Name:        ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 0),
 					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{},
-					Labels:      label.New().Instance(tc.GetLabels()[label.InstanceLabelKey]).TiKV().Labels(),
+					Labels:      label.New().Instance(tc.GetInstanceName()).TiKV().Labels(),
 				},
 			}
 			if test.updatePod != nil {
@@ -1400,7 +1400,7 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1431,7 +1431,7 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
 					},
 					PublishNotReadyAddresses: true,
@@ -1906,7 +1906,7 @@ func TestGetTiKVConfigMap(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "",
+						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/meta/meta_manager.go
+++ b/pkg/manager/meta/meta_manager.go
@@ -56,7 +56,7 @@ func NewMetaManager(
 
 func (pmm *metaManager) Sync(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 
 	l, err := label.New().Instance(instanceName).Selector()
 	if err != nil {

--- a/pkg/manager/meta/meta_manager_test.go
+++ b/pkg/manager/meta/meta_manager_test.go
@@ -417,7 +417,7 @@ func newPod(tc *v1alpha1.TidbCluster) *corev1.Pod {
 				label.NameLabelKey:      controller.TestName,
 				label.ComponentLabelKey: controller.TestComponentName,
 				label.ManagedByLabelKey: controller.TestManagedByName,
-				label.InstanceLabelKey:  tc.GetLabels()[label.InstanceLabelKey],
+				label.InstanceLabelKey:  tc.GetInstanceName(),
 			},
 		},
 		Spec: newPodSpec(v1alpha1.PDMemberType.String(), "pvc-1"),

--- a/pkg/manager/meta/reclaim_policy_manager.go
+++ b/pkg/manager/meta/reclaim_policy_manager.go
@@ -40,7 +40,7 @@ func NewReclaimPolicyManager(pvcLister corelisters.PersistentVolumeClaimLister,
 
 func (rpm *reclaimPolicyManager) Sync(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
-	instanceName := tc.GetLabels()[label.InstanceLabelKey]
+	instanceName := tc.GetInstanceName()
 
 	l, err := label.New().Instance(instanceName).Selector()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

close #1418 
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 -->
 ```release-note
The instance label key of resources owned by `tidbcluster` is default to the cluster name now. 
```
