### PR TITLE
update the function to get the image tag

### DIFF
--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -15,7 +15,6 @@ package backup
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup"
@@ -270,13 +269,6 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		return nil, fmt.Sprintf("failed to fetch tidbcluster %s/%s", backupNamespace, backup.Spec.BR.Cluster), err
 	}
 
-	var tikvVersion string
-	tikvImage := tc.TiKVImage()
-	imageVersion := strings.Split(tikvImage, ":")
-	if len(imageVersion) == 2 {
-		tikvVersion = imageVersion[1]
-	}
-
 	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, backup.Spec.From.SecretName, backup.Spec.UseKMS, bm.kubeCli)
 	if err != nil {
 		return nil, reason, err
@@ -298,6 +290,8 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		fmt.Sprintf("--namespace=%s", ns),
 		fmt.Sprintf("--backupName=%s", name),
 	}
+	tikvImage := tc.TiKVImage()
+	tikvVersion := backuputil.GetImageTag(tikvImage)
 	if tikvVersion != "" {
 		args = append(args, fmt.Sprintf("--tikvVersion=%s", tikvVersion))
 	}

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -291,7 +291,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		fmt.Sprintf("--backupName=%s", name),
 	}
 	tikvImage := tc.TiKVImage()
-	tikvVersion := backuputil.GetImageTag(tikvImage)
+	_, tikvVersion := backuputil.ParseImage(tikvImage)
 	if tikvVersion != "" {
 		args = append(args, fmt.Sprintf("--tikvVersion=%s", tikvVersion))
 	}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -275,7 +275,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		fmt.Sprintf("--restoreName=%s", name),
 	}
 	tikvImage := tc.TiKVImage()
-	tikvVersion := backuputil.GetImageTag(tikvImage)
+	_, tikvVersion := backuputil.ParseImage(tikvImage)
 	if tikvVersion != "" {
 		args = append(args, fmt.Sprintf("--tikvVersion=%s", tikvVersion))
 	}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -15,7 +15,6 @@ package restore
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup"
@@ -255,13 +254,6 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		return nil, fmt.Sprintf("failed to fetch tidbcluster %s/%s", restoreNamespace, restore.Spec.BR.Cluster), err
 	}
 
-	var tikvVersion string
-	tikvImage := tc.TiKVImage()
-	imageVersion := strings.Split(tikvImage, ":")
-	if len(imageVersion) == 2 {
-		tikvVersion = imageVersion[1]
-	}
-
 	envVars, reason, err := backuputil.GenerateTidbPasswordEnv(ns, name, restore.Spec.To.SecretName, restore.Spec.UseKMS, rm.kubeCli)
 	if err != nil {
 		return nil, reason, err
@@ -282,6 +274,8 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		fmt.Sprintf("--namespace=%s", ns),
 		fmt.Sprintf("--restoreName=%s", name),
 	}
+	tikvImage := tc.TiKVImage()
+	tikvVersion := backuputil.GetImageTag(tikvImage)
 	if tikvVersion != "" {
 		args = append(args, fmt.Sprintf("--tikvVersion=%s", tikvVersion))
 	}

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -410,3 +410,13 @@ func ValidateRestore(restore *v1alpha1.Restore) error {
 	}
 	return nil
 }
+
+// GetImageTag get the image tag
+func GetImageTag(image string) string {
+	var tag string
+	colonIdx := strings.LastIndexByte(image, ':')
+	if colonIdx >= 0 {
+		tag = image[colonIdx+1:]
+	}
+	return tag
+}

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -411,12 +411,15 @@ func ValidateRestore(restore *v1alpha1.Restore) error {
 	return nil
 }
 
-// GetImageTag get the image tag
-func GetImageTag(image string) string {
-	var tag string
+// ParseImage returns the image name and the tag from the input image string
+func ParseImage(image string) (string, string) {
+	var name, tag string
 	colonIdx := strings.LastIndexByte(image, ':')
 	if colonIdx >= 0 {
+		name = image[:colonIdx]
 		tag = image[colonIdx+1:]
+	} else {
+		name = image
 	}
-	return tag
+	return name, tag
 }

--- a/pkg/backup/util/utils_test.go
+++ b/pkg/backup/util/utils_test.go
@@ -23,48 +23,56 @@ func TestGetImageTag(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type testcase struct {
-		name   string
-		image  string
-		expect string
+		name      string
+		image     string
+		imageName string
+		tag       string
 	}
 
 	tests := []*testcase{
 		{
-			name:   "with repo",
-			image:  "localhost:5000/tikv:v3.1.0",
-			expect: "v3.1.0",
+			name:      "with repo",
+			image:     "localhost:5000/tikv:v3.1.0",
+			imageName: "localhost:5000/tikv",
+			tag:       "v3.1.0",
 		},
 		{
-			name:   "no colon",
-			image:  "tikv",
-			expect: "",
+			name:      "no colon",
+			image:     "tikv",
+			imageName: "tikv",
+			tag:       "",
 		},
 		{
-			name:   "no repo",
-			image:  "tikv:nightly",
-			expect: "nightly",
+			name:      "no repo",
+			image:     "tikv:nightly",
+			imageName: "tikv",
+			tag:       "nightly",
 		},
 		{
-			name:   "start with colon",
-			image:  ":v4.0.0",
-			expect: "v4.0.0",
+			name:      "start with colon",
+			image:     ":v4.0.0",
+			imageName: "",
+			tag:       "v4.0.0",
 		},
 		{
-			name:   "end with colon",
-			image:  "tikv:",
-			expect: "",
+			name:      "end with colon",
+			image:     "tikv:",
+			imageName: "tikv",
+			tag:       "",
 		},
 		{
-			name:   "only colon",
-			image:  ":",
-			expect: "",
+			name:      "only colon",
+			image:     ":",
+			imageName: "",
+			tag:       "",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			version := GetImageTag(test.image)
-			g.Expect(version).To(Equal(test.expect))
+			name, version := ParseImage(test.image)
+			g.Expect(version).To(Equal(test.tag))
+			g.Expect(name).To(Equal(test.imageName))
 		})
 	}
 }

--- a/pkg/backup/util/utils_test.go
+++ b/pkg/backup/util/utils_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetImageTag(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name   string
+		image  string
+		expect string
+	}
+
+	tests := []*testcase{
+		{
+			name:   "with repo",
+			image:  "localhost:5000/tikv:v3.1.0",
+			expect: "v3.1.0",
+		},
+		{
+			name:   "no colon",
+			image:  "tikv",
+			expect: "",
+		},
+		{
+			name:   "no repo",
+			image:  "tikv:nightly",
+			expect: "nightly",
+		},
+		{
+			name:   "start with colon",
+			image:  ":v4.0.0",
+			expect: "v4.0.0",
+		},
+		{
+			name:   "end with colon",
+			image:  "tikv:",
+			expect: "",
+		},
+		{
+			name:   "only colon",
+			image:  ":",
+			expect: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			version := GetImageTag(test.image)
+			g.Expect(version).To(Equal(test.expect))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
The original way to get the image tag did not consider the "127.0.0.1:30002/pingcap/tidb-operator:v3.1.0" case.
### What is changed and how does it work?
Update the function to get the image tag.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Backup and Restore with v3.1.0-rc
   - Backup and Restore with nightly

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
