### PR TITLE
Added marketplace product code filter for bastion to avoid selecting AMI from wrong vendor

### DIFF
--- a/deploy/modules/aws/bastion/data.tf
+++ b/deploy/modules/aws/bastion/data.tf
@@ -17,4 +17,9 @@ data "aws_ami" "centos" {
     name   = "root-device-type"
     values = ["ebs"]
   }
+
+  filter {
+    name   = "product-code"
+    values = ["aw0evgkw8e5c1q413zgy5pjce"]
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fixes #1774 

### What is changed and how does it work?
Adds a filter on marketplace Product Code (in addition to existing filters) to make sure the correct product is chosen.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

I simply tested `terraform apply` after applying this change and the correct AMI was chosen (whereas the *incorrect* AMI was being chosen before applying the change).

Code changes

 - Has Terraform scripts change


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
