### PR TITLE
fix the wrong script name in `CONTRIBUTING.md`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -116,7 +116,7 @@ run the following command to install them into our local binary directory:
 `output/bin`.
 
 ```
-$ hack/install-up-operator.sh -i
+$ hack/local-up-operator.sh -i
 $ export PATH=$(pwd)/output/bin:$PATH
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This fix the wrong script name in `CONTRIBUTING.md`,  which mentioned in #2264 .
### What is changed and how does it work?

Just change the `install-up-operator.sh` into `local-up-operator.sh`.
### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
