### PR TITLE
fix br log issue and include both 3.1 and 4.0 br in the tidb-backup-manager image

### DIFF
--- a/cmd/backup-manager/app/cmd/backup.go
+++ b/cmd/backup-manager/app/cmd/backup.go
@@ -42,6 +42,7 @@ func NewBackupCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&bo.Namespace, "namespace", "", "Backup CR's namespace")
 	cmd.Flags().StringVar(&bo.ResourceName, "backupName", "", "Backup CRD object name")
+	cmd.Flags().StringVar(&bo.TiKVVersion, "tikvVersion", util.DefaultVersion, "TiKV version")
 	cmd.Flags().BoolVar(&bo.TLSClient, "client-tls", false, "Whether client tls is enabled")
 	cmd.Flags().BoolVar(&bo.TLSCluster, "cluster-tls", false, "Whether cluster tls is enabled")
 	return cmd

--- a/cmd/backup-manager/app/cmd/restore.go
+++ b/cmd/backup-manager/app/cmd/restore.go
@@ -44,6 +44,7 @@ func NewRestoreCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&ro.Namespace, "namespace", "", "Restore CR's namespace")
 	cmd.Flags().StringVar(&ro.ResourceName, "restoreName", "", "Restore CRD object name")
+	cmd.Flags().StringVar(&ro.TiKVVersion, "tikvVersion", util.DefaultVersion, "TiKV version")
 	cmd.Flags().BoolVar(&ro.TLSClient, "client-tls", false, "Whether client tls is enabled")
 	cmd.Flags().BoolVar(&ro.TLSCluster, "cluster-tls", false, "Whether cluster tls is enabled")
 	return cmd

--- a/cmd/backup-manager/app/util/generic.go
+++ b/cmd/backup-manager/app/util/generic.go
@@ -39,6 +39,7 @@ type GenericOptions struct {
 	Port         int32
 	Password     string
 	User         string
+	TiKVVersion  string
 }
 
 func (bo *GenericOptions) String() string {

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -30,8 +30,8 @@ import (
 var (
 	cmdHelpMsg        string
 	supportedVersions = map[string]struct{}{
-		"3.1": struct{}{},
-		"4.0": struct{}{},
+		"3.1": {},
+		"4.0": {},
 	}
 	// DefaultVersion is the default tikv and br version
 	DefaultVersion = "4.0"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/mocks v0.3.0 // indirect
 	github.com/BurntSushi/toml v0.3.1
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e // indirect
+	github.com/Masterminds/semver v1.4.2
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e h1:eb0Pzkt15Bm7f2FFYv7sjY7NPFi3cPkS3tv1CcrFBWA=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=

--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -2,19 +2,15 @@ FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_VERSION=v3.0.12
+ARG TOOLKIT_V31=v3.1.0-rc
+ARG TOOLKIT_V40=v4.0.0-rc
 RUN apk update && apk add ca-certificates
 
 RUN wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
-	&& unzip rclone-${VERSION}-linux-amd64.zip \
-	&& mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin \
-	&& chmod 755 /usr/local/bin/rclone \
-	&& rm -rf rclone-${VERSION}-linux-amd64.zip rclone-${VERSION}-linux-amd64
-
-RUN wget -nv http://download.pingcap.org/br-latest-linux-amd64.tar.gz \
-    && tar -xzf br-latest-linux-amd64.tar.gz \
-    && mv bin/br /usr/local/bin \
-    && chmod 755 /usr/local/bin/br \
-    && rm -rf br-latest-linux-amd64.tar.gz
+  && unzip rclone-${VERSION}-linux-amd64.zip \
+  && mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm -rf rclone-${VERSION}-linux-amd64.zip rclone-${VERSION}-linux-amd64
 
 RUN wget -nv https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_amd64 \
   && mv shush_linux_amd64 /usr/local/bin/shush \
@@ -28,6 +24,22 @@ RUN \
   && chmod 755 /tidb-lightning /tidb-lightning-ctl \
   && rm -rf tidb-toolkit-${TOOLKIT_VERSION}-linux-amd64.tar.gz \
   && rm -rf tidb-toolkit-${TOOLKIT_VERSION}-linux-amd64
+
+RUN \
+  wget -nv https://download.pingcap.org/tidb-toolkit-${TOOLKIT_V31}-linux-amd64.tar.gz \
+  && tar -xzf tidb-toolkit-${TOOLKIT_V31}-linux-amd64.tar.gz \
+  && mv tidb-toolkit-${TOOLKIT_V31}-linux-amd64/bin/br /usr/local/bin/br31 \
+  && chmod 755 /usr/local/bin/br31 \
+  && rm -rf tidb-toolkit-${TOOLKIT_V31}-linux-amd64.tar.gz \
+  && rm -rf tidb-toolkit-${TOOLKIT_V31}-linux-amd64
+
+RUN \
+  wget -nv https://download.pingcap.org/tidb-toolkit-${TOOLKIT_V40}-linux-amd64.tar.gz \
+  && tar -xzf tidb-toolkit-${TOOLKIT_V40}-linux-amd64.tar.gz \
+  && mv tidb-toolkit-${TOOLKIT_V40}-linux-amd64/bin/br /usr/local/bin/br40 \
+  && chmod 755 /usr/local/bin/br40 \
+  && rm -rf tidb-toolkit-${TOOLKIT_V40}-linux-amd64.tar.gz \
+  && rm -rf tidb-toolkit-${TOOLKIT_V40}-linux-amd64
 
 COPY bin/tidb-backup-manager /tidb-backup-manager
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
…anager image

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
- The stderr logs from BR are missed
- The backup-manager cannot backup or restore v3.1 TiDB Cluster
### What is changed and how does it work?
- Add the stderr logs from BR
- Include both 3.1 and 4.0 br in the tidb-backup-manager image
- Backup controller gets the tikv version from tc and passes it to backup-manager
- backup-manager chooses the correct BR version to do backup and restore according to the tikv version
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Backup and Restore for TiDB Cluster v3.1.0-rc
   - Backup and Restore for TiDB Cluster v4.0.0-rc
   - Backup and Restore for TiDB Cluster nightly

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add stderr logs from BR to the backup-manager logs
```
