### PR TITLE
tidb-backup: restore respects resources, imagePullPolicy, nodeSelector

### DIFF
--- a/charts/tidb-backup/templates/backup-job.yaml
+++ b/charts/tidb-backup/templates/backup-job.yaml
@@ -33,6 +33,8 @@ spec:
       {{- if .Values.serviceAccount }}
       serviceAccount: {{ .Values.serviceAccount }}
       {{- end }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
       containers:
       - name: backup
         image: {{ .Values.image.backup }}

--- a/charts/tidb-backup/templates/restore-job.yaml
+++ b/charts/tidb-backup/templates/restore-job.yaml
@@ -25,6 +25,8 @@ spec:
     {{- end }}
     spec:
       restartPolicy: OnFailure
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
       containers:
       - name: tidb-restore-job
         image: {{ .Values.image.backup }}

--- a/charts/tidb-backup/templates/restore-job.yaml
+++ b/charts/tidb-backup/templates/restore-job.yaml
@@ -28,6 +28,11 @@ spec:
       containers:
       - name: tidb-restore-job
         image: {{ .Values.image.backup }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+    {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- end }}
         command:
         - /bin/sh
         - -c

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -29,6 +29,10 @@ image:
   # https://github.com/pingcap/tidb-cloud-backup
   backup: pingcap/tidb-cloud-backup:20191217
 
+## nodeSelector ensure pods only assigning to nodes which have each of the indicated key-value pairs as labels
+## ref:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
 # Add additional labels for backup/restore job's pod
 # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 extraLabels: {}


### PR DESCRIPTION
# What problem does this PR solve? <!--add and issue link with summary if exists-->

* Makes the templates for the restore job respect `resources` and `imagePullPolicy` from the `values.yaml`, making it mirror the backup job better.
* Add `nodeSelector` to both backup and restore.
* ~Fixes: the restore job expects a PVC, but doesn't attempt to create the PVC in
restore mode.~ Removed from PR