### PR TITLE
Sync labels for Monitor's PersistentVolume

### DIFF
--- a/pkg/controller/pv_control.go
+++ b/pkg/controller/pv_control.go
@@ -150,7 +150,7 @@ func (rpc *realPVControl) UpdateMetaInfo(obj runtime.Object, pv *corev1.Persiste
 		var updateErr error
 		updatePV, updateErr = rpc.kubeCli.CoreV1().PersistentVolumes().Update(pv)
 		if updateErr == nil {
-			glog.Infof("PV: [%s] updated successfully, kind: %s/%s", pvName, kind, ns, name)
+			glog.Infof("PV: [%s] updated successfully, %s: %s/%s", pvName, kind, ns, name)
 			return nil
 		}
 		glog.Errorf("failed to update PV: [%s], %s %s/%s, error: %v", pvName, kind, ns, name, err)

--- a/pkg/controller/pv_control.go
+++ b/pkg/controller/pv_control.go
@@ -15,12 +15,13 @@ package controller
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
 
-	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -34,8 +35,8 @@ import (
 
 // PVControlInterface manages PVs used in TidbCluster
 type PVControlInterface interface {
-	PatchPVReclaimPolicy(*v1alpha1.TidbCluster, *corev1.PersistentVolume, corev1.PersistentVolumeReclaimPolicy) error
-	UpdateMetaInfo(*v1alpha1.TidbCluster, *corev1.PersistentVolume) (*corev1.PersistentVolume, error)
+	PatchPVReclaimPolicy(runtime.Object, *corev1.PersistentVolume, corev1.PersistentVolumeReclaimPolicy) error
+	UpdateMetaInfo(runtime.Object, *corev1.PersistentVolume) (*corev1.PersistentVolume, error)
 }
 
 type realPVControl struct {
@@ -60,7 +61,13 @@ func NewRealPVControl(
 	}
 }
 
-func (rpc *realPVControl) PatchPVReclaimPolicy(tc *v1alpha1.TidbCluster, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
+func (rpc *realPVControl) PatchPVReclaimPolicy(obj runtime.Object, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return fmt.Errorf("%+v is not a runtime.Object, cannot get controller from it", obj)
+	}
+
+	name := metaObj.GetName()
 	pvName := pv.GetName()
 	patchBytes := []byte(fmt.Sprintf(`{"spec":{"persistentVolumeReclaimPolicy":"%s"}}`, reclaimPolicy))
 
@@ -68,13 +75,19 @@ func (rpc *realPVControl) PatchPVReclaimPolicy(tc *v1alpha1.TidbCluster, pv *cor
 		_, err := rpc.kubeCli.CoreV1().PersistentVolumes().Patch(pvName, types.StrategicMergePatchType, patchBytes)
 		return err
 	})
-	rpc.recordPVEvent("patch", tc, pvName, err)
+	rpc.recordPVEvent("patch", obj, name, pvName, err)
 	return err
 }
 
-func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
-	ns := tc.GetNamespace()
-	tcName := tc.GetName()
+func (rpc *realPVControl) UpdateMetaInfo(obj runtime.Object, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("%+v is not a runtime.Object, cannot get controller from it", obj)
+	}
+
+	ns := metaObj.GetNamespace()
+	name := metaObj.GetName()
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
 
 	if pv.Annotations == nil {
 		pv.Annotations = make(map[string]string)
@@ -85,7 +98,7 @@ func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.Pe
 	pvName := pv.GetName()
 	pvcRef := pv.Spec.ClaimRef
 	if pvcRef == nil {
-		glog.Warningf("PV: [%s] doesn't have a ClaimRef, skipping, TidbCluster: %s/%s", pvName, ns, tcName)
+		glog.Warningf("PV: [%s] doesn't have a ClaimRef, skipping, %s: %s/%s", kind, pvName, ns, name)
 		return pv, nil
 	}
 
@@ -96,7 +109,7 @@ func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.Pe
 			return pv, err
 		}
 
-		glog.Warningf("PV: [%s]'s PVC: [%s/%s] doesn't exist, skipping. TidbCluster: %s", pvName, ns, pvcName, tcName)
+		glog.Warningf("PV: [%s]'s PVC: [%s/%s] doesn't exist, skipping. %s: %s", pvName, ns, pvcName, kind, name)
 		return pv, nil
 	}
 
@@ -115,7 +128,7 @@ func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.Pe
 		pv.Labels[label.MemberIDLabelKey] == memberID &&
 		pv.Labels[label.StoreIDLabelKey] == storeID &&
 		pv.Annotations[label.AnnPodNameKey] == podName {
-		glog.V(4).Infof("pv %s already has labels and annotations synced, skipping. TidbCluster: %s/%s", pvName, ns, tcName)
+		glog.V(4).Infof("pv %s already has labels and annotations synced, skipping. %s: %s/%s", pvName, kind, ns, name)
 		return pv, nil
 	}
 
@@ -137,10 +150,10 @@ func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.Pe
 		var updateErr error
 		updatePV, updateErr = rpc.kubeCli.CoreV1().PersistentVolumes().Update(pv)
 		if updateErr == nil {
-			glog.Infof("PV: [%s] updated successfully, TidbCluster: %s/%s", pvName, ns, tcName)
+			glog.Infof("PV: [%s] updated successfully, kind: %s/%s", pvName, kind, ns, name)
 			return nil
 		}
-		glog.Errorf("failed to update PV: [%s], TidbCluster %s/%s, error: %v", pvName, ns, tcName, err)
+		glog.Errorf("failed to update PV: [%s], %s %s/%s, error: %v", pvName, kind, ns, name, err)
 
 		if updated, err := rpc.pvLister.Get(pvName); err == nil {
 			// make a copy so we don't mutate the shared cache
@@ -156,18 +169,17 @@ func (rpc *realPVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.Pe
 	return updatePV, err
 }
 
-func (rpc *realPVControl) recordPVEvent(verb string, tc *v1alpha1.TidbCluster, pvName string, err error) {
-	tcName := tc.GetName()
+func (rpc *realPVControl) recordPVEvent(verb string, obj runtime.Object, objName, pvName string, err error) {
 	if err == nil {
 		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s PV %s in TidbCluster %s successful",
-			strings.ToLower(verb), pvName, tcName)
-		rpc.recorder.Event(tc, corev1.EventTypeNormal, reason, msg)
+			strings.ToLower(verb), pvName, objName)
+		rpc.recorder.Event(obj, corev1.EventTypeNormal, reason, msg)
 	} else {
 		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s PV %s in TidbCluster %s failed error: %s",
-			strings.ToLower(verb), pvName, tcName, err)
-		rpc.recorder.Event(tc, corev1.EventTypeWarning, reason, msg)
+			strings.ToLower(verb), pvName, objName, err)
+		rpc.recorder.Event(obj, corev1.EventTypeWarning, reason, msg)
 	}
 }
 
@@ -195,7 +207,7 @@ func (fpc *FakePVControl) SetUpdatePVError(err error, after int) {
 }
 
 // PatchPVReclaimPolicy patchs the reclaim policy of PV
-func (fpc *FakePVControl) PatchPVReclaimPolicy(_ *v1alpha1.TidbCluster, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
+func (fpc *FakePVControl) PatchPVReclaimPolicy(_ runtime.Object, pv *corev1.PersistentVolume, reclaimPolicy corev1.PersistentVolumeReclaimPolicy) error {
 	defer fpc.updatePVTracker.Inc()
 	if fpc.updatePVTracker.ErrorReady() {
 		defer fpc.updatePVTracker.Reset()
@@ -207,13 +219,18 @@ func (fpc *FakePVControl) PatchPVReclaimPolicy(_ *v1alpha1.TidbCluster, pv *core
 }
 
 // UpdateMetaInfo update the meta info of pv
-func (fpc *FakePVControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+func (fpc *FakePVControl) UpdateMetaInfo(obj runtime.Object, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
 	defer fpc.updatePVTracker.Inc()
+
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("%+v is not a runtime.Object, cannot get controller from it", obj)
+	}
+	ns := metaObj.GetNamespace()
 	if fpc.updatePVTracker.ErrorReady() {
 		defer fpc.updatePVTracker.Reset()
 		return nil, fpc.updatePVTracker.GetError()
 	}
-	ns := tc.GetNamespace()
 	pvcName := pv.Spec.ClaimRef.Name
 	pvc, err := fpc.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 	if err != nil {

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -63,7 +63,7 @@ func NewController(
 	tidbMonitorInformer := informerFactory.Pingcap().V1alpha1().TidbMonitors()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	typedControl := controller.NewTypedControl(controller.NewRealGenericControl(genericCli, recorder))
-	monitorManager := monitor.NewMonitorManager(informerFactory, kubeInformerFactory, typedControl, recorder)
+	monitorManager := monitor.NewMonitorManager(kubeCli, informerFactory, kubeInformerFactory, typedControl, recorder)
 
 	tmc := &Controller{
 		cli:      genericCli,

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -750,7 +750,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		tc, err := cli.PingcapV1alpha1().TidbClusters(cluster.Namespace).Get(cluster.ClusterName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Expected get tidbcluster")
 
-		tm := fixture.NewTidbMonitor("e2e-monitor", tc.Namespace, tc, true, false)
+		tm := fixture.NewTidbMonitor("e2e-monitor", tc.Namespace, tc, true, true)
 		_, err = cli.PingcapV1alpha1().TidbMonitors(tc.Namespace).Create(tm)
 		framework.ExpectNoError(err, "Expected tidbmonitor deployed success")
 		err = tests.CheckTidbMonitor(tm, c, fw)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -755,6 +755,24 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		framework.ExpectNoError(err, "Expected tidbmonitor deployed success")
 		err = tests.CheckTidbMonitor(tm, c, fw)
 		framework.ExpectNoError(err, "Expected tidbmonitor checked success")
+
+		pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get("e2e-monitor-monitor", metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected fetch tidbmonitor pvc success")
+		pvName := pvc.Spec.VolumeName
+		pv, err := c.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "Expected fetch tidbmonitor pv success")
+		value, existed := pv.Labels[label.ComponentLabelKey]
+		framework.ExpectEqual(existed, true)
+		framework.ExpectEqual(value, label.TiDBMonitorVal)
+		value, existed = pv.Labels[label.InstanceLabelKey]
+		framework.ExpectEqual(existed, true)
+		framework.ExpectEqual(value, "e2e-monitor")
+		value, existed = pv.Labels[label.InstanceLabelKey]
+		framework.ExpectEqual(existed, true)
+		framework.ExpectEqual(value, "e2e-monitor")
+		value, existed = pv.Labels[label.ManagedByLabelKey]
+		framework.ExpectEqual(existed, true)
+		framework.ExpectEqual(value, label.TiDBOperator)
 	})
 })
 

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -184,6 +184,10 @@ func NewTidbMonitor(name, namespace string, tc *v1alpha1.TidbCluster, grafanaEna
 			},
 		}
 	}
-
+	if persist {
+		storageClassName := "local-storage"
+		monitor.Spec.StorageClassName = &storageClassName
+		monitor.Spec.Storage = "2Gi"
+	}
 	return monitor
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Ref #1586

### What problem does this PR solve? <!--add and issue link with summary if exists-->
In this request, `TidbMonitor` controller would sync its pv to update the label just like other `tidbcluster` components.
This request is only for `TidbMonitor`, 

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add labels for `TidbMonitor`'s `PersistentVolume`
```
