### PR TITLE
actions: update actions/checkout to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,16 +25,17 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-        fetch-depth: 1
-        path: go/src/github.com/pingcap/tidb-operator
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: go/src/github.com/${{ github.repository }}
 
     - name: make ${{ matrix.target }}
       run: |
         # workaround for https://github.com/actions/setup-go/issues/14
-        export GOPATH=/home/runner/work/tidb-operator/go
+        export GOPATH=${GITHUB_WORKSPACE}/go
         export PATH=$PATH:$GOPATH/bin
         make $target
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
       env:
         target: ${{ matrix.target }}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

update actions/checkout to v2, in this version it can fetch the HEAD commit of PR only and we don't need to specify `fetch-depth`.

https://github.com/actions/checkout#checkout-v2

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
