### PR TITLE
upgrade cert-manager to v0.14.1 in example tests

### DIFF
--- a/tests/examples/002-selfsigned-tls.sh
+++ b/tests/examples/002-selfsigned-tls.sh
@@ -20,6 +20,7 @@ source "${ROOT}/hack/lib.sh"
 source "${ROOT}/tests/examples/t.sh"
 
 NS=$(basename ${0%.*})
+CERT_MANAGER_VERSION=0.14.1
 
 PORT_FORWARD_PID=
 
@@ -29,7 +30,7 @@ function cleanup() {
         kill $PORT_FORWARD_PID
     fi
     kubectl delete -f examples/selfsigned-tls/ --ignore-not-found
-    kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml --ignore-not-found
+    kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml --ignore-not-found
     kubectl delete ns $NS
 }
 
@@ -38,7 +39,7 @@ trap cleanup EXIT
 kubectl create ns $NS
 hack::wait_for_success 10 3 "t::ns_is_active $NS"
 
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 hack::wait_for_success 10 3 "t::crds_are_ready certificaterequests.cert-manager.io certificates.cert-manager.io challenges.acme.cert-manager.io clusterissuers.cert-manager.io issuers.cert-manager.io orders.acme.cert-manager.io"
 for d in cert-manager cert-manager-cainjector cert-manager-webhook; do
     hack::wait_for_success 300 3 "t::deploy_is_ready cert-manager $d"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
