### PR TITLE
fix scaling pd with Advanced StatefulSet

### DIFF
--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -73,10 +74,10 @@ func (psd *pdScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet
 		return nil
 	}
 
-	var i int32 = 0
 	healthCount := 0
 	totalCount := *oldSet.Spec.Replicas
-	for ; i < totalCount; i++ {
+	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
+	for _, i := range podOrdinals {
 		podName := ordinalPodName(v1alpha1.PDMemberType, tcName, i)
 		if member, ok := tc.Status.PD.Members[podName]; ok && member.Health {
 			healthCount++

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -193,16 +193,16 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					deleteSlots: sets.NewInt32(),
 				},
 				{
-					name:        "Scaling in tidb from 0 to 2",
+					name:        "Scaling out tidb from 0 to 2 by adding pods 0 and 2",
 					component:   "tidb",
 					replicas:    2,
-					deleteSlots: sets.NewInt32(),
+					deleteSlots: sets.NewInt32(1),
 				},
 				{
-					name:        "Scaling out tidb from 2 to 4 by adding pods 3 and 4",
+					name:        "Scaling tidb from 2 to 4 by deleting pods 2 and adding pods 3, 4 and 5",
 					component:   "tidb",
 					replicas:    4,
-					deleteSlots: sets.NewInt32(1),
+					deleteSlots: sets.NewInt32(1, 2),
 				},
 				{
 					name:        "Scaling out pd from 3 to 5 by adding pods 3, 4",
@@ -214,6 +214,12 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					name:        "Scaling in pd from 5 to 3 by deleting pods 0 and 3",
 					component:   "pd",
 					replicas:    3,
+					deleteSlots: sets.NewInt32(0, 3),
+				},
+				{
+					name:        "Scaling out pd from 3 to 5 by adding pods 5 and 6",
+					component:   "pd",
+					replicas:    5,
 					deleteSlots: sets.NewInt32(0, 3),
 				},
 			}


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fix scaling pd with Advanced StatefulSet

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
