### PR TITLE
Mount google-cloud-sdk into e2e image

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -28,6 +28,7 @@ GCP_PROJECT=${GCP_PROJECT:-}
 GCP_REGION=${GCP_REGION:-}
 GCP_ZONE=${GCP_ZONE:-}
 GCP_CREDENTIALS=${GCP_CREDENTIALS:-}
+GCP_SDK=${GCP_SDK:-/google-cloud-sdk}
 IMAGE_TAG=${IMAGE_TAG:-}
 SKIP_IMAGE_LOAD=${SKIP_IMAGE_LOAD:-}
 TIDB_OPERATOR_IMAGE=${TIDB_OPERATOR_IMAGE:-localhost:5000/pingcap/tidb-operator:latest}
@@ -369,6 +370,15 @@ elif [ "$PROVIDER" == "gke" ]; then
     docker_args+=(
         -v ${GCP_CREDENTIALS}:${GCP_CREDENTIALS}
         --env GOOGLE_APPLICATION_CREDENTIALS=${GCP_CREDENTIALS}
+    )
+    # google-cloud-sdk is very large, we didn't pack it into our e2e image.
+    # instead, we use the sdk installed in CI image.
+    if [ ! -e "${GCP_SDK}/bin/gcloud" ]; then
+        echo "error: ${GCP_SDK} is not google cloud sdk, please install it here or specify correct path via GCP_SDK env"
+        exit 1
+    fi
+    docker_args+=(
+        -v ${GCP_SDK}:/google-cloud-sdk
     )
 else
     e2e_args+=(

--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -28,3 +28,6 @@ ADD bin/e2e.test /usr/local/bin/
 ADD bin/webhook /usr/local/bin/
 ADD bin/blockwriter /usr/local/bin/
 ADD bin/apiserver /usr/local/bin/
+
+ADD entrypoint.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/tests/images/e2e/entrypoint.sh
+++ b/tests/images/e2e/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Add default command if no command provided or the first argument is an
+# option.
+if [ $# -lt 1 -o "${1:0:1}" = '-' ]; then
+    set -- /usr/local/bin/ginkgo "$@"
+fi
+
+# If google-cloud-sdk is detected, install it.
+if [ -d /google-cloud-sdk ]; then
+    source /google-cloud-sdk/path.bash.inc
+    export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+fi
+
+exec "$@"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb-operator-e2e-gke-ci-master/detail/tidb-operator-e2e-gke-ci-master/62/pipeline

```
[2020-03-19T19:01:24.731Z] [5] E0319 19:01:24.307547      15 actions.go:907] failed to get tidbcluster: tidb-cluster-4946/basic-v2, Get https://104.155.180.0/apis/pingcap.com/v1alpha1/namespaces/tidb-cluster-4946/tidbclusters/basic-v2: error executing access token command "/google-cloud-sdk/bin/gcloud config config-helper --format=json": err=fork/exec /google-cloud-sdk/bin/gcloud: no such file or directory output= stderr=
```

e2e image needs to run `/google-cloud-sdk/bin/gcloud config config-helper` to refresh the auth token when it expired.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
