### PR TITLE
Fix upgrader error when advanced statefulset disabled 

### DIFF
--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -16,6 +16,8 @@ package upgrader
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	asappsv1 "github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1"
 	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	asclientset "github.com/pingcap/advanced-statefulset/pkg/client/clientset/versioned"
@@ -108,6 +110,13 @@ func (u *upgrader) Upgrade() error {
 	} else {
 		stsList, err := u.asCli.AppsV1().StatefulSets(u.ns).List(metav1.ListOptions{})
 		if err != nil {
+			if err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("Upgrader: Kubernetes server haven't Advanced StatefulSets resources, skip to revert")
+					return nil
+				}
+				return err
+			}
 			return err
 		}
 		stsToMigrate := make([]asappsv1.StatefulSet, 0)

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -110,12 +110,9 @@ func (u *upgrader) Upgrade() error {
 	} else {
 		stsList, err := u.asCli.AppsV1().StatefulSets(u.ns).List(metav1.ListOptions{})
 		if err != nil {
-			if err != nil {
-				if errors.IsNotFound(err) {
-					klog.Infof("Upgrader: Kubernetes server haven't Advanced StatefulSets resources, skip to revert")
-					return nil
-				}
-				return err
+			if errors.IsNotFound(err) {
+				klog.Infof("Upgrader: Kubernetes server haven't Advanced StatefulSets resources, skip to revert")
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fixes #1595

### What is changed and how does it work?
Skip to revert when there isn't any resources of `apps.pingcap.com/statefulsets`

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
