### PR TITLE
Explicit statement port in peer url

### DIFF
--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -458,6 +458,12 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 					TargetPort: intstr.FromInt(2380),
 					Protocol:   corev1.ProtocolTCP,
 				},
+				{
+					Name:       "peer-client",
+					Port:       2379,
+					TargetPort: intstr.FromInt(2379),
+					Protocol:   corev1.ProtocolTCP,
+				},
 			},
 			Selector:                 pdLabel,
 			PublishNotReadyAddresses: true,

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -875,6 +875,12 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 							TargetPort: intstr.FromInt(2380),
 							Protocol:   corev1.ProtocolTCP,
 						},
+						{
+							Name:       "peer-client",
+							Port:       2379,
+							TargetPort: intstr.FromInt(2379),
+							Protocol:   corev1.ProtocolTCP,
+						},
 					},
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",


### PR DESCRIPTION
### What problem does this PR solve? 
#1764 

### What is changed and how does it work?
I find discovery will write peer url with 2379 port, so we need to explicit statement `2379`  port .

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test


Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 None


```