### PR TITLE
Default TidbMonitor targetRef Namespace

### DIFF
--- a/pkg/monitor/monitor/monitor_manager.go
+++ b/pkg/monitor/monitor/monitor_manager.go
@@ -147,6 +147,10 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(monitor *v1alpha1.TidbMonito
 	}
 
 	targetTcRef := monitor.Spec.Clusters[0]
+	if len(targetTcRef.Namespace) < 1 {
+		targetTcRef.Namespace = monitor.Namespace
+	}
+
 	tc, err := mm.tcLister.TidbClusters(targetTcRef.Namespace).Get(targetTcRef.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
When TidbMonitor's targetRef namespace is not set, it is supposed to be the tidbmonitor's namespace instead

Fixes https://github.com/pingcap/tidb-operator/issues/1825

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
TidbMonitor would use its namespace for the targetRef if it is not defined.
```
