### PR TITLE
cleanup hack/kind-cluster-build.sh

### DIFF
--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -238,14 +238,7 @@ echo "init tidb-operator env"
 $KUBECTL_BIN apply -f ${ROOT}/manifests/local-dind/local-volume-provisioner.yaml
 $KUBECTL_BIN apply -f ${ROOT}/manifests/tiller-rbac.yaml
 $KUBECTL_BIN apply -f ${ROOT}/manifests/crd.yaml
-$KUBECTL_BIN create ns tidb-operator-e2e
 $HELM_BIN init --service-account=tiller --wait
-
-# This is required because current tidb-operator-e2e use a DIND-only image `mirantis/hypokube:final`
-# FIXME: remove this
-docker pull gcr.io/google-containers/kube-scheduler:${k8sVersion}
-docker tag gcr.io/google-containers/kube-scheduler:${k8sVersion} mirantis/hypokube:final
-$KIND_BIN load docker-image --name=${clusterName} mirantis/hypokube:final
 
 echo "############# success create cluster:[${clusterName}] #############"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

no need to set up for e2e testing anymore

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
