### PR TITLE
install python for gcloud CLI in e2e image

### DIFF
--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -4,7 +4,8 @@ ENV KUBECTL_VERSION=v1.12.2
 ENV HELM_VERSION=v2.9.1
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl git openssl default-mysql-client unzip
+    apt-get install -y ca-certificates curl git openssl default-mysql-client unzip && \
+    apt-get install -y python # required by gcloud
 RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
     -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

```
error executing access token command "/google-cloud-sdk/bin/gcloud config config-helper --format=json": err=exit status 127 output= stderr=/google-cloud-sdk/bin/gcloud: 191: exec: python: not found
```

https://internal.pingcap.net/idc-jenkins/view/tidb-operator/job/tidb-operator-e2e-gke-ci-master-serial/19/console

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
