### PR TITLE
Check bash version in e2e test

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -131,6 +131,9 @@ Now you can run the following command to run all e2e test.
 $ ./hack/e2e.sh
 ```
 
+**NOTE**: We don't support bash version < 4 for now. For those who using a not supported version of bash, especially macOS (which default bash version is 3.2)
+users, please use containerized environment or upgrade your bash manually.
+
 It's possible to limit specs to run, for example:
 
 ```

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -132,6 +132,15 @@ echo "DOCKER_IO_MIRROR: $DOCKER_IO_MIRROR"
 echo "GCR_IO_MIRROR: $GCR_IO_MIRROR"
 echo "QUAY_IO_MIRROR: $QUAY_IO_MIRROR"
 
+# check bash version
+BASH_MAJOR_VERSION=$(echo "$BASH_VERSION" | grep -o "^\d\{1,3\}")
+# we need bash version >= 4
+if [ $BASH_MAJOR_VERSION -lt 4 ]
+then
+  echo "error: e2e.sh could not work with bash version earlier than 4 for now, please upgrade your bash"
+  exit 1
+fi
+
 # https://github.com/kubernetes-sigs/kind/releases/tag/v0.6.1
 declare -A kind_node_images
 kind_node_images["v1.11.10"]="kindest/node:v1.11.10@sha256:e6f3dade95b7cb74081c5b9f3291aaaa6026a90a977e0b990778b6adc9ea6248"


### PR DESCRIPTION
Add bash version requirements note in doc.
fix #1560

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Check bash version in e2e test script.
It add bash version requirements note in doc.
### What is changed and how does it work?

`e2e.sh` and `CONTRIBUTIN.md`.

In `e2e.sh` , we check the `$BASH_VERSION` and make sure it >= 4 before really execute anything which requires bash newer than version 4.

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
