### PR TITLE
Check store owner for tikv manager

### DIFF
--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -590,9 +590,8 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	addressPrefix := fmt.Sprintf("%s-tikv-", tc.Name)
 	addressSuffix := fmt.Sprintf("%s-tikv-peer.%s.svc:20160", tc.Name, tc.Namespace)
 	for _, store := range storesInfo.Stores {
-		address := store.Store.Address
 		// make sure that the store belongs to the tikv
-		if !(strings.HasPrefix(address, addressPrefix) && strings.HasSuffix(address, addressSuffix)) {
+		if store.Store != nil && !(strings.HasPrefix(store.Store.Address, addressPrefix) && strings.HasSuffix(store.Store.Address, addressSuffix)) {
 			continue
 		}
 		status := tkmm.getTiKVStore(store)

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -588,12 +588,13 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 		return err
 	}
 
-	pattern, err := regexp.Compile(fmt.Sprintf("%s-tikv-\\d+\\.%s-tikv-peer\\.%s\\.svc\\:\\d+", tc.Name, tc.Name, tc.Namespace))
+	pattern, err := regexp.Compile(fmt.Sprintf(`%s-tikv-\d+\.%s-tikv-peer\.%s\.svc\:\d+`, tc.Name, tc.Name, tc.Namespace))
 	if err != nil {
 		return err
 	}
 	for _, store := range storesInfo.Stores {
-		// make sure that the store belongs to the tikv
+		// In theory, the external tikv can join the cluster, and the operator would only manage the internal tikv.
+		// So we check the store owner to make sure it.
 		if store.Store != nil && !pattern.Match([]byte(store.Store.Address)) {
 			continue
 		}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -587,7 +587,14 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 		return err
 	}
 
+	addressPrefix := fmt.Sprintf("%s-tikv-", tc.Name)
+	addressSuffix := fmt.Sprintf("%s-tikv-peer.%s.svc:20160", tc.Name, tc.Namespace)
 	for _, store := range storesInfo.Stores {
+		address := store.Store.Address
+		// make sure that the store belongs to the tikv
+		if !(strings.HasPrefix(address, addressPrefix) && strings.HasSuffix(address, addressSuffix)) {
+			continue
+		}
 		status := tkmm.getTiKVStore(store)
 		if status == nil {
 			continue

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -514,7 +514,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 		if test.hasPod {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-1",
+					Name:      "test-tikv-1",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: corev1.PodSpec{
@@ -612,7 +612,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -641,7 +641,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -669,7 +669,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -715,7 +715,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -749,7 +749,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -1007,6 +1007,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 					LastHeartbeatTime: now,
 				}
 			},
+
 			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
 				return false, nil
 			},
@@ -1017,7 +1018,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1057,7 +1058,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1097,7 +1098,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1135,7 +1136,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1175,7 +1176,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1216,7 +1217,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Down",
 						},
@@ -1257,7 +1258,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1294,7 +1295,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1311,7 +1312,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: "pod-1.ns-1",
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Tombstone",
 						},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Fixes https://github.com/pingcap/tidb-operator/issues/1582

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Currently, `tikv-manager` would sync all the store info in the `tikv status`, which is not suitable if we add `tiflash` in the future. In this request, the `tikv-manager` would check the store owner by comparing the address of each store. 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
