### PR TITLE
e2e: don't use TiDB 2 version except backward compatibility test

### DIFF
--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -495,19 +495,19 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					TiDB: v1alpha1.TiDBSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3Version),
 						},
 					},
 					TiKV: v1alpha1.TiKVSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV3Version),
 						},
 					},
 					PD: v1alpha1.PDSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV3Version),
 						},
 					},
 				},
@@ -546,17 +546,17 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: v1alpha1.TiDBSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3Version),
 						},
 					},
 					TiKV: v1alpha1.TiKVSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV3Version),
 						},
 					},
 					PD: v1alpha1.PDSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV2Version),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV3Version),
 						},
 					},
 				},

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -704,7 +704,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 	})
 
 	ginkgo.It("should be operable without helm [API]", func() {
-		tc := fixture.GetTidbCluster(ns, "plain-cr", utilimage.TiDBV2Version)
+		tc := fixture.GetTidbCluster(ns, "plain-cr", utilimage.TiDBV3Version)
 		err := genericCli.Create(context.TODO(), tc)
 		framework.ExpectNoError(err, "Expected TiDB cluster created")
 		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

pd 2 sometimes fails to scale-out and we don't need to use tidb 2 anymore [except the backward compatibility test](https://github.com/pingcap/tidb-operator/blob/c45c031667dbebc1d2c56d27ee2cbe73e0184a25/tests/e2e/tidbcluster/tidbcluster.go#L137-L143)

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/operator_ghpr_e2e_test_kind/detail/operator_ghpr_e2e_test_kind/2455/pipeline

Fixes https://github.com/pingcap/tidb-operator/issues/1592

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
