### PR TITLE
Fix the error that `kubectl get tc` cannot show correct images 

### DIFF
--- a/docs/api-references/docs.html
+++ b/docs/api-references/docs.html
@@ -5339,6 +5339,16 @@ map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.UnjoinedMe
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="pingcap.com/v1alpha1.PDStoreLabel">PDStoreLabel
@@ -8049,6 +8059,16 @@ map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiDBFailur
 <code>resignDDLOwnerRetryCount</code></br>
 <em>
 int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
 </em>
 </td>
 <td>
@@ -11333,6 +11353,16 @@ map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVStore
 <a href="#pingcap.com/v1alpha1.TiKVFailureStore">
 map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVFailureStore
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
 </em>
 </td>
 <td>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: tidbclusters.pingcap.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.pd.image
+  - JSONPath: .status.pd.image
     description: The image for PD cluster
     name: PD
     type: string
@@ -22,7 +22,7 @@ spec:
     description: The desired replicas number of PD cluster
     name: Desire
     type: integer
-  - JSONPath: .spec.tikv.image
+  - JSONPath: .status.tikv.image
     description: The image for TiKV cluster
     name: TiKV
     type: string
@@ -38,7 +38,7 @@ spec:
     description: The desired replicas number of TiKV cluster
     name: Desire
     type: integer
-  - JSONPath: .spec.tidb.image
+  - JSONPath: .status.tidb.image
     description: The image for TiDB cluster
     name: TiDB
     type: string

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -513,6 +513,7 @@ type PDStatus struct {
 	Leader          PDMember                   `json:"leader,omitempty"`
 	FailureMembers  map[string]PDFailureMember `json:"failureMembers,omitempty"`
 	UnjoinedMembers map[string]UnjoinedMember  `json:"unjoinedMembers,omitempty"`
+	Image           string                     `json:"image,omitempty"`
 }
 
 // PDMember is PD member
@@ -550,6 +551,7 @@ type TiDBStatus struct {
 	Members                  map[string]TiDBMember        `json:"members,omitempty"`
 	FailureMembers           map[string]TiDBFailureMember `json:"failureMembers,omitempty"`
 	ResignDDLOwnerRetryCount int32                        `json:"resignDDLOwnerRetryCount,omitempty"`
+	Image                    string                       `json:"image,omitempty"`
 }
 
 // TiDBMember is TiDB member
@@ -576,6 +578,7 @@ type TiKVStatus struct {
 	Stores          map[string]TiKVStore        `json:"stores,omitempty"`
 	TombstoneStores map[string]TiKVStore        `json:"tombstoneStores,omitempty"`
 	FailureStores   map[string]TiKVFailureStore `json:"failureStores,omitempty"`
+	Image           string                      `json:"image,omitempty"`
 }
 
 // TiKVStores is either Up/Down/Offline/Tombstone

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -329,6 +329,11 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 	tc.Status.PD.Synced = true
 	tc.Status.PD.Members = pdStatus
 	tc.Status.PD.Leader = tc.Status.PD.Members[leader.GetName()]
+	tc.Status.PD.Image = ""
+	c := filterContainer(set, "pd")
+	if c != nil {
+		tc.Status.PD.Image = c.Image
+	}
 
 	// k8s check
 	err = pmm.collectUnjoinedMembers(tc, set, pdStatus)

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -744,7 +744,11 @@ func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, se
 		tidbStatus[name] = newTidbMember
 	}
 	tc.Status.TiDB.Members = tidbStatus
-
+	tc.Status.TiDB.Image = ""
+	c := filterContainer(set, "tidb")
+	if c != nil {
+		tc.Status.TiDB.Image = c.Image
+	}
 	return nil
 }
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -626,6 +626,11 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	tc.Status.TiKV.Synced = true
 	tc.Status.TiKV.Stores = stores
 	tc.Status.TiKV.TombstoneStores = tombstoneStores
+	tc.Status.TiKV.Image = ""
+	c := filterContainer(set, "tikv")
+	if c != nil {
+		tc.Status.TiKV.Image = c.Image
+	}
 	return nil
 }
 

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -309,4 +310,14 @@ func updateStatefulSet(setCtl controller.StatefulSetControlInterface, tc *v1alph
 
 func clusterSecretName(tc *v1alpha1.TidbCluster, component string) string {
 	return fmt.Sprintf("%s-%s-cluster-secret", tc.Name, component)
+}
+
+// filter targetContainer by  containerName, If not find, then return nil
+func filterContainer(sts *apps.StatefulSet, containerName string) *corev1.Container {
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			return &c
+		}
+	}
+	return nil
 }

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -28,7 +28,7 @@ var (
 		Name:        "PD",
 		Type:        "string",
 		Description: "The image for PD cluster",
-		JSONPath:    ".spec.pd.image",
+		JSONPath:    ".status.pd.image",
 	}
 	tidbClusterPDStorageColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Storage",
@@ -52,7 +52,7 @@ var (
 		Name:        "TiKV",
 		Type:        "string",
 		Description: "The image for TiKV cluster",
-		JSONPath:    ".spec.tikv.image",
+		JSONPath:    ".status.tikv.image",
 	}
 	tidbClusterTiKVStorageColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Storage",
@@ -76,7 +76,7 @@ var (
 		Name:        "TiDB",
 		Type:        "string",
 		Description: "The image for TiDB cluster",
-		JSONPath:    ".spec.tidb.image",
+		JSONPath:    ".status.tidb.image",
 	}
 	tidbClusterTiDBReadyColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Ready",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Close https://github.com/pingcap/tidb-operator/issues/1623

### What is changed and how does it work?
Adding the new property in `status` as `image` for each tidbcluster component. And changing the CRD column defination.

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the error that `kubectl get tc` cannot show correct images 
```
