### PR TITLE
[Advanced StatefulSet] e2e case: upgrade cluster while pods are not consecutive

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -35,8 +35,8 @@ spec:
           - /usr/local/bin/tidb-controller-manager
           {{- if .Values.tidbBackupManagerImage }}
           - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
-          - -tidb-discovery-image={{ .Values.operatorImage }}
           {{- end }}
+          - -tidb-discovery-image={{ .Values.operatorImage }}
           - -cluster-scoped={{ .Values.clusterScoped }}
           - -auto-failover={{ .Values.controllerManager.autoFailover | default true }}
           - -pd-failover-period={{ .Values.controllerManager.pdFailoverPeriod | default "5m" }}

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -16,6 +16,7 @@ package member
 import (
 	"fmt"
 
+	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
@@ -76,7 +77,9 @@ func (pu *pdUpgrader) gracefulUpgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Sta
 	}
 
 	setUpgradePartition(newSet, *oldSet.Spec.UpdateStrategy.RollingUpdate.Partition)
-	for i := tc.PDStsActualReplicas() - 1; i >= 0; i-- {
+	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
+	for _i := len(podOrdinals) - 1; _i >= 0; _i-- {
+		i := podOrdinals[_i]
 		podName := PdPodName(tcName, i)
 		pod, err := pu.podLister.Pods(ns).Get(podName)
 		if err != nil {

--- a/pkg/manager/member/tidb_upgrader.go
+++ b/pkg/manager/member/tidb_upgrader.go
@@ -14,6 +14,7 @@
 package member
 
 import (
+	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	apps "k8s.io/api/apps/v1"
@@ -74,7 +75,9 @@ func (tdu *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Stateful
 	}
 
 	setUpgradePartition(newSet, *oldSet.Spec.UpdateStrategy.RollingUpdate.Partition)
-	for i := tc.TiDBStsActualReplicas() - 1; i >= 0; i-- {
+	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
+	for _i := len(podOrdinals) - 1; _i >= 0; _i-- {
+		i := podOrdinals[_i]
 		podName := tidbPodName(tcName, i)
 		pod, err := tdu.podLister.Pods(ns).Get(podName)
 		if err != nil {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/proxiedpdclient"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/proxiedtidbclient"
+	utilstatefulset "github.com/pingcap/tidb-operator/tests/e2e/util/statefulset"
 	"github.com/pingcap/tidb-operator/tests/pkg/apimachinery"
 	"github.com/pingcap/tidb-operator/tests/pkg/blockwriter"
 	"github.com/pingcap/tidb-operator/tests/pkg/client"
@@ -1416,6 +1417,10 @@ func (oa *operatorActions) pdMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, err
 		return false, nil
 	}
 
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(oa.kubeCli, oa.asCli), pdSet) {
+		return false, nil
+	}
+
 	if tc.Status.PD.StatefulSet == nil {
 		glog.Infof("tidbcluster: %s/%s .status.PD.StatefulSet is nil", ns, tcName)
 		return false, nil
@@ -1489,6 +1494,10 @@ func (oa *operatorActions) tikvMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, e
 		return false, nil
 	}
 
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(oa.kubeCli, oa.asCli), tikvSet) {
+		return false, nil
+	}
+
 	if tc.Status.TiKV.StatefulSet == nil {
 		glog.Infof("tidbcluster: %s/%s .status.TiKV.StatefulSet is nil", ns, tcName)
 		return false, nil
@@ -1553,6 +1562,10 @@ func (oa *operatorActions) tidbMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, e
 	tidbSet, err := oa.tcStsGetter.StatefulSets(ns).Get(tidbSetName, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("failed to get statefulset: %s/%s, %v", ns, tidbSetName, err)
+		return false, nil
+	}
+
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(oa.kubeCli, oa.asCli), tidbSet) {
 		return false, nil
 	}
 

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -718,7 +718,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		framework.ExpectNoError(err, "Expected TiDB cluster scaled out and ready")
 
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = utilimage.TiDBV3Version
+			tc.Spec.Version = utilimage.TiDBV3UpgradeVersion
 			return nil
 		})
 		framework.ExpectNoError(err, "Expected TiDB cluster updated")
@@ -770,6 +770,50 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		value, existed = pv.Labels[label.ManagedByLabelKey]
 		framework.ExpectEqual(existed, true)
 		framework.ExpectEqual(value, label.TiDBOperator)
+	})
+
+	ginkgo.It("[Feature: AdvancedStatefulSet] Upgrading tidb cluster while pods are not consecutive", func() {
+		if !ocfg.Enabled(features.AdvancedStatefulSet) {
+			framework.Skipf("AdvancedStatefulSet feature of default operator is not enabled, skipping")
+		}
+		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV3Version)
+		tc.Spec.PD.Replicas = 3
+		tc.Spec.TiKV.Replicas = 4
+		tc.Spec.TiDB.Replicas = 3
+		err := genericCli.Create(context.TODO(), tc)
+		framework.ExpectNoError(err)
+		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Scaling in the cluster by deleting some pods not at the end")
+		tc, err = cli.PingcapV1alpha1().TidbClusters(ns).Get(tc.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+			if tc.Annotations == nil {
+				tc.Annotations = map[string]string{}
+			}
+			tc.Annotations[label.AnnPDDeleteSlots] = "[1]"
+			tc.Annotations[label.AnnTiKVDeleteSlots] = "[0]"
+			tc.Annotations[label.AnnTiDBDeleteSlots] = "[1]"
+			tc.Spec.PD.Replicas = 2
+			tc.Spec.TiKV.Replicas = 3
+			tc.Spec.TiDB.Replicas = 2
+			return nil
+		})
+		framework.ExpectNoError(err)
+		ginkgo.By("Checking for tidb cluster is ready")
+		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Upgrding the cluster")
+		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+			tc.Spec.Version = utilimage.TiDBV3UpgradeVersion
+			return nil
+		})
+		framework.ExpectNoError(err)
+		ginkgo.By("Checking for tidb cluster is ready")
+		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
+		framework.ExpectNoError(err)
 	})
 })
 

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -777,7 +777,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 			framework.Skipf("AdvancedStatefulSet feature of default operator is not enabled, skipping")
 		}
 		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV3Version)
-		tc.Spec.PD.Replicas = 3
+		tc.Spec.PD.Replicas = 5
 		tc.Spec.TiKV.Replicas = 4
 		tc.Spec.TiDB.Replicas = 3
 		err := genericCli.Create(context.TODO(), tc)
@@ -795,7 +795,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 			tc.Annotations[label.AnnPDDeleteSlots] = "[1]"
 			tc.Annotations[label.AnnTiKVDeleteSlots] = "[0]"
 			tc.Annotations[label.AnnTiDBDeleteSlots] = "[1]"
-			tc.Spec.PD.Replicas = 2
+			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 3
 			tc.Spec.TiDB.Replicas = 2
 			return nil

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	TiDBV3Version  = "v3.0.8"
-	TiDBTLSVersion = TiDBV3Version // must >= 3.0.5
-	TiDBV2Version  = "v2.1.19"
+	TiDBV3Version        = "v3.0.8"
+	TiDBV3UpgradeVersion = "v3.0.9"
+	TiDBTLSVersion       = TiDBV3Version // must >= 3.0.5
+	TiDBV2Version        = "v2.1.19"
 )
 
 func ListImages() []string {


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes #1590 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
