### PR TITLE
Fix pdapi cache when cluster TLS enabled

### DIFF
--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -67,7 +67,6 @@ func NewDefaultPDControl(kubeCli kubernetes.Interface) PDControlInterface {
 // It loads in-cluster root ca if caCert is empty.
 func GetTLSConfig(kubeCli kubernetes.Interface, namespace Namespace, tcName string, caCert []byte) (*tls.Config, error) {
 	secretName := util.ClusterClientTLSSecretName(tcName)
-	// TODO use secretLister instead of kubeCli.CoreV1().Secrets().Get() to optimize the performance
 	secret, err := kubeCli.CoreV1().Secrets(string(namespace)).Get(secretName, types.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to load certificates from secret %s/%s: %v", namespace, secretName, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

fixes: https://github.com/pingcap/tidb-operator/issues/2253

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix pdapi cache issue while cluster TLS is enabled
```
