### PR TITLE
disable current delete slot annotations check in Advanced Statefulset upgrader

### DIFF
--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -73,18 +73,22 @@ func isOwnedByTidbCluster(obj metav1.Object) bool {
 func (u *upgrader) Upgrade() error {
 	if features.DefaultFeatureGate.Enabled(features.AdvancedStatefulSet) {
 		klog.Infof("Upgrader: migrating Kubernetes StatefulSets to Advanced StatefulSets")
-		tcList, err := u.cli.PingcapV1alpha1().TidbClusters(u.ns).List(metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-		for _, tc := range tcList.Items {
-			// Existing delete slots annotations must be removed first. This is
-			// a safety check to ensure no pods are affected in upgrading
-			// process.
-			if anns := deleteSlotAnns(&tc); len(anns) > 0 {
-				return fmt.Errorf("Upgrader: TidbCluster %s/%s has delete slot annotations %v, please remove them before enabling AdvancedStatefulSet feature", tc.Namespace, tc.Name, anns)
-			}
-		}
+		// We should not check this, otherwise the controller-manager with
+		// advanced statefulset cannot be restarted when some clusters have
+		// delete slot annotations set.
+		// TODO find a better way
+		// tcList, err := u.cli.PingcapV1alpha1().TidbClusters(u.ns).List(metav1.ListOptions{})
+		// if err != nil {
+		// return err
+		// }
+		// for _, tc := range tcList.Items {
+		// // Existing delete slots annotations must be removed first. This is
+		// // a safety check to ensure no pods are affected in upgrading
+		// // process.
+		// if anns := deleteSlotAnns(&tc); len(anns) > 0 {
+		// return fmt.Errorf("Upgrader: TidbCluster %s/%s has delete slot annotations %v, please remove them before enabling AdvancedStatefulSet feature", tc.Namespace, tc.Name, anns)
+		// }
+		// }
 		stsList, err := u.kubeCli.AppsV1().StatefulSets(u.ns).List(metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/pkg/upgrader/upgrader_test.go
+++ b/pkg/upgrader/upgrader_test.go
@@ -314,70 +314,70 @@ func TestUpgrade(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "should not upgrade if tc has delete slot annotations",
-			tidbClusters: []v1alpha1.TidbCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							label.AnnTiDBDeleteSlots: "[1,2]",
-						},
-					},
-				},
-			},
-			statefulsets: []appsv1.StatefulSet{
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "sts1",
-						Namespace:       "sts",
-						OwnerReferences: validOwnerRefs,
-					},
-				},
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "sts2",
-						Namespace:       "sts",
-						OwnerReferences: validOwnerRefs,
-					},
-				},
-			},
-			feature:                  "AdvancedStatefulSet=true",
-			ns:                       metav1.NamespaceAll,
-			wantErr:                  true,
-			wantAdvancedStatefulsets: nil,
-			wantStatefulsets: []appsv1.StatefulSet{
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "sts1",
-						Namespace:       "sts",
-						OwnerReferences: validOwnerRefs,
-					},
-				},
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "StatefulSet",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "sts2",
-						Namespace:       "sts",
-						OwnerReferences: validOwnerRefs,
-					},
-				},
-			},
-		},
+		// {
+		// name: "should not upgrade if tc has delete slot annotations",
+		// tidbClusters: []v1alpha1.TidbCluster{
+		// {
+		// ObjectMeta: metav1.ObjectMeta{
+		// Annotations: map[string]string{
+		// label.AnnTiDBDeleteSlots: "[1,2]",
+		// },
+		// },
+		// },
+		// },
+		// statefulsets: []appsv1.StatefulSet{
+		// {
+		// TypeMeta: metav1.TypeMeta{
+		// Kind:       "StatefulSet",
+		// APIVersion: "apps/v1",
+		// },
+		// ObjectMeta: metav1.ObjectMeta{
+		// Name:            "sts1",
+		// Namespace:       "sts",
+		// OwnerReferences: validOwnerRefs,
+		// },
+		// },
+		// {
+		// TypeMeta: metav1.TypeMeta{
+		// Kind:       "StatefulSet",
+		// APIVersion: "apps/v1",
+		// },
+		// ObjectMeta: metav1.ObjectMeta{
+		// Name:            "sts2",
+		// Namespace:       "sts",
+		// OwnerReferences: validOwnerRefs,
+		// },
+		// },
+		// },
+		// feature:                  "AdvancedStatefulSet=true",
+		// ns:                       metav1.NamespaceAll,
+		// wantErr:                  true,
+		// wantAdvancedStatefulsets: nil,
+		// wantStatefulsets: []appsv1.StatefulSet{
+		// {
+		// TypeMeta: metav1.TypeMeta{
+		// Kind:       "StatefulSet",
+		// APIVersion: "apps/v1",
+		// },
+		// ObjectMeta: metav1.ObjectMeta{
+		// Name:            "sts1",
+		// Namespace:       "sts",
+		// OwnerReferences: validOwnerRefs,
+		// },
+		// },
+		// {
+		// TypeMeta: metav1.TypeMeta{
+		// Kind:       "StatefulSet",
+		// APIVersion: "apps/v1",
+		// },
+		// ObjectMeta: metav1.ObjectMeta{
+		// Name:            "sts2",
+		// Namespace:       "sts",
+		// OwnerReferences: validOwnerRefs,
+		// },
+		// },
+		// },
+		// },
 		{
 			name:         "should ignore if sts is not owned by TidbCluster",
 			tidbClusters: nil,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

We should not check this, otherwise the controller-manager with advanced statefulset cannot be restarted when some clusters have delete slot annotations set.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
