### PR TITLE
Fix TidbMonitor template error (#1745)

### DIFF
--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -74,7 +74,7 @@ func init() {
 	if err != nil {
 		klog.Fatalf("monitor regex template parse error,%v", err)
 	}
-	tikvPattern, err = config.NewRegexp(".*\\-tikv\\-\\d*$")
+	tikvPattern, err = config.NewRegexp("tikv")
 	if err != nil {
 		klog.Fatalf("monitor regex template parse error,%v", err)
 	}

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -137,7 +137,7 @@ scrape_configs:
     regex: target
     action: keep
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
-    regex: .*\-tikv\-\d*$
+    regex: tikv
     action: keep
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
     regex: "true"


### PR DESCRIPTION
* Fix TidbMonitor template error, manually cp #1745 


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the template error which would cause TidbMonitor can't srape tikv metrics
```
