### PR TITLE
check TLS certificate for mysql client before creating TiDB StatefulSet

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -91,6 +91,7 @@ func NewController(
 	pvInformer := kubeInformerFactory.Core().V1().PersistentVolumes()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
+	secretInformer := kubeInformerFactory.Core().V1().Secrets()
 
 	tcControl := controller.NewRealTidbClusterControl(cli, tcInformer.Lister(), recorder)
 	pdControl := pdapi.NewDefaultPDControl(kubeCli)
@@ -158,6 +159,7 @@ func NewController(
 				setInformer.Lister(),
 				svcInformer.Lister(),
 				podInformer.Lister(),
+				secretInformer.Lister(),
 				tidbUpgrader,
 				autoFailover,
 				tidbFailover,

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -784,6 +784,7 @@ func newFakeTiDBMemberManager() (*tidbMemberManager, *controller.FakeStatefulSet
 		svcInformer.Lister(),
 		podInformer.Lister(),
 		cmInformer.Lister(),
+		secretInformer.Lister(),
 		tidbUpgrader,
 		true,
 		tidbFailover,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
When TLS for mysql client is enabled, if `tls.crt` key's value in `tlsClientSecret` is empty, tidb will start successfully, and TLS is disabled. When certificate is ready, We need to restart tidb pod to let TLS cert take effect.

### What is changed and how does it work?
If we're going to apply certificate from Letsencrypt, we need to wait for the service LB to be successfully created before applying for a certificate. When certificate is ready, then create TiDB StatefulSet.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
```
mysql> \s;
--------------
mysql  Ver 14.14 Distrib 5.7.29, for Linux (x86_64) using  EditLine wrapper

Connection id:		72
Current database:
Current user:		root@10.250.27.122
SSL:			Cipher in use is ECDHE-RSA-AES128-GCM-SHA256
Current pager:		stdout
Using outfile:		''
Using delimiter:	;
Server version:		5.7.25-TiDB-v4.0.0-beta.2-290-ga0c740784 TiDB Server (Apache License 2.0), MySQL 5.7 compatible
```
 - No code

Code changes

 - Has Go code change


Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
1.1
 - Need to update the documentation
None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
