### PR TITLE
Fix hot region label setting for tikv auto-scaling

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
@@ -39,10 +39,7 @@ ARGS="--pd={{ template "cluster.scheme" . }}://${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tikv/tikv.toml
 "
 
-if [ ! -z "${STORE_LABELS:-}" ]; then
-  LABELS=" --labels ${STORE_LABELS} "
-  ARGS="${ARGS}${LABELS}"
-fi
+{{ .Values.tikv.postArgScript }}
 
 echo "starting tikv-server ..."
 echo "/tikv-server ${ARGS}"

--- a/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tikv.sh.tpl
@@ -39,6 +39,11 @@ ARGS="--pd={{ template "cluster.scheme" . }}://${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tikv/tikv.toml
 "
 
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
 echo "starting tikv-server ..."
 echo "/tikv-server ${ARGS}"
 exec /tikv-server ${ARGS}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -284,6 +284,13 @@ tikv:
   # After waiting for 5 minutes, TiDB Operator creates a new TiKV node if this TiKV node is still down.
   # maxFailoverCount is used to configure the maximum number of TiKV nodes that TiDB Operator can create when failover occurs.
   maxFailoverCount: 3
+  # postArgscript is the script executed after the normal tikv instance start args is built,
+  # it is recommended to modify the args constructor logic if you have any special needs.
+  postArgScript: |
+    if [ ! -z "${STORE_LABELS:-}" ]; then
+      LABELS=" --labels ${STORE_LABELS} "
+      ARGS="${ARGS}${LABELS}"
+    fi
 
 tidb:
   # Please refer to https://github.com/pingcap/tidb/blob/master/config/config.toml.example for the default

--- a/charts/tidb-operator/templates/admission/admission-webhook-rbac.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-rbac.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets","configmaps"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["events"]

--- a/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
@@ -190,5 +190,9 @@ webhooks:
         apiGroups: [ "pingcap.com"]
         apiVersions: ["v1alpha1"]
         resources: ["tidbclusters"]
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
 {{- end }}
 {{- end }}

--- a/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
@@ -194,8 +194,8 @@ webhooks:
       caBundle: null
       {{- end }}
     rules:
-      - operations: [ "CREATE" ]
-        apiGroups: [ ""]
+      - operations: ["CREATE"]
+        apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
 {{- end }}

--- a/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
@@ -162,4 +162,41 @@ webhooks:
         apiVersions: ["v1alpha1"]
         resources: ["tidbclusters"]
 {{- end }}
+---
+{{- if .Values.admissionWebhook.mutation.pods }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutation-tidb-pod-webhook-cfg
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admission-webhook
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+webhooks:
+  - name: podadmission.tidb.pingcap.com
+    {{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+    objectSelector:
+      matchLabels:
+        "app.kubernetes.io/managed-by": "tidb-operator"
+        "app.kubernetes.io/name": "tidb-cluster"
+    {{- end }}
+    failurePolicy: {{ .Values.admissionWebhook.failurePolicy.mutation | default "Ignore" }}
+    clientConfig:
+      service:
+        name: kubernetes
+        namespace: default
+        path: "/apis/admission.tidb.pingcap.com/v1alpha1/mutatingreviews"
+      {{- if .Values.admissionWebhook.cabundle }}
+      caBundle: {{ .Values.admissionWebhook.cabundle | b64enc }}
+      {{- else }}
+      caBundle: null
+      {{- end }}
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ ""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+{{- end }}
 {{- end }}

--- a/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
@@ -190,9 +190,5 @@ webhooks:
         apiGroups: [ "pingcap.com"]
         apiVersions: ["v1alpha1"]
         resources: ["tidbclusters"]
-      - operations: ["CREATE"]
-        apiGroups: [""]
-        apiVersions: ["v1"]
-        resources: ["pods"]
 {{- end }}
 {{- end }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -197,6 +197,9 @@ admissionWebhook:
     pingcapResources: false
   ## mutation webhook would mutate the given request for the specific resource and operation
   mutation:
+    ## pods mutation hook would mutate the pod. Currently It is used for TiKV Auto-Scaling.
+    ## refer to https://github.com/pingcap/tidb-operator/issues/1651
+    pods: true
     ## defaulting hook set default values for the the resources under pingcap.com group
     pingcapResources: true
   ## failurePolicy are applied to ValidatingWebhookConfiguration which affect tidb-admission-webhook

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -139,7 +139,6 @@ func NewController(
 				pdFailover,
 			),
 			mm.NewTiKVMemberManager(
-				cmInformer.Lister(),
 				pdControl,
 				setControl,
 				svcControl,

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -139,6 +139,7 @@ func NewController(
 				pdFailover,
 			),
 			mm.NewTiKVMemberManager(
+				cmInformer.Lister(),
 				pdControl,
 				setControl,
 				svcControl,

--- a/pkg/manager/member/scaler.go
+++ b/pkg/manager/member/scaler.go
@@ -35,13 +35,6 @@ const (
 	skipReasonScalerAnnDeferDeletingIsEmpty = "scaler: pvc annotations defer deleting is empty"
 )
 
-// TODO: add document to explain the hot region label
-var (
-	hostRegionLabel = map[string]string{
-		"specialUse": "hotRegion",
-	}
-)
-
 // Scaler implements the logic for scaling out or scaling in the cluster.
 type Scaler interface {
 	// Scale scales the cluster. It does nothing if scaling is not needed.

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -225,6 +225,11 @@ ARGS="--pd={{ .Scheme }}://${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tikv/tikv.toml
 "
 
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
 echo "starting tikv-server ..."
 echo "/tikv-server ${ARGS}"
 exec /tikv-server ${ARGS}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -44,7 +44,6 @@ const (
 
 // tikvMemberManager implements manager.Manager.
 type tikvMemberManager struct {
-	cmLister                     corelisters.ConfigMapLister
 	setControl                   controller.StatefulSetControlInterface
 	svcControl                   controller.ServiceControlInterface
 	pdControl                    pdapi.PDControlInterface
@@ -63,7 +62,6 @@ type tikvMemberManager struct {
 
 // NewTiKVMemberManager returns a *tikvMemberManager
 func NewTiKVMemberManager(
-	cmLister corelisters.ConfigMapLister,
 	pdControl pdapi.PDControlInterface,
 	setControl controller.StatefulSetControlInterface,
 	svcControl controller.ServiceControlInterface,
@@ -78,7 +76,6 @@ func NewTiKVMemberManager(
 	tikvScaler Scaler,
 	tikvUpgrader Upgrader) manager.Manager {
 	kvmm := tikvMemberManager{
-		cmLister:     cmLister,
 		pdControl:    pdControl,
 		podLister:    podLister,
 		nodeLister:   nodeLister,

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -303,7 +303,7 @@ func (tkmm *tikvMemberManager) syncTiKVAutoScalingConfigMap(tc *v1alpha1.TidbClu
 	}
 	v, ok := cm.Data["config-file"]
 	if !ok {
-		return fmt.Errorf("")
+		return fmt.Errorf("tc[%s/%s]'s tikv config[config-file] is missing", tc.Namespace, tc.Name)
 	}
 	config := &v1alpha1.TiKVConfig{}
 	err = UnmarshalTOML([]byte(v), config)
@@ -318,7 +318,6 @@ func (tkmm *tikvMemberManager) syncTiKVAutoScalingConfigMap(tc *v1alpha1.TidbClu
 	}
 	// TODO: add document to explain the hot region label
 	config.Server.Labels["specialUse"] = "hotRegion"
-	klog.Infof("%v", config)
 
 	confText, err := MarshalTOML(config)
 	if err != nil {

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -209,6 +209,10 @@ func MarshalTOML(v interface{}) ([]byte, error) {
 	return data, nil
 }
 
+func UnmarshalTOML(b []byte, obj interface{}) error {
+	return toml.Unmarshal(b, obj)
+}
+
 func Sha256Sum(v interface{}) (string, error) {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/pkg/webhook/pod/pod_mutater.go
+++ b/pkg/webhook/pod/pod_mutater.go
@@ -1,0 +1,94 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
+	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
+	"github.com/pingcap/tidb-operator/pkg/webhook/util"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+func (pc *PodAdmissionControl) mutatePod(ar *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	pod := &corev1.Pod{}
+	if err := json.Unmarshal(ar.Object.Raw, pod); err != nil {
+		klog.Errorf("admission validating failed: cannot unmarshal %s to %T", ar.Kind, pod)
+		return util.ARFail(err)
+	}
+	original := pod.DeepCopy()
+
+	l := label.Label(pod.Labels)
+	if !l.IsManagedByTiDBOperator() {
+		return util.ARSuccess()
+	}
+	if !l.IsTiKV() {
+		return util.ARSuccess()
+	}
+	klog.Infof("receive mutation core mutate tikv pod")
+
+	tcName, exist := pod.Labels[label.InstanceLabelKey]
+	if !exist {
+		return util.ARSuccess()
+	}
+	namespace := ar.Namespace
+
+	tc, err := pc.operatorCli.PingcapV1alpha1().TidbClusters(namespace).Get(tcName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return util.ARSuccess()
+		}
+		return util.ARFail(err)
+	}
+	klog.Infof("annotations =%v", tc.Annotations)
+	podName := pod.Name
+	ordinal, err := operatorUtils.GetOrdinalFromPodName(podName)
+	if err != nil {
+		return util.ARFail(err)
+	}
+	sets := operatorUtils.GetAutoScalingOutSlots(tc, v1alpha1.TiKVMemberType)
+	klog.Infof("sets = %v", sets.List())
+
+	if !sets.Has(ordinal) {
+		klog.Infof("receive mutation core mutate tikv normal pod")
+		return util.ARSuccess()
+	}
+
+	klog.Infof("receive mutation core mutate tikv auto-scaling pod")
+	cmName := fmt.Sprintf("%s-autoscaling", controller.TiKVMemberName(tcName))
+	klog.Infof("origin pod %v", original)
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "config" && v.ConfigMap != nil {
+			klog.Info("here! find it !!!!!!!!!!!!1")
+			v.ConfigMap.LocalObjectReference = corev1.LocalObjectReference{
+				Name: cmName,
+			}
+			break
+		}
+	}
+	klog.Infof("update pod %v", pod)
+	patch, err := util.CreateJsonPatch(original, pod)
+	if err != nil {
+		return util.ARFail(err)
+	}
+	return util.ARPatch(patch)
+}

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -85,7 +85,6 @@ func (pc *PodAdmissionControl) MutatePods(ar *admission.AdmissionRequest) *admis
 	if ar.Operation != admission.Create && ar.Operation != admission.Update {
 		return util.ARSuccess()
 	}
-	klog.Infof("receive mutation core mutate pod")
 	return pc.mutatePod(ar)
 }
 

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -81,6 +81,14 @@ type admitPayload struct {
 	pdClient pdapi.PDClient
 }
 
+func (pc *PodAdmissionControl) MutatePods(ar *admission.AdmissionRequest) *admission.AdmissionResponse {
+	if ar.Operation != admission.Create && ar.Operation != admission.Update {
+		return util.ARSuccess()
+	}
+	klog.Infof("receive mutation core mutate pod")
+	return pc.mutatePod(ar)
+}
+
 func (pc *PodAdmissionControl) AdmitPods(ar *admission.AdmissionRequest) *admission.AdmissionResponse {
 
 	name := ar.Name

--- a/pkg/webhook/pod/util.go
+++ b/pkg/webhook/pod/util.go
@@ -180,3 +180,26 @@ func checkFormerPodRestartStatus(kubeCli kubernetes.Interface, memberType v1alph
 	}
 	return false, nil
 }
+
+func appendExtraLabelsENVForTiKV(labels map[string]string, container *core.Container) {
+	s := ""
+	for k, v := range labels {
+		s = fmt.Sprintf("%s,%s", s, fmt.Sprintf("%s=%s", k, v))
+	}
+	s = s[1:]
+	existed := false
+	for id, env := range container.Env {
+		if env.Name == "STORE_LABELS" {
+			env.Value = fmt.Sprintf("%s,%s", env.Value, s)
+			container.Env[id] = env
+			existed = true
+			break
+		}
+	}
+	if !existed {
+		container.Env = append(container.Env, core.EnvVar{
+			Name:  "STORE_LABELS",
+			Value: s,
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When tikv is scaled-out by auto-scaler, It should be added special hot region label by starting configuration instead of pdapi after started.

This request use mutation pod webhook to add env for the tikv created by auto scaler, which would inject special label durint it starting.

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
The TiKV created by the Auto-scaler would only schedule the hot region if `admission.mutation.pods` is enabled.
```
