### PR TITLE
PD: auto-created failover pods should be deleted when failed members are recovered

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -367,6 +367,7 @@ elif [ "$PROVIDER" == "gke" ]; then
         --gce-project="${GCP_PROJECT}"
         --gce-region="${GCP_REGION}"
         --gce-zone="${GCP_ZONE}"
+        --gke-cluster="${CLUSTER}"
     )
     docker_args+=(
         -v ${GCP_CREDENTIALS}:${GCP_CREDENTIALS}
@@ -379,6 +380,8 @@ elif [ "$PROVIDER" == "gke" ]; then
         exit 1
     fi
     docker_args+=(
+        # gcloud config
+        -v $HOME/.config/gcloud:/root/.config/gcloud
         -v ${GCP_SDK}:/google-cloud-sdk
         # ~/.ssh/google_compute_engine must be mounted into e2e container to run ssh
         -v $HOME/.ssh/google_compute_engine:/root/.ssh/google_compute_engine

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -14,10 +14,13 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/pingcap/advanced-statefulset/pkg/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -178,6 +181,37 @@ func (tc *TidbCluster) TiFlashUpgrading() bool {
 	return tc.Status.TiFlash.Phase == UpgradePhase
 }
 
+func (tc *TidbCluster) getDeleteSlots(component string) (deleteSlots sets.Int32) {
+	deleteSlots = sets.NewInt32()
+	annotations := tc.GetAnnotations()
+	if annotations == nil {
+		return deleteSlots
+	}
+	var key string
+	if component == label.PDLabelVal {
+		key = label.AnnPDDeleteSlots
+	} else if component == label.TiDBLabelVal {
+		key = label.AnnTiDBDeleteSlots
+	} else if component == label.TiKVLabelVal {
+		key = label.AnnTiKVDeleteSlots
+	} else if component == label.TiFlashLabelVal {
+		key = label.AnnTiFlashDeleteSlots
+	} else {
+		return
+	}
+	value, ok := annotations[key]
+	if !ok {
+		return
+	}
+	var slice []int32
+	err := json.Unmarshal([]byte(value), &slice)
+	if err != nil {
+		return
+	}
+	deleteSlots.Insert(slice...)
+	return
+}
+
 func (tc *TidbCluster) PDAllPodsStarted() bool {
 	return tc.PDStsDesiredReplicas() == tc.PDStsActualReplicas()
 }
@@ -220,6 +254,14 @@ func (tc *TidbCluster) PDStsActualReplicas() int32 {
 	return stsStatus.Replicas
 }
 
+func (tc *TidbCluster) PDStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	replicas := tc.Spec.PD.Replicas
+	if !excludeFailover {
+		replicas = tc.PDStsDesiredReplicas()
+	}
+	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.PDLabelVal))
+}
+
 func (tc *TidbCluster) TiKVAllPodsStarted() bool {
 	return tc.TiKVStsDesiredReplicas() == tc.TiKVStsActualReplicas()
 }
@@ -248,6 +290,14 @@ func (tc *TidbCluster) TiKVStsActualReplicas() int32 {
 		return 0
 	}
 	return stsStatus.Replicas
+}
+
+func (tc *TidbCluster) TiKVStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	replicas := tc.Spec.TiKV.Replicas
+	if !excludeFailover {
+		replicas = tc.TiKVStsDesiredReplicas()
+	}
+	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiKVLabelVal))
 }
 
 func (tc *TidbCluster) TiFlashAllPodsStarted() bool {
@@ -280,6 +330,14 @@ func (tc *TidbCluster) TiFlashStsActualReplicas() int32 {
 	return stsStatus.Replicas
 }
 
+func (tc *TidbCluster) TiFlashStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	replicas := tc.Spec.TiFlash.Replicas
+	if !excludeFailover {
+		replicas = tc.TiFlashStsDesiredReplicas()
+	}
+	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiFlashLabelVal))
+}
+
 func (tc *TidbCluster) TiDBAllPodsStarted() bool {
 	return tc.TiDBStsDesiredReplicas() == tc.TiDBStsActualReplicas()
 }
@@ -308,6 +366,14 @@ func (tc *TidbCluster) TiDBStsActualReplicas() int32 {
 		return 0
 	}
 	return stsStatus.Replicas
+}
+
+func (tc *TidbCluster) TiDBStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	replicas := tc.Spec.TiDB.Replicas
+	if !excludeFailover {
+		replicas = tc.TiDBStsDesiredReplicas()
+	}
+	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiDBLabelVal))
 }
 
 func (tc *TidbCluster) PDIsAvailable() bool {

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -98,6 +98,8 @@ const (
 	AnnTiDBDeleteSlots = "tidb.tidb.pingcap.com/delete-slots"
 	// TiKVDeleteSlots is annotation key of tikv delete slots.
 	AnnTiKVDeleteSlots = "tikv.tidb.pingcap.com/delete-slots"
+	// TiFlashDeleteSlots is annotation key of tiflash delete slots.
+	AnnTiFlashDeleteSlots = "tiflash.tidb.pingcap.com/delete-slots"
 
 	// AnnTiDBLastAutoScalingTimestamp is annotation key of tidbcluster to indicate the last timestamp for tidb auto-scaling
 	AnnTiDBLastAutoScalingTimestamp = "tidb.tidb.pingcap.com/last-autoscaling-timestamp"

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -34,6 +34,7 @@ import (
 	v1 "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 const (
@@ -252,7 +253,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 	}
 
 	if pmm.autoFailover {
-		if tc.PDAllPodsStarted() && tc.PDAllMembersReady() && tc.Status.PD.FailureMembers != nil {
+		if pmm.shouldRecover(tc) {
 			pmm.pdFailover.Recover(tc)
 		} else if tc.PDAllPodsStarted() && !tc.PDAllMembersReady() || tc.PDAutoFailovering() {
 			if err := pmm.pdFailover.Failover(tc); err != nil {
@@ -262,6 +263,32 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 	}
 
 	return updateStatefulSet(pmm.setControl, tc, newPDSet, oldPDSet)
+}
+
+// shouldRecover checks whether we should perform recovery operation.
+func (pmm *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
+	if tc.Status.PD.FailureMembers == nil {
+		return false
+	}
+	// If all desired replicas (excluding failover pods) of tidb cluster are
+	// healthy, we can perform our failover recovery operation.
+	// Note that failover pods may fail (e.g. lack of resources) and we don't care
+	// about them because we're going to delete them.
+	for _, ordinal := range tc.PDStsDesiredOrdinals(true) {
+		name := fmt.Sprintf("%s-%d", controller.PDMemberName(tc.GetName()), ordinal)
+		pod, err := pmm.podLister.Pods(tc.Namespace).Get(name)
+		if err != nil {
+			return false
+		}
+		if !podutil.IsPodReady(pod) {
+			return false
+		}
+		status, ok := tc.Status.PD.Members[pod.Name]
+		if !ok || !status.Health {
+			return false
+		}
+	}
+	return true
 }
 
 func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -274,10 +274,11 @@ func (pmm *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	// healthy, we can perform our failover recovery operation.
 	// Note that failover pods may fail (e.g. lack of resources) and we don't care
 	// about them because we're going to delete them.
-	for _, ordinal := range tc.PDStsDesiredOrdinals(true) {
+	for ordinal := range tc.PDStsDesiredOrdinals(true) {
 		name := fmt.Sprintf("%s-%d", controller.PDMemberName(tc.GetName()), ordinal)
 		pod, err := pmm.podLister.Pods(tc.Namespace).Get(name)
 		if err != nil {
+			klog.Errorf("pod %s/%s does not exist: %v", tc.Namespace, name, err)
 			return false
 		}
 		if !podutil.IsPodReady(pod) {

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -14,6 +14,7 @@
 package member
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -1685,5 +1686,200 @@ func TestPDMemberManagerSyncPDStsWhenPdNotJoinCluster(t *testing.T) {
 		t.Logf("begin: %s", tests[i].name)
 		testFn(&tests[i], t)
 		t.Logf("end: %s", tests[i].name)
+	}
+}
+
+func TestPDShouldRecover(t *testing.T) {
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "failover-pd-0",
+				Namespace: v1.NamespaceDefault,
+			},
+			Status: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "failover-pd-1",
+				Namespace: v1.NamespaceDefault,
+			},
+			Status: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+	podsWithFailover := append(pods, &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failover-pd-2",
+			Namespace: v1.NamespaceDefault,
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	})
+	tests := []struct {
+		name string
+		tc   *v1alpha1.TidbCluster
+		pods []*v1.Pod
+		want bool
+	}{
+		{
+			name: "should not recover if no failure members",
+			tc: &v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "failover",
+					Namespace: v1.NamespaceDefault,
+				},
+				Status: v1alpha1.TidbClusterStatus{},
+			},
+			pods: pods,
+			want: false,
+		},
+		{
+			name: "should not recover if a member is not healthy",
+			tc: &v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "failover",
+					Namespace: v1.NamespaceDefault,
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					PD: v1alpha1.PDSpec{
+						Replicas: 2,
+					},
+				},
+				Status: v1alpha1.TidbClusterStatus{
+					PD: v1alpha1.PDStatus{
+						Members: map[string]v1alpha1.PDMember{
+							"failover-pd-0": {
+								Name:   "failover-pd-0",
+								Health: false,
+							},
+							"failover-pd-1": {
+								Name:   "failover-pd-1",
+								Health: true,
+							},
+						},
+						FailureMembers: map[string]v1alpha1.PDFailureMember{
+							"failover-pd-0": {
+								PodName: "failover-pd-0",
+							},
+						},
+					},
+				},
+			},
+			pods: pods,
+			want: false,
+		},
+		{
+			name: "should recover if all members are ready and healthy",
+			tc: &v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "failover",
+					Namespace: v1.NamespaceDefault,
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					PD: v1alpha1.PDSpec{
+						Replicas: 2,
+					},
+				},
+				Status: v1alpha1.TidbClusterStatus{
+					PD: v1alpha1.PDStatus{
+						Members: map[string]v1alpha1.PDMember{
+							"failover-pd-0": {
+								Name:   "failover-pd-0",
+								Health: true,
+							},
+							"failover-pd-1": {
+								Name:   "failover-pd-1",
+								Health: true,
+							},
+						},
+						FailureMembers: map[string]v1alpha1.PDFailureMember{
+							"failover-pd-0": {
+								PodName: "failover-pd-0",
+							},
+						},
+					},
+				},
+			},
+			pods: pods,
+			want: true,
+		},
+		{
+			name: "should recover if all members are ready and healthy (ignore auto-created failover pods)",
+			tc: &v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "failover",
+					Namespace: v1.NamespaceDefault,
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					PD: v1alpha1.PDSpec{
+						Replicas: 2,
+					},
+				},
+				Status: v1alpha1.TidbClusterStatus{
+					PD: v1alpha1.PDStatus{
+						Members: map[string]v1alpha1.PDMember{
+							"failover-pd-0": {
+								Name:   "failover-pd-0",
+								Health: true,
+							},
+							"failover-pd-1": {
+								Name:   "failover-pd-1",
+								Health: true,
+							},
+							"failover-pd-2": {
+								Name:   "failover-pd-1",
+								Health: false,
+							},
+						},
+						FailureMembers: map[string]v1alpha1.PDFailureMember{
+							"failover-pd-0": {
+								PodName: "failover-pd-0",
+							},
+						},
+					},
+				},
+			},
+			pods: podsWithFailover,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			client := kubefake.NewSimpleClientset()
+			for _, pod := range tt.pods {
+				client.CoreV1().Pods(pod.Namespace).Create(pod)
+			}
+			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(client, 0)
+			podLister := kubeInformerFactory.Core().V1().Pods().Lister()
+			kubeInformerFactory.Start(ctx.Done())
+			kubeInformerFactory.WaitForCacheSync(ctx.Done())
+			pdMemberManager := &pdMemberManager{podLister: podLister}
+			got := pdMemberManager.shouldRecover(tt.tc)
+			if got != tt.want {
+				t.Fatalf("wants %v, got %v", tt.want, got)
+			}
+		})
 	}
 }

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -580,6 +580,9 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 					Name:      fmt.Sprintf("pd-%s-pd-%d", clusterName, 3),
 				},
 				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
 					StorageClassName: pointer.StringPtr("does-not-exist"),
 				},
 			}

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -49,6 +49,8 @@ import (
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -91,6 +93,9 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 		framework.ExpectNoError(err, "failed to create port forwarder")
 		fwCancel = cancel
 		cfg = e2econfig.TestConfig
+		// We may do destructive operations in stability tests, so we wait for all nodes to ready before proceeeding.
+		ginkgo.By("Wait for all nodes are schedulable")
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})
 
 	ginkgo.AfterEach(func() {
@@ -265,9 +270,6 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 			if !supportedProviders.Has(framework.TestContext.Provider) {
 				framework.Skipf("current provider is not supported list %v, skipping", supportedProviders.List())
 			}
-
-			ginkgo.By("Wait for all nodes are schedulable")
-			framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 
 			ginkgo.By("Make sure we have at least 3 schedulable nodes")
 			nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
@@ -552,6 +554,85 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 				}
 				return true, nil
 			})
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("[Feature: AutoFailover] PD: one replacement for one failed member and replacements should be deleted when failed members are recovered", func() {
+			// TODO make storageutils.KubeletCommand work with KIND provider
+			supportedProviders := sets.NewString("aws", "gke")
+			if !supportedProviders.Has(framework.TestContext.Provider) {
+				framework.Skipf("current provider is not supported list %v, skipping", supportedProviders.List())
+			}
+			clusterName := "failover"
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc.Spec.PD.Replicas = 3
+			tc.Spec.TiKV.Replicas = 1
+			tc.Spec.TiDB.Replicas = 1
+			err := genericCli.Create(context.TODO(), tc)
+			framework.ExpectNoError(err)
+			err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Pre-create an invalid PVC to fail the auto-created failover member")
+			invalidPVC := v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      fmt.Sprintf("pd-%s-pd-%d", clusterName, 3),
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					StorageClassName: pointer.StringPtr("does-not-exist"),
+				},
+			}
+			_, err = c.CoreV1().PersistentVolumeClaims(ns).Create(&invalidPVC)
+			framework.ExpectNoError(err)
+
+			// Note that we shouldn't simply delete PD data here, because
+			// tidb-operator will try to deleting pod & pvc to recover soon
+			// after a new replacement is created.
+			ginkgo.By("Fail a PD")
+			listOptions := metav1.ListOptions{
+				LabelSelector: labels.SelectorFromSet(
+					label.New().Instance(clusterName).Component(label.PDLabelVal).Labels()).String(),
+			}
+			pdPodList, err := c.CoreV1().Pods(ns).List(listOptions)
+			framework.ExpectNoError(err)
+			gomega.Expect(len(pdPodList.Items)).To(gomega.BeNumerically("==", 3), "the number of pd nodes should be 3")
+			pod0 := pdPodList.Items[0]
+			// This command is to make sure kubelet is started after test finishes no matter it fails or not.
+			defer func() {
+				storageutils.KubeletCommand(storageutils.KStart, c, &pod0)
+			}()
+			storageutils.KubeletCommand(storageutils.KStop, c, &pod0)
+
+			ginkgo.By("Wait for a replacement to be created")
+			podName := controller.PDMemberName(clusterName) + "-3"
+			err = wait.PollImmediate(time.Second*10, 10*time.Minute /* 5 minutes failover period + 5 extra minute */, func() (bool, error) {
+				_, err := c.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return !apierrors.IsNotFound(err), nil
+			})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Wait for only one replacement to be created")
+			err = wait.PollImmediate(time.Second*10, 5*time.Minute, func() (bool, error) {
+				pdPodList, err := c.CoreV1().Pods(ns).List(listOptions)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				if len(pdPodList.Items) != 4 {
+					return true, nil
+				}
+				return false, nil
+			})
+			framework.ExpectEqual(err, wait.ErrWaitTimeout)
+
+			ginkgo.By("Recover failed PD")
+			storageutils.KubeletCommand(storageutils.KStart, c, &pod0)
+
+			ginkgo.By("Wait for the replacement to be gone")
+			e2epod.WaitForPodNotFoundInNamespace(c, podName, ns, time.Minute*5)
 			framework.ExpectNoError(err)
 		})
 	})

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/scheme"
 	"github.com/pingcap/tidb-operator/tests"
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	utilcloud "github.com/pingcap/tidb-operator/tests/e2e/util/cloud"
 	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
 	utilnode "github.com/pingcap/tidb-operator/tests/e2e/util/node"
 	utilpod "github.com/pingcap/tidb-operator/tests/e2e/util/pod"
@@ -40,6 +41,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -93,9 +95,6 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 		framework.ExpectNoError(err, "failed to create port forwarder")
 		fwCancel = cancel
 		cfg = e2econfig.TestConfig
-		// We may do destructive operations in stability tests, so we wait for all nodes to ready before proceeeding.
-		ginkgo.By("Wait for all nodes are schedulable")
-		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})
 
 	ginkgo.AfterEach(func() {
@@ -558,11 +557,15 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 		})
 
 		ginkgo.It("[Feature: AutoFailover] PD: one replacement for one failed member and replacements should be deleted when failed members are recovered", func() {
-			// TODO make storageutils.KubeletCommand work with KIND provider
-			supportedProviders := sets.NewString("aws", "gke")
+			// TODO support aws (eks), kind
+			supportedProviders := sets.NewString("gke")
 			if !supportedProviders.Has(framework.TestContext.Provider) {
 				framework.Skipf("current provider is not supported list %v, skipping", supportedProviders.List())
 			}
+			// Disable node auto repair, otherwise the node on which the
+			// kubelet is not running will be recreated.
+			defer utilcloud.EnableNodeAutoRepair()
+			utilcloud.DisableNodeAutoRepair()
 			clusterName := "failover"
 			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
 			tc.Spec.PD.Replicas = 3
@@ -584,14 +587,19 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 						v1.ReadWriteOnce,
 					},
 					StorageClassName: pointer.StringPtr("does-not-exist"),
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+						},
+					},
 				},
 			}
 			_, err = c.CoreV1().PersistentVolumeClaims(ns).Create(&invalidPVC)
 			framework.ExpectNoError(err)
 
-			// Note that we shouldn't simply delete PD data here, because
-			// tidb-operator will try to deleting pod & pvc to recover soon
-			// after a new replacement is created.
+			// We should stop the kubelet after failing the PD. Because
+			// tidb-operator will try to recreate POD & PVC soon after a new
+			// replacement is created.
 			ginkgo.By("Fail a PD")
 			listOptions := metav1.ListOptions{
 				LabelSelector: labels.SelectorFromSet(
@@ -601,6 +609,7 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 			framework.ExpectNoError(err)
 			gomega.Expect(len(pdPodList.Items)).To(gomega.BeNumerically("==", 3), "the number of pd nodes should be 3")
 			pod0 := pdPodList.Items[0]
+			f.ExecCommandInContainer(pod0.Name, "pd", "sh", "-c", "rm -rf /var/lib/pd/member")
 			// This command is to make sure kubelet is started after test finishes no matter it fails or not.
 			defer func() {
 				storageutils.KubeletCommand(storageutils.KStart, c, &pod0)
@@ -619,7 +628,7 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Wait for only one replacement to be created")
-			err = wait.PollImmediate(time.Second*10, 5*time.Minute, func() (bool, error) {
+			err = wait.PollImmediate(time.Second*10, 1*time.Minute, func() (bool, error) {
 				pdPodList, err := c.CoreV1().Pods(ns).List(listOptions)
 				if err != nil && !apierrors.IsNotFound(err) {
 					return false, nil
@@ -634,8 +643,12 @@ var _ = ginkgo.Describe("[tidb-operator][Stability]", func() {
 			ginkgo.By("Recover failed PD")
 			storageutils.KubeletCommand(storageutils.KStart, c, &pod0)
 
+			ginkgo.By("Wait for the failed PD to be recovered")
+			err = e2epod.WaitTimeoutForPodRunningInNamespace(c, pod0.Name, ns, time.Minute*5)
+			framework.ExpectNoError(err)
+
 			ginkgo.By("Wait for the replacement to be gone")
-			e2epod.WaitForPodNotFoundInNamespace(c, podName, ns, time.Minute*5)
+			err = e2epod.WaitForPodNotFoundInNamespace(c, podName, ns, time.Minute*5)
 			framework.ExpectNoError(err)
 		})
 	})

--- a/tests/e2e/util/cloud/cloud.go
+++ b/tests/e2e/util/cloud/cloud.go
@@ -1,0 +1,89 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"os/exec"
+	"strings"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func getClusterLocation() string {
+	if isRegionalCluster() {
+		return "--region=" + framework.TestContext.CloudConfig.Region
+	}
+	return "--zone=" + framework.TestContext.CloudConfig.Zone
+}
+
+func getGcloudCommandFromTrack(commandTrack string, args []string) []string {
+	command := []string{"gcloud"}
+	if commandTrack == "beta" || commandTrack == "alpha" {
+		command = append(command, commandTrack)
+	}
+	command = append(command, args...)
+	command = append(command, getClusterLocation())
+	command = append(command, "--project="+framework.TestContext.CloudConfig.ProjectID)
+	return command
+}
+
+func getGcloudCommand(args []string) []string {
+	track := ""
+	if isRegionalCluster() {
+		track = "beta"
+	}
+	return getGcloudCommandFromTrack(track, args)
+}
+
+func isRegionalCluster() bool {
+	return framework.TestContext.CloudConfig.MultiZone
+}
+
+func execCmd(args ...string) *exec.Cmd {
+	klog.Infof("Executing: %s", strings.Join(args, " "))
+	return exec.Command(args[0], args[1:]...)
+}
+
+func DisableNodeAutoRepair() {
+	if framework.TestContext.Provider == "gke" {
+		// https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair
+		nodePool := "default-pool"
+		klog.Infof("Using gcloud to disable auto-repair for pool %s", nodePool)
+		args := []string{"container", "node-pools", "update", "default-pool", "--cluster", framework.TestContext.CloudConfig.Cluster,
+			"--no-enable-autorepair"}
+		output, err := execCmd(getGcloudCommand(args)...).CombinedOutput()
+		klog.Infof("Config update result: %s", output)
+		framework.ExpectNoError(err)
+	} else {
+		// TODO support AWS (EKS)
+		framework.Failf("unsupported provider %q", framework.TestContext.Provider)
+	}
+}
+
+func EnableNodeAutoRepair() {
+	if framework.TestContext.Provider == "gke" {
+		// https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair
+		nodePool := "default-pool"
+		klog.Infof("Using gcloud to disable auto-repair for pool %s", nodePool)
+		args := []string{"container", "node-pools", "update", "default-pool", "--cluster", framework.TestContext.CloudConfig.Cluster,
+			"--enable-autorepair"}
+		output, err := execCmd(getGcloudCommand(args)...).CombinedOutput()
+		klog.Infof("Config update result: %s", output)
+		framework.ExpectNoError(err)
+	} else {
+		// TODO support AWS (EKS)
+		framework.Failf("unsupported provider %q", framework.TestContext.Provider)
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #2161 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
