### PR TITLE
fix default value of separateSlowLog

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -357,7 +357,7 @@ func (tidb *TiDBSpec) IsAdvertiseAddressEnabled() bool {
 func (tidb *TiDBSpec) ShouldSeparateSlowLog() bool {
 	separateSlowLog := tidb.SeparateSlowLog
 	if separateSlowLog == nil {
-		return defaultEnableTLSClient
+		return defaultSeparateSlowLog
 	}
 	return *separateSlowLog
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
The default value of separateSlowLog is set to the incorrect value.
### What is changed and how does it work?
Set it to the correct value.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
