### PR TITLE
Enable defaulting for tidbcluster

### DIFF
--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -195,7 +195,7 @@ admissionWebhook:
     ## validating hook validates the correctness of the resources under pingcap.com group
     validating: false
     ## defaulting hook set default values for the the resources under pingcap.com group
-    defaulting: false
+    defaulting: true
   ## failurePolicy are applied to ValidatingWebhookConfiguration which affect tidb-admission-webhook
   ## refer to https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
   failurePolicy:

--- a/ci/deploy_tidb_operator_staging.groovy
+++ b/ci/deploy_tidb_operator_staging.groovy
@@ -28,7 +28,7 @@ admissionWebhook:
     pods: true
     # TODO: enable validating and defaulting after we ease the constrain
     validating: false
-    defaulting: false
+    defaulting: true
 features:
   - AutoScaling=true
 '''

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
@@ -26,28 +26,59 @@ const (
 )
 
 func SetTidbClusterDefault(tc *v1alpha1.TidbCluster) {
+	setTidbClusterSpecDefault(tc)
+	setPdSpecDefault(tc)
+	setTikvSpecDefault(tc)
+	setTidbSpecDefault(tc)
+	if tc.Spec.Pump != nil {
+		setPumpSpecDefault(tc)
+	}
+}
+
+// setTidbClusterSpecDefault is only managed the property under Spec
+func setTidbClusterSpecDefault(tc *v1alpha1.TidbCluster) {
+	if string(tc.Spec.ImagePullPolicy) == "" {
+		tc.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	}
+	if tc.Spec.EnableTLSCluster == nil {
+		d := false
+		tc.Spec.EnableTLSCluster = &d
+	}
+	if tc.Spec.EnablePVReclaim == nil {
+		d := false
+		tc.Spec.EnablePVReclaim = &d
+	}
+}
+
+func setTidbSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiDB.BaseImage == "" {
 		tc.Spec.TiDB.BaseImage = defaultTiDBImage
-	}
-	if tc.Spec.TiKV.BaseImage == "" {
-		tc.Spec.TiKV.BaseImage = defaultTiKVImage
-	}
-	if tc.Spec.PD.BaseImage == "" {
-		tc.Spec.PD.BaseImage = defaultPDImage
-	}
-	if tc.Spec.Pump != nil && tc.Spec.Pump.BaseImage == "" {
-		tc.Spec.Pump.BaseImage = defaultBinlogImage
 	}
 	if tc.Spec.TiDB.Config == nil {
 		tc.Spec.TiDB.Config = &v1alpha1.TiDBConfig{}
 	}
+}
+
+func setTikvSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiKV.Config == nil {
 		tc.Spec.TiKV.Config = &v1alpha1.TiKVConfig{}
 	}
+	if tc.Spec.TiKV.BaseImage == "" {
+		tc.Spec.TiKV.BaseImage = defaultTiKVImage
+	}
+}
+
+func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.PD.Config == nil {
 		tc.Spec.PD.Config = &v1alpha1.PDConfig{}
 	}
-	if string(tc.Spec.ImagePullPolicy) == "" {
-		tc.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	if tc.Spec.PD.BaseImage == "" {
+		tc.Spec.PD.BaseImage = defaultPDImage
+	}
+}
+
+func setPumpSpecDefault(tc *v1alpha1.TidbCluster) {
+	if tc.Spec.Pump.BaseImage == "" {
+		tc.Spec.Pump.BaseImage = defaultBinlogImage
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Enable tidbcluster webhook defaulting both in idc configuration and operat chart values.


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Enable TidbCluster defaulting mutation by default which is recommended when admission webhook is used
```
