### PR TITLE
Fix sts webhook error

### DIFF
--- a/pkg/webhook/statefulset/statefulset.go
+++ b/pkg/webhook/statefulset/statefulset.go
@@ -110,12 +110,17 @@ func (sc *StatefulSetAdmissionControl) AdmitStatefulSets(ar *admission.Admission
 		return util.ARFail(err)
 	}
 
-	if stsPartition != nil && *stsPartition > 0 && *stsPartition <= int32(partition) {
-		klog.Infof("statefulset %s/%s has been protect by partition %s annotations", namespace, name, partitionStr)
-		return util.ARFail(errors.New("protect by partition annotation"))
+	if stsPartition != nil {
+		if *stsPartition > 0 && *stsPartition <= int32(partition) {
+			klog.Infof("statefulset %s/%s has been protect by partition %s annotations", namespace, name, partitionStr)
+			return util.ARFail(errors.New("protect by partition annotation"))
+		} else {
+			klog.Infof("admit statefulset %s/%s update partition to %d, protect partition is %d", namespace, name, *stsPartition, partition)
+			return util.ARSuccess()
+		}
+	} else {
+		return util.ARSuccess()
 	}
-	klog.Infof("admit statefulset %s/%s update partition to %d, protect partition is %d", namespace, name, *stsPartition, partition)
-	return util.ARSuccess()
 }
 
 func getStsAttributes(data []byte, apiVersion string) (*metav1.ObjectMeta, *int32, error) {

--- a/pkg/webhook/statefulset/statefulset.go
+++ b/pkg/webhook/statefulset/statefulset.go
@@ -118,9 +118,8 @@ func (sc *StatefulSetAdmissionControl) AdmitStatefulSets(ar *admission.Admission
 			klog.Infof("admit statefulset %s/%s update partition to %d, protect partition is %d", namespace, name, *stsPartition, partition)
 			return util.ARSuccess()
 		}
-	} else {
-		return util.ARSuccess()
 	}
+	return util.ARSuccess()
 }
 
 func getStsAttributes(data []byte, apiVersion string) (*metav1.ObjectMeta, *int32, error) {

--- a/pkg/webhook/statefulset/statefulset.go
+++ b/pkg/webhook/statefulset/statefulset.go
@@ -114,10 +114,8 @@ func (sc *StatefulSetAdmissionControl) AdmitStatefulSets(ar *admission.Admission
 		if *stsPartition > 0 && *stsPartition <= int32(partition) {
 			klog.Infof("statefulset %s/%s has been protect by partition %s annotations", namespace, name, partitionStr)
 			return util.ARFail(errors.New("protect by partition annotation"))
-		} else {
-			klog.Infof("admit statefulset %s/%s update partition to %d, protect partition is %d", namespace, name, *stsPartition, partition)
-			return util.ARSuccess()
 		}
+		klog.Infof("admit statefulset %s/%s update partition to %d, protect partition is %d", namespace, name, *stsPartition, partition)
 	}
 	return util.ARSuccess()
 }

--- a/pkg/webhook/statefulset/statefulset.go
+++ b/pkg/webhook/statefulset/statefulset.go
@@ -63,7 +63,7 @@ func (sc *StatefulSetAdmissionControl) AdmitStatefulSets(ar *admission.Admission
 
 	klog.Infof("admit %s [%s/%s]", setResource, namespace, name)
 
-	stsObjectMeta, stsPartition, err := getStsAttributes(ar.OldObject.Raw, apiVersion)
+	stsObjectMeta, stsPartition, err := getStsAttributes(ar.OldObject.Raw)
 	if err != nil {
 		err = fmt.Errorf("statefulset %s/%s, decode request failed, err: %v", namespace, name, err)
 		klog.Error(err)
@@ -120,18 +120,7 @@ func (sc *StatefulSetAdmissionControl) AdmitStatefulSets(ar *admission.Admission
 	return util.ARSuccess()
 }
 
-func getStsAttributes(data []byte, apiVersion string) (*metav1.ObjectMeta, *int32, error) {
-	if apiVersion == "v1" {
-		set := apps.StatefulSet{}
-		if _, _, err := deserializer.Decode(data, nil, &set); err != nil {
-			return nil, nil, err
-		}
-		if set.Spec.UpdateStrategy.RollingUpdate != nil {
-			return &(set.ObjectMeta), set.Spec.UpdateStrategy.RollingUpdate.Partition, nil
-		}
-		return &(set.ObjectMeta), nil, nil
-	}
-
+func getStsAttributes(data []byte) (*metav1.ObjectMeta, *int32, error) {
 	set := apps.StatefulSet{}
 	if _, _, err := deserializer.Decode(data, nil, &set); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix the error which would cause panic for sts webhook when sts updated strategy is not rolling updated.

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix a bug which would cause panic in statefulset webhook when update strategy of `StatefulSet` is not `RollingUpdate`
```
