### PR TITLE
Fix defaulting bug

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
@@ -54,8 +54,10 @@ func setTidbSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiDB.BaseImage == "" {
 		tc.Spec.TiDB.BaseImage = defaultTiDBImage
 	}
-	if tc.Spec.TiDB.Config == nil {
-		tc.Spec.TiDB.Config = &v1alpha1.TiDBConfig{}
+	if len(tc.Spec.Version) > 0 || tc.Spec.TiDB.Version != nil {
+		if tc.Spec.TiDB.Config == nil {
+			tc.Spec.TiDB.Config = &v1alpha1.TiDBConfig{}
+		}
 	}
 }
 
@@ -63,8 +65,10 @@ func setTikvSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiKV.Config == nil {
 		tc.Spec.TiKV.Config = &v1alpha1.TiKVConfig{}
 	}
-	if tc.Spec.TiKV.BaseImage == "" {
-		tc.Spec.TiKV.BaseImage = defaultTiKVImage
+	if len(tc.Spec.Version) > 0 || tc.Spec.TiKV.Version != nil {
+		if tc.Spec.TiKV.BaseImage == "" {
+			tc.Spec.TiKV.BaseImage = defaultTiKVImage
+		}
 	}
 }
 
@@ -72,13 +76,17 @@ func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.PD.Config == nil {
 		tc.Spec.PD.Config = &v1alpha1.PDConfig{}
 	}
-	if tc.Spec.PD.BaseImage == "" {
-		tc.Spec.PD.BaseImage = defaultPDImage
+	if len(tc.Spec.Version) > 0 || tc.Spec.PD.Version != nil {
+		if tc.Spec.PD.BaseImage == "" {
+			tc.Spec.PD.BaseImage = defaultPDImage
+		}
 	}
 }
 
 func setPumpSpecDefault(tc *v1alpha1.TidbCluster) {
-	if tc.Spec.Pump.BaseImage == "" {
-		tc.Spec.Pump.BaseImage = defaultBinlogImage
+	if len(tc.Spec.Version) > 0 || tc.Spec.Pump.Version != nil {
+		if tc.Spec.Pump.BaseImage == "" {
+			tc.Spec.Pump.BaseImage = defaultBinlogImage
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
We only add default base image when the necessary version property is defined.


Related changes

 - Need to cherry-pick to the release branch
### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
