### PR TITLE
ignore not found error to fix "TiDBCluster Restarter" e2e test

### DIFF
--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -671,6 +671,10 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		f := func(name, namespace string, uid types.UID) (bool, error) {
 			pod, err := c.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 			if err != nil {
+				if errors.IsNotFound(err) {
+					// ignore not found error (pod is deleted and recreated again in restarting)
+					return false, nil
+				}
 				return false, err
 			}
 			if _, existed := pod.Annotations[label.AnnPodDeferDeleting]; existed {


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes https://github.com/pingcap/tidb-operator/issues/1539

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
