### PR TITLE
add AGE column for all CRDs

### DIFF
--- a/cmd/to-crdgen/main.go
+++ b/cmd/to-crdgen/main.go
@@ -16,9 +16,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/pingcap/tidb-operator/pkg/to-crdgen/cmd"
 	"github.com/spf13/pflag"
-	"os"
 )
 
 func main() {

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -50,6 +50,9 @@ spec:
     description: The desired replicas number of TiDB cluster
     name: Desire
     type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: TidbCluster
@@ -7748,6 +7751,9 @@ spec:
     name: Completed
     priority: 1
     type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: Backup
@@ -8588,6 +8594,9 @@ spec:
   - JSONPath: .status.timeCompleted
     description: The time at which the restore was completed
     name: Completed
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
     type: date
   group: pingcap.com
   names:
@@ -9440,6 +9449,9 @@ spec:
     description: The last time the backup was successfully created
     name: LastBackupTime
     priority: 1
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
     type: date
   group: pingcap.com
   names:
@@ -10456,6 +10468,9 @@ spec:
     name: Phase
     priority: 1
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: TidbInitializer
@@ -10558,6 +10573,9 @@ spec:
     description: The minimal replicas of TiKV
     name: TiKV-MinReplicas
     type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: TidbClusterAutoScaler

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -198,19 +198,24 @@ var (
 		Description: "The minimal replicas of TiDB",
 		JSONPath:    ".spec.tidb.minReplicas",
 	}
+	ageColumn = extensionsobj.CustomResourceColumnDefinition{
+		Name:     "Age",
+		Type:     "date",
+		JSONPath: ".metadata.creationTimestamp",
+	}
 )
 
 func init() {
 	tidbClusteradditionalPrinterColumns = append(tidbClusteradditionalPrinterColumns,
 		tidbClusterPDColumn, tidbClusterPDStorageColumn, tidbClusterPDReadyColumn, tidbClusterPDDesireColumn,
 		tidbClusterTiKVColumn, tidbClusterTiKVStorageColumn, tidbClusterTiKVReadyColumn, tidbClusterTiKVDesireColumn,
-		tidbClusterTiDBColumn, tidbClusterTiDBReadyColumn, tidbClusterTiDBDesireColumn)
-	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn)
-	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStartedColumn, restoreCompletedColumn)
-	bksAdditionalPrinterColumns = append(bksAdditionalPrinterColumns, bksScheduleColumn, bksMaxBackups, bksLastBackup, bksLastBackupTime)
-	tidbInitializerPrinterColumns = append(tidbInitializerPrinterColumns, tidbInitializerPhase)
+		tidbClusterTiDBColumn, tidbClusterTiDBReadyColumn, tidbClusterTiDBDesireColumn, ageColumn)
+	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn, ageColumn)
+	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStartedColumn, restoreCompletedColumn, ageColumn)
+	bksAdditionalPrinterColumns = append(bksAdditionalPrinterColumns, bksScheduleColumn, bksMaxBackups, bksLastBackup, bksLastBackupTime, ageColumn)
+	tidbInitializerPrinterColumns = append(tidbInitializerPrinterColumns, tidbInitializerPhase, ageColumn)
 	autoScalerPrinterColumns = append(autoScalerPrinterColumns, autoScalerTiDBMaxReplicasColumn, autoScalerTiDBMinReplicasColumn,
-		autoScalerTiKVMaxReplicasColumn, autoScalerTiKVMinReplicasColumn)
+		autoScalerTiKVMaxReplicasColumn, autoScalerTiKVMinReplicasColumn, ageColumn)
 }
 
 func NewCustomResourceDefinition(crdKind v1alpha1.CrdKind, group string, labels map[string]string, validation bool) *extensionsobj.CustomResourceDefinition {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Add the `AGE` column to show creation timestamp for all CRDs. This is convenient for users to know when the object was created. By the way, almost all Kubernetes built-in objects have this column too. `AGE` column is the default column in Kubernetes if `additionalPrinterColumns` is empty.

example:
```
$ kubectl  get tc
NAME    PD                  STORAGE   READY   DESIRE   TIKV                  STORAGE   READY   DESIRE   TIDB                  READY   DESIRE   AGE
basic   pingcap/pd:v3.0.8   1Gi       3       3        pingcap/tikv:v3.0.8   1Gi       3       3        pingcap/tidb:v3.0.8   2       2        5h8m
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add the `AGE` column to show creation timestamp for all CRDs.
```
