### PR TITLE
Move some checks from Jenkins job to Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+    - master
+    - release-*
+
+jobs:
+
+  pull:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - "check-setup check"
+        - "docker e2e-docker cli"
+        - "test GOFLAGS=-race"
+    steps:
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+        path: go/src/github.com/pingcap/tidb-operator
+
+    - name: make ${{ matrix.target }}
+      run: |
+        # workaround for https://github.com/actions/setup-go/issues/14
+        export GOPATH=/home/runner/work/tidb-operator/go
+        export PATH=$PATH:$GOPATH/bin
+        make $target
+      env:
+        target: ${{ matrix.target }}

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -191,16 +191,17 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 						}
 					}
 
-					stage("Check") {
-						ansiColor('xterm') {
-							sh """
-							export GOPATH=${WORKSPACE}/go
-							export PATH=${WORKSPACE}/go/bin:\$PATH
-							make check-setup
-							make check
-							"""
-						}
-					}
+					// moved to Github Actions
+					// stage("Check") {
+						// ansiColor('xterm') {
+							// sh """
+							// export GOPATH=${WORKSPACE}/go
+							// export PATH=${WORKSPACE}/go/bin:\$PATH
+							// make check-setup
+							// make check
+							// """
+						// }
+					// }
 
 					stage("Build and Test") {
 						ansiColor('xterm') {
@@ -209,10 +210,10 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 							make e2e-build
 							if [ ${BUILD_BRANCH} == "master" ]
 							then
-								make test GO_COVER=y
+								make test GOFLAGS='-race' GO_COVER=y
 								curl -s https://codecov.io/bash | bash -s - -t ${CODECOV_TOKEN} || echo 'Codecov did not collect coverage reports'
 							else
-								make test
+								make test GOFLAGS='-race'
 							fi
 							"""
 						}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

- run checks via Github Actions
- don't run checks in Jenkins job (this speeds up the job)

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
