### PR TITLE
cherry-pick PR 1430

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -79,7 +79,7 @@ pd:
     clusterIP: "None"
 
   replicas: 3
-  image: pingcap/pd:v3.0.5
+  image: pingcap/pd:v3.0.8
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -226,7 +226,7 @@ tikv:
   # we can only set capacity in tikv.resources.limits.storage.
 
   replicas: 3
-  image: pingcap/tikv:v3.0.5
+  image: pingcap/tikv:v3.0.8
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -316,7 +316,7 @@ tidb:
   # initSqlConfigMapName: tidb-initsql
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v3.0.5
+  image: pingcap/tidb:v3.0.8
   # Image pull policy.
   imagePullPolicy: IfNotPresent
 
@@ -456,7 +456,7 @@ monitor:
   storageClassName: local-storage
   storage: 10Gi
   initializer:
-    image: pingcap/tidb-monitor-initializer:v3.0.5
+    image: pingcap/tidb-monitor-initializer:v3.0.8
     imagePullPolicy: IfNotPresent
     config:
       K8S_PROMETHEUS_URL: http://prometheus-k8s.monitoring.svc:9090
@@ -537,7 +537,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v3.0.5
+    image: pingcap/tidb-binlog:v3.0.8
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -605,7 +605,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v3.0.5
+    image: pingcap/tidb-binlog:v3.0.8
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -759,7 +759,7 @@ scheduledBackup:
 
 importer:
   create: false
-  image: pingcap/tidb-lightning:v3.0.5
+  image: pingcap/tidb-lightning:v3.0.8
   imagePullPolicy: IfNotPresent
   storageClassName: local-storage
   storage: 200Gi

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -7,7 +7,7 @@ timezone: UTC
 
 # clusterName is the TiDB cluster name that should backup from or restore to.
 clusterName: demo
-clusterVersion: v3.0.5
+clusterVersion: v3.0.8
 
 baseImage: pingcap/tidb-binlog
 imagePullPolicy: IfNotPresent

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -5,7 +5,7 @@
 # timezone is the default system timzone
 timezone: UTC
 
-image: pingcap/tidb-lightning:v3.0.5
+image: pingcap/tidb-lightning:v3.0.8
 imagePullPolicy: IfNotPresent
 service:
   type: NodePort

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -36,7 +36,7 @@ variable "cluster_name" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v3.0.5"
+  default     = "v3.0.8"
 }
 variable "tidb_cluster_chart_version" {
   description = "tidb-cluster chart version"

--- a/deploy/aws/clusters.tf
+++ b/deploy/aws/clusters.tf
@@ -24,7 +24,7 @@ provider "helm" {
 #
 #  # NOTE: cluster_name cannot be changed after creation
 #  cluster_name                  = "demo-cluster"
-#  cluster_version               = "v3.0.5"
+#  cluster_version               = "v3.0.8"
 #  ssh_key_name                  = module.key-pair.key_name
 #  pd_count                      = 1
 #  pd_instance_type              = "t2.xlarge"

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -80,7 +80,7 @@ variable "bastion_instance_type" {
 
 # For aws tutorials compatiablity
 variable "default_cluster_version" {
-  default = "v3.0.5"
+  default = "v3.0.8"
 }
 
 variable "default_cluster_pd_count" {

--- a/deploy/gcp/examples/tidb-customized.tfvars
+++ b/deploy/gcp/examples/tidb-customized.tfvars
@@ -3,7 +3,7 @@ tikv_instance_type = "n1-highmem-4"
 tidb_instance_type = "n1-standard-8"
 
 # specify tidb version
-tidb_version = "3.0.5"
+tidb_version = "3.0.8"
 
 # override tidb cluster values
 override_values = <<EOF

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -24,7 +24,7 @@ variable "node_locations" {
 
 variable "tidb_version" {
   description = "TiDB version"
-  default     = "v3.0.5"
+  default     = "v3.0.8"
 }
 
 variable "tidb_operator_version" {

--- a/deploy/modules/aliyun/tidb-cluster/variables.tf
+++ b/deploy/modules/aliyun/tidb-cluster/variables.tf
@@ -12,7 +12,7 @@ variable "image_id" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v3.0.0"
+  default     = "v3.0.8"
 }
 
 variable "tidb_cluster_chart_version" {

--- a/deploy/modules/aws/tidb-cluster/variables.tf
+++ b/deploy/modules/aws/tidb-cluster/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v3.0.5"
+  default = "v3.0.8"
 }
 
 variable "ssh_key_name" {

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -9,7 +9,7 @@ variable "tidb_operator_id" {
 variable "cluster_name" {}
 variable "cluster_version" {
   description = "The TiDB cluster version"
-  default     = "v3.0.5"
+  default     = "v3.0.8"
 }
 variable "tidb_cluster_chart_version" {
   description = "The TiDB cluster chart version"

--- a/deploy/modules/share/tidb-cluster-release/variables.tf
+++ b/deploy/modules/share/tidb-cluster-release/variables.tf
@@ -20,7 +20,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v3.0.5"
+  default = "v3.0.8"
 }
 
 variable "pd_count" {

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -81,7 +81,7 @@ e2e_args=(
     --operator-image=${TIDB_OPERATOR_IMAGE}
     --e2e-image=${E2E_IMAGE}
     # two tidb versions can be configuraed: <defaultVersion>,<upgradeToVersion>
-    --tidb-versions=v3.0.6,v3.0.7
+    --tidb-versions=v3.0.7,v3.0.8
     --chart-dir=/charts
     -v=4
 )

--- a/images/tidb-operator-e2e/tidb-cluster-values.yaml
+++ b/images/tidb-operator-e2e/tidb-cluster-values.yaml
@@ -36,7 +36,7 @@ discovery:
 
 pd:
   replicas: 3
-  image: pingcap/pd:v3.0.5
+  image: pingcap/pd:v3.0.8
   imagePullPolicy: IfNotPresent
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -81,7 +81,7 @@ pd:
 
 tikv:
   replicas: 3
-  image: pingcap/tikv:v3.0.5
+  image: pingcap/tikv:v3.0.8
   imagePullPolicy: IfNotPresent
   logLevel: info
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -134,7 +134,7 @@ tidb:
   # initSql is the SQL statements executed after the TiDB cluster is bootstrapped.
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v3.0.5
+  image: pingcap/tidb:v3.0.8
   imagePullPolicy: IfNotPresent
   logLevel: info
   resources:
@@ -222,7 +222,7 @@ monitor:
 
 fullbackup:
   create: false
-  binlogImage: pingcap/tidb-binlog:v3.0.5
+  binlogImage: pingcap/tidb-binlog:v3.0.8
   binlogImagePullPolicy: IfNotPresent
   # https://github.com/tennix/tidb-cloud-backup
   mydumperImage: pingcap/tidb-cloud-backup:20190610
@@ -263,7 +263,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v3.0.5
+    image: pingcap/tidb-binlog:v3.0.8
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -280,7 +280,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v3.0.5
+    image: pingcap/tidb-binlog:v3.0.8
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.

--- a/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
@@ -39,7 +39,7 @@ func TestValidateDeletedSlots(t *testing.T) {
 					},
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: "v3.0.7",
+					Version: "v3.0.8",
 					PD: v1alpha1.PDSpec{
 						BaseImage: "pingcap/pd",
 						Config:    &v1alpha1.PDConfig{},
@@ -63,7 +63,7 @@ func TestValidateDeletedSlots(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: "v3.0.7",
+					Version: "v3.0.8",
 					PD: v1alpha1.PDSpec{
 						BaseImage: "pingcap/pd",
 						Config:    &v1alpha1.PDConfig{},
@@ -103,7 +103,7 @@ func TestValidateDeletedSlots(t *testing.T) {
 					},
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: "v3.0.7",
+					Version: "v3.0.8",
 					PD: v1alpha1.PDSpec{
 						BaseImage: "pingcap/pd",
 						Config:    &v1alpha1.PDConfig{},
@@ -135,7 +135,7 @@ func TestValidateDeletedSlots(t *testing.T) {
 					},
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: "v3.0.7",
+					Version: "v3.0.8",
 					PD: v1alpha1.PDSpec{
 						BaseImage: "pingcap/pd",
 						Config:    &v1alpha1.PDConfig{},

--- a/pkg/controller/tidbcluster/tidb_cluster_control_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control_test.go
@@ -348,7 +348,7 @@ func newTidbClusterForTidbClusterControl() *v1alpha1.TidbCluster {
 			UID:       types.UID("test"),
 		},
 		Spec: v1alpha1.TidbClusterSpec{
-			Version: "v3.0.7",
+			Version: "v3.0.8",
 			PD: v1alpha1.PDSpec{
 				Replicas:  3,
 				BaseImage: "pingcap/pd",

--- a/tests/config.go
+++ b/tests/config.go
@@ -92,7 +92,7 @@ type Node struct {
 // NewDefaultConfig creates a default configuration.
 func NewDefaultConfig() *Config {
 	return &Config{
-		AdditionalDrainerVersion: "v3.0.2",
+		AdditionalDrainerVersion: "v3.0.8",
 
 		PDMaxReplicas:       5,
 		TiDBTokenLimit:      1024,
@@ -113,7 +113,7 @@ func NewConfig() (*Config, error) {
 	flag.StringVar(&cfg.configFile, "config", "", "Config file")
 	flag.StringVar(&cfg.LogDir, "log-dir", "/logDir", "log directory")
 	flag.IntVar(&cfg.FaultTriggerPort, "fault-trigger-port", 23332, "the http port of fault trigger service")
-	flag.StringVar(&cfg.TidbVersions, "tidb-versions", "v3.0.2,v3.0.3,v3.0.4,v3.0.5", "tidb versions")
+	flag.StringVar(&cfg.TidbVersions, "tidb-versions", "v3.0.6,v3.0.7,v3.0.8", "tidb versions")
 	flag.StringVar(&cfg.OperatorTag, "operator-tag", "master", "operator tag used to choose charts")
 	flag.StringVar(&cfg.OperatorImage, "operator-image", "pingcap/tidb-operator:latest", "operator image")
 	flag.StringVar(&cfg.E2EImage, "e2e-image", "pingcap/tidb-operator-e2e:latest", "operator-e2e image")

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -33,7 +33,7 @@ var TestConfig *tests.Config = tests.NewDefaultConfig()
 func RegisterTiDBOperatorFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestConfig.LogDir, "log-dir", "/logDir", "log directory")
 	flags.IntVar(&TestConfig.FaultTriggerPort, "fault-trigger-port", 23332, "the http port of fault trigger service")
-	flags.StringVar(&TestConfig.TidbVersions, "tidb-versions", "v3.0.2,v3.0.3,v3.0.4", "tidb versions")
+	flags.StringVar(&TestConfig.TidbVersions, "tidb-versions", "v3.0.6,v3.0.7,v3.0.8", "tidb versions")
 	flags.StringVar(&TestConfig.E2EImage, "e2e-image", "", "e2e image")
 	flags.BoolVar(&TestConfig.InstallOperator, "install-operator", true, "install a default operator")
 	flags.StringVar(&TestConfig.OperatorTag, "operator-tag", "master", "operator tag used to choose charts")


### PR DESCRIPTION
* update tidb default version to v3.0.7

* update tidbcluster.go

* run hack/codegen.sh

* update tidb default version to v3.0.7

* update tidbcluster.go

* run hack/codegen.sh

* run hack/codegen.sh

* update tidb default version to v3.0.7

* update tidbcluster.go

* update to 3.0.7

* update to v3.0.8

* Update image.go

Co-authored-by: Song Gao <disxiaofei@163.com>
Co-authored-by: pingcap-github-bot <sre-bot@pingcap.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

cherry-pick #1430 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
