### PR TITLE
support starting tidb-server with `-advertise-address` parameter

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
@@ -26,7 +26,10 @@ then
     tail -f /dev/null
 fi
 
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
+--advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml

--- a/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
@@ -29,7 +29,9 @@ fi
 # Use HOSTNAME if POD_NAME is unset for backward compatibility.
 POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
+{{- if .Values.tidb.enableAdvertiseAddress | default false }}
 --advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
+{{- end }}
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -401,7 +401,7 @@ tidb:
   separateSlowLog: true
 
   # Add --advertise-address to TiDB's startup parameters
-	enableAdvertiseAddress: false
+  enableAdvertiseAddress: false
 
   slowLogTailer:
     image: busybox:1.26.2

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -399,6 +399,10 @@ tidb:
     # annotations:
       # cloud.google.com/load-balancer-type: Internal
   separateSlowLog: true
+
+  # Add --advertise-address to TiDB's startup parameters
+	enableAdvertiseAddress: false
+
   slowLogTailer:
     image: busybox:1.26.2
     resources:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -3782,6 +3782,10 @@ spec:
                     cluster-level updateStrategy if present Optional: Defaults to
                     cluster-level setting'
                   type: string
+                enableAdvertiseAddress:
+                  description: 'Add --advertise-address to TiDB''s startup parameters
+                    Optional: Defaults to false'
+                  type: boolean
                 hostNetwork:
                   description: 'Whether Hostnetwork of the component is enabled. Override
                     the cluster-level setting if present Optional: Defaults to cluster-level

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -3595,6 +3595,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"enableAdvertiseAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Add --advertise-address to TiDB's startup parameters Optional: Defaults to false",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"maxFailoverCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MaxFailoverCount limit the max replicas could be added in failover, 0 means unlimited Optional: Defaults to 0",

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -22,13 +22,14 @@ import (
 
 const (
 	// defaultHelperImage is default image of helper
-	defaultHelperImage      = "busybox:1.26.2"
-	defaultTimeZone         = "UTC"
-	defaultEnableTLSCluster = false
-	defaultEnableTLSClient  = false
-	defaultExposeStatus     = true
-	defaultSeparateSlowLog  = true
-	defaultEnablePVReclaim  = false
+	defaultHelperImage                = "busybox:1.26.2"
+	defaultTimeZone                   = "UTC"
+	defaultEnableTLSCluster           = false
+	defaultEnableTLSClient            = false
+	defaultExposeStatus               = true
+	defaultSeparateSlowLog            = true
+	defaultEnablePVReclaim            = false
+	defaultEnableTiDBAdvertiseAddress = false
 )
 
 var (
@@ -340,6 +341,13 @@ func (tc *TidbCluster) IsTiDBBinlogEnabled() bool {
 
 func (tidb *TiDBSpec) IsTLSClientEnabled() bool {
 	return tidb.TLSClient != nil && tidb.TLSClient.Enabled
+}
+
+func (tidb *TiDBSpec) IsAdvertiseAddressEnabled() bool {
+	if tidb.EnableAdvertiseAddress == nil {
+		return defaultEnableTiDBAdvertiseAddress
+	}
+	return *tidb.EnableAdvertiseAddress
 }
 
 func (tidb *TiDBSpec) IsUserGeneratedCertificate() bool {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -296,6 +296,11 @@ type TiDBSpec struct {
 	// +optional
 	BinlogEnabled *bool `json:"binlogEnabled,omitempty"`
 
+	// Add --advertise-address to TiDB's startup parameters
+	// Optional: Defaults to false
+	// +optional
+	EnableAdvertiseAddress *bool `json:"enableAdvertiseAddress,omitempty"`
+
 	// MaxFailoverCount limit the max replicas could be added in failover, 0 means unlimited
 	// Optional: Defaults to 0
 	// +kubebuilder:validation:Minimum=0

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -2521,6 +2521,11 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableAdvertiseAddress != nil {
+		in, out := &in.EnableAdvertiseAddress, &out.EnableAdvertiseAddress
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MaxFailoverCount != nil {
 		in, out := &in.MaxFailoverCount, &out.MaxFailoverCount
 		*out = new(int32)

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -50,7 +50,9 @@ fi
 # Use HOSTNAME if POD_NAME is unset for backward compatibility.
 POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
+{{- if .EnableAdvertiseAddress }}
 --advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
+{{- end }}
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml
@@ -77,10 +79,11 @@ exec /tidb-server ${ARGS}
 `))
 
 type TidbStartScriptModel struct {
-	ClusterName     string
-	EnablePlugin    bool
-	PluginDirectory string
-	PluginList      string
+	ClusterName            string
+	EnableAdvertiseAddress bool
+	EnablePlugin           bool
+	PluginDirectory        string
+	PluginList             string
 }
 
 func RenderTiDBStartScript(model *TidbStartScriptModel) (string, error) {

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -47,7 +47,10 @@ then
     tail -f /dev/null
 fi
 
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
+--advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -580,6 +580,7 @@ func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.S
 func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) *apps.StatefulSet {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
+	headlessSvcName := controller.TiDBPeerMemberName(tcName)
 	baseTiDBSpec := tc.BaseTiDBSpec()
 	instanceName := tc.GetInstanceName()
 	tidbConfigMap := controller.MemberConfigMapName(tc, v1alpha1.TiDBMemberType)
@@ -713,8 +714,28 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	}
 	envs := []corev1.EnvVar{
 		{
+			Name: "NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
 			Name:  "CLUSTER_NAME",
 			Value: tc.GetName(),
+		},
+		{
+			Name:  "HEADLESS_SERVICE_NAME",
+			Value: headlessSvcName,
 		},
 		{
 			Name:  "TZ",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Closes https://github.com/pingcap/tidb-operator/issues/1439

v2.1.0 and later versions have this argument:
https://github.com/pingcap/tidb/blob/v2.1.0/config/config.go#L48


### What is changed and how does it work?
start tidb-server with `-advertise-address` parameter, refer to https://github.com/pingcap/tidb/pull/7078.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)

When `EnableAdvertiseAddress` is set to false:
```
/ # ps
PID   USER     TIME  COMMAND
    1 root      0:00 /tidb-server --store=tikv --host=0.0.0.0 --path=db-pd:2379 --config=/etc/tidb/tidb.toml --log-slow-query=/var/log/tidb/slowlog
```

When `EnableAdvertiseAddress` is set to true:
```
# kubectl exec -it db-tidb-0 sh -n tidb10 -c tidb
/ # ps
PID   USER     TIME  COMMAND
    1 root      0:01 /tidb-server --store=tikv --advertise-address=db-tidb-0.db-tidb-peer.tidb10.svc --host=0.0.0.0 --path=db-pd:2379 --config=/etc/tidb/tidb
```

 - No code

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch
1.1
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
support starting tidb-server with `-advertise-address` parameter
```
