### PR TITLE
optimize  pd service yaml config

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -76,7 +76,10 @@ pd:
   # pd Service
   # we can only specify clusterIP and loadBalancerIP now
   service:
-    clusterIP: "None"
+    # type: "<the default name will be used>"
+    # loadBalancerIP: "<the default name will be used>"
+    # clusterIP: "<>"
+    annotations: {}
 
   replicas: 3
   image: pingcap/pd:v3.0.8

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -76,9 +76,9 @@ pd:
   # pd Service
   # we can only specify clusterIP and loadBalancerIP now
   service:
-    # type: "<the default name will be used>"
-    # loadBalancerIP: "<the default name will be used>"
-    # clusterIP: "<>"
+    # type: "< default use global service type >"
+    # loadBalancerIP: "<if you set service type as loadBalancerIP,you can specify loadBalancerIP>"
+    # clusterIP: "<if you set service type as ClusterIP,you can specify ClusterIP>"
     annotations: {}
 
   replicas: 3

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3452,7 +3452,7 @@ func (oa *operatorActions) CheckScaleTidbClusterToZeroReplica(info *TidbClusterC
 	})
 }
 func (oa *operatorActions) CheckTidbClusterHaveFailedMemberOrDie(info *TidbClusterConfig) {
-	if err := oa.CheckTidbClusterHaveFailedMember(info, 5*time.Minute, 15*time.Second); err != nil {
+	if err := oa.CheckTidbClusterHaveFailedMember(info, 30*time.Minute, 15*time.Second); err != nil {
 		slack.NotifyAndPanic(err)
 	}
 }

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3434,7 +3434,12 @@ func (oa *operatorActions) CheckTidbClusterHaveFailedMember(info *TidbClusterCon
 			glog.Errorf("failed to get tidbcluster: %s/%s, %v", ns, tcName, err)
 			return false, nil
 		}
-		return len(tc.Status.TiDB.FailureMembers) != 0, nil
+		if len(tc.Status.TiDB.FailureMembers) == 0 {
+			glog.Infof("the number of failed member is zero")
+			return false, nil
+		} else {
+			return true, nil
+		}
 	})
 }
 func (oa *operatorActions) CheckScaleTidbClusterToZeroReplica(info *TidbClusterConfig, timeout, pollInterval time.Duration) error {
@@ -3447,8 +3452,12 @@ func (oa *operatorActions) CheckScaleTidbClusterToZeroReplica(info *TidbClusterC
 			glog.Errorf("failed to get tidbcluster: %s/%s, %v", ns, tcName, err)
 			return false, nil
 		}
-
-		return tc.Status.TiDB.StatefulSet.Replicas == 0, nil
+		if tc.Status.TiDB.StatefulSet.Replicas != 0 {
+			glog.Infof("fail to scale tidb member to zero")
+			return false, nil
+		} else {
+			return true, nil
+		}
 	})
 }
 func (oa *operatorActions) CheckTidbClusterHaveFailedMemberOrDie(info *TidbClusterConfig) {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -3453,7 +3453,7 @@ func (oa *operatorActions) CheckScaleTidbClusterToZeroReplica(info *TidbClusterC
 			return false, nil
 		}
 		if tc.Status.TiDB.StatefulSet.Replicas != 0 {
-			glog.Infof("fail to scale tidb member to zero")
+			glog.Infof("failed to scale tidb member to zero")
 			return false, nil
 		} else {
 			return true, nil
@@ -3461,7 +3461,7 @@ func (oa *operatorActions) CheckScaleTidbClusterToZeroReplica(info *TidbClusterC
 	})
 }
 func (oa *operatorActions) CheckTidbClusterHaveFailedMemberOrDie(info *TidbClusterConfig) {
-	if err := oa.CheckTidbClusterHaveFailedMember(info, 30*time.Minute, 15*time.Second); err != nil {
+	if err := oa.CheckTidbClusterHaveFailedMember(info, 10*time.Minute, 15*time.Second); err != nil {
 		slack.NotifyAndPanic(err)
 	}
 }

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -207,6 +207,22 @@ func run() {
 			// wait upgrade complete
 			oa.CheckUpgradeOrDie(ctx, cluster)
 			oa.CheckTidbClusterStatusOrDie(cluster)
+
+			// scale have failed member tidb to zero replica
+			cluster.TiDBPreStartScript = strconv.Quote("exit 1")
+			oa.UpgradeTidbClusterOrDie(cluster)
+			time.Sleep(30 * time.Second)
+			// wait check fail members
+			oa.CheckTidbClusterHaveFailedMemberOrDie(cluster)
+			//scale tidb member to zero replica
+			cluster.ScaleTiDB(0)
+			oa.ScaleTidbClusterOrDie(cluster)
+			oa.CheckScaleTidbClusterToZeroReplicaOrDie(cluster)
+			//rollback conf
+			cluster.TiDBPreStartScript = strconv.Quote("")
+			cluster.ScaleTiDB(2)
+			oa.ScaleTidbClusterOrDie(cluster)
+
 		}
 		cancel()
 		oa.CleanWebHookAndServiceOrDie(ocfg.WebhookConfigName)


### PR DESCRIPTION
# What is changed and how does it work?
Original pd clusterIP is none, it will be parsed "None" string. It's an error.
So I comment pd service config，and remind users of this feature.
### Check List 
Tests 
 - Unit test




