### PR TITLE
Ignore NotFound error because resources may be deleted by namespace controller first

### DIFF
--- a/tests/e2e/tidbcluster/tls.go
+++ b/tests/e2e/tidbcluster/tls.go
@@ -141,7 +141,7 @@ func installCertManager(cli clientset.Interface) error {
 }
 
 func deleteCertManager(cli clientset.Interface) error {
-	cmd := "kubectl delete -f /cert-manager.yaml"
+	cmd := "kubectl delete -f /cert-manager.yaml --ignore-not-found"
 	if data, err := exec.Command("sh", "-c", cmd).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to delete cert-manager %s %v", string(data), err)
 	}


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb-operator-e2e-gke-ci-master/detail/tidb-operator-e2e-gke-ci-master/102/tests
 
If namespace controller responds quickly, the resources under `cert-manager` may be deleted by it before kube-apiserver. So we should ignore NotFound error.


### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
