### PR TITLE
add `DOCKER_REPO` to specify full image repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 # Set DEBUGGER=1 to build debug symbols
 LDFLAGS = $(if $(DEBUGGER),,-s -w) $(shell ./hack/version.sh)
 
-# SET DOCKER_REGISTRY to change the docker registry
-DOCKER_REGISTRY := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY),localhost:5000)
-
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")
 GO113 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 13 ]; echo $$?)
@@ -19,6 +16,8 @@ GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go
 GO_BUILD := $(GO) build -trimpath
 
+DOCKER_REGISTRY ?= localhost:5000
+DOCKER_REPO ?= ${DOCKER_REGISTRY}/pingcap
 IMAGE_TAG ?= latest
 PACKAGE_LIST := go list ./... | grep -vE "client/(clientset|informers|listers)"
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tidb-operator/||'
@@ -29,8 +28,8 @@ TEST_COVER_PACKAGES:=go list ./pkg/... | grep -vE "pkg/client" | grep -vE "pkg/t
 default: build
 
 docker-push: docker backup-docker
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator:${IMAGE_TAG}"
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-backup-manager:${IMAGE_TAG}"
+	docker push "${DOCKER_REPO}/tidb-operator:${IMAGE_TAG}"
+	docker push "${DOCKER_REPO}/tidb-backup-manager:${IMAGE_TAG}"
 
 ifeq ($(NO_BUILD),y)
 docker:
@@ -38,8 +37,8 @@ docker:
 else
 docker: build
 endif
-	docker build --tag "${DOCKER_REGISTRY}/pingcap/tidb-operator:${IMAGE_TAG}" images/tidb-operator
-	docker build --tag "${DOCKER_REGISTRY}/pingcap/tidb-backup-manager:${IMAGE_TAG}" images/tidb-backup-manager
+	docker build --tag "${DOCKER_REPO}/tidb-operator:${IMAGE_TAG}" images/tidb-operator
+	docker build --tag "${DOCKER_REPO}/tidb-backup-manager:${IMAGE_TAG}" images/tidb-backup-manager
 
 build: controller-manager scheduler discovery admission-webhook apiserver backup-manager
 
@@ -67,10 +66,10 @@ backup-docker:
 else
 backup-docker: backup-manager
 endif
-	docker build --tag "${DOCKER_REGISTRY}/pingcap/tidb-backup-manager:${IMAGE_TAG}" images/tidb-backup-manager
+	docker build --tag "${DOCKER_REPO}/tidb-backup-manager:${IMAGE_TAG}" images/tidb-backup-manager
 
 e2e-docker-push: e2e-docker
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator-e2e:${IMAGE_TAG}"
+	docker push "${DOCKER_REPO}/tidb-operator-e2e:${IMAGE_TAG}"
 
 ifeq ($(NO_BUILD),y)
 e2e-docker:
@@ -86,7 +85,7 @@ endif
 	cp -r charts/tidb-cluster tests/images/e2e
 	cp -r charts/tidb-backup tests/images/e2e
 	cp -r manifests tests/images/e2e
-	docker build -t "${DOCKER_REGISTRY}/pingcap/tidb-operator-e2e:${IMAGE_TAG}" tests/images/e2e
+	docker build -t "${DOCKER_REPO}/tidb-operator-e2e:${IMAGE_TAG}" tests/images/e2e
 
 e2e-build:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o tests/images/e2e/bin/ginkgo github.com/onsi/ginkgo/ginkgo
@@ -106,10 +105,10 @@ stability-test-build:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o tests/images/stability-test/bin/stability-test ./tests/cmd/stability
 
 stability-test-docker: stability-test-build
-	docker build -t "${DOCKER_REGISTRY}/pingcap/tidb-operator-stability-test:${IMAGE_TAG}" tests/images/stability-test
+	docker build -t "${DOCKER_REPO}/tidb-operator-stability-test:${IMAGE_TAG}" tests/images/stability-test
 
 stability-test-push: stability-test-docker
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-operator-stability-test:${IMAGE_TAG}"
+	docker push "${DOCKER_REPO}/tidb-operator-stability-test:${IMAGE_TAG}"
 
 fault-trigger:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o tests/images/fault-trigger/bin/fault-trigger tests/cmd/fault-trigger/*.go
@@ -206,14 +205,14 @@ cli:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o tkctl cmd/tkctl/main.go
 
 debug-docker-push: debug-build-docker
-	docker push "${DOCKER_REGISTRY}/pingcap/debug-launcher:latest"
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-control:latest"
-	docker push "${DOCKER_REGISTRY}/pingcap/tidb-debug:latest"
+	docker push "${DOCKER_REPO}/debug-launcher:latest"
+	docker push "${DOCKER_REPO}/tidb-control:latest"
+	docker push "${DOCKER_REPO}/tidb-debug:latest"
 
 debug-build-docker: debug-build
-	docker build -t "${DOCKER_REGISTRY}/pingcap/debug-launcher:latest" misc/images/debug-launcher
-	docker build -t "${DOCKER_REGISTRY}/pingcap/tidb-control:latest" misc/images/tidb-control
-	docker build -t "${DOCKER_REGISTRY}/pingcap/tidb-debug:latest" misc/images/tidb-debug
+	docker build -t "${DOCKER_REPO}/debug-launcher:latest" misc/images/debug-launcher
+	docker build -t "${DOCKER_REPO}/tidb-control:latest" misc/images/tidb-control
+	docker build -t "${DOCKER_REPO}/tidb-debug:latest" misc/images/tidb-debug
 
 debug-build:
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o misc/images/debug-launcher/bin/debug-launcher misc/cmd/debug-launcher/main.go

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -47,7 +47,7 @@ Usage: hack/e2e.sh [-h] -- [extra test args]
 Environments:
 
     PROVIDER              Kubernetes provider, e.g. kind, gke, eks, defaults: kind
-    DOCKER_REGISTRY       image docker registry
+    DOCKER_REPO           docker image repo
     IMAGE_TAG             image tag
     CLUSTER               the name of e2e cluster, defaults: tidb-operator
     KUBECONFIG            path to the kubeconfig file, defaults: ~/.kube/config
@@ -172,7 +172,7 @@ if [ "${1:-}" == "--" ]; then
 fi
 
 PROVIDER=${PROVIDER:-kind}
-DOCKER_REGISTRY=${DOCKER_REGISTRY:-localhost:5000}
+DOCKER_REPO=${DOCKER_REPO:-localhost:5000/pingcap}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 CLUSTER=${CLUSTER:-tidb-operator}
 KUBECONFIG=${KUBECONFIG:-~/.kube/config}
@@ -204,7 +204,7 @@ SKIP_GINKGO=${SKIP_GINKGO:-}
 RUNNER_SUITE_NAME=${RUNNER_SUITE_NAME:-}
 
 echo "PROVIDER: $PROVIDER"
-echo "DOCKER_REGISTRY: $DOCKER_REGISTRY"
+echo "DOCKER_REPO: $DOCKER_REPO"
 echo "IMAGE_TAG: $IMAGE_TAG"
 echo "CLUSTER: $CLUSTER"
 echo "KUBECONFIG: $KUBECONFIG"
@@ -248,8 +248,8 @@ function e2e::image_build() {
         echo "info: skip building and pushing images"
         return
     fi
-    DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$IMAGE_TAG make docker
-    DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$IMAGE_TAG make e2e-docker
+    DOCKER_REPO=$DOCKER_REPO IMAGE_TAG=$IMAGE_TAG make docker
+    DOCKER_REPO=$DOCKER_REPO IMAGE_TAG=$IMAGE_TAG make e2e-docker
 }
 
 function e2e::__restart_docker() {
@@ -523,9 +523,9 @@ export AWS_ZONE
 export IMAGE_TAG
 export SKIP_GINKGO
 export SKIP_IMAGE_LOAD
-export TIDB_OPERATOR_IMAGE=$DOCKER_REGISTRY/pingcap/tidb-operator:${IMAGE_TAG}
-export TIDB_BACKUP_MANAGER_IMAGE=$DOCKER_REGISTRY/pingcap/tidb-backup-manager:${IMAGE_TAG}
-export E2E_IMAGE=$DOCKER_REGISTRY/pingcap/tidb-operator-e2e:${IMAGE_TAG}
+export TIDB_OPERATOR_IMAGE=$DOCKER_REPO/tidb-operator:${IMAGE_TAG}
+export TIDB_BACKUP_MANAGER_IMAGE=$DOCKER_REPO/tidb-backup-manager:${IMAGE_TAG}
+export E2E_IMAGE=$DOCKER_REPO/tidb-operator-e2e:${IMAGE_TAG}
 export PATH=$OUTPUT_BIN:$PATH
 
 # Environments for kubetest2


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

See examples:

```
DOCKER_REPO=hub.pingcap.net/fuyecheng make docker
docker push hub.pingcap.net/fuyecheng/tidb-backup-manager:latest
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
