### PR TITLE
WIP: More matrix jobs

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -242,6 +242,12 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		builds["E2E v1.12.10 AdvancedStatefulSet"] = {
 			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_advanced_statefulset ./hack/e2e.sh -- --preload-images --ginkgo.skip='\\[Serial\\]' --operator-features AdvancedStatefulSet=true", artifacts)
 		}
+		builds["E2E v1.12.10 Webhook"] = {
+			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_webhook ./hack/e2e.sh -- --preload-images --ginkgo.skip='\\[Serial\\]' --operator-webhook=true", artifacts)
+		}
+		builds["E2E v1.12.10 AdvancedStatefulSet Webhook"] = {
+			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.12.10 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.12.10_advanced_statefulset_webhook ./hack/e2e.sh -- --preload-images --ginkgo.skip='\\[Serial\\]' --operator-features AdvancedStatefulSet=true --operator-webhook=true", artifacts)
+		}
 		builds["E2E v1.17.0"] = {
 			build("${MIRRORS} IMAGE_TAG=${GITHASH} SKIP_BUILD=y GINKGO_NODES=8 KUBE_VERSION=v1.17.0 REPORT_DIR=\$(pwd)/artifacts REPORT_PREFIX=v1.17.0_ ./hack/e2e.sh -- -preload-images --ginkgo.skip='\\[Serial\\]'", artifacts)
 		}

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -410,7 +410,6 @@ func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {
 	set := map[string]string{
 		"operatorImage":                              oi.Image,
 		"controllerManager.autoFailover":             "true",
-		"scheduler.kubeSchedulerImageName":           oi.SchedulerImage,
 		"controllerManager.logLevel":                 oi.LogLevel,
 		"scheduler.logLevel":                         "4",
 		"imagePullPolicy":                            string(oi.ImagePullPolicy),
@@ -421,6 +420,9 @@ func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {
 		"admissionWebhook.hooksEnabled.statefulSets": strconv.FormatBool(oi.StsWebhookEnabled),
 		"admissionWebhook.hooksEnabled.defaulting":   strconv.FormatBool(oi.DefaultingEnabled),
 		"admissionWebhook.hooksEnabled.validating":   strconv.FormatBool(oi.ValidatingEnabled),
+	}
+	if oi.SchedulerImage != "" {
+		set["scheduler.kubeSchedulerImageName"] = oi.SchedulerImage
 	}
 	if oi.ControllerManagerReplicas != nil {
 		set["controllerManager.replicas"] = strconv.Itoa(*oi.ControllerManagerReplicas)

--- a/tests/config.go
+++ b/tests/config.go
@@ -40,18 +40,20 @@ const (
 type Config struct {
 	configFile string
 
-	TidbVersions         string          `yaml:"tidb_versions" json:"tidb_versions"`
-	InstallOperator      bool            `yaml:"install_opeartor" json:"install_opeartor"`
-	OperatorTag          string          `yaml:"operator_tag" json:"operator_tag"`
-	OperatorImage        string          `yaml:"operator_image" json:"operator_image"`
-	OperatorFeatures     map[string]bool `yaml:"operator_features" json:"operator_features"`
-	UpgradeOperatorTag   string          `yaml:"upgrade_operator_tag" json:"upgrade_operator_tag"`
-	UpgradeOperatorImage string          `yaml:"upgrade_operator_image" json:"upgrade_operator_image"`
-	LogDir               string          `yaml:"log_dir" json:"log_dir"`
-	FaultTriggerPort     int             `yaml:"fault_trigger_port" json:"fault_trigger_port"`
-	Nodes                []Nodes         `yaml:"nodes" json:"nodes"`
-	ETCDs                []Nodes         `yaml:"etcds" json:"etcds"`
-	APIServers           []Nodes         `yaml:"apiservers" json:"apiservers"`
+	TidbVersions     string          `yaml:"tidb_versions" json:"tidb_versions"`
+	InstallOperator  bool            `yaml:"install_opeartor" json:"install_opeartor"`
+	OperatorTag      string          `yaml:"operator_tag" json:"operator_tag"`
+	OperatorImage    string          `yaml:"operator_image" json:"operator_image"`
+	OperatorFeatures map[string]bool `yaml:"operator_features" json:"operator_features"`
+	// If true, operator admssion webhook is deployed and enabled.
+	OperatorWebhook      bool    `yaml:"operator_webhook" json:"operator_webhook"`
+	UpgradeOperatorTag   string  `yaml:"upgrade_operator_tag" json:"upgrade_operator_tag"`
+	UpgradeOperatorImage string  `yaml:"upgrade_operator_image" json:"upgrade_operator_image"`
+	LogDir               string  `yaml:"log_dir" json:"log_dir"`
+	FaultTriggerPort     int     `yaml:"fault_trigger_port" json:"fault_trigger_port"`
+	Nodes                []Nodes `yaml:"nodes" json:"nodes"`
+	ETCDs                []Nodes `yaml:"etcds" json:"etcds"`
+	APIServers           []Nodes `yaml:"apiservers" json:"apiservers"`
 	CertFile             string
 	KeyFile              string
 

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -228,7 +228,10 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		oa.CheckTidbClusterStatusOrDie(&cluster)
 	})
 
-	ginkgo.It("Upgrading TiDB Cluster", func() {
+	ginkgo.It("Upgrading TiDB Cluster with partition", func() {
+		if !ocfg.StsWebhookEnabled {
+			framework.Skipf("Partition upgrading requires StatefulSet webhook, skipped")
+		}
 		cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", "")
 		cluster.Resources["pd.replicas"] = "3"
 
@@ -237,7 +240,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		certCtx, err := apimachinery.SetupServerCert(ns, svcName)
 		framework.ExpectNoError(err, fmt.Sprintf("unable to setup certs for webservice %s", tests.WebhookServiceName))
 
-		ginkgo.By("Starting webhook pod")
+		ginkgo.By("Starting webhook pod to validate pod states")
 		webhookPod, svc := startWebhook(f, cfg.E2EImage, ns, svcName, certCtx.Cert, certCtx.Key)
 
 		ginkgo.By("Register webhook")


### PR DESCRIPTION
Signed-off-by: Yecheng Fu <fuyecheng@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

- we should have a job to test default values of tidb-operator chart
- add two more jobs
  - Webhook (true)  x AdvancedStatefulSet (true)
  - Webhook (true) x AdvancedStatefulSet (false)

### What is changed and how does it work?

- Webhook (false) x AdvancedStatefulSet (false) (tidb-operator default
  values)
- Webhook (false) x AdvancedStatefulSet (true)
- Webhook (true)  x AdvancedStatefulSet (true)
- Webhook (true) x AdvancedStatefulSet (false)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
