### PR TITLE
use fixed names for CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-        - "check-setup check"
-        - "docker e2e-docker cli debug-build-docker"
-        - "test GOFLAGS=-race"
-        - "e2e-examples"
+        job:
+        - verify
+        - build
+        - test
+        - e2e-examples
     steps:
     - name: Set up Go 1.13
       uses: actions/setup-go@v1
@@ -31,12 +31,20 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         path: go/src/github.com/${{ github.repository }}
 
-    - name: make ${{ matrix.target }}
+    - name: ${{ matrix.job }}
       run: |
         # workaround for https://github.com/actions/setup-go/issues/14
         export GOPATH=${GITHUB_WORKSPACE}/go
         export PATH=$PATH:$GOPATH/bin
-        make $target
+        if [[ "$job" == "verify" ]]; then
+          make check-setup check
+        elif [[ "$job" == "build" ]]; then
+          make docker e2e-docker cli debug-build-docker
+        elif [[ "$job" == "test" ]]; then
+          make test GOFLAGS=-race
+        else
+          make $job
+        fi
       working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
       env:
-        target: ${{ matrix.target }}
+        job: ${{ matrix.job }}

--- a/Makefile
+++ b/Makefile
@@ -218,4 +218,4 @@ debug-build-docker: debug-build
 debug-build:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o misc/images/debug-launcher/bin/debug-launcher misc/cmd/debug-launcher/main.go
 
-.PHONY: check check-setup check-all build e2e-build debug-build cli e2e
+.PHONY: check check-setup check-all build e2e-build debug-build cli e2e test docker e2e-docker debug-build-docker


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

We use fixed names for CI jobs, then we don't need to update branch protection rules when we modified the command we run in CI jobs.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
