### PR TITLE
Fix nil error for update statefulset util

### DIFF
--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -267,6 +267,12 @@ func MapContainers(podSpec *corev1.PodSpec) map[string]corev1.Container {
 // updateStatefulSet is a template function to update the statefulset of components
 func updateStatefulSet(setCtl controller.StatefulSetControlInterface, tc *v1alpha1.TidbCluster, newSet, oldSet *apps.StatefulSet) error {
 	isOrphan := metav1.GetControllerOf(oldSet) == nil
+	if newSet.Annotations == nil {
+		newSet.Annotations = map[string]string{}
+	}
+	if oldSet.Annotations == nil {
+		oldSet.Annotations = map[string]string{}
+	}
 	if !statefulSetEqual(*newSet, *oldSet) || isOrphan {
 		set := *oldSet
 		// Retain the deprecated last applied pod template annotation for backward compatibility


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What is changed and how does it work?
Fix the nil error check for `updateStatefulSet` which would cause controller-manager crash.


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
