### PR TITLE
backup: fix issue 1657

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -65,13 +65,14 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
 	cmd := exec.Command("br", fullArgs...)
+	cmd.Stderr = cmd.Stdout
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
 		return remotePath, fmt.Errorf("cluster %s, create stdout pipe failed, err: %v", bo, err)
 	}
 	err = cmd.Start()
 	if err != nil {
-		return remotePath, fmt.Errorf("cluster %s, execute br command %v failed, output: %s, err: %v", bo, fullArgs, err)
+		return remotePath, fmt.Errorf("cluster %s, execute br command failed, output: %s, err: %v", bo, fullArgs, err)
 	}
 	var tmpOutput, errMsg string
 	for {

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -46,7 +46,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 		return "", err
 	}
 	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, clusterNamespace))
-	if bo.TLSCluster {
+	if backup.Spec.BR.TLSCluster != nil && backup.Spec.BR.TLSCluster.Enabled {
 		args = append(args, fmt.Sprintf("--ca=%s", path.Join(util.ClusterClientTLSPath, corev1.ServiceAccountRootCAKey)))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSCertKey)))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSPrivateKeyKey)))

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -46,7 +46,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 		return "", err
 	}
 	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, clusterNamespace))
-	if backup.Spec.BR.TLSCluster != nil && backup.Spec.BR.TLSCluster.Enabled {
+	if bo.TLSCluster {
 		args = append(args, fmt.Sprintf("--ca=%s", path.Join(util.ClusterClientTLSPath, corev1.ServiceAccountRootCAKey)))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSCertKey)))
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSPrivateKeyKey)))

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -72,7 +72,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 	}
 	err = cmd.Start()
 	if err != nil {
-		return remotePath, fmt.Errorf("cluster %s, execute br command failed, output: %s, err: %v", bo, fullArgs, err)
+		return remotePath, fmt.Errorf("cluster %s, execute br command failed, args: %s, err: %v", bo, fullArgs, err)
 	}
 	var tmpOutput, errMsg string
 	for {
@@ -82,7 +82,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) (string, error) {
 		if strings.Contains(tmpOutput, "[ERROR]") {
 			errMsg += tmpOutput
 		}
-		klog.Infof(tmpOutput)
+		klog.Infof(strings.Replace(tmpOutput, "\n", "", -1))
 		if err != nil {
 			break
 		}

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -59,13 +59,14 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
 	cmd := exec.Command("br", fullArgs...)
+	cmd.Stderr = cmd.Stdout
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("cluster %s, create stdout pipe failed, err: %v", ro, err)
 	}
 	err = cmd.Start()
 	if err != nil {
-		return fmt.Errorf("cluster %s, execute br command %v failed, output: %s, err: %v", ro, fullArgs, err)
+		return fmt.Errorf("cluster %s, execute br command failed, output: %s, err: %v", ro, fullArgs, err)
 	}
 	var tmpOutput, errMsg string
 	for {

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strings"
 
 	backupUtil "github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -57,11 +58,33 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	}
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
-	output, err := exec.Command("br", fullArgs...).CombinedOutput()
+	cmd := exec.Command("br", fullArgs...)
+	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("cluster %s, execute br command %v failed, output: %s, err: %v", ro, fullArgs, string(output), err)
+		return fmt.Errorf("cluster %s, create stdout pipe failed, err: %v", ro, err)
 	}
-	klog.Infof("Restore data for cluster %s successfully, output: %s", ro, string(output))
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("cluster %s, execute br command %v failed, output: %s, err: %v", ro, fullArgs, err)
+	}
+	var tmpOutput, errMsg string
+	for {
+		tmp := make([]byte, 1024)
+		_, err := stdOut.Read(tmp)
+		tmpOutput = string(tmp)
+		if strings.Contains(tmpOutput, "[ERROR]") {
+			errMsg += tmpOutput
+		}
+		klog.Infof(tmpOutput)
+		if err != nil {
+			break
+		}
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("cluster %s, wait pipe message failed, errMsg %s, err: %v", ro, errMsg, err)
+	}
+	klog.Infof("Restore data for cluster %s successfully", ro)
 	return nil
 }
 

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -66,7 +66,7 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	}
 	err = cmd.Start()
 	if err != nil {
-		return fmt.Errorf("cluster %s, execute br command failed, output: %s, err: %v", ro, fullArgs, err)
+		return fmt.Errorf("cluster %s, execute br command failed, args: %s, err: %v", ro, fullArgs, err)
 	}
 	var tmpOutput, errMsg string
 	for {
@@ -76,7 +76,7 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 		if strings.Contains(tmpOutput, "[ERROR]") {
 			errMsg += tmpOutput
 		}
-		klog.Infof(tmpOutput)
+		klog.Infof(strings.Replace(tmpOutput, "\n", "", -1))
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #1657
### What is changed and how does it work?
create a stdout pipe from the exec process, and read the pipe message in a for loop, If the output meesage with ERROR, add to the backup status message information
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
It seems the log will output intime and the backup status messsage is 
```
  status:
    backupPath: ""
    backupSize: 0
    commitTs: ""
    conditions:
    - lastTransitionTime: "2020-03-30T12:14:02Z"
      message: ""
      reason: ""
      status: "True"
      type: Scheduled
    - lastTransitionTime: "2020-03-30T12:14:03Z"
      message: ""
      reason: ""
      status: "True"
      type: Running
    - lastTransitionTime: "2020-03-30T12:14:36Z"
      message: "cluster cluster/sa-backup-s3, wait pipe message failed, errMsg [2020/03/30
        12:14:36.196 +00:00] [ERROR] [push.go:106] [\"backup occur unknown error\"]
        [error=\"Io(Custom { kind: Other, error: \\\"failed to put object Couldn\\\\'t
        find AWS credentials in environment, credentials file, or IAM role.\\\" })\"]
        [stack=\"github.com/pingcap/log.Error\\n\\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20200117041106-d28c14d3b1cd/global.go:42\\ngithub.com/pingcap/br/pkg/backup.(*pushDown).pushBackup\\n\\t/home/jenkins/agent/workspace/build_br_master/go/src/github.com/pingcap/br/pkg/backup/push.go:106\\ngithub.com/pingcap/br/pkg/backup.(*Client).backupRange\\n\\t/home/jenkins/agent/workspace/build_br_master/go/src/github.com/pingcap/br/pkg/backup/client.go:404\\ngithub.com/pingcap/br/pkg/backup.(*Client).BackupRanges.func2\\n\\t/home/jenkins/agent/workspace/build_br_master/go/src/github.com/pingcap/br/pkg/backup/client.go:316\"]\n\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0,
        err: exit status 1"
      reason: BackupDataToRemoteFailed
      status: "True"
      type: Failed
    timeCompleted: null
    timeStarted: null
```
Code changes

 - Has Go code change