### PR TITLE
some cleanups in e2e

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -153,6 +153,17 @@ function hack::wait_for_success() {
     return 1
 }
 
+#
+# Concatenates the elements with an separator between them.
+#
+# Usage: hack::join ',' a b c
+#
+function hack::join() {
+	local IFS="$1"
+	shift
+	echo "$*"
+}
+
 function hack::__verify_kubetest2() {
     local n="$1"
     local v="$2"

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -214,9 +214,10 @@ function e2e::image_load() {
         $E2E_IMAGE
     )
     if [ "$PROVIDER" == "kind" ]; then
+        local nodes=$($KIND_BIN get nodes --name $CLUSTER | grep -v 'control-plane$')
         echo "info: load images ${images[@]}"
         for n in ${images[@]}; do
-            $KIND_BIN load docker-image --name $CLUSTER $n
+            $KIND_BIN load docker-image --name $CLUSTER $n --nodes $(hack::join ',' ${nodes[@]})
         done
     elif [ "$PROVIDER" == "gke" ]; then
         unset DOCKER_CONFIG # We don't need this and it may be read-only and fail the command to fail

--- a/tests/images/test-apiserver/Dockerfile
+++ b/tests/images/test-apiserver/Dockerfile
@@ -1,3 +1,0 @@
-FROM alpine:3.10
-
-ADD bin/tidb-apiserver /usr/local/bin/tidb-apiserver


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

- skip master node in image loading (speed up e2e process)
- remove unused Dockefile

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
