### PR TITLE
add more SANs to tidb server certificate

### DIFF
--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -99,9 +99,9 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end }}
-  {{- if .Values.tidb.extraSANDomain }}
-    extraSANDomain:
-    {{- range .Values.tidb.extraSANDomain }}
+  {{- if .Values.tidb.extraSANDomainList }}
+    extraSANDomainList:
+    {{- range .Values.tidb.extraSANDomainList }}
     - {{ . }}
     {{- end }}
   {{- end }}

--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -93,6 +93,18 @@ spec:
     maxFailoverCount: {{ .Values.tikv.maxFailoverCount | default 3 }}
   tidb:
     enableTLSClient: {{ .Values.tidb.enableTLSClient | default false }}
+  {{- if .Values.tidb.extraSANIPList }}
+    extraSANIPList:
+    {{- range .Values.tidb.extraSANIPList }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.tidb.extraSANDomain }}
+    extraSANDomain:
+    {{- range .Values.tidb.extraSANDomain }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
     replicas: {{ .Values.tidb.replicas }}
     image: {{ .Values.tidb.image }}
     imagePullPolicy: {{ .Values.tidb.imagePullPolicy | default "IfNotPresent" }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -436,8 +436,8 @@ tidb:
   # extraSANIPList:
   #   - 1.1.1.1
   #   - 2.2.2.2
-  # # extra SAN Domain when you set tidb.enableTLSClient to true
-  # extraSANDomain:
+  # # extra SAN Domain List when you set tidb.enableTLSClient to true
+  # extraSANDomainList:
   #   - example1.com
   #   - example2.com
 

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -432,6 +432,14 @@ tidb:
   # automatically.
   # Note: TLS connection is not forced on the server side, plain connections are also accepted after enableing.
   enableTLSClient: false
+  # # extra SAN IP list when you set tidb.enableTLSClient to true
+  # extraSANIPList:
+  #   - 1.1.1.1
+  #   - 2.2.2.2
+  # # extra SAN Domain when you set tidb.enableTLSClient to true
+  # extraSANDomain:
+  #   - example1.com
+  #   - example2.com
 
 # mysqlClient is used to set password for TiDB
 # it must has Python MySQL client installed

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -3783,6 +3783,17 @@ spec:
                   description: 'Whether enable the TLS connection between the SQL
                     client and TiDB server Optional: Defaults to false'
                   type: boolean
+                extraSANDomainList:
+                  description: extra SAN Domain list when setting EnableTLSClient
+                    to true
+                  items:
+                    type: string
+                  type: array
+                extraSANIPList:
+                  description: extra SAN IP list when setting EnableTLSClient to true
+                  items:
+                    type: string
+                  type: array
                 hostNetwork:
                   description: 'Whether Hostnetwork of the component is enabled. Override
                     the cluster-level setting if present Optional: Defaults to cluster-level

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -3534,6 +3534,34 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"extraSANIPList": {
+						SchemaProps: spec.SchemaProps{
+							Description: "extra SAN IP list when setting EnableTLSClient to true",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"extraSANDomainList": {
+						SchemaProps: spec.SchemaProps{
+							Description: "extra SAN Domain list when setting EnableTLSClient to true",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 					"slowLogTailer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The spec of the slow log tailer sidecar",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -315,8 +315,8 @@ type TiDBSpec struct {
 	// extra SAN IP list when setting EnableTLSClient to true
 	ExtraSANIPList []string `json:"extraSANIPList,omitempty"`
 
-	// extra SAN Domain when setting EnableTLSClient to true
-	ExtraSANDomain []string `json:"extraSANDomain,omitempty"`
+	// extra SAN Domain list when setting EnableTLSClient to true
+	ExtraSANDomainList []string `json:"extraSANDomainList,omitempty"`
 
 	// The spec of the slow log tailer sidecar
 	// +optional

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -312,6 +312,12 @@ type TiDBSpec struct {
 	// +optional
 	EnableTLSClient *bool `json:"enableTLSClient,omitempty"`
 
+	// extra SAN IP list when setting EnableTLSClient to true
+	ExtraSANIPList []string `json:"extraSANIPList,omitempty"`
+
+	// extra SAN Domain when setting EnableTLSClient to true
+	ExtraSANDomain []string `json:"extraSANDomain,omitempty"`
+
 	// The spec of the slow log tailer sidecar
 	// +optional
 	SlowLogTailer *TiDBSlowLogTailerSpec `json:"slowLogTailer,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -2454,6 +2454,16 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExtraSANIPList != nil {
+		in, out := &in.ExtraSANIPList, &out.ExtraSANIPList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ExtraSANDomainList != nil {
+		in, out := &in.ExtraSANDomainList, &out.ExtraSANDomainList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SlowLogTailer != nil {
 		in, out := &in.SlowLogTailer, &out.SlowLogTailer
 		*out = new(TiDBSlowLogTailerSpec)

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -288,8 +288,8 @@ func (tmm *tidbMemberManager) syncTiDBServerCerts(tc *v1alpha1.TidbCluster) erro
 		fmt.Sprintf("%s.%s.svc", svcName, ns),
 		"localhost",
 	}
-	if len(tc.Spec.TiDB.ExtraSANDomain) != 0 {
-		hostList = append(hostList, tc.Spec.TiDB.ExtraSANDomain...)
+	if len(tc.Spec.TiDB.ExtraSANDomainList) != 0 {
+		hostList = append(hostList, tc.Spec.TiDB.ExtraSANDomainList...)
 	}
 
 	ipList := []string{

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -288,17 +288,13 @@ func (tmm *tidbMemberManager) syncTiDBServerCerts(tc *v1alpha1.TidbCluster) erro
 		fmt.Sprintf("%s.%s.svc", svcName, ns),
 		"localhost",
 	}
-	if len(tc.Spec.TiDB.ExtraSANDomainList) != 0 {
-		hostList = append(hostList, tc.Spec.TiDB.ExtraSANDomainList...)
-	}
+	hostList = append(hostList, tc.Spec.TiDB.ExtraSANDomainList...)
 
 	ipList := []string{
 		"127.0.0.1", "::1",
 		svc.Spec.ClusterIP,
 	}
-	if len(tc.Spec.TiDB.ExtraSANIPList) != 0 {
-		ipList = append(ipList, tc.Spec.TiDB.ExtraSANIPList...)
-	}
+	ipList = append(ipList, tc.Spec.TiDB.ExtraSANIPList...)
 
 	certOpts := &controller.TiDBClusterCertOptions{
 		Namespace:  ns,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
This PR fixes: #1699 , add more SANs to tidb server certificate.
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has Terraform scripts change

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
add more SANs to tidb server certificate
```
