### PR TITLE
require more ephemeral storage in periodical KIND jobs

### DIFF
--- a/ci/e2e_kind.groovy
+++ b/ci/e2e_kind.groovy
@@ -7,10 +7,7 @@
 // Note that parameters of the job is configured in this script.
 //
 
-import groovy.transform.Field
-
-@Field
-def podYAML = '''
+podYAML = '''\
 apiVersion: v1
 kind: Pod
 metadata:
@@ -45,11 +42,11 @@ spec:
       requests:
         memory: "8000Mi"
         cpu: 8000m
-        ephemeral-storage: "50Gi"
+        ephemeral-storage: "70Gi"
       limits:
         memory: "8000Mi"
         cpu: 8000m
-        ephemeral-storage: "50Gi"
+        ephemeral-storage: "70Gi"
     # kind needs /lib/modules and cgroups from the host
     volumeMounts:
     - mountPath: /lib/modules


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

e.g. https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb-operator-e2e-kind-ci-master-1.17/detail/tidb-operator-e2e-kind-ci-master-1.17/19/pipeline

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
