### PR TITLE
backup: support kms decryption secret

### DIFF
--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -1,5 +1,6 @@
 FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.51.0
+ARG SHUSH_VERSION=v1.4.0
 RUN apk update && apk add ca-certificates
 
 RUN wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
@@ -13,6 +14,10 @@ RUN wget -nv http://download.pingcap.org/br-latest-linux-amd64.tar.gz \
     && mv bin/br /usr/local/bin \
     && chmod 755 /usr/local/bin/br \
     && rm -rf br-latest-linux-amd64.tar.gz
+
+RUN wget -nv https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_amd64 \
+  && mv shush_linux_amd64 /usr/local/bin/shush \
+  && chmod 755 /usr/local/bin/shush
 
 COPY bin/tidb-backup-manager /tidb-backup-manager
 COPY entrypoint.sh /entrypoint.sh

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -51,33 +51,40 @@ else
 fi
 
 BACKUP_BIN=/tidb-backup-manager
+if [[ -n "${AWS_DEFAULT_REGION}"]]; then
+	EXEC_COMMAND="exec"
+else
+	EXEC_COMMAND="/usr/local/bin/shush exec --"
+fi
+
+cat /tmp/rclone.conf
 
 # exec command
 case "$1" in
     backup)
         shift 1
         echo "$BACKUP_BIN backup $@"
-        exec $BACKUP_BIN backup "$@"
+        $EXEC_COMMAND $BACKUP_BIN backup "$@"
         ;;
     export)
         shift 1
         echo "$BACKUP_BIN export $@"
-        exec $BACKUP_BIN export "$@"
+        $EXEC_COMMAND $BACKUP_BIN export "$@"
         ;;
     restore)
         shift 1
         echo "$BACKUP_BIN restore $@"
-        exec $BACKUP_BIN restore "$@"
+        $EXEC_COMMAND $BACKUP_BIN restore "$@"
         ;;
     import)
         shift 1
         echo "$BACKUP_BIN import $@"
-        exec $BACKUP_BIN import "$@"
+        $EXEC_COMMAND $BACKUP_BIN import "$@"
         ;;
     clean)
         shift 1
         echo "$BACKUP_BIN clean $@"
-        exec $BACKUP_BIN clean "$@"
+        $EXEC_COMMAND $BACKUP_BIN clean "$@"
         ;;
     *)
         echo "Usage: $0 {backup|restore|clean}"

--- a/manifests/backup/backup-aws-s3-br.yaml
+++ b/manifests/backup/backup-aws-s3-br.yaml
@@ -8,6 +8,7 @@ metadata:
     # iam.amazonaws.com/role: "arn:aws:iam::123456789:role"
 spec:
   # backupType: full
+  # useKMS: false
   # serviceAccount: myServiceAccount
   br:
     cluster: myCluster

--- a/manifests/backup/backup-s3-br.yaml
+++ b/manifests/backup/backup-s3-br.yaml
@@ -8,6 +8,7 @@ metadata:
     # iam.amazonaws.com/role: "arn:aws:iam::123456789:role"
 spec:
   # backupType: full
+  # useKMS: false
   # serviceAccount: myServiceAccount
   br:
     cluster: myCluster

--- a/manifests/backup/backup-schedule-aws-s3-br.yaml
+++ b/manifests/backup/backup-schedule-aws-s3-br.yaml
@@ -13,6 +13,7 @@ spec:
   schedule: "*/2 * * * *"
   backupTemplate:
     #backupType: full
+    # useKMS: false
     # serviceAccount: myServiceAccount
     br:
       cluster: myCluster

--- a/manifests/backup/backup-schedule-s3-br.yaml
+++ b/manifests/backup/backup-schedule-s3-br.yaml
@@ -13,6 +13,7 @@ spec:
   schedule: "*/2 * * * *"
   backupTemplate:
     #backupType: full
+    # useKMS: false
     # serviceAccount: myServiceAccount
     br:
       cluster: myCluster

--- a/manifests/backup/restore-aws-s3-br.yaml
+++ b/manifests/backup/restore-aws-s3-br.yaml
@@ -8,6 +8,7 @@ metadata:
     # iam.amazonaws.com/role: "arn:aws:iam::123456789:role"
 spec:
   # backupType: full
+  # useKMS: false
   # serviceAccount: myServiceAccount
   br:
     cluster: myCluster

--- a/manifests/backup/restore-s3-br.yaml
+++ b/manifests/backup/restore-s3-br.yaml
@@ -8,6 +8,7 @@ metadata:
     # iam.amazonaws.com/role: "arn:aws:iam::123456789:role"
 spec:
   # backupType: full
+  # useKMS: false
   # serviceAccount: myServiceAccount
   br:
     cluster: myCluster

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6954,6 +6954,9 @@ spec:
                     type: string
                 type: object
               type: array
+            useKMS:
+              description: Use KMS to encrypt the secrets
+              type: boolean
           type: object
       type: object
   version: v1alpha1
@@ -7795,6 +7798,9 @@ spec:
                     type: string
                 type: object
               type: array
+            useKMS:
+              description: Use KMS to encrypt the secrets
+              type: boolean
           type: object
       type: object
   version: v1alpha1
@@ -8680,6 +8686,9 @@ spec:
                         type: string
                     type: object
                   type: array
+                useKMS:
+                  description: Use KMS to encrypt the secrets
+                  type: boolean
               type: object
             maxBackups:
               description: MaxBackups is to specify how many backups we want to keep

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6955,7 +6955,7 @@ spec:
                 type: object
               type: array
             useKMS:
-              description: Use KMS to encrypt the secrets
+              description: Use KMS to decrypt the secrets
               type: boolean
           type: object
       type: object
@@ -7799,7 +7799,7 @@ spec:
                 type: object
               type: array
             useKMS:
-              description: Use KMS to encrypt the secrets
+              description: Use KMS to decrypt the secrets
               type: boolean
           type: object
       type: object
@@ -8687,7 +8687,7 @@ spec:
                     type: object
                   type: array
                 useKMS:
-                  description: Use KMS to encrypt the secrets
+                  description: Use KMS to decrypt the secrets
                   type: boolean
               type: object
             maxBackups:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -772,6 +772,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 							Ref:         ref("k8s.io/api/core/v1.Affinity"),
 						},
 					},
+					"useKMS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use KMS to encrypt the secrets",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"serviceAccount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specify service account of backup",
@@ -2848,6 +2855,13 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 						SchemaProps: spec.SchemaProps{
 							Description: "Affinity of restore Pods",
 							Ref:         ref("k8s.io/api/core/v1.Affinity"),
+						},
+					},
+					"useKMS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use KMS to encrypt the secrets",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"serviceAccount": {

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -774,7 +774,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 					},
 					"useKMS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Use KMS to encrypt the secrets",
+							Description: "Use KMS to decrypt the secrets",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2859,7 +2859,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"useKMS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Use KMS to encrypt the secrets",
+							Description: "Use KMS to decrypt the secrets",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -804,7 +804,7 @@ type BackupSpec struct {
 	// Affinity of backup Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// Use KMS to encrypt the secrets
+	// Use KMS to decrypt the secrets
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of backup
 	ServiceAccount string `json:"serviceAccount,omitempty"`
@@ -1026,7 +1026,7 @@ type RestoreSpec struct {
 	// Affinity of restore Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// Use KMS to encrypt the secrets
+	// Use KMS to decrypt the secrets
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -804,6 +804,8 @@ type BackupSpec struct {
 	// Affinity of backup Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// Use KMS to encrypt the secrets
+	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of backup
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
@@ -1024,6 +1026,8 @@ type RestoreSpec struct {
 	// Affinity of restore Pods
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// Use KMS to encrypt the secrets
+	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 }

--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -112,7 +112,7 @@ func (bc *backupCleaner) makeCleanJob(backup *v1alpha1.Backup) (*batchv1.Job, st
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bc.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bc.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}

--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -112,7 +112,7 @@ func (bc *backupCleaner) makeCleanJob(backup *v1alpha1.Backup) (*batchv1.Job, st
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bc.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bc.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}
@@ -128,7 +128,6 @@ func (bc *backupCleaner) makeCleanJob(backup *v1alpha1.Backup) (*batchv1.Job, st
 		serviceAccount = backup.Spec.ServiceAccount
 	}
 	backupLabel := label.NewBackup().Instance(backup.GetInstanceName()).CleanJob().Backup(name)
-
 	podSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      backupLabel.Labels(),

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -168,7 +168,7 @@ func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
 	}
@@ -260,7 +260,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
 	}

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -163,12 +163,12 @@ func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
-	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, backup.Spec.From.SecretName, bm.secretLister)
+	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, backup.Spec.From.SecretName, backup.Spec.UseKMS, bm.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
 	}
@@ -255,12 +255,12 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
-	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, backup.Spec.From.SecretName, bm.secretLister)
+	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, backup.Spec.From.SecretName, backup.Spec.UseKMS, bm.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.StorageProvider, bm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, backup.Spec.UseKMS, backup.Spec.StorageProvider, bm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
 	}

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -55,4 +55,7 @@ const (
 
 	// ServiceAccountCAPath is where is CABundle of serviceaccount locates
 	ServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	// KMS secret env prefix
+	KMSSecretPrefix = "KMS_ENCRYPTED"
 )

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -159,7 +159,7 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.UseKMS, restore.Spec.StorageProvider, rm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.StorageProvider, rm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("restore %s/%s, %v", ns, name, err)
 	}
@@ -245,7 +245,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.UseKMS, restore.Spec.StorageProvider, rm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.StorageProvider, rm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("restore %s/%s, %v", ns, name, err)
 	}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -154,12 +154,12 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 	ns := restore.GetNamespace()
 	name := restore.GetName()
 
-	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, restore.Spec.To.SecretName, rm.secretLister)
+	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, restore.Spec.To.SecretName, restore.Spec.UseKMS, rm.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.StorageProvider, rm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.UseKMS, restore.Spec.StorageProvider, rm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("restore %s/%s, %v", ns, name, err)
 	}
@@ -240,12 +240,12 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 	ns := restore.GetNamespace()
 	name := restore.GetName()
 
-	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, restore.Spec.To.SecretName, rm.secretLister)
+	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, restore.Spec.To.SecretName, restore.Spec.UseKMS, rm.secretLister)
 	if err != nil {
 		return nil, reason, err
 	}
 
-	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.StorageProvider, rm.secretLister)
+	storageEnv, reason, err := backuputil.GenerateStorageCertEnv(ns, restore.Spec.UseKMS, restore.Spec.StorageProvider, rm.secretLister)
 	if err != nil {
 		return nil, reason, fmt.Errorf("restore %s/%s, %v", ns, name, err)
 	}

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -39,7 +39,7 @@ func CheckAllKeysExistInSecret(secret *corev1.Secret, keys ...string) (string, b
 }
 
 // GenerateS3CertEnvVar generate the env info in order to access S3 compliant storage
-func GenerateS3CertEnvVar(s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, string, error) {
+func GenerateS3CertEnvVar(useKMS bool, s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, string, error) {
 	var envVars []corev1.EnvVar
 
 	switch s3.Provider {
@@ -87,10 +87,22 @@ func GenerateS3CertEnvVar(s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, stri
 			Value: s3.StorageClass,
 		},
 	}
+	accessKeyName := "AWS_ACCESS_KEY_ID"
+	secretKeyName := "AWS_SECRET_ACCESS_KEY"
+	if useKMS {
+		envVars = append(envVars, []corev1.EnvVar{
+			{
+				Name:  "AWS_DEFAULT_REGION",
+				Value: s3.Region,
+			},
+		}...)
+		accessKeyName = fmt.Sprintf("%s_AWS_ACCESS_KEY_ID", constants.KMSSecretPrefix)
+		secretKeyName = fmt.Sprintf("%s_AWS_SECRET_ACCESS_KEY", constants.KMSSecretPrefix)
+	}
 	if s3.SecretName != "" {
 		envVars = append(envVars, []corev1.EnvVar{
 			{
-				Name: "AWS_ACCESS_KEY_ID",
+				Name: accessKeyName,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: s3.SecretName},
@@ -99,7 +111,7 @@ func GenerateS3CertEnvVar(s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, stri
 				},
 			},
 			{
-				Name: "AWS_SECRET_ACCESS_KEY",
+				Name: secretKeyName,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: s3.SecretName},
@@ -152,7 +164,7 @@ func GenerateGcsCertEnvVar(gcs *v1alpha1.GcsStorageProvider) ([]corev1.EnvVar, s
 }
 
 // GenerateStorageCertEnv generate the env info in order to access backend backup storage
-func GenerateStorageCertEnv(ns string, provider v1alpha1.StorageProvider, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
+func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StorageProvider, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
 	var certEnv []corev1.EnvVar
 	var reason string
 	var err error
@@ -179,7 +191,7 @@ func GenerateStorageCertEnv(ns string, provider v1alpha1.StorageProvider, secret
 			}
 		}
 
-		certEnv, reason, err = GenerateS3CertEnvVar(provider.S3.DeepCopy())
+		certEnv, reason, err = GenerateS3CertEnvVar(useKMS, provider.S3.DeepCopy())
 		if err != nil {
 			return certEnv, reason, err
 		}
@@ -213,8 +225,9 @@ func GenerateStorageCertEnv(ns string, provider v1alpha1.StorageProvider, secret
 }
 
 // GenerateTidbPasswordEnv generate the password EnvVar
-func GenerateTidbPasswordEnv(ns, name, tidbSecretName string, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
+func GenerateTidbPasswordEnv(ns, name, tidbSecretName string, useKMS bool, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
 	var certEnv []corev1.EnvVar
+	var passwordKey string
 	secret, err := secretLister.Secrets(ns).Get(tidbSecretName)
 	if err != nil {
 		err = fmt.Errorf("backup %s/%s get tidb secret %s failed, err: %v", ns, name, tidbSecretName, err)
@@ -226,9 +239,16 @@ func GenerateTidbPasswordEnv(ns, name, tidbSecretName string, secretLister corel
 		err = fmt.Errorf("backup %s/%s, tidb secret %s missing password key %s", ns, name, tidbSecretName, keyStr)
 		return certEnv, "KeyNotExist", err
 	}
+
+	if useKMS {
+		passwordKey = fmt.Sprintf("%s_%s_%s", constants.KMSSecretPrefix, constants.BackupManagerEnvVarPrefix, strings.ToUpper(constants.TidbPasswordKey))
+	} else {
+		passwordKey = fmt.Sprintf("%s_%s", constants.BackupManagerEnvVarPrefix, strings.ToUpper(constants.TidbPasswordKey))
+	}
+
 	certEnv = []corev1.EnvVar{
 		{
-			Name: fmt.Sprintf("%s_%s", constants.BackupManagerEnvVarPrefix, strings.ToUpper(constants.TidbPasswordKey)),
+			Name: passwordKey,
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: tidbSecretName},

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -89,7 +89,7 @@ func GenerateS3CertEnvVar(useKMS bool, s3 *v1alpha1.S3StorageProvider) ([]corev1
 	}
 	// KMS has to use with IAM for get credentail to decryption the code
 	// so if use KMS, the secretKey and accesssKey can be ignore
-	if s3.SecretName != "" && !useKMS {
+	if s3.SecretName != "" {
 		envVars = append(envVars, []corev1.EnvVar{
 			{
 				Name: "AWS_ACCESS_KEY_ID",
@@ -169,7 +169,7 @@ func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StoragePro
 		s3SecretName := provider.S3.SecretName
 		// KMS has to use with IAM for get credentail to decryption the code
 		// so if use KMS, the secretKey and accesssKey can be ignore
-		if s3SecretName != "" && !useKMS {
+		if s3SecretName != "" {
 			secret, err := secretLister.Secrets(ns).Get(s3SecretName)
 			if err != nil {
 				err := fmt.Errorf("get s3 secret %s/%s failed, err: %v", ns, s3SecretName, err)

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -152,7 +152,7 @@ func GenerateGcsCertEnvVar(gcs *v1alpha1.GcsStorageProvider) ([]corev1.EnvVar, s
 }
 
 // GenerateStorageCertEnv generate the env info in order to access backend backup storage
-func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StorageProvider, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
+func GenerateStorageCertEnv(ns string, provider v1alpha1.StorageProvider, secretLister corelisters.SecretLister) ([]corev1.EnvVar, string, error) {
 	var certEnv []corev1.EnvVar
 	var reason string
 	var err error

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -39,7 +39,7 @@ func CheckAllKeysExistInSecret(secret *corev1.Secret, keys ...string) (string, b
 }
 
 // GenerateS3CertEnvVar generate the env info in order to access S3 compliant storage
-func GenerateS3CertEnvVar(useKMS bool, s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, string, error) {
+func GenerateS3CertEnvVar(s3 *v1alpha1.S3StorageProvider) ([]corev1.EnvVar, string, error) {
 	var envVars []corev1.EnvVar
 
 	switch s3.Provider {
@@ -87,8 +87,6 @@ func GenerateS3CertEnvVar(useKMS bool, s3 *v1alpha1.S3StorageProvider) ([]corev1
 			Value: s3.StorageClass,
 		},
 	}
-	// KMS has to use with IAM for get credentail to decryption the code
-	// so if use KMS, the secretKey and accesssKey can be ignore
 	if s3.SecretName != "" {
 		envVars = append(envVars, []corev1.EnvVar{
 			{
@@ -167,8 +165,6 @@ func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StoragePro
 		}
 
 		s3SecretName := provider.S3.SecretName
-		// KMS has to use with IAM for get credentail to decryption the code
-		// so if use KMS, the secretKey and accesssKey can be ignore
 		if s3SecretName != "" {
 			secret, err := secretLister.Secrets(ns).Get(s3SecretName)
 			if err != nil {
@@ -183,7 +179,7 @@ func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StoragePro
 			}
 		}
 
-		certEnv, reason, err = GenerateS3CertEnvVar(useKMS, provider.S3.DeepCopy())
+		certEnv, reason, err = GenerateS3CertEnvVar(provider.S3.DeepCopy())
 		if err != nil {
 			return certEnv, reason, err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
support kms decryption secret in tidb-operator
### What is changed and how does it work?
add KMS field in backup CRD, it should set to be true if the secret has been encrypted by KMS
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add `spec.useKMS` field in `Backup`, `Restore` and `BackupSchedule` custom resources. Set it to `true` if you want to decrypt the secrets encrypted with KMS.
```
