### PR TITLE
fix args passing in run-e2e.sh

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -325,11 +325,11 @@ e2e_args=(
     --
     --clean-start=true
     --delete-namespace-on-failure=false
-    --repo-root=$ROOT
+    --repo-root="$ROOT"
     # tidb-operator e2e flags
     --operator-tag=e2e
-    --operator-image=${TIDB_OPERATOR_IMAGE}
-    --e2e-image=${E2E_IMAGE}
+    --operator-image="${TIDB_OPERATOR_IMAGE}"
+    --e2e-image="${E2E_IMAGE}"
     # two tidb versions can be configuraed: <defaultVersion>,<upgradeToVersion>
     --tidb-versions=v3.0.7,v3.0.8
     --chart-dir=/charts
@@ -354,7 +354,7 @@ docker_args=(
 if [ "$PROVIDER" == "eks" ]; then
     e2e_args+=(
         --provider=aws
-        --gce-zone ${AWS_REGION}
+        --gce-zone="${AWS_REGION}"
     )
     # aws credential is required to get token for EKS
     docker_args+=(
@@ -362,10 +362,10 @@ if [ "$PROVIDER" == "eks" ]; then
     )
 elif [ "$PROVIDER" == "gke" ]; then
     e2e_args+=(
-        --provider=${PROVIDER}
-        --gce-project ${GCP_PROJECT}
-        --gce-region ${GCP_REGION}
-        --gce-zone ${GCP_ZONE}
+        --provider="${PROVIDER}"
+        --gce-project="${GCP_PROJECT}"
+        --gce-region="${GCP_REGION}"
+        --gce-zone="${GCP_ZONE}"
     )
     docker_args+=(
         -v ${GCP_CREDENTIALS}:${GCP_CREDENTIALS}
@@ -382,7 +382,7 @@ elif [ "$PROVIDER" == "gke" ]; then
     )
 else
     e2e_args+=(
-        --provider=${PROVIDER}
+        --provider="${PROVIDER}"
     )
 fi
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
@@ -51,6 +52,10 @@ func init() {
 func TestMain(m *testing.M) {
 	// Register test flags, then parse flags.
 	handleFlags()
+
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 
 	// Now that we know which Viper config (if any) was chosen,
 	// parse it and update those options which weren't already set via command line flags


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

- fix arg passing in run-e2e.sh
- log args

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb-operator-e2e-gke-ci-master/detail/tidb-operator-e2e-gke-ci-master/65/artifacts

report-dir is not passed into e2e, no test results are reported. 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
