### PR TITLE
skip restarting docker if already configured

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -209,19 +209,29 @@ function e2e::__cluster_is_alive() {
     return $ret
 }
 
+function e2e::__configure_docker_mirror_for_dind() {
+    echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
+cat <<EOF > /etc/docker/daemon.json.tmp
+{
+    "registry-mirrors": ["$DOCKER_IO_MIRROR"]
+}
+EOF
+    if diff /etc/docker/daemon.json.tmp /etc/docker/daemon.json 1>/dev/null 2>&1; then
+        echo "info: already configured"
+        rm /etc/docker/daemon.json.tmp
+    else
+        mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+        e2e::__restart_docker
+    fi
+}
+
 function e2e::up() {
     if [ -n "$SKIP_UP" ]; then
         echo "info: skip starting a new cluster"
         return
     fi
     if [ -n "$DOCKER_IO_MIRROR" -a -n "${DOCKER_IN_DOCKER_ENABLED:-}" ]; then
-        echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
-cat <<EOF > /etc/docker/daemon.json
-{
-    "registry-mirrors": ["$DOCKER_IO_MIRROR"]
-}
-EOF
-        e2e::__restart_docker
+        e2e::__configure_docker_mirror_for_dind
     fi
     if e2e::cluster_exists $CLUSTER; then
         if [ -n "$REUSE_CLUSTER" ]; then


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

using with `REUSE_CLUSTER=y`, we don't want to restart docker every time.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```