### PR TITLE
Delete Occupied store when tikv scale-out

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -104,7 +104,7 @@ func NewController(
 	podControl := controller.NewRealPodControl(kubeCli, pdControl, podInformer.Lister(), recorder)
 	typedControl := controller.NewTypedControl(controller.NewRealGenericControl(genericCli, recorder))
 	pdScaler := mm.NewPDScaler(pdControl, pvcInformer.Lister(), pvcControl)
-	tikvScaler := mm.NewTiKVScaler(pdControl, pvcInformer.Lister(), pvcControl, podInformer.Lister())
+	tikvScaler := mm.NewTiKVScaler(pdControl, pvcInformer.Lister(), pvcControl, podInformer.Lister(), recorder)
 	tiflashScaler := mm.NewTiFlashScaler(pdControl, pvcInformer.Lister(), pvcControl, podInformer.Lister())
 	pdFailover := mm.NewPDFailover(cli, pdControl, pdFailoverPeriod, podInformer.Lister(), podControl, pvcInformer.Lister(), pvcControl, pvInformer.Lister(), recorder)
 	tikvFailover := mm.NewTiKVFailover(tikvFailoverPeriod, recorder)

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -16,6 +16,7 @@ package member
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
@@ -82,7 +83,7 @@ func (tsd *tikvScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 	// In that case, the address might been registered but the data couldn't be persisted which would occupied the address until
 	// be deleted manually.
 	for _, store := range storesInfo.Stores {
-		if store.Store.Address == scaleOutTikvAddresss {
+		if strings.HasPrefix(store.Store.Address, scaleOutTikvAddresss) {
 			err := pdClient.DeleteStore(store.Store.Id)
 			if err == nil {
 				err = fmt.Errorf("tc[%s/%s]'s tikv found occupied store address before scale-out, start to delete store[%d/%s]",

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -85,8 +85,8 @@ func (tsd *tikvScaler) ScaleOut(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 		if store.Store.Address == scaleOutTikvAddresss {
 			err := pdClient.DeleteStore(store.Store.Id)
 			if err == nil {
-				err = fmt.Errorf("tc[%s/%s]'s tikv found occupied store address before scale,start to delete store[%d/%s]", tc.Name, tc.Namespace, store.Store.Id, store.Store.Address)
-
+				err = fmt.Errorf("tc[%s/%s]'s tikv found occupied store address before scale-out, start to delete store[%d/%s]",
+					tc.Name, tc.Namespace, store.Store.Id, store.Store.Address)
 			}
 			klog.Error(err.Error())
 			return err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -226,3 +226,7 @@ func IsOwnedByTidbCluster(obj metav1.Object) (bool, *metav1.OwnerReference) {
 	}
 	return ref.Kind == v1alpha1.TiDBClusterKind && gv.Group == v1alpha1.SchemeGroupVersion.Group, ref
 }
+
+func GetPeerServiceName(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType) string {
+	return fmt.Sprintf("%s-%s-peer", tc.Name, memberType.String())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Delete store if its address occupied the address during tikv scale-out. The store which occupied the address could be caused in following case:
1. tidbcluster with 2 tikv up
2. tidbcluster scale tikv to 3
3. During tikv-2 start process, the unexpected termination kill the tikv-2. The store is registered but the data lost.
4. The new tikv-2 restarted and encounter the duplicate address error and never start success.

To solve this problem, we would delete the store during tikv scale-out if the store occupied the target tikv store address.


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the error when newly tikv created failed, it would never started success.
```
