### PR TITLE
remove enableAdvertiseAddress field, --advertise-address should be always configured

### DIFF
--- a/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
+++ b/charts/tidb-cluster/templates/scripts/_start_tidb.sh.tpl
@@ -29,9 +29,7 @@ fi
 # Use HOSTNAME if POD_NAME is unset for backward compatibility.
 POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
-{{- if .Values.tidb.enableAdvertiseAddress | default false }}
 --advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
-{{- end }}
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -433,9 +433,6 @@ tidb:
       # cloud.google.com/load-balancer-type: Internal
   separateSlowLog: true
 
-  # Add --advertise-address to TiDB's startup parameters
-  enableAdvertiseAddress: false
-
   slowLogTailer:
     image: busybox:1.26.2
     resources:

--- a/docs/api-references/docs.html
+++ b/docs/api-references/docs.html
@@ -7927,19 +7927,6 @@ Optional: Defaults to true if PumpSpec is non-nil, otherwise false</p>
 </tr>
 <tr>
 <td>
-<code>enableAdvertiseAddress</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Add &ndash;advertise-address to TiDB&rsquo;s startup parameters
-Optional: Defaults to false</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>maxFailoverCount</code></br>
 <em>
 int32

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4075,10 +4075,6 @@ spec:
                     cluster-level updateStrategy if present Optional: Defaults to
                     cluster-level setting'
                   type: string
-                enableAdvertiseAddress:
-                  description: 'Add --advertise-address to TiDB''s startup parameters
-                    Optional: Defaults to false'
-                  type: boolean
                 env:
                   description: List of environment variables to set in the container,
                     like v1.Container.Env. Note that following env names cannot be

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -3874,13 +3874,6 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
-					"enableAdvertiseAddress": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Add --advertise-address to TiDB's startup parameters Optional: Defaults to false",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"maxFailoverCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MaxFailoverCount limit the max replicas could be added in failover, 0 means no failover Optional: Defaults to 3",

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -22,14 +22,13 @@ import (
 
 const (
 	// defaultHelperImage is default image of helper
-	defaultHelperImage                = "busybox:1.26.2"
-	defaultTimeZone                   = "UTC"
-	defaultEnableTLSCluster           = false
-	defaultEnableTLSClient            = false
-	defaultExposeStatus               = true
-	defaultSeparateSlowLog            = true
-	defaultEnablePVReclaim            = false
-	defaultEnableTiDBAdvertiseAddress = false
+	defaultHelperImage      = "busybox:1.26.2"
+	defaultTimeZone         = "UTC"
+	defaultEnableTLSCluster = false
+	defaultEnableTLSClient  = false
+	defaultExposeStatus     = true
+	defaultSeparateSlowLog  = true
+	defaultEnablePVReclaim  = false
 )
 
 var (
@@ -345,13 +344,6 @@ func (tc *TidbCluster) IsTiDBBinlogEnabled() bool {
 
 func (tidb *TiDBSpec) IsTLSClientEnabled() bool {
 	return tidb.TLSClient != nil && tidb.TLSClient.Enabled
-}
-
-func (tidb *TiDBSpec) IsAdvertiseAddressEnabled() bool {
-	if tidb.EnableAdvertiseAddress == nil {
-		return defaultEnableTiDBAdvertiseAddress
-	}
-	return *tidb.EnableAdvertiseAddress
 }
 
 func (tidb *TiDBSpec) ShouldSeparateSlowLog() bool {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -304,11 +304,6 @@ type TiDBSpec struct {
 	// +optional
 	BinlogEnabled *bool `json:"binlogEnabled,omitempty"`
 
-	// Add --advertise-address to TiDB's startup parameters
-	// Optional: Defaults to false
-	// +optional
-	EnableAdvertiseAddress *bool `json:"enableAdvertiseAddress,omitempty"`
-
 	// MaxFailoverCount limit the max replicas could be added in failover, 0 means no failover
 	// Optional: Defaults to 3
 	// +kubebuilder:validation:Minimum=0

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -2726,11 +2726,6 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnableAdvertiseAddress != nil {
-		in, out := &in.EnableAdvertiseAddress, &out.EnableAdvertiseAddress
-		*out = new(bool)
-		**out = **in
-	}
 	if in.MaxFailoverCount != nil {
 		in, out := &in.MaxFailoverCount, &out.MaxFailoverCount
 		*out = new(int32)

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -50,9 +50,7 @@ fi
 # Use HOSTNAME if POD_NAME is unset for backward compatibility.
 POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--store=tikv \
-{{- if .EnableAdvertiseAddress }}
 --advertise-address=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc \
-{{- end }}
 --host=0.0.0.0 \
 --path=${CLUSTER_NAME}-pd:2379 \
 --config=/etc/tidb/tidb.toml
@@ -79,11 +77,10 @@ exec /tidb-server ${ARGS}
 `))
 
 type TidbStartScriptModel struct {
-	ClusterName            string
-	EnableAdvertiseAddress bool
-	EnablePlugin           bool
-	PluginDirectory        string
-	PluginList             string
+	ClusterName     string
+	EnablePlugin    bool
+	PluginDirectory string
+	PluginList      string
 }
 
 func RenderTiDBStartScript(model *TidbStartScriptModel) (string, error) {

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -337,11 +337,10 @@ func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 
 	plugins := tc.Spec.TiDB.Plugins
 	startScript, err := RenderTiDBStartScript(&TidbStartScriptModel{
-		ClusterName:            tc.Name,
-		EnableAdvertiseAddress: tc.Spec.TiDB.IsAdvertiseAddressEnabled(),
-		EnablePlugin:           len(plugins) > 0,
-		PluginDirectory:        "/plugins",
-		PluginList:             strings.Join(plugins, ","),
+		ClusterName:     tc.Name,
+		EnablePlugin:    len(plugins) > 0,
+		PluginDirectory: "/plugins",
+		PluginList:      strings.Join(plugins, ","),
 	})
 	if err != nil {
 		return nil, err
@@ -609,32 +608,26 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			Name:  "SLOW_LOG_FILE",
 			Value: slowLogFileEnvVal,
 		},
-	}
-
-	if tc.Spec.TiDB.IsAdvertiseAddressEnabled() {
-		advertiseEnvs := []corev1.EnvVar{
-			{
-				Name: "POD_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
 				},
 			},
-			{
-				Name: "NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
+		},
+		{
+			Name: "NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
 				},
 			},
-			{
-				Name:  "HEADLESS_SERVICE_NAME",
-				Value: headlessSvcName,
-			},
-		}
-		envs = append(envs, advertiseEnvs...)
+		},
+		{
+			Name:  "HEADLESS_SERVICE_NAME",
+			Value: headlessSvcName,
+		},
 	}
 
 	scheme := corev1.URISchemeHTTP


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

After https://github.com/pingcap/tidb-operator/pull/2013, users can set `spec.paused` to `true` if they want to avoid `tidb-server` rolling upgrade in tidb-operator upgrading. Note that users should set it back to `false` when it's ok to upgrade `tidb-server`. 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
ACTION REQUIRED: `--advertise-address` will be configured for `tidb-server` which will trigger rolling-upgrade for `tidb-server` component, you can set `spec.paused` to `true` to avoid it before upgrading tidb-operator and set it back to `false` when it's ready to upgrade your tidb server.
```