### PR TITLE
disable docker registry mirrors temporarily (except docker.io)

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -26,11 +26,11 @@ spec:
       requests:
         memory: "8000Mi"
         cpu: 8000m
-        ephemeral-storage: "40Gi"
+        ephemeral-storage: "50Gi"
       limits:
         memory: "8000Mi"
         cpu: 8000m
-        ephemeral-storage: "40Gi"
+        ephemeral-storage: "50Gi"
     # kind needs /lib/modules and cgroups from the host
     volumeMounts:
     - mountPath: /lib/modules
@@ -185,7 +185,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		def artifacts = "go/src/github.com/pingcap/tidb-operator/artifacts"
 		// unstable in our IDC, disable temporarily
 		//def MIRRORS = "DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn GCR_IO_MIRROR=https://gcr.azk8s.cn QUAY_IO_MIRROR=https://quay.azk8s.cn"
-		def MIRRORS = "DOCKER_IO_MIRROR=http://registry-proxy-docker-io.fuyecheng:5000"
+		def MIRRORS = "DOCKER_IO_MIRROR=http://172.16.4.143:5000"
 		def builds = [:]
 		builds["E2E v1.12.10"] = {
 			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_ ./hack/e2e.sh -- --ginkgo.skip='\\[Serial\\]'", artifacts)

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -185,7 +185,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		def artifacts = "go/src/github.com/pingcap/tidb-operator/artifacts"
 		// unstable in our IDC, disable temporarily
 		//def MIRRORS = "DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn GCR_IO_MIRROR=https://gcr.azk8s.cn QUAY_IO_MIRROR=https://quay.azk8s.cn"
-		def MIRRORS = "DOCKER_IO_MIRROR=https://hub-mirror.c.163.com"
+		def MIRRORS = "DOCKER_IO_MIRROR=http://registry-proxy-docker-io.fuyecheng:5000"
 		def builds = [:]
 		builds["E2E v1.12.10"] = {
 			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_ ./hack/e2e.sh -- --ginkgo.skip='\\[Serial\\]'", artifacts)

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -183,7 +183,9 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		}
 
 		def artifacts = "go/src/github.com/pingcap/tidb-operator/artifacts"
-		def MIRRORS = "DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn GCR_IO_MIRROR=https://gcr.azk8s.cn QUAY_IO_MIRROR=https://quay.azk8s.cn"
+		// unstable in our IDC, disable temporarily
+		//def MIRRORS = "DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn GCR_IO_MIRROR=https://gcr.azk8s.cn QUAY_IO_MIRROR=https://quay.azk8s.cn"
+		def MIRRORS = "DOCKER_IO_MIRROR=https://hub-mirror.c.163.com"
 		def builds = [:]
 		builds["E2E v1.12.10"] = {
 			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_ ./hack/e2e.sh -- --ginkgo.skip='\\[Serial\\]'", artifacts)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -206,19 +206,11 @@ function e2e::up() {
     fi
     if [ -n "$DOCKER_IO_MIRROR" -a -n "${DOCKER_IN_DOCKER_ENABLED:-}" ]; then
         echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
-        if [[ "$DOCKER_IO_MIRROR" = https://* ]]; then
 cat <<EOF > /etc/docker/daemon.json
 {
     "registry-mirrors": ["$DOCKER_IO_MIRROR"]
 }
 EOF
-        else
-cat <<EOF > /etc/docker/daemon.json
-{
-    "insecure-registries": ["$DOCKER_IO_MIRROR"]
-}
-EOF
-        fi
         e2e::__restart_docker
     fi
     if e2e::cluster_exists $CLUSTER; then

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -77,7 +77,7 @@ Examples:
 
 4) use registry mirrors
 
-    DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn QUAY_IO_MIRROR=quay.azk8s.cn GCR_IO_MIRROR=gcr.azk8s.cn ./hack/e2e.sh -- <e2e args>
+    DOCKER_IO_MIRROR=https://dockerhub.azk8s.cn QUAY_IO_MIRROR=https://quay.azk8s.cn GCR_IO_MIRROR=https://gcr.azk8s.cn ./hack/e2e.sh -- <e2e args>
 
 EOF
 
@@ -206,11 +206,19 @@ function e2e::up() {
     fi
     if [ -n "$DOCKER_IO_MIRROR" -a -n "${DOCKER_IN_DOCKER_ENABLED:-}" ]; then
         echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
+        if [[ "$DOCKER_IO_MIRROR" = https://* ]]; then
 cat <<EOF > /etc/docker/daemon.json
 {
     "registry-mirrors": ["$DOCKER_IO_MIRROR"]
 }
 EOF
+        else
+cat <<EOF > /etc/docker/daemon.json
+{
+    "insecure-registries": ["$DOCKER_IO_MIRROR"]
+}
+EOF
+        fi
         e2e::__restart_docker
     fi
     if e2e::cluster_exists $CLUSTER; then

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -75,11 +75,13 @@ e2e_args=(
     --provider=skeleton
     --clean-start=true
     --delete-namespace-on-failure=false
+    --repo-root=$ROOT
     # tidb-operator e2e flags
     --operator-tag=e2e
     --operator-image=${TIDB_OPERATOR_IMAGE}
     --e2e-image=${E2E_IMAGE}
-    --tidb-versions=v3.0.2,v3.0.3,v3.0.4,v3.0.5
+    # two tidb versions can be configuraed: <defaultVersion>,<upgradeToVersion>
+    --tidb-versions=v3.0.2,v3.0.3
     --chart-dir=/charts
     -v=4
 )
@@ -97,6 +99,8 @@ docker_args=(
     run
     --rm
     --net=host
+    --privileged
+    -v /:/rootfs
     -v $ROOT:$ROOT
     -w $ROOT
     -v $KUBECONFIG:/etc/kubernetes/admin.conf:ro

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -81,7 +81,7 @@ e2e_args=(
     --operator-image=${TIDB_OPERATOR_IMAGE}
     --e2e-image=${E2E_IMAGE}
     # two tidb versions can be configuraed: <defaultVersion>,<upgradeToVersion>
-    --tidb-versions=v3.0.2,v3.0.3
+    --tidb-versions=v3.0.6,v3.0.7
     --chart-dir=/charts
     -v=4
 )

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -461,8 +461,6 @@ func (oa *operatorActions) CleanCRDOrDie() {
 
 // InstallCRDOrDie install CRDs and wait for them to be established in Kubernetes.
 func (oa *operatorActions) InstallCRDOrDie() {
-	oa.runKubectlOrDie("apply", "-f", oa.manifestPath("e2e/crd.yaml"))
-	oa.runKubectlOrDie("apply", "-f", oa.manifestPath("e2e/data-resource-crd.yaml"))
 	if isSupported, err := utildiscovery.IsAPIGroupVersionSupported(oa.kubeCli.Discovery(), "apiextensions.k8s.io/v1"); err != nil {
 		glog.Fatal(err)
 	} else if isSupported {
@@ -470,6 +468,8 @@ func (oa *operatorActions) InstallCRDOrDie() {
 	} else {
 		oa.runKubectlOrDie("apply", "-f", oa.manifestPath("e2e/advanced-statefulset-crd.v1beta1.yaml"))
 	}
+	oa.runKubectlOrDie("apply", "-f", oa.manifestPath("e2e/crd.yaml"))
+	oa.runKubectlOrDie("apply", "-f", oa.manifestPath("e2e/data-resource-crd.yaml"))
 	out := oa.runKubectlOrDie([]string{"get", "crds", "--no-headers", `-ojsonpath={range .items[*]}{.metadata.name}{" "}{end}`}...)
 	waitArgs := []string{"wait", "--for=condition=Established"}
 	for _, crd := range strings.Split(out, " ") {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -523,7 +523,7 @@ func (oa *operatorActions) DeployOperator(info *OperatorConfig) error {
 
 	// wait for all apiservices are available
 	// '-l a!=b' is a workaround solution for '--all' flag which is introduced only in kubectl 1.14+
-	oa.runKubectlOrDie("wait", "--for=condition=Available", "apiservices", "-l", "a!=b")
+	oa.runKubectlOrDie("wait", "--for=condition=Available", "apiservices", "-l", "a!=b", "--timeout=60s")
 	return nil
 }
 

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/version"
 	"github.com/pingcap/tidb-operator/tests"
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
@@ -142,6 +143,10 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	e2econfig.TestConfig.ManifestDir = "/manifests"
 	framework.Logf("====== e2e configuration ======")
 	framework.Logf("%s", e2econfig.TestConfig.MustPrettyPrintJSON())
+	// preload images
+	if err := utilimage.PreloadImages(); err != nil {
+		framework.Failf("failed to pre-load images: %v", err)
+	}
 	// Get clients
 	config, err := framework.LoadConfig()
 	framework.ExpectNoError(err, "failed to load config")

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/tests"
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
 	utilstatefulset "github.com/pingcap/tidb-operator/tests/e2e/util/statefulset"
 	v1 "k8s.io/api/core/v1"
@@ -384,19 +385,19 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					TiDB: v1alpha1.TiDBSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/tidb:v2.1.18",
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV2Version),
 						},
 					},
 					TiKV: v1alpha1.TiKVSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/tikv:v2.1.18",
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV2Version),
 						},
 					},
 					PD: v1alpha1.PDSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/pd:v2.1.18",
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV2Version),
 						},
 					},
 				},
@@ -408,7 +409,7 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 			ocfg.WebhookEnabled = true
 			oa.UpgradeOperatorOrDie(ocfg)
 			// now the webhook enabled
-			legacyTc.Spec.TiDB.Image = "pingcap/tidb:v3.0.7"
+			legacyTc.Spec.TiDB.Image = fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3Version)
 			legacyTc, err = cli.PingcapV1alpha1().TidbClusters(ns).Update(legacyTc)
 			framework.ExpectNoError(err, "Update legacy tidbcluster should not be influenced by validating")
 			framework.ExpectEqual(legacyTc.Spec.TiDB.BaseImage, "", "Update legacy tidbcluster should not be influenced by defaulting")
@@ -417,7 +418,7 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 			legacyTc.Spec.TiDB.BaseImage = "pingcap/tidb"
 			legacyTc.Spec.TiKV.BaseImage = "pingcap/tikv"
 			legacyTc.Spec.PD.BaseImage = "pingcap/pd"
-			legacyTc.Spec.PD.Version = pointer.StringPtr("v3.0.7")
+			legacyTc.Spec.PD.Version = pointer.StringPtr(utilimage.TiDBV3Version)
 			legacyTc, err = cli.PingcapV1alpha1().TidbClusters(ns).Update(legacyTc)
 			framework.ExpectNoError(err, "Expected update tidbcluster")
 			legacyTc.Spec.TiDB.BaseImage = ""
@@ -435,17 +436,17 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: v1alpha1.TiDBSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/tidb:v2.1.18",
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV2Version),
 						},
 					},
 					TiKV: v1alpha1.TiKVSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/tikv:v2.1.18",
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV2Version),
 						},
 					},
 					PD: v1alpha1.PDSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: "pingcap/pd:v2.1.18",
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV2Version),
 						},
 					},
 				},
@@ -461,7 +462,7 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					Name:      "newly-created",
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: "v3.0.7",
+					Version: utilimage.TiDBV3Version,
 					TiDB: v1alpha1.TiDBSpec{
 						Replicas: 1,
 					},

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb-operator/tests"
 	"github.com/pingcap/tidb-operator/tests/apiserver"
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
 	"github.com/pingcap/tidb-operator/tests/pkg/apimachinery"
 	"github.com/pingcap/tidb-operator/tests/pkg/blockwriter"
@@ -111,11 +112,11 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 			Values  map[string]string
 		}{
 			{
-				Version: "v3.0.5",
+				Version: utilimage.TiDBV3Version,
 				Name:    "basic-v3",
 			},
 			{
-				Version: "v2.1.16",
+				Version: utilimage.TiDBV2Version,
 				Name:    "basic-v2",
 				Values: map[string]string{
 					// verify v2.1.x configuration compatibility
@@ -124,7 +125,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 				},
 			},
 			{
-				Version: "v3.0.5",
+				Version: utilimage.TiDBTLSVersion,
 				Name:    "basic-v3-cluster-tls",
 				Values: map[string]string{
 					"enableTLSCluster": "true",
@@ -690,7 +691,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		framework.ExpectNoError(err, "Expected TiDB cluster scaled out and ready")
 
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = "v3.0.7"
+			tc.Spec.Version = utilimage.TiDBV3Version
 			return nil
 		})
 		framework.ExpectNoError(err, "Expected TiDB cluster updated")

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -1,0 +1,124 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	TiDBV3Version  = "v3.0.7"
+	TiDBTLSVersion = TiDBV3Version // must >= 3.0.5
+	TiDBV2Version  = "v2.1.18"
+)
+
+func ListImages() []string {
+	images := []string{}
+	versions := strings.Split(e2econfig.TestConfig.TidbVersions, ",")
+	versions = append(versions, TiDBV3Version)
+	versions = append(versions, TiDBTLSVersion)
+	versions = append(versions, TiDBV2Version)
+	for _, v := range versions {
+		images = append(images, fmt.Sprintf("pingcap/pd:%s", v))
+		images = append(images, fmt.Sprintf("pingcap/tidb:%s", v))
+		images = append(images, fmt.Sprintf("pingcap/tikv:%s", v))
+	}
+	imagesFromOperator, err := readImagesFromValues(filepath.Join(framework.TestContext.RepoRoot, "charts/tidb-operator/values.yaml"))
+	if err != nil {
+		framework.ExpectNoError(err)
+	}
+	images = append(images, imagesFromOperator...)
+	imagesFromTiDBCluster, err := readImagesFromValues(filepath.Join(framework.TestContext.RepoRoot, "charts/tidb-cluster/values.yaml"))
+	if err != nil {
+		framework.ExpectNoError(err)
+	}
+	images = append(images, imagesFromTiDBCluster...)
+	return images
+}
+
+// values represents a collection of chart values.
+type values map[string]interface{}
+
+func walkValues(vals values, fn func(k string, v interface{})) {
+	for k, v := range vals {
+		fn(k, v)
+		valsMap, ok := v.(map[string]interface{})
+		if ok {
+			walkValues(valsMap, fn)
+		}
+	}
+}
+
+func readImagesFromValues(f string) ([]string, error) {
+	var vals values
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(data, &vals)
+	if err != nil {
+		return nil, err
+	}
+	if len(vals) == 0 {
+		vals = values{}
+	}
+	images := []string{}
+	walkValues(vals, func(k string, v interface{}) {
+		if k != "image" {
+			return
+		}
+		if image, ok := v.(string); ok {
+			images = append(images, image)
+		}
+	})
+	return images, nil
+}
+
+func nsenter(args ...string) error {
+	nsenter_args := []string{
+		"--mount=/rootfs/proc/1/ns/mnt",
+		fmt.Sprintf("--wd=%s", framework.TestContext.RepoRoot),
+		"--",
+	}
+	nsenter_args = append(nsenter_args, args...)
+	klog.Infof("run nsenter command: %s %s", "nsenter", strings.Join(nsenter_args, " "))
+	return exec.Command("nsenter", nsenter_args...).Run()
+}
+
+// PreloadImages pre-loads images into the e2e cluster.
+// This is used to speed up the e2e process.
+// NOTE: it supports kind only right now
+func PreloadImages() error {
+	images := ListImages()
+	cluster := "tidb-operator" // TODO: make it configurable
+	kindBin := "./output/bin/kind"
+	for _, image := range images {
+		if err := nsenter("docker", "pull", image); err != nil {
+			return err
+		}
+		if err := nsenter(kindBin, "load", "docker-image", "--name", cluster, image); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tests/e2e/util/image/image_test.go
+++ b/tests/e2e/util/image/image_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"io/ioutil"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReadImagesFromValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     string
+		wantImages []string
+	}{
+		{
+			name: "basic",
+			values: `
+image: pingcap/tidb:v3.0.4
+foo:
+  image: busybox:latest
+  mysql:
+    image: pingcap/tidb-monitor-reloader:v1.0.1
+`,
+			wantImages: []string{
+				"pingcap/tidb-monitor-reloader:v1.0.1",
+				"pingcap/tidb:v3.0.4",
+				"busybox:latest",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpfile, err := ioutil.TempFile("", "values")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name()) // clean up
+			_, err = tmpfile.Write([]byte(tt.values))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := readImagesFromValues(tmpfile.Name())
+			if err != nil {
+				t.Error(err)
+			}
+			sort.Strings(got)
+			sort.Strings(tt.wantImages)
+			if diff := cmp.Diff(got, tt.wantImages); diff != "" {
+				t.Errorf("unexpected (-want, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
