### PR TITLE
show cli flags in logs

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -19,11 +19,11 @@ import (
 	"time"
 
 	"github.com/openshift/generic-admission-server/pkg/cmd"
-
 	"github.com/pingcap/tidb-operator/pkg/features"
 	"github.com/pingcap/tidb-operator/pkg/version"
 	"github.com/pingcap/tidb-operator/pkg/webhook"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 )
 
 var (
@@ -50,6 +50,10 @@ func main() {
 		os.Exit(0)
 	}
 	version.LogVersionInfo()
+
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 
 	ah := &webhook.AdmissionHook{
 		ExtraServiceAccounts:     extraServiceAccounts,

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -93,6 +93,10 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+
 	hostName, err := os.Hostname()
 	if err != nil {
 		klog.Fatalf("failed to get hostname: %v", err)

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -52,6 +52,10 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		klog.Fatalf("failed to get config: %v", err)

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -54,6 +54,10 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		klog.Fatalf("failed to get config: %v", err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

this is useful in debugging. in addition to component version, we can know CLI flags from logs.

example logs of tidb-controller-manager:

```
I0227 17:36:49.969981   88390 version.go:38] Welcome to TiDB Operator.
I0227 17:36:49.970745   88390 version.go:39] TiDB Operator Version: version.Info{GitVersion:"v1.1.0-beta.1.97+89e0c38525404a", GitCommit:"89e0c38525404aea9c085a64848ad36bcbcd8bf1", GitTreeState:"clean", BuildDate:"2020-02-27T09:36:35Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}
I0227 17:36:49.970794   88390 main.go:97] FLAG: --V="false"
I0227 17:36:49.970805   88390 main.go:97] FLAG: --add_dir_header="false"
I0227 17:36:49.970809   88390 main.go:97] FLAG: --alsologtostderr="false"
I0227 17:36:49.970814   88390 main.go:97] FLAG: --auto-failover="true"
I0227 17:36:49.970817   88390 main.go:97] FLAG: --cluster-scoped="true"
I0227 17:36:49.970827   88390 main.go:97] FLAG: --features="AdvancedStatefulSet=false,AutoScaling=false,StableScheduling=true"
I0227 17:36:49.970859   88390 main.go:97] FLAG: --log_backtrace_at=":0"
I0227 17:36:49.970867   88390 main.go:97] FLAG: --log_dir=""
I0227 17:36:49.970871   88390 main.go:97] FLAG: --log_file=""
I0227 17:36:49.970878   88390 main.go:97] FLAG: --log_file_max_size="1800"
I0227 17:36:49.970882   88390 main.go:97] FLAG: --logtostderr="true"
I0227 17:36:49.970895   88390 main.go:97] FLAG: --pd-failover-period="5m0s"
I0227 17:36:49.970899   88390 main.go:97] FLAG: --pod-webhook-enabled="false"
I0227 17:36:49.970903   88390 main.go:97] FLAG: --resync-duration="30s"
I0227 17:36:49.970906   88390 main.go:97] FLAG: --skip_headers="false"
I0227 17:36:49.970909   88390 main.go:97] FLAG: --skip_log_headers="false"
I0227 17:36:49.970919   88390 main.go:97] FLAG: --stderrthreshold="2"
I0227 17:36:49.970943   88390 main.go:97] FLAG: --test-mode="false"
I0227 17:36:49.970948   88390 main.go:97] FLAG: --tidb-backup-manager-image="pingcap/tidb-backup-manager:latest"
I0227 17:36:49.970952   88390 main.go:97] FLAG: --tidb-discovery-image="pingcap/tidb-operator:latest"
I0227 17:36:49.970955   88390 main.go:97] FLAG: --tidb-failover-period="5m0s"
I0227 17:36:49.970958   88390 main.go:97] FLAG: --tikv-failover-period="5m0s"
I0227 17:36:49.970960   88390 main.go:97] FLAG: --v="1"
I0227 17:36:49.970970   88390 main.go:97] FLAG: --version="false"
I0227 17:36:49.970973   88390 main.go:97] FLAG: --vmodule=""
I0227 17:36:49.970977   88390 main.go:97] FLAG: --workers="5"
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
