### PR TITLE
CI: Running on TiDB Operator Nodes.

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -74,15 +74,9 @@ spec:
   tolerations:
   - effect: NoSchedule
     key: tidb-operator
+    operator: Exists
   affinity:
-    # worker nodes only
-    #nodeAffinity:
-    #  requiredDuringSchedulingIgnoredDuringExecution:
-    #    nodeSelectorTerms:
-    #    - matchExpressions:
-    #      - key: node-role.kubernetes.io/master
-    #        operator: DoesNotExist
-    # running on tidb-operator nodes only
+    # running on nodes for tidb-operator only
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -173,6 +173,8 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 			container("golang") {
 				def WORKSPACE = pwd()
 				dir("${PROJECT_DIR}") {
+					deleteDir()
+
 					stage('Checkout') {
 						checkout changelog: false,
 						poll: false,

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -71,14 +71,26 @@ spec:
     emptyDir: {}
   - name: docker-graph
     emptyDir: {}
+  tolerations:
+  - effect: NoSchedule
+    key: tidb-operator
   affinity:
     # worker nodes only
+    #nodeAffinity:
+    #  requiredDuringSchedulingIgnoredDuringExecution:
+    #    nodeSelectorTerms:
+    #    - matchExpressions:
+    #      - key: node-role.kubernetes.io/master
+    #        operator: DoesNotExist
+    # running on tidb-operator nodes only
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: node-role.kubernetes.io/master
-            operator: DoesNotExist
+          - key: ci.pingcap.com
+            operator: In
+            values:
+            - tidb-operator
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100

--- a/hack/check-terraform.sh
+++ b/hack/check-terraform.sh
@@ -22,7 +22,7 @@ source $ROOT/hack/lib.sh
 
 hack::ensure_terraform
 
-terraform_modules=$(find ${ROOT}/deploy -not -path '*/\.*' -type f -name variables.tf | xargs -I{} -n1 dirname {})
+terraform_modules=$(find ${ROOT}/deploy -mindepth 1 -maxdepth 1 -type d -a -not -name 'modules')
 
 for module in $terraform_modules; do
     echo "Checking module ${module}"

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -671,6 +671,10 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		f := func(name, namespace string, uid types.UID) (bool, error) {
 			pod, err := c.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 			if err != nil {
+				if errors.IsNotFound(err) {
+					// ignore not found error (pod is deleted and recreated again in restarting)
+					return false, nil
+				}
 				return false, err
 			}
 			if _, existed := pod.Annotations[label.AnnPodDeferDeleting]; existed {


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

On these nodes, we configured 'cgroup.memory=nokmem' to avoid issues in
CentOS 7.6.

https://github.com/pingcap/tidb-operator/issues/1603#issuecomment-583263692

it also fixes https://github.com/pingcap/tidb-operator/issues/1539

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
