### PR TITLE
update permission for tidb-controller-manager and add example for tidb-monitor

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-rbac.yaml
+++ b/charts/tidb-operator/templates/controller-manager-rbac.yaml
@@ -135,7 +135,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "update", "get", "list", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/charts/tidb-operator/templates/controller-manager-rbac.yaml
+++ b/charts/tidb-operator/templates/controller-manager-rbac.yaml
@@ -38,7 +38,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "update", "get", "list", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/manifests/monitor/tidb-monitor.yaml
+++ b/manifests/monitor/tidb-monitor.yaml
@@ -8,13 +8,13 @@ spec:
   prometheus:
     baseImage: prom/prometheus
     version: v2.11.1
-    resources:
-      limits: {}
-      #   cpu: 8000m
-      #   memory: 8Gi
-      requests: {}
-      #   cpu: 4000m
-      #   memory: 4Gi
+    resources: {}
+    #  limits:
+    #    cpu: 8000m
+    #    memory: 8Gi
+    #  requests:
+    #    cpu: 4000m
+    #    memory: 4Gi
     imagePullPolicy: IfNotPresent
     logLevel: info
     reserveDays: 12
@@ -26,13 +26,13 @@ spec:
     version: 6.0.1
     imagePullPolicy: IfNotPresent
     logLevel: info
-    resources:
-      limits: {}
-      #   cpu: 8000m
-      #   memory: 8Gi
-      requests: {}
-      #   cpu: 4000m
-      #   memory: 4Gi
+    resources: {}
+    #  limits:
+    #    cpu: 8000m
+    #    memory: 8Gi
+    #  requests:
+    #    cpu: 4000m
+    #    memory: 4Gi
     username: admin
     password: admin
     envs:
@@ -52,12 +52,12 @@ spec:
     version: v3.0.9
     imagePullPolicy: Always
     resources: {}
-    # limits:
-    #  cpu: 50m
-    #  memory: 64Mi
-    # requests:
-    #  cpu: 50m
-    #  memory: 64Mi
+    #  limits:
+    #    cpu: 50m
+    #    memory: 64Mi
+    #  requests:
+    #    cpu: 50m
+    #    memory: 64Mi
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1
@@ -66,12 +66,12 @@ spec:
       type: NodePort
       portName: tcp-reloader
     resources: {}
-      # limits:
-      #  cpu: 50m
-      #  memory: 64Mi
-      # requests:
-      #  cpu: 50m
-      #  memory: 64Mi
+    #  limits:
+    #    cpu: 50m
+    #    memory: 64Mi
+    #  requests:
+    #    cpu: 50m
+    #    memory: 64Mi
   imagePullPolicy: IfNotPresent
   persistent: true
   storageClassName: local-storage

--- a/manifests/monitor/tidb-monitor.yaml
+++ b/manifests/monitor/tidb-monitor.yaml
@@ -1,0 +1,83 @@
+apiVersion: pingcap.com/v1alpha1
+kind: TidbMonitor
+metadata:
+  name: demo
+spec:
+  clusters:
+  - name: demo
+  prometheus:
+    baseImage: prom/prometheus
+    version: v2.11.1
+    resources:
+      limits: {}
+      #   cpu: 8000m
+      #   memory: 8Gi
+      requests: {}
+      #   cpu: 4000m
+      #   memory: 4Gi
+    imagePullPolicy: IfNotPresent
+    logLevel: info
+    reserveDays: 12
+    service:
+      type: NodePort
+      portName: http-prometheus 
+  grafana:
+    baseImage: grafana/grafana
+    version: 6.0.1
+    imagePullPolicy: IfNotPresent
+    logLevel: info
+    resources:
+      limits: {}
+      #   cpu: 8000m
+      #   memory: 8Gi
+      requests: {}
+      #   cpu: 4000m
+      #   memory: 4Gi
+    username: admin
+    password: admin
+    envs:
+      # Configure Grafana using environment variables except GF_PATHS_DATA, GF_SECURITY_ADMIN_USER and GF_SECURITY_ADMIN_PASSWORD
+      # Ref https://grafana.com/docs/installation/configuration/#using-environment-variables
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_NAME: "Main Org."
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+      # if grafana is running behind a reverse proxy with subpath http://foo.bar/grafana
+      # GF_SERVER_DOMAIN: foo.bar
+      # GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana/"
+    service:
+      type: NodePort
+      portName: http-grafana
+  initializer:
+    baseImage: pingcap/tidb-monitor-initializer
+    version: v3.0.9
+    imagePullPolicy: Always
+    resources: {}
+    # limits:
+    #  cpu: 50m
+    #  memory: 64Mi
+    # requests:
+    #  cpu: 50m
+    #  memory: 64Mi
+  reloader:
+    baseImage: pingcap/tidb-monitor-reloader
+    version: v1.0.1
+    imagePullPolicy: IfNotPresent
+    service:
+      type: NodePort
+      portName: tcp-reloader
+    resources: {}
+      # limits:
+      #  cpu: 50m
+      #  memory: 64Mi
+      # requests:
+      #  cpu: 50m
+      #  memory: 64Mi
+  imagePullPolicy: IfNotPresent
+  persistent: true
+  storageClassName: local-storage
+  storage: 10Gi
+  nodeSelector: {}
+  annotations: {}
+  tolerations: []
+  kubePrometheusURL: http://prometheus-k8s.monitoring.svc:9090
+  alertmanagerURL: ""


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

1. After upgrade TiDB Operator from v1.0 to v1.1, then create TiDB Monitor CR, tidb-controller-manager reports below error:
```
Event(v1.ObjectReference{Kind:"TidbMonitor", Namespace:"dan10", Name:"dan10", UID:"c8b9b9ed-67f9-11ea-8886-8a678ff421f7", APIVersion:"pingcap.com/v1alpha1", ResourceVersion:"68470646", FieldPath:""}): type: 'Warning' reason: 'FailedSync' Sync TidbMonitor[dan10/dan10] Deployment failed,err:secrets "dan10-monitor" is forbidden: User "system:serviceaccount:tidb-admin:tidb-controller-manager" cannot update resource "secrets" in API group "" in the namespace "dan10"
 ```
2. No full example for TiDB Monitor.

### What is changed and how does it work?
update permission for tidb-controller-manager and add example for tidb-monitor
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   TiDB Monitor CR can be created and synced.

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```

Other issues during test of TiDB Monitor are recorded in #1949.