### PR TITLE
fix drainer installation error

### DIFF
--- a/charts/tidb-drainer/templates/_helpers.tpl
+++ b/charts/tidb-drainer/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "drainer.name" -}}
-{{- if .Values.drainerName }}
+{{- if .Values.drainerName -}}
 {{ .Values.drainerName }}
 {{- else -}}
 {{ .Values.clusterName }}-{{ .Release.Name }}-drainer


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Drainer installation failed when `drainerName` is set:
```
Error: YAML parse error on tidb-drainer/templates/drainer-statefulset.yaml: error converting YAML to JSON: yaml: line 5: could not find expected ':'
```
The `drainerName` is in separate line:
```
metadata:
  name: 
dan10-drainer
  labels:
```
### What is changed and how does it work?
Remove the newline character. 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   tidb-drainer can be installed successfully with below cases:

    -    Set `drainerName`
    -    Do not set `drainerName`

Code changes

- Has Helm scripts change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the drainer installation error when `drainerName` is set
```
