### PR TITLE
tidb-backup: add restoreUsingExistingVolume option

### DIFF
--- a/charts/tidb-backup/templates/backup-pvc.yaml
+++ b/charts/tidb-backup/templates/backup-pvc.yaml
@@ -1,8 +1,12 @@
-{{- if (or (eq .Values.mode "backup") (eq .Values.mode "scheduled-restore")) }}
+{{- if (or (eq .Values.mode "backup") (eq .Values.mode "scheduled-restore") (and (eq .Values.mode "restore") (not .Values.restoreUsingExistingVolume))) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
+  {{- if eq .Values.mode "restore" }}
+  name: restore-{{ tpl .Values.name . }}
+  {{- else }}
   name: {{ tpl .Values.name . }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "chart.name" . }}
     app.kubernetes.io/managed-by: tidb-operator

--- a/charts/tidb-backup/templates/restore-job.yaml
+++ b/charts/tidb-backup/templates/restore-job.yaml
@@ -77,7 +77,9 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
-    {{- if .Values.scheduledBackupName }}
+    {{- if not .Values.restoreUsingExistingVolume }}
+          claimName: restore-{{ .Values.name }}
+    {{- else if .Values.scheduledBackupName }}
           claimName: {{ .Values.name }}-scheduled-backup
     {{- else }}
           claimName: {{ .Values.name }}

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -80,6 +80,11 @@ restoreOptions: "-t 16"
 # When a GC happens, the current time minus this value is the safe point.
 tikvGCLifeTime: 720h
 
+# By default, restores are performed by binding to an existing volume containing backup data.
+# To restore from gcp, ceph, or s3, set this to false to create a new volume to load the backup into
+# This setting only affects the "restore" mode.
+restoreUsingExistingVolume: true
+
 # By default, the backup/restore uses PV to store/load backup data
 # You can choose to store/load backup data to/from gcp, ceph or s3 bucket by enabling the following corresponding section:
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
It looks like for ad-hoc backup and restore (at least in the failing test), the helm chart expects the same pvc from the backup to be kept around and used for the subsequent restore. This only works if the source and target clusters are in the same namespace.

I would like to restore to a cluster without any local backups, running on a different Kubernetes cluster in a different region, via S3.

This is split from https://github.com/pingcap/tidb-operator/pull/1705

### What is changed and how does it work?

This adds a `restoreUsingExistingVolume` defaulting to `true`. If set to `false`, then a new volume in the `restore` mode to hold data loaded from s3, gcp, ceph, etc.

This option has the same effect as simply setting the mode to `scheduled-restore`, but I didn't really understand what `scheduled-restore` meant.