### PR TITLE
defaulting tikv container privileged field

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -67,6 +67,14 @@ func (tc *TidbCluster) TiKVImage() string {
 	return image
 }
 
+func (tc *TidbCluster) TiKVContainerPrivilege() *bool {
+	if tc.Spec.TiKV.Privileged == nil {
+		pri := false
+		return &pri
+	}
+	return tc.Spec.TiKV.Privileged
+}
+
 func (tc *TidbCluster) TiDBImage() string {
 	image := tc.Spec.TiDB.Image
 	baseImage := tc.Spec.TiDB.BaseImage

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -15,7 +15,6 @@ package member
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb-operator/pkg/util"
 	"path"
 	"reflect"
 	"regexp"
@@ -27,6 +26,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/manager"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
+	"github.com/pingcap/tidb-operator/pkg/util"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -416,7 +416,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 		ImagePullPolicy: baseTiKVSpec.ImagePullPolicy(),
 		Command:         []string{"/bin/sh", "/usr/local/bin/tikv_start_script.sh"},
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: tc.Spec.TiKV.Privileged,
+			Privileged: tc.TiKVContainerPrivilege(),
 		},
 		Ports: []corev1.ContainerPort{
 			{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #1932 
### What is changed and how does it work?
Defaulting tikv container privileged field to false if not set.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    Upgrade tidb-operator from v1.0 to v1.1 and no rolling update for PD/TiDB/TiKV.

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
