### PR TITLE
Fix auto scaler status syncing error

### DIFF
--- a/pkg/autoscaler/autoscaler/autoscaler_manager.go
+++ b/pkg/autoscaler/autoscaler/autoscaler_manager.go
@@ -148,7 +148,9 @@ func (am *autoScalerManager) updateAutoScaling(oldTc *v1alpha1.TidbCluster,
 	}
 
 	if tac.Spec.TiKV != nil {
-		tac.Status.TiKV.CurrentReplicas = oldTc.Status.TiKV.StatefulSet.CurrentReplicas
+		if oldTc.Status.TiKV.StatefulSet != nil {
+			tac.Status.TiKV.CurrentReplicas = oldTc.Status.TiKV.StatefulSet.CurrentReplicas
+		}
 		lastTimestamp, err := f(label.AnnTiKVLastAutoScalingTimestamp)
 		if err != nil {
 			return err
@@ -160,7 +162,9 @@ func (am *autoScalerManager) updateAutoScaling(oldTc *v1alpha1.TidbCluster,
 		tac.Status.TiKV = nil
 	}
 	if tac.Spec.TiDB != nil {
-		tac.Status.TiDB.CurrentReplicas = oldTc.Status.TiDB.StatefulSet.CurrentReplicas
+		if oldTc.Status.TiDB.StatefulSet != nil {
+			tac.Status.TiDB.CurrentReplicas = oldTc.Status.TiDB.StatefulSet.CurrentReplicas
+		}
 		lastTimestamp, err := f(label.AnnTiDBLastAutoScalingTimestamp)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix the error when syncing tidbclusterautoscaler status, add check whether the target sts is existed.


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the error in syncing tidbclusterautoscaler status would cause panic when target tidbcluster is not existed.
```
