### PR TITLE
tidb-initializer:close connection after set privilege

### DIFF
--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -294,6 +294,7 @@ if permit_host != '%%':
     conn.cursor().execute("update mysql.user set Host=%s where User='root';", (permit_host,))
 conn.cursor().execute("flush privileges;")
 conn.commit()
+conn.close()
 `))
 
 type TiDBInitStartScriptModel struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close db connect after set privilege in tidb initializer

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes

 - Has Go code change