### PR TITLE
Support no secret for s3/ceph

### DIFF
--- a/charts/tidb-backup/templates/scripts/_start_backup.sh.tpl
+++ b/charts/tidb-backup/templates/scripts/_start_backup.sh.tpl
@@ -89,13 +89,24 @@ uploader \
 {{- end }}
 
 {{- if .Values.s3 }}
-uploader \
-  --cloud=aws \
-  --region={{ .Values.s3.region }} \
-  {{- if .Values.s3.prefix }}
-  --bucket={{ .Values.s3.bucket }}/{{ .Values.s3.prefix }} \
-  {{- else }}
-  --bucket={{ .Values.s3.bucket }} \
-  {{- end }}
-  --backup-dir=${dirname}
+# Once we know there are no more credentials that will be logged we can run with -x
+set -x
+bucket={{ .Values.s3.bucket }}
+
+cat <<EOF > /tmp/rclone.conf
+[aws]
+type = s3
+provider = AWS
+env_auth = true
+region = us-west-2
+EOF
+
+cd "${backup_base_dir}"
+{{- if .Values.s3.prefix }}
+tar -cf - "${backup_name}" | pigz -p 16 \
+  | rclone --config /tmp/rclone.conf rcat s3:${bucket}/{{ .Values.s3.prefix }}/${backup_name}/${backup_name}.tgz
+{{- else }}
+tar -cf - "${backup_name}" | pigz -p 16 \
+  | rclone --config /tmp/rclone.conf rcat s3:${bucket}/${backup_name}/${backup_name}.tgz
+{{- end }}
 {{- end }}

--- a/charts/tidb-backup/templates/scripts/_start_backup.sh.tpl
+++ b/charts/tidb-backup/templates/scripts/_start_backup.sh.tpl
@@ -94,11 +94,11 @@ set -x
 bucket={{ .Values.s3.bucket }}
 
 cat <<EOF > /tmp/rclone.conf
-[aws]
+[s3]
 type = s3
 provider = AWS
 env_auth = true
-region = us-west-2
+region = {{ .Values.s3.region }}
 EOF
 
 cd "${backup_base_dir}"

--- a/charts/tidb-backup/values.yaml
+++ b/charts/tidb-backup/values.yaml
@@ -27,7 +27,7 @@ name: fullbackup-{{ date "200601021504" .Release.Time }}
 image:
   pullPolicy: IfNotPresent
   # https://github.com/pingcap/tidb-cloud-backup
-  backup: pingcap/tidb-cloud-backup:20191217
+  backup: pingcap/tidb-cloud-backup:20200229
 
 ## nodeSelector ensure pods only assigning to nodes which have each of the indicated key-value pairs as labels
 ## ref:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
+++ b/charts/tidb-cluster/templates/scheduled-backup-cronjob.yaml
@@ -74,7 +74,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /gcp/credentials.json
           {{- end }}
-          {{- if or .Values.scheduledBackup.ceph .Values.scheduledBackup.s3 }}
+          {{- if or .Values.scheduledBackup.ceph.secretName .Values.scheduledBackup.s3.secretName }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -700,7 +700,7 @@ binlog:
 scheduledBackup:
   create: false
   # https://github.com/pingcap/tidb-cloud-backup
-  mydumperImage: pingcap/tidb-cloud-backup:20191217
+  mydumperImage: pingcap/tidb-cloud-backup:20200229
   mydumperImagePullPolicy: IfNotPresent
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -741,6 +741,7 @@ scheduledBackup:
   # backup to gcp
   gcp: {}
   # bucket: ""
+  # prefix: ""
   # secretName is the name of the secret which stores the gcp service account credentials json file
   # The service account must have read/write permission to the above bucket.
   # Read the following document to create the service account and download the credentials file as credentials.json:
@@ -761,6 +762,7 @@ scheduledBackup:
   s3: {}
   # region: ""
   # bucket: ""
+  # prefix: ""
   # secretName is the name of the secret which stores s3 object store access key and secret key
   # You can create the secret by:
   # kubectl create secret generic s3-backup-secret --from-literal=access_key=<access-key> --from-literal=secret_key=<secret-key>


### PR DESCRIPTION
This is required if you use EKS ServiceAccount -> IAM role authentication using OIDC.

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Support no secret for s3/ceph when using OIDC authentication
```