### PR TITLE
Backup: support TLS for br component

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -40,11 +40,15 @@ func (bo *Options) String() string {
 }
 
 func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
+	clusterNamespace := backup.Spec.BR.ClusterNamespace
+	if backup.Spec.BR.ClusterNamespace == "" {
+		clusterNamespace = backup.Namespace
+	}
 	args, remotePath, err := constructOptions(backup)
 	if err != nil {
 		return "", err
 	}
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, backup.Spec.BR.ClusterNamespace))
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, clusterNamespace))
 	if backup.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -73,7 +73,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 	if err != nil {
 		return remotePath, fmt.Errorf("cluster %s, execute br command %v failed, output: %s, err: %v", bo, fullArgs, string(output), err)
 	}
-	glog.Infof("Backup data for cluster %s successfully, output: %s", bo, string(output))
+	klog.Infof("Backup data for cluster %s successfully, output: %s", bo, string(output))
 	return remotePath, nil
 }
 

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -40,18 +40,12 @@ func (bo *Options) String() string {
 }
 
 func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
-	var backupNamespace string
 	args, remotePath, err := constructOptions(backup)
 	if err != nil {
 		return "", err
 	}
-	if backup.Spec.BackupNamespace == "" {
-		backupNamespace = bo.Namespace
-	} else {
-		backupNamespace = backup.Spec.BackupNamespace
-	}
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.Cluster, backupNamespace))
-	if backup.Spec.EnableTLSClient {
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, backup.Spec.BR.ClusterNamespace))
+	if backup.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Options contains the input arguments to the backup command
@@ -51,8 +52,8 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, clusterNamespace))
 	if backup.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
-		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
-		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))
+		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, corev1.TLSCertKey)))
+		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, corev1.TLSPrivateKeyKey)))
 	}
 
 	var btype string

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -50,13 +50,11 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 	} else {
 		backupNamespace = backup.Spec.BackupNamespace
 	}
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.Cluster, backupNamespace))
 	if backup.Spec.EnableTLSClient {
-		args = append(args, fmt.Sprintf("--pd=https://%s-pd.%s", backup.Spec.Cluster, backupNamespace))
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))
-	} else {
-		args = append(args, fmt.Sprintf("--pd=http://%s-pd.%s", backup.Spec.Cluster, backupNamespace))
 	}
 
 	var btype string

--- a/cmd/backup-manager/app/constants/constants.go
+++ b/cmd/backup-manager/app/constants/constants.go
@@ -56,4 +56,10 @@ const (
 
 	// MetaFile is the file name for meta data of backup with BR
 	MetaFile = "backupmeta"
+
+	// BR certificate storage path
+	BRCertPath = "/var/lib/br-tls"
+
+	// ServiceAccountCAPath is where is CABundle of serviceaccount locates
+	ServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -45,13 +45,12 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	} else {
 		restoreNamespace = restore.Spec.RestoreNamespace
 	}
+
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.Cluster, restoreNamespace))
 	if restore.Spec.EnableTLSClient {
-		args = append(args, fmt.Sprintf("--pd=https://%s-pd.%s", restore.Spec.Cluster, restoreNamespace))
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))
-	} else {
-		args = append(args, fmt.Sprintf("--pd=http://%s-pd.%s", restore.Spec.Cluster, restoreNamespace))
 	}
 
 	var restoreType string

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -35,19 +35,12 @@ func (ro *Options) String() string {
 }
 
 func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
-	var restoreNamespace string
 	args, err := constructBROptions(restore)
 	if err != nil {
 		return err
 	}
-	if restore.Spec.RestoreNamespace == "" {
-		restoreNamespace = ro.Namespace
-	} else {
-		restoreNamespace = restore.Spec.RestoreNamespace
-	}
-
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.Cluster, restoreNamespace))
-	if restore.Spec.EnableTLSClient {
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.BR.Cluster, restore.Spec.BR.ClusterNamespace))
+	if restore.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -35,11 +35,15 @@ func (ro *Options) String() string {
 }
 
 func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
+	clusterNamespace := restore.Spec.BR.ClusterNamespace
+	if restore.Spec.BR.ClusterNamespace == "" {
+		clusterNamespace = restore.Namespace
+	}
 	args, err := constructBROptions(restore)
 	if err != nil {
 		return err
 	}
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.BR.Cluster, restore.Spec.BR.ClusterNamespace))
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.BR.Cluster, clusterNamespace))
 	if restore.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type Options struct {
@@ -46,8 +47,8 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.BR.Cluster, clusterNamespace))
 	if restore.Spec.BR.EnableTLSClient {
 		args = append(args, fmt.Sprintf("--ca=%s", constants.ServiceAccountCAPath))
-		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, "cert")))
-		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, "key")))
+		args = append(args, fmt.Sprintf("--cert=%s", path.Join(constants.BRCertPath, corev1.TLSCertKey)))
+		args = append(args, fmt.Sprintf("--key=%s", path.Join(constants.BRCertPath, corev1.TLSPrivateKeyKey)))
 	}
 
 	var restoreType string

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -119,7 +119,7 @@ func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, strin
 		return nil, "", fmt.Errorf("no config for br in backup %s/%s", backup.Namespace, backup.Name)
 	}
 	args = append(args, constructBRGlobalOptions(config)...)
-	storageArgs, path, err := getRemoteStorage(backup.Spec.StorageProvider)
+	storageArgs, remotePath, err := getRemoteStorage(backup.Spec.StorageProvider)
 	if err != nil {
 		return nil, "", err
 	}
@@ -130,7 +130,7 @@ func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, strin
 	if backup.Spec.Type == v1alpha1.BackupTypeTable && config.Table != "" {
 		args = append(args, fmt.Sprintf("--table=%s", config.Table))
 	}
-	return args, path, nil
+	return args, remotePath, nil
 }
 
 // ConstructBRGlobalOptionsForRestore constructs BR global options for restore.
@@ -158,16 +158,6 @@ func ConstructBRGlobalOptionsForRestore(restore *v1alpha1.Restore) ([]string, er
 // constructBRGlobalOptions constructs BR basic global options.
 func constructBRGlobalOptions(config *v1alpha1.BRConfig) []string {
 	var args []string
-	args = append(args, fmt.Sprintf("--pd=%s", config.PDAddress))
-	if config.CA != "" {
-		args = append(args, fmt.Sprintf("--ca=%s", config.CA))
-	}
-	if config.Cert != "" {
-		args = append(args, fmt.Sprintf("--cert=%s", config.Cert))
-	}
-	if config.Key != "" {
-		args = append(args, fmt.Sprintf("--key=%s", config.Key))
-	}
 	if config.LogLevel != "" {
 		args = append(args, fmt.Sprintf("--log-level=%s", config.LogLevel))
 	}

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6792,6 +6792,8 @@ spec:
                   description: TimeAgo is the history version of the backup task,
                     e.g. 1m, 1h
                   type: string
+              required:
+              - cluster
               type: object
             from:
               description: TiDBAccessConfig defines the configuration for access tidb
@@ -7623,6 +7625,8 @@ spec:
                   description: TimeAgo is the history version of the backup task,
                     e.g. 1m, 1h
                   type: string
+              required:
+              - cluster
               type: object
             gcs:
               description: GcsStorageProvider represents the google cloud storage
@@ -8497,6 +8501,8 @@ spec:
                       description: TimeAgo is the history version of the backup task,
                         e.g. 1m, 1h
                       type: string
+                  required:
+                  - cluster
                   type: object
                 from:
                   description: TiDBAccessConfig defines the configuration for access

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6749,7 +6749,7 @@ spec:
                   description: Checksum specifies whether to run checksum after backup
                   type: boolean
                 cluster:
-                  description: ClusterName of backup cluster
+                  description: ClusterName of backup/restore cluster
                   type: string
                 clusterNamespace:
                   description: Namespace of backup/restore cluster
@@ -7580,7 +7580,7 @@ spec:
                   description: Checksum specifies whether to run checksum after backup
                   type: boolean
                 cluster:
-                  description: ClusterName of backup cluster
+                  description: ClusterName of backup/restore cluster
                   type: string
                 clusterNamespace:
                   description: Namespace of backup/restore cluster
@@ -8453,7 +8453,7 @@ spec:
                         backup
                       type: boolean
                     cluster:
-                      description: ClusterName of backup cluster
+                      description: ClusterName of backup/restore cluster
                       type: string
                     clusterNamespace:
                       description: Namespace of backup/restore cluster

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6742,15 +6742,15 @@ spec:
             br:
               description: BRConfig contains config for BR
               properties:
-                ca:
-                  description: CA is the CA certificate path for TLS connection
-                  type: string
-                cert:
-                  description: Cert is the certificate path for TLS connection
-                  type: string
                 checksum:
                   description: Checksum specifies whether to run checksum after backup
                   type: boolean
+                cluster:
+                  description: ClusterName of backup cluster
+                  type: string
+                clusterNamespace:
+                  description: Namespace of backup/restore cluster
+                  type: string
                 concurrency:
                   description: Concurrency is the size of thread pool on each node
                     that execute the backup task
@@ -6759,18 +6759,15 @@ spec:
                 db:
                   description: DB is the specific DB which will be backed-up or restored
                   type: string
-                key:
-                  description: Key is the private key path for TLS connection
-                  type: string
+                enableTLSClient:
+                  description: Whether enable TLS in TiDBCluster
+                  type: boolean
                 logLevel:
                   description: LogLevel is the log level
                   type: string
                 onLine:
                   description: OnLine specifies whether online during restore
                   type: boolean
-                pd:
-                  description: PDAddress is the PD address of the tidb cluster
-                  type: string
                 rateLimit:
                   description: RateLimit is the rate limit of the backup task, MB/s
                     per node
@@ -6792,8 +6789,6 @@ spec:
                   description: TimeAgo is the history version of the backup task,
                     e.g. 1m, 1h
                   type: string
-              required:
-              - pd
               type: object
             from:
               description: TiDBAccessConfig defines the configuration for access tidb
@@ -7578,15 +7573,15 @@ spec:
             br:
               description: BRConfig contains config for BR
               properties:
-                ca:
-                  description: CA is the CA certificate path for TLS connection
-                  type: string
-                cert:
-                  description: Cert is the certificate path for TLS connection
-                  type: string
                 checksum:
                   description: Checksum specifies whether to run checksum after backup
                   type: boolean
+                cluster:
+                  description: ClusterName of backup cluster
+                  type: string
+                clusterNamespace:
+                  description: Namespace of backup/restore cluster
+                  type: string
                 concurrency:
                   description: Concurrency is the size of thread pool on each node
                     that execute the backup task
@@ -7595,18 +7590,15 @@ spec:
                 db:
                   description: DB is the specific DB which will be backed-up or restored
                   type: string
-                key:
-                  description: Key is the private key path for TLS connection
-                  type: string
+                enableTLSClient:
+                  description: Whether enable TLS in TiDBCluster
+                  type: boolean
                 logLevel:
                   description: LogLevel is the log level
                   type: string
                 onLine:
                   description: OnLine specifies whether online during restore
                   type: boolean
-                pd:
-                  description: PDAddress is the PD address of the tidb cluster
-                  type: string
                 rateLimit:
                   description: RateLimit is the rate limit of the backup task, MB/s
                     per node
@@ -7628,8 +7620,6 @@ spec:
                   description: TimeAgo is the history version of the backup task,
                     e.g. 1m, 1h
                   type: string
-              required:
-              - pd
               type: object
             gcs:
               description: GcsStorageProvider represents the google cloud storage
@@ -8455,16 +8445,16 @@ spec:
                 br:
                   description: BRConfig contains config for BR
                   properties:
-                    ca:
-                      description: CA is the CA certificate path for TLS connection
-                      type: string
-                    cert:
-                      description: Cert is the certificate path for TLS connection
-                      type: string
                     checksum:
                       description: Checksum specifies whether to run checksum after
                         backup
                       type: boolean
+                    cluster:
+                      description: ClusterName of backup cluster
+                      type: string
+                    clusterNamespace:
+                      description: Namespace of backup/restore cluster
+                      type: string
                     concurrency:
                       description: Concurrency is the size of thread pool on each
                         node that execute the backup task
@@ -8474,18 +8464,15 @@ spec:
                       description: DB is the specific DB which will be backed-up or
                         restored
                       type: string
-                    key:
-                      description: Key is the private key path for TLS connection
-                      type: string
+                    enableTLSClient:
+                      description: Whether enable TLS in TiDBCluster
+                      type: boolean
                     logLevel:
                       description: LogLevel is the log level
                       type: string
                     onLine:
                       description: OnLine specifies whether online during restore
                       type: boolean
-                    pd:
-                      description: PDAddress is the PD address of the tidb cluster
-                      type: string
                     rateLimit:
                       description: RateLimit is the rate limit of the backup task,
                         MB/s per node
@@ -8507,8 +8494,6 @@ spec:
                       description: TimeAgo is the history version of the backup task,
                         e.g. 1m, 1h
                       type: string
-                  required:
-                  - pd
                   type: object
                 from:
                   description: TiDBAccessConfig defines the configuration for access

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -384,7 +384,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 					},
 					"cluster": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterName of backup cluster",
+							Description: "ClusterName of backup/restore cluster",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -375,9 +375,23 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 				Description: "BRConfig contains config for BR",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"pd": {
+					"enableTLSClient": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PDAddress is the PD address of the tidb cluster",
+							Description: "Whether enable TLS in TiDBCluster",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"cluster": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClusterName of backup cluster",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"clusterNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of backup/restore cluster",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -392,27 +406,6 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 					"table": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Table is the specific table which will be backed-up or restored",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"ca": {
-						SchemaProps: spec.SchemaProps{
-							Description: "CA is the CA certificate path for TLS connection",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"cert": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Cert is the certificate path for TLS connection",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"key": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Key is the private key path for TLS connection",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -474,7 +467,6 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 						},
 					},
 				},
-				Required: []string{"pd"},
 			},
 		},
 	}

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -467,6 +467,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 						},
 					},
 				},
+				Required: []string{"cluster"},
 			},
 		},
 	}

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -781,21 +781,17 @@ type BackupSpec struct {
 	// Affinity of backup Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// Whether enable TLS in TiDBCluster
-	// Optional: Defaults to false
-	// +optional
-	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
-	// ClusterName of backup cluster
-	// Required
-	Cluster string `json:"cluster,omitempty"`
-	// Namespace of backup cluster
-	// Optional: Defaults to namespace of backup job
-	BackupNamespace string `json:"backupNamespace,omitempty"`
 }
 
 // +k8s:openapi-gen=true
 // BRConfig contains config for BR
 type BRConfig struct {
+	// Whether enable TLS in TiDBCluster
+	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
+	// ClusterName of backup cluster
+	Cluster string `json:"cluster,omitempty"`
+	// Namespace of backup/restore cluster
+	ClusterNamespace string `json:"clusterNamespace,omitempty"`
 	// DB is the specific DB which will be backed-up or restored
 	DB string `json:"db,omitempty"`
 	// Table is the specific table which will be backed-up or restored
@@ -999,16 +995,6 @@ type RestoreSpec struct {
 	// Affinity of restore Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// Whether enable TLS in TiDBCluster
-	// Optional: Defaults to false
-	// +optional
-	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
-	// ClusterName of restore cluster
-	// Required
-	Cluster string `json:"cluster,omitempty"`
-	// Namespace of restore cluster
-	// Optional: Defaults to namespace of restore job
-	RestoreNamespace string `json:"restoreNamespace,omitempty"`
 }
 
 // RestoreStatus represents the current status of a tidb cluster restore.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -789,7 +789,7 @@ type BRConfig struct {
 	// Whether enable TLS in TiDBCluster
 	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
 	// ClusterName of backup/restore cluster
-	Cluster string `json:"cluster,omitempty"`
+	Cluster string `json:"cluster"`
 	// Namespace of backup/restore cluster
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
 	// DB is the specific DB which will be backed-up or restored

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -788,7 +788,7 @@ type BackupSpec struct {
 type BRConfig struct {
 	// Whether enable TLS in TiDBCluster
 	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
-	// ClusterName of backup cluster
+	// ClusterName of backup/restore cluster
 	Cluster string `json:"cluster,omitempty"`
 	// Namespace of backup/restore cluster
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -781,23 +781,25 @@ type BackupSpec struct {
 	// Affinity of backup Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// Whether enable TLS in TiDBCluster
+	// Optional: Defaults to false
+	// +optional
+	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
+	// ClusterName of backup cluster
+	// Required
+	Cluster string `json:"cluster,omitempty"`
+	// Namespace of backup cluster
+	// Optional: Defaults to namespace of backup job
+	BackupNamespace string `json:"backupNamespace,omitempty"`
 }
 
 // +k8s:openapi-gen=true
 // BRConfig contains config for BR
 type BRConfig struct {
-	// PDAddress is the PD address of the tidb cluster
-	PDAddress string `json:"pd"`
 	// DB is the specific DB which will be backed-up or restored
 	DB string `json:"db,omitempty"`
 	// Table is the specific table which will be backed-up or restored
 	Table string `json:"table,omitempty"`
-	// CA is the CA certificate path for TLS connection
-	CA string `json:"ca,omitempty"`
-	// Cert is the certificate path for TLS connection
-	Cert string `json:"cert,omitempty"`
-	// Key is the private key path for TLS connection
-	Key string `json:"key,omitempty"`
 	// LogLevel is the log level
 	LogLevel string `json:"logLevel,omitempty"`
 	// StatusAddr is the HTTP listening address for the status report service. Set to empty string to disable
@@ -997,6 +999,16 @@ type RestoreSpec struct {
 	// Affinity of restore Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// Whether enable TLS in TiDBCluster
+	// Optional: Defaults to false
+	// +optional
+	EnableTLSClient bool `json:"enableTLSClient,omitempty"`
+	// ClusterName of restore cluster
+	// Required
+	Cluster string `json:"cluster,omitempty"`
+	// Namespace of restore cluster
+	// Optional: Defaults to namespace of restore job
+	RestoreNamespace string `json:"restoreNamespace,omitempty"`
 }
 
 // RestoreStatus represents the current status of a tidb cluster restore.

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	glog "k8s.io/klog"
 )
 
 type backupManager struct {
@@ -250,7 +249,6 @@ func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	return job, "", nil
 }
 func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, string, error) {
-	glog.Info("by jony %#v", backup)
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
@@ -266,19 +264,8 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	}
 
 	backupLabel := label.NewBackup().Instance(backup.GetInstanceName()).BackupJob().Backup(name)
-	volumeMounts := []corev1.VolumeMount{
-		{Name: label.BackupJobLabelVal, MountPath: constants.BackupRootPath},
-	}
-	volumes := []corev1.Volume{
-		{
-			Name: label.BackupJobLabelVal,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: backup.GetBackupPVCName(),
-				},
-			},
-		},
-	}
+	volumeMounts := []corev1.VolumeMount{}
+	volumes := []corev1.Volume{}
 	if backup.Spec.EnableTLSClient {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name: "br-tls", ReadOnly: true, MountPath: constants.BRCertPath,

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -208,7 +208,7 @@ func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 					Name:            label.BackupJobLabelVal,
 					Image:           controller.TidbBackupManagerImage,
 					Args:            args,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: label.BackupJobLabelVal, MountPath: constants.BackupRootPath},
 					},
@@ -266,14 +266,14 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	backupLabel := label.NewBackup().Instance(backup.GetInstanceName()).BackupJob().Backup(name)
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
-	if backup.Spec.EnableTLSClient {
+	if backup.Spec.BR.EnableTLSClient {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name: "br-tls", ReadOnly: true, MountPath: constants.BRCertPath,
 		})
 		volumes = append(volumes, corev1.Volume{
 			Name: "br-tls", VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: fmt.Sprintf("%s-client", controller.PDMemberName(backup.Spec.Cluster)),
+					SecretName: fmt.Sprintf("%s-client", controller.PDMemberName(backup.Spec.BR.Cluster)),
 				},
 			},
 		})
@@ -290,7 +290,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 					Name:            label.BackupJobLabelVal,
 					Image:           controller.TidbBackupManagerImage,
 					Args:            args,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts:    volumeMounts,
 					Env:             envVars,
 				},

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -215,13 +215,8 @@ func (bm *backupScheduleManager) createBackup(bs *v1alpha1.BackupSchedule, times
 			}
 		}
 	} else {
-		var backupNamespace, pdAddress string
-		if backupSpec.BackupNamespace == "" {
-			backupNamespace = ns
-		} else {
-			backupNamespace = backupSpec.BackupNamespace
-		}
-		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.Cluster, backupNamespace)
+		var pdAddress string
+		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.BR.Cluster, backupSpec.BR.ClusterNamespace)
 
 		if backupSpec.S3 != nil {
 			backupSpec.S3.Prefix = path.Join(backupSpec.S3.Prefix,

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -215,8 +215,12 @@ func (bm *backupScheduleManager) createBackup(bs *v1alpha1.BackupSchedule, times
 			}
 		}
 	} else {
-		var pdAddress string
-		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.BR.Cluster, backupSpec.BR.ClusterNamespace)
+		var pdAddress, clusterNamespace string
+		clusterNamespace = backupSpec.BR.ClusterNamespace
+		if backupSpec.BR.ClusterNamespace == "" {
+			clusterNamespace = ns
+		}
+		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.BR.Cluster, clusterNamespace)
 
 		if backupSpec.S3 != nil {
 			backupSpec.S3.Prefix = path.Join(backupSpec.S3.Prefix,

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -215,9 +215,21 @@ func (bm *backupScheduleManager) createBackup(bs *v1alpha1.BackupSchedule, times
 			}
 		}
 	} else {
+		var backupNamespace, pdAddress string
+		if backupSpec.BackupNamespace == "" {
+			backupNamespace = ns
+		} else {
+			backupNamespace = backupSpec.BackupNamespace
+		}
+		if backupSpec.EnableTLSClient {
+			pdAddress = fmt.Sprintf("https://%s-pd.%s", backupSpec.Cluster, backupNamespace)
+		} else {
+			pdAddress = fmt.Sprintf("http://%s-pd.%s", backupSpec.Cluster, backupNamespace)
+		}
+
 		if backupSpec.S3 != nil {
 			backupSpec.S3.Prefix = path.Join(backupSpec.S3.Prefix,
-				strings.ReplaceAll(backupSpec.BR.PDAddress, ":", "-")+"-"+timestamp.UTC().Format(constants.TimeFormat))
+				strings.ReplaceAll(pdAddress, ":", "-")+"-"+timestamp.UTC().Format(constants.TimeFormat))
 		}
 	}
 

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -221,11 +221,7 @@ func (bm *backupScheduleManager) createBackup(bs *v1alpha1.BackupSchedule, times
 		} else {
 			backupNamespace = backupSpec.BackupNamespace
 		}
-		if backupSpec.EnableTLSClient {
-			pdAddress = fmt.Sprintf("https://%s-pd.%s", backupSpec.Cluster, backupNamespace)
-		} else {
-			pdAddress = fmt.Sprintf("http://%s-pd.%s", backupSpec.Cluster, backupNamespace)
-		}
+		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.Cluster, backupNamespace)
 
 		if backupSpec.S3 != nil {
 			backupSpec.S3.Prefix = path.Join(backupSpec.S3.Prefix,

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -49,4 +49,10 @@ const (
 
 	// BackupManagerEnvVarPrefix represents the environment variable used for tidb-backup-manager must include this prefix
 	BackupManagerEnvVarPrefix = "BACKUP_MANAGER"
+
+	// BR certificate storage path
+	BRCertPath = "/var/lib/br-tls"
+
+	// ServiceAccountCAPath is where is CABundle of serviceaccount locates
+	ServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -252,14 +252,14 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 	restoreLabel := label.NewBackup().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
-	if restore.Spec.EnableTLSClient {
+	if restore.Spec.BR.EnableTLSClient {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name: "br-tls", ReadOnly: true, MountPath: constants.BRCertPath,
 		})
 		volumes = append(volumes, corev1.Volume{
 			Name: "br-tls", VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: fmt.Sprintf("%s-client", controller.PDMemberName(restore.Spec.Cluster)),
+					SecretName: fmt.Sprintf("%s-client", controller.PDMemberName(restore.Spec.BR.Cluster)),
 				},
 			},
 		})

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -298,8 +298,13 @@ func ValidateBackup(backup *v1alpha1.Backup) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if backup.Spec.Cluster == "" {
-			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
+		if backup.Spec.BR != nil {
+			if backup.Spec.BR.Cluster == "" {
+				return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
+			}
+			if backup.Spec.BR.ClusterNamespace == "" {
+				backup.Spec.BR.ClusterNamespace = ns
+			}
 		}
 
 		if backup.Spec.Type != "" &&
@@ -350,8 +355,13 @@ func ValidateRestore(restore *v1alpha1.Restore) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if restore.Spec.Cluster == "" {
-			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
+		if restore.Spec.BR != nil {
+			if restore.Spec.BR.Cluster == "" {
+				return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
+			}
+			if restore.Spec.BR.ClusterNamespace == "" {
+				restore.Spec.BR.ClusterNamespace = ns
+			}
 		}
 		if restore.Spec.Type != "" &&
 			restore.Spec.Type != v1alpha1.BackupTypeFull &&

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -298,15 +298,9 @@ func ValidateBackup(backup *v1alpha1.Backup) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if backup.Spec.BR != nil {
-			if backup.Spec.BR.Cluster == "" {
-				return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
-			}
-			if backup.Spec.BR.ClusterNamespace == "" {
-				backup.Spec.BR.ClusterNamespace = ns
-			}
+		if backup.Spec.BR.Cluster == "" {
+			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
 		}
-
 		if backup.Spec.Type != "" &&
 			backup.Spec.Type != v1alpha1.BackupTypeFull &&
 			backup.Spec.Type != v1alpha1.BackupTypeDB &&
@@ -355,13 +349,8 @@ func ValidateRestore(restore *v1alpha1.Restore) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if restore.Spec.BR != nil {
-			if restore.Spec.BR.Cluster == "" {
-				return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
-			}
-			if restore.Spec.BR.ClusterNamespace == "" {
-				restore.Spec.BR.ClusterNamespace = ns
-			}
+		if restore.Spec.BR.Cluster == "" {
+			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
 		}
 		if restore.Spec.Type != "" &&
 			restore.Spec.Type != v1alpha1.BackupTypeFull &&

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -298,9 +298,10 @@ func ValidateBackup(backup *v1alpha1.Backup) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if backup.Spec.BR.PDAddress == "" {
-			return fmt.Errorf("pd address should be configured for BR in spec of %s/%s", ns, name)
+		if backup.Spec.Cluster == "" {
+			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
 		}
+
 		if backup.Spec.Type != "" &&
 			backup.Spec.Type != v1alpha1.BackupTypeFull &&
 			backup.Spec.Type != v1alpha1.BackupTypeDB &&
@@ -349,8 +350,8 @@ func ValidateRestore(restore *v1alpha1.Restore) error {
 			return fmt.Errorf("missing StorageSize config in spec of %s/%s", ns, name)
 		}
 	} else {
-		if restore.Spec.BR.PDAddress == "" {
-			return fmt.Errorf("pd address should be configured for BR in spec of %s/%s", ns, name)
+		if restore.Spec.Cluster == "" {
+			return fmt.Errorf("cluster should be configured for BR in spec of %s/%s", ns, name)
 		}
 		if restore.Spec.Type != "" &&
 			restore.Spec.Type != v1alpha1.BackupTypeFull &&


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
use BR as the backup tool in an TLS cluster
### What is changed and how does it work?
use client certification for BR communicate with TiKV and PD
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
use operator and backup manager with this PR
```
helm install --values values.yaml --name operator --namespace tidb-admin . --set-string -operatorImage=hub.pingcap.net/yinliang/pingcap/tidb-operator:latest,tidbBackupManagerImage=hub.pingcap.net/yinliang/pingcap/tidb-backup-manager:latest
```

create backup and restore cluster
```
helm install --values values.yaml --name cluster --namespace cluster . --set-string enableTLSCluster=true,tidb.image=pingcap/tidb:latest,tikv.image=pingcap/tikv:latest,pd.image=pingcap/pd:latest
helm install --values values.yaml --name cluster1 --namespace cluster . --set-string enableTLSCluster=true,tidb.image=pingcap/tidb:latest,tikv.image=pingcap/tikv:latest,pd.image=pingcap/pd:latest
```

insert some data to tidbcluster cluster

create secret of tidb endpoint for mysql client
```
kubectl create secret generic backup-secret -n <namespace> --from-literal=user=<user> --from-literal=password=<password>
```

create secret for aws accesskey and secretkey
```
 kubectl create secret generic s3-secret-aws --from-literal=secret_key=<secret_key> --from-literal=access_key=<access_key> --namespace=cluster
 ```


apply backup rbac 
```
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1beta1
metadata:
  name: tidb-backup-manager
  labels:
    app.kubernetes.io/component: tidb-backup-manager
rules:
- apiGroups: [""]
  resources: ["events"]
  verbs: ["*"]
- apiGroups: ["pingcap.com"]
  resources: ["backups", "restores"]
  verbs: ["get", "watch", "list", "update"]

---
kind: ServiceAccount
apiVersion: v1
metadata:
  name: tidb-backup-manager

---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1beta1
metadata:
  name: tidb-backup-manager
  labels:
    app.kubernetes.io/component: tidb-backup-manager
subjects:
- kind: ServiceAccount
  name: tidb-backup-manager
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: tidb-backup-manager
```

use backup yaml to create backup CRD
```
apiVersion: pingcap.com/v1alpha1
kind: Backup
metadata:
  name: jony-backup-aws-202003021703
  namespace: cluster
spec:
  br:
    enableTLSClient: true
    cluster: cluster
    clusterNamespce: cluster
  from:
    host: cluster-tidb
    port: 4000
    user: root
    secretName: backup-secret
  s3:
    provider: aws
    region: us-west-2
    secretName: s3-secret-aws
    bucket: backup.jony3.us-west-2.tidbcloud.com
    prefix: "202003021703"
  storageClassName: local-storage
  storageSize: 10Gi

  ```


check backup files from aws console

use restore yaml to restore 
```
apiVersion: pingcap.com/v1alpha1
kind: Restore
metadata:
  name: jony-restore-aws-202003021703
  namespace: cluster
spec:
  br:
    enableTLSClient: true
    cluster: cluster1
    clusterNamespce: cluster
  to:
    host: cluster1-tidb
    port: 4000
    user: root
    secretName: backup-secret
  s3:
    provider: aws
    region: us-west-2
    secretName: s3-secret-aws
    bucket: backup.jony3.us-west-2.tidbcloud.com
    prefix: "202003021703"
  storageClassName: local-storage
  storageSize: 10Gi
```

check the cluster and cluster1 data, whether they are consistence

Code changes

 - Has Go code change
