### PR TITLE
Retain last applied pod template to keep backward-compatibility

### DIFF
--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -225,7 +225,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		if force {
 			tc.Status.PD.Phase = v1alpha1.UpgradePhase
 			setUpgradePartition(newPDSet, 0)
-			errSTS := pmm.updateStatefulSet(tc, newPDSet, oldPDSet)
+			errSTS := updateStatefulSet(pmm.setControl, tc, newPDSet, oldPDSet)
 			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
 		}
 	}
@@ -250,7 +250,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		}
 	}
 
-	return pmm.updateStatefulSet(tc, newPDSet, oldPDSet)
+	return updateStatefulSet(pmm.setControl, tc, newPDSet, oldPDSet)
 }
 
 func (pmm *pdMemberManager) syncPDClientCerts(tc *v1alpha1.TidbCluster) error {
@@ -307,24 +307,6 @@ func (pmm *pdMemberManager) syncPDServerCerts(tc *v1alpha1.TidbCluster) error {
 	}
 
 	return pmm.certControl.Create(controller.GetOwnerRef(tc), certOpts)
-}
-
-func (pmm *pdMemberManager) updateStatefulSet(tc *v1alpha1.TidbCluster, newPDSet, oldPDSet *apps.StatefulSet) error {
-	if !statefulSetEqual(*newPDSet, *oldPDSet) {
-		set := *oldPDSet
-		set.Annotations = newPDSet.Annotations
-		set.Spec.Template = newPDSet.Spec.Template
-		*set.Spec.Replicas = *newPDSet.Spec.Replicas
-		set.Spec.UpdateStrategy = newPDSet.Spec.UpdateStrategy
-		err := SetStatefulSetLastAppliedConfigAnnotation(&set)
-		if err != nil {
-			return err
-		}
-		_, err = pmm.setControl.UpdateStatefulSet(tc, &set)
-		return err
-	}
-
-	return nil
 }
 
 func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -222,21 +222,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		}
 	}
 
-	if !statefulSetEqual(*newTiDBSet, *oldTiDBSet) {
-		set := *oldTiDBSet
-		set.Annotations = newTiDBSet.Annotations
-		set.Spec.Template = newTiDBSet.Spec.Template
-		*set.Spec.Replicas = *newTiDBSet.Spec.Replicas
-		set.Spec.UpdateStrategy = newTiDBSet.Spec.UpdateStrategy
-		err := SetStatefulSetLastAppliedConfigAnnotation(&set)
-		if err != nil {
-			return err
-		}
-		_, err = tmm.setControl.UpdateStatefulSet(tc, &set)
-		return err
-	}
-
-	return nil
+	return updateStatefulSet(tmm.setControl, tc, newTiDBSet, oldTiDBSet)
 }
 
 // syncTiDBClusterCerts creates the cert pair for TiDB if not exist, the cert

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -225,21 +225,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		}
 	}
 
-	if !statefulSetEqual(*newSet, *oldSet) {
-		set := *oldSet
-		set.Annotations = newSet.Annotations
-		set.Spec.Template = newSet.Spec.Template
-		*set.Spec.Replicas = *newSet.Spec.Replicas
-		set.Spec.UpdateStrategy = newSet.Spec.UpdateStrategy
-		err := SetStatefulSetLastAppliedConfigAnnotation(&set)
-		if err != nil {
-			return err
-		}
-		_, err = tkmm.setControl.UpdateStatefulSet(tc, &set)
-		return err
-	}
-
-	return nil
+	return updateStatefulSet(tkmm.setControl, tc, newSet, oldSet)
 }
 
 func (tkmm *tikvMemberManager) syncTiKVServerCerts(tc *v1alpha1.TidbCluster) error {


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #1475 
### What is changed and how does it work?
Now the `last-applied-config` annotation of statefulset's PodTemplate will be retained during update to keep the backward-compatibility.

In addition, we need #1440 to help us prevent such issues.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Retain last-applied-config of StatefulSet's `PodTemplate` during updates to keep backward compatibility.
```
