### PR TITLE
Add authorization configuration for lighting

### DIFF
--- a/charts/tidb-lightning/templates/job.yaml
+++ b/charts/tidb-lightning/templates/job.yaml
@@ -1,7 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.jobName }}
+  name: {{ .Values.jobName }}
+  {{- else}}
   name: {{ include "tidb-lightning.name" . }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "tidb-lightning.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -69,6 +73,22 @@ spec:
         - name: FAIL_FAST
           value: "true"
         {{- end }}
+        {{- if .Values.targetTidbCluster.secretName }}
+        {{- if .Values.targetTidbCluster.secretUserKey }}
+        - name: TIDB_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.targetTidbCluster.secretName }}
+              key: {{ .Values.targetTidbCluster.secretUserKey }}
+        {{- end }}
+        {{- if .Values.targetTidbCluster.secretPwdKey }}
+        - name: TIDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.targetTidbCluster.secretName }}
+              key: {{ .Values.targetTidbCluster.secretPwdKey }}
+        {{- end }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/tidb-lightning
@@ -95,9 +115,18 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.dataSource.adhoc.pvcName }}
       {{ else }}
+      {{- if .Values.dataSource.remote.rcloneConfig }}
+      - name: credentials
+        configMap:
+          name: rclone-{{ include "tidb-lightning.name" . }}
+          items:
+          - key: config-file
+            path: rclone.conf
+      {{ else }}
       - name: credentials
         secret:
           secretName: {{ .Values.dataSource.remote.secretName }}
+      {{ end -}}
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "tidb-lightning.name" . }}

--- a/charts/tidb-lightning/templates/rclone-conf.yaml
+++ b/charts/tidb-lightning/templates/rclone-conf.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rclone-{{ include "tidb-lightning.name" . }}
+type: Opaque
+data:
+  config-file: |-
+    {{- if .Values.dataSource.remote.rcloneConfig }}
+{{ .Values.dataSource.remote.rcloneConfig | indent 4 }}
+    {{- end -}}

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -22,7 +22,14 @@ fi
     --backend tidb \
 {{- end }}
     --server-mode=false \
+{{- if and .Values.targetTidbCluster.secretName .Values.targetTidbCluster.secretUserKey -}}
+    --tidb-user=${TIDB_USER} \
+{{- else }}
     --tidb-user={{ .Values.targetTidbCluster.user | default "root" }} \
+{{- end }}
+{{- if and .Values.targetTidbCluster.secretName .Values.targetTidbCluster.secretPwdKey -}}
+    --tidb-password=${TIDB_PASSWORD} \
+{{- end }}
     --tidb-host={{ .Values.targetTidbCluster.name }}-tidb.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }} \
     --d=${data_dir} \
     --config=/etc/tidb-lightning/tidb-lightning.toml

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -5,7 +5,7 @@
 # timezone is the default system timzone
 timezone: UTC
 
-image: pingcap/tidb-lightning:v3.0.8
+image: pingcap/tidb-lightning:v3.0.9
 imagePullPolicy: IfNotPresent
 service:
   type: NodePort
@@ -30,12 +30,30 @@ dataSource:
     storage: 100Gi
     secretName: cloud-storage-secret
     path: s3:bench-data-us/sysbench/sbtest_16_1e7.tar.gz
+    # If rcloneConfig is configured, then `secretName` will be ignored,
+    # `rcloneConfig` should only be used for the cases where no sensitive
+    # information need to be configured, e.g. the configuration as below,
+    # the Pod will get the credentials from the infrastructure.
+    #rcloneConfig: |
+    #  [s3]
+    #  type = s3
+    #  provider = AWS
+    #  env_auth = true
+    #  region = us-west-2
 
 targetTidbCluster:
   name: tidb-cluster
   # namespace is the target tidb cluster namespace, can be omitted if the lightning is deployed in the same namespace of the target tidb cluster
   namespace: ""
   user: root
+  # If the `secretName` and `secretUserKey` are set,
+  # the `user` will be ignored and the user in the
+  # `secretName` will be used by lightning.
+  # If the `secretName` and `secretPwdKey` are set, the
+  # password in the `secretName` will be used by lightning.
+  #secretName: ""
+  #secretUserKey: user
+  #secretPwdKey: password
 
 resources: {}
   # limits:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix https://github.com/pingcap/tidb-operator/issues/1566
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test (add detailed scripts or steps below)
Test restore with lightning with below config in values.yaml:
- Set jobName
- Set targetTidbCluster.secretName
   - Set targetTidbCluster.secretUserKey
      -  Set targetTidbCluster.secretPwdKey
      -  Do not set targetTidbCluster.secretPwdKey
   - Do not set targetTidbCluster.secretUserKey
      - Set targetTidbCluster.secretPwdKey
      - Do not set targetTidbCluster.secretPwdKey
- Do not set targetTidbCluster.secretName
- Set dataSource.remote.rcloneConfig
- Do not set dataSource.remote.rcloneConfig
- local

Code changes

 - Has Helm scripts change

Related changes

 - Need to cherry-pick to the release-1.1

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
- Support customizing job name in tidb-lightning chart.
- Support setting rclone configs in tidb-lightning chart.
- Support setting password by secret in tidb-lightning chart.
```
