### PR TITLE
backup: mask visual tables when dumper 

### DIFF
--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -64,7 +64,7 @@ func (bo *Options) dumpTidbClusterData() (string, error) {
 		"--tidb-force-priority=LOW_PRIORITY",
 		"--verbose=3",
 		"--regex",
-		"^(?!(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA))",
+		"^(?!(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA))",
 	}
 
 	output, err := exec.Command("/mydumper", args...).CombinedOutput()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
mask visual tables when dumper 
### What is changed and how does it work?
add ignore policy when dumper
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
dumper with backup yaml 
```
---
apiVersion: pingcap.com/v1alpha1
kind: Backup
metadata:
  name: export-backup-s3
  namespace: tidb4
  annotations:
    iam.amazonaws.com/role: "arn:aws:iam::123456789012:role/user"
spec:
  backupType: full
  useKMS: true
  tikvGCLifeTime: 100h
  storageClassName: gp2
  storageSize: 1Gi
  from:
    host: 172.30.2.6
    secretName: mysql-pwd-1584498036384022997
    port: 4000
    user: root
  s3:
    provider: aws
    region: us-west-2
    bucket: my-backup-bucket
```
Code changes

 - Has Go code change