### PR TITLE
Backup: make tikv support add serviceaccount and switch rclone env_auth to true

### DIFF
--- a/docs/api-references/docs.html
+++ b/docs/api-references/docs.html
@@ -10703,6 +10703,17 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
+<code>serviceAccount</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specify a Service Account for tikv</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replicas</code></br>
 <em>
 int32

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Create rclone.conf file."
 cat <<EOF > /tmp/rclone.conf
 [s3]
 type = s3
-env_auth = false
+env_auth = true
 provider =  ${S3_PROVIDER}
 access_key_id = ${AWS_ACCESS_KEY_ID}
 secret_access_key = ${AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_KEY}

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -5996,6 +5996,9 @@ spec:
                   description: 'SchedulerName of the component. Override the cluster-level
                     one if present Optional: Defaults to cluster-level setting'
                   type: string
+                serviceAccount:
+                  description: Specify a Service Account for tikv
+                  type: string
                 storageClassName:
                   description: The storageClassName of the persistent volume for TiKV
                     data storage. Defaults to Kubernetes default storage class.

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -5449,6 +5449,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"serviceAccount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify a Service Account for tikv",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired ready replicas",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -238,6 +238,9 @@ type TiKVSpec struct {
 	ComponentSpec               `json:",inline"`
 	corev1.ResourceRequirements `json:",inline"`
 
+	// Specify a Service Account for tikv
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
 	// The desired ready replicas
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas"`

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -445,6 +445,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	podSpec.SecurityContext = podSecurityContext
 	podSpec.InitContainers = initContainers
 	podSpec.Containers = []corev1.Container{tikvContainer}
+	podSpec.ServiceAccountName = tc.Spec.TiKV.ServiceAccount
 
 	tikvset := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
support tikv specify a serviceAccount name and make rclone can use iam in cloud env
### What is changed and how does it work?
support tikv specify a serviceAccount name and make rclone can use iam in cloud env
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
modify tc and then verify serviceaccount is changed in tikv pod
use rclone in cloud env without set secretkey and accesskey

Code changes

 - Has Go code change

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
Add `spec.tikv.serviceAccount` field in `TiDBCluster` custom resources. To specify a service account name for tikv pods.
```
