### PR TITLE
[UCP] Noise reduction support when cluster auto scaling

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1623,6 +1623,13 @@ TidbMonitorStatus
 </tr>
 </tbody>
 </table>
+<h3 id="autoscalerphase">AutoScalerPhase</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#basicautoscalerstatus">BasicAutoScalerStatus</a>)
+</p>
+<p>
+</p>
 <h3 id="brconfig">BRConfig</h3>
 <p>
 (<em>Appears on:</em>
@@ -2465,6 +2472,19 @@ to fetch the recommended replicas for TiKV/TiDB</p>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#autoscalerphase">
+AutoScalerPhase
+</a>
+</em>
+</td>
+<td>
+<p>Phase describes cluster auto scaling phase</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>metrics</code></br>
@@ -15363,6 +15383,20 @@ BasicAutoScalerSpec
 <p>
 (Members of <code>BasicAutoScalerSpec</code> are embedded into this type.)
 </p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyToScaleThresholdSeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReadyToScaleThresholdSeconds represents duration that the ReadyToScale phase
+should last for before auto scaling.
+If not set, the default ReadyToScaleThresholdSeconds will be set to 30.</p>
 </td>
 </tr>
 </tbody>

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.13.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/jonboulle/clockwork v0.1.0
 	github.com/juju/errors v0.0.0-20180806074554-22422dad46e1
 	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
 	github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073 // indirect

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6218,6 +6218,9 @@ spec:
                 minReplicas:
                   format: int32
                   type: integer
+                readyToScaleThresholdSeconds:
+                  format: int32
+                  type: integer
                 scaleInIntervalSeconds:
                   format: int32
                   type: integer
@@ -6261,6 +6264,8 @@ spec:
                     - thresholdValue
                     type: object
                   type: array
+                phase:
+                  type: string
                 recommendedReplicas:
                   format: int32
                   type: integer
@@ -6290,6 +6295,8 @@ spec:
                     - thresholdValue
                     type: object
                   type: array
+                phase:
+                  type: string
                 recommendedReplicas:
                   format: int32
                   type: integer

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -916,6 +916,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BasicAutoScalerStatus(ref common.Reference
 				Description: "BasicAutoScalerStatus describe the basic auto-scaling status",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Phase describes cluster auto scaling phase",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"metrics": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MetricsStatusList describes the metrics status in the last auto-scaling reconciliation",
@@ -7489,6 +7496,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbAutoScalerStatus(ref common.ReferenceC
 				Description: "TidbAutoScalerStatus describe the auto-scaling status of tidb",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Phase describes cluster auto scaling phase",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"metrics": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MetricsStatusList describes the metrics status in the last auto-scaling reconciliation",
@@ -8528,6 +8542,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TikvAutoScalerSpec(ref common.ReferenceCal
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.ExternalEndpoint"),
 						},
 					},
+					"readyToScaleThresholdSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ReadyToScaleThresholdSeconds represents duration that the ReadyToScale phase should last for before auto scaling. If not set, the default ReadyToScaleThresholdSeconds will be set to 30.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"maxReplicas"},
 			},
@@ -8544,6 +8565,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TikvAutoScalerStatus(ref common.ReferenceC
 				Description: "TikvAutoScalerStatus describe the auto-scaling status of tikv",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Phase describes cluster auto scaling phase",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"metrics": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MetricsStatusList describes the metrics status in the last auto-scaling reconciliation",

--- a/pkg/apis/pingcap/v1alpha1/tidbclusterautoscaler_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbclusterautoscaler_types.go
@@ -18,6 +18,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type AutoScalerPhase string
+
+const (
+	NormalAutoScalerPhase          AutoScalerPhase = "Normal"
+	ReadyToScaleOutAutoScalerPhase AutoScalerPhase = "ReadyToScaleOut"
+	ReadyToScaleInAutoScalerPhase  AutoScalerPhase = "ReadyToScaleIn"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -76,6 +84,12 @@ type TidbClusterAutoScalerSpec struct {
 // TikvAutoScalerSpec describes the spec for tikv auto-scaling
 type TikvAutoScalerSpec struct {
 	BasicAutoScalerSpec `json:",inline"`
+
+	// ReadyToScaleThresholdSeconds represents duration that the ReadyToScale phase
+	// should last for before auto scaling.
+	// If not set, the default ReadyToScaleThresholdSeconds will be set to 30.
+	// +optional
+	ReadyToScaleThresholdSeconds *int32 `json:"readyToScaleThresholdSeconds,omitempty"`
 }
 
 // +k8s:openapi-gen=true
@@ -184,6 +198,8 @@ type TikvAutoScalerStatus struct {
 // +k8s:openapi-gen=true
 // BasicAutoScalerStatus describe the basic auto-scaling status
 type BasicAutoScalerStatus struct {
+	// Phase describes cluster auto scaling phase
+	Phase AutoScalerPhase `json:"phase,omitempty"`
 	// MetricsStatusList describes the metrics status in the last auto-scaling reconciliation
 	// +optional
 	MetricsStatusList []MetricsStatus `json:"metrics,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -6837,6 +6837,11 @@ func (in *TidbMonitorStatus) DeepCopy() *TidbMonitorStatus {
 func (in *TikvAutoScalerSpec) DeepCopyInto(out *TikvAutoScalerSpec) {
 	*out = *in
 	in.BasicAutoScalerSpec.DeepCopyInto(&out.BasicAutoScalerSpec)
+	if in.ReadyToScaleThresholdSeconds != nil {
+		in, out := &in.ReadyToScaleThresholdSeconds, &out.ReadyToScaleThresholdSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/autoscaler/autoscaler/autoscaler_manager.go
+++ b/pkg/autoscaler/autoscaler/autoscaler_manager.go
@@ -151,6 +151,8 @@ func (am *autoScalerManager) updateAutoScaling(oldTc *v1alpha1.TidbCluster,
 		return nil, nil
 	}
 
+	tac.Annotations[label.AnnLastSyncingTimestamp] = fmt.Sprintf("%d", time.Now().Unix())
+
 	if tac.Spec.TiKV != nil {
 		if oldTc.Status.TiKV.StatefulSet != nil {
 			tac.Status.TiKV.CurrentReplicas = oldTc.Status.TiKV.StatefulSet.CurrentReplicas

--- a/pkg/autoscaler/autoscaler/util.go
+++ b/pkg/autoscaler/autoscaler/util.go
@@ -18,7 +18,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -57,11 +59,81 @@ func checkStsAutoScalingPrerequisites(set *appsv1.StatefulSet) bool {
 	return true
 }
 
-// checkStsAutoScalingInterval would check whether there is enough interval duration between every two auto-scaling
-func checkStsAutoScalingInterval(tac *v1alpha1.TidbClusterAutoScaler, intervalSeconds int32, memberType v1alpha1.MemberType) (bool, error) {
+func checkStsAutoScaling(tac *v1alpha1.TidbClusterAutoScaler, thresholdSeconds, intervalSeconds int32, memberType v1alpha1.MemberType) (bool, error) {
+	realClock := clockwork.NewRealClock()
 	if tac.Annotations == nil {
 		tac.Annotations = map[string]string{}
 	}
+	// 3*controller.ResyncDuration is maximum time allowed before reset phase status
+	ableToScale, err := checkLastSyncingTimestamp(tac, 3*controller.ResyncDuration, realClock)
+	if err != nil {
+		return false, err
+	}
+	if !ableToScale {
+		return false, nil
+	}
+	ableToScale, err = checkStsReadyAutoScalingTimestamp(tac, thresholdSeconds, realClock)
+	if err != nil {
+		return false, err
+	}
+	if !ableToScale {
+		return false, nil
+	}
+	ableToScale, err = checkStsAutoScalingInterval(tac, intervalSeconds, memberType)
+	if err != nil {
+		return false, err
+	}
+	if !ableToScale {
+		return false, nil
+	}
+	return true, nil
+}
+
+// checkLastSyncingTimestamp reset TiKV phase if last auto scaling timestamp is longer than thresholdSec
+func checkLastSyncingTimestamp(tac *v1alpha1.TidbClusterAutoScaler, thresholdSec time.Duration, clock clockwork.Clock) (bool, error) {
+	if tac.Annotations == nil {
+		tac.Annotations = map[string]string{}
+	}
+
+	lastAutoScalingTimestamp, existed := tac.Annotations[label.AnnLastSyncingTimestamp]
+	if !existed {
+		// NOTE: because record autoscaler sync timestamp happens after check auto scale,
+		// label will not exist during first sync, return allow auto scale in this case.
+		return true, nil
+	}
+	t, err := strconv.ParseInt(lastAutoScalingTimestamp, 10, 64)
+	if err != nil {
+		return false, err
+	}
+	// if there's no resync within thresholdSec, reset TiKV phase to Normal
+	if clock.Now().After(time.Unix(t, 0).Add(thresholdSec)) {
+		tac.Status.TiKV.Phase = v1alpha1.NormalAutoScalerPhase
+		return false, nil
+	}
+	return true, nil
+}
+
+// checkStsReadyAutoScalingTimestamp would check whether there is enough time window after ready to scale
+func checkStsReadyAutoScalingTimestamp(tac *v1alpha1.TidbClusterAutoScaler, thresholdSeconds int32, clock clockwork.Clock) (bool, error) {
+	readyAutoScalingTimestamp, existed := tac.Annotations[label.AnnTiKVReadyToScaleTimestamp]
+
+	if !existed {
+		tac.Annotations[label.AnnTiKVReadyToScaleTimestamp] = fmt.Sprintf("%d", clock.Now().Unix())
+		return false, nil
+	}
+	t, err := strconv.ParseInt(readyAutoScalingTimestamp, 10, 32)
+	if err != nil {
+		return false, err
+	}
+	readyAutoScalingSec := int32(clock.Now().Sub(time.Unix(t, 0)).Seconds())
+	if thresholdSeconds > readyAutoScalingSec {
+		return false, nil
+	}
+	return true, nil
+}
+
+// checkStsAutoScalingInterval would check whether there is enough interval duration between every two auto-scaling
+func checkStsAutoScalingInterval(tac *v1alpha1.TidbClusterAutoScaler, intervalSeconds int32, memberType v1alpha1.MemberType) (bool, error) {
 	lastAutoScalingTimestamp, existed := tac.Annotations[label.AnnTiDBLastAutoScalingTimestamp]
 	if memberType == v1alpha1.TiKVMemberType {
 		lastAutoScalingTimestamp, existed = tac.Annotations[label.AnnTiKVLastAutoScalingTimestamp]
@@ -146,6 +218,9 @@ func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler) {
 			if tac.Spec.TiKV.MetricsTimeDuration == nil {
 				tac.Spec.TiKV.MetricsTimeDuration = pointer.StringPtr("3m")
 			}
+		}
+		if tac.Spec.TiKV.ReadyToScaleThresholdSeconds == nil {
+			tac.Spec.TiKV.ReadyToScaleThresholdSeconds = pointer.Int32Ptr(30)
 		}
 	}
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -109,6 +109,12 @@ const (
 	// AnnTiKVLastAutoScalingTimestamp is annotation key of tidbclusterto which ordinal is created by tikv auto-scaling
 	AnnTiKVLastAutoScalingTimestamp = "tikv.tidb.pingcap.com/last-autoscaling-timestamp"
 
+	// AnnTiKVReadyToScaleTimestamp records timestamp when tikv ready to scale
+	AnnTiKVReadyToScaleTimestamp = "tikv.tidb.pingcap.com/ready-to-scale-timestamp"
+
+	// AnnLastSyncingTimestamp records last sync timestamp
+	AnnLastSyncingTimestamp = "tidb.pingcap.com/last-syncing-timestamp"
+
 	// AnnTiDBConsecutiveScaleOutCount describes the least consecutive count to scale-out for tidb
 	AnnTiDBConsecutiveScaleOutCount = "tidb.tidb.pingcap.com/consecutive-scale-out-count"
 	// AnnTiDBConsecutiveScaleInCount describes the least consecutive count to scale-in for tidb

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -435,6 +435,7 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					MetricsTimeDuration:    &duration,
 					ScaleInIntervalSeconds: pointer.Int32Ptr(100),
 				},
+				ReadyToScaleThresholdSeconds: pointer.Int32Ptr(40),
 			}
 			tac.Spec.TiKV.Metrics = []autoscalingv2beta2.MetricSpec{}
 			tac.Spec.TiKV.Metrics = append(tac.Spec.TiKV.Metrics, defaultMetricSpec)
@@ -445,23 +446,49 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 			framework.ExpectNoError(err, "create pdapi error")
 			defer cancel()
 			var firstScaleTimestamp int64
-			err = wait.Poll(10*time.Second, 10*time.Minute, func() (done bool, err error) {
+			var readyToScaleTimestamp int64
+			err = wait.Poll(10*time.Second, 5*time.Minute, func() (done bool, err error) {
+				tac, err = cli.PingcapV1alpha1().TidbClusterAutoScalers(ns).Get(tac.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				if tac.Annotations == nil || len(tac.Annotations) < 1 {
+					framework.Logf("tac haven't marked any annotation")
+					return false, nil
+				}
+				t, ok := tac.Annotations[label.AnnTiKVReadyToScaleTimestamp]
+				if !ok {
+					framework.Logf("tac has no tikv.tidb.pingcap.com/ready-to-scale-timestamp annotation")
+					return false, nil
+				}
+				readyToScaleTimestamp, err = strconv.ParseInt(t, 10, 64)
+				if err != nil {
+					return false, err
+				}
+				if tac.Status.TiKV.Phase != v1alpha1.ReadyToScaleOutAutoScalerPhase {
+					framework.Logf("tac dont' have the right ReadyToScale phase, expect: %s, got %s", v1alpha1.ReadyToScaleOutAutoScalerPhase, tac.Status.TiKV.Phase)
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "check tikv has ready-to-scale-timestamp")
+			err = wait.Poll(10*time.Second, 5*time.Minute, func() (done bool, err error) {
 				tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
 				}
 				// check replicas
 				if tc.Spec.TiKV.Replicas != int32(4) {
-					klog.Infof("tikv haven't auto-scale to 4 replicas")
+					framework.Logf("tikv haven't auto-scale to 4 replicas")
 					return false, nil
 				}
 				if len(tc.Status.TiKV.Stores) != 4 {
-					klog.Infof("tikv's stores haven't auto-scale to 4")
+					framework.Logf("tikv's stores haven't auto-scale to 4")
 					return false, nil
 				}
 				// check annotations
 				if tc.Annotations == nil || len(tc.Annotations) < 1 {
-					klog.Infof("tc haven't marked any annotation")
+					framework.Logf("tc haven't marked any annotation")
 					return false, nil
 				}
 				tac, err = cli.PingcapV1alpha1().TidbClusterAutoScalers(ns).Get(tac.Name, metav1.GetOptions{})
@@ -469,17 +496,24 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					return false, nil
 				}
 				if tac.Annotations == nil || len(tac.Annotations) < 1 {
-					klog.Infof("tac haven't marked any annotation")
+					framework.Logf("tac haven't marked any annotation")
 					return false, nil
 				}
 				v, ok := tac.Annotations[label.AnnTiKVLastAutoScalingTimestamp]
 				if !ok {
-					klog.Infof("tac haven't marked any annotation")
+					framework.Logf("tac has no tikv.tidb.pingcap.com/last-autoscaling-timestamp annotation")
 					return false, nil
 				}
 				firstScaleTimestamp, err = strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					return false, err
+				}
+				// check readyToScaleTimestamp
+				if time.Now().Sub(time.Unix(readyToScaleTimestamp, 0)).Seconds() < 40 {
+					return false, fmt.Errorf("tikv doesn't meet the ReadyToScale threshold")
+				}
+				if tac.Status.TiKV.Phase != v1alpha1.NormalAutoScalerPhase {
+					return false, fmt.Errorf("tikv don't have right ReadyToScale phase")
 				}
 				// check store label
 				storeId := ""
@@ -509,7 +543,7 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 				return false, nil
 			})
 			framework.ExpectNoError(err, "check tikv auto-scale to 4 error")
-			klog.Info("success to check tikv auto scale-out to 4 replicas")
+			framework.Logf("success to check tikv auto scale-out to 4 replicas")
 
 			mp = &mock.MonitorParams{
 				Name:       tc.Name,
@@ -523,23 +557,48 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 			err = mock.SetPrometheusResponse(monitor.Name, monitor.Namespace, mp, fw)
 			framework.ExpectNoError(err, "set tikv mock metrics error")
 
+			err = wait.Poll(10*time.Second, 5*time.Minute, func() (done bool, err error) {
+				tac, err = cli.PingcapV1alpha1().TidbClusterAutoScalers(ns).Get(tac.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				if tac.Annotations == nil || len(tac.Annotations) < 1 {
+					framework.Logf("tac haven't marked any annotation")
+					return false, nil
+				}
+				t, ok := tac.Annotations[label.AnnTiKVReadyToScaleTimestamp]
+				if !ok {
+					framework.Logf("tac has no tikv.tidb.pingcap.com/ready-to-scale-timestamp annotation")
+					return false, nil
+				}
+				readyToScaleTimestamp, err = strconv.ParseInt(t, 10, 64)
+				if err != nil {
+					return false, err
+				}
+				if tac.Status.TiKV.Phase != v1alpha1.ReadyToScaleInAutoScalerPhase {
+					framework.Logf("tac dont' have the right ReadyToScale phase, expect: %s, got %s", v1alpha1.ReadyToScaleOutAutoScalerPhase, tac.Status.TiKV.Phase)
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "check tikv has ready-to-scale-timestamp")
 			err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
 				tc, err = cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
 				}
 				if tc.Spec.TiKV.Replicas != 3 {
-					klog.Info("tikv haven't auto-scale to 3 replicas")
+					framework.Logf("tikv haven't auto-scale to 3 replicas")
 					return false, nil
 				}
 				if len(tc.Status.TiKV.Stores) != 3 {
-					klog.Info("tikv's store haven't auto-scale to 3")
+					framework.Logf("tikv's store haven't auto-scale to 3")
 					return false, nil
 				}
 				if tc.Annotations != nil && len(tc.Annotations) > 0 {
 					_, ok := tc.Annotations[label.AnnTiKVAutoScalingOutOrdinals]
 					if ok {
-						klog.Infof("tikv auto-scale out annotation still exists")
+						framework.Logf("tikv auto-scale out annotation still exists")
 						return false, nil
 					}
 				}
@@ -548,12 +607,12 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					return false, nil
 				}
 				if tac.Annotations == nil || len(tac.Annotations) < 1 {
-					klog.Infof("tc haven't marked any annotation")
+					framework.Logf("tac haven't marked any annotation")
 					return false, nil
 				}
 				v, ok := tac.Annotations[label.AnnTiKVLastAutoScalingTimestamp]
 				if !ok {
-					klog.Infof("tac haven't marked any annotation")
+					framework.Logf("tac has no tikv.tidb.pingcap.com/last-autoscaling-timestamp annotation")
 					return false, nil
 				}
 				secondTs, err := strconv.ParseInt(v, 10, 64)
@@ -561,16 +620,22 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 					return false, err
 				}
 				if secondTs == firstScaleTimestamp {
-					klog.Info("tikv haven't scale yet")
+					framework.Logf("tikv haven't scale yet")
 					return false, nil
 				}
 				if secondTs-firstScaleTimestamp < 100 {
 					return false, fmt.Errorf("tikv second scale's interval isn't meeting the interval requirement")
 				}
+				if time.Now().Sub(time.Unix(readyToScaleTimestamp, 0)).Seconds() < 40 {
+					return false, fmt.Errorf("tikv doesn't meet the ReadyToScale threshold")
+				}
+				if tac.Status.TiKV.Phase != v1alpha1.NormalAutoScalerPhase {
+					return false, fmt.Errorf("tikv don't have right ReadyToScale phase")
+				}
 				return true, nil
 			})
 			framework.ExpectNoError(err, "check tikv auto-scale to 3 error")
-			klog.Info("success to check tikv auto scale-in to 3 replicas")
+			framework.Logf("success to check tikv auto scale-in to 3 replicas")
 
 			mp = &mock.MonitorParams{
 				Name:       tc.Name,


### PR DESCRIPTION
### What problem does this PR solve?

UCP #2241 

### What is changed and how does it work?

Add Phrase for `TidbClusterAutoScaler`, it has three optional values: Normal, ReadyToScaleOut, ReadyToScaleIn.
Add user defined autoscale threshold.

use tidb as an example, tikv should be the same.

1. check phase
after autoscaler calculate the target replica, if target replica equals to current replica, set auto scaler phase to normal and return, otherwise check if the phase equal to scaleOut or scaleIn, if not, update the phase and record timestamp. go to 2.

2. check timestamp threshold
check the record timestamp remains longer than threshold which user defined. If not, return, otherwise go to 3.

3. do autoscale
set phase to normal and do normal autoscale.

**Design for e2e tests:**
After mock response from Prometheus, without noise reduction, it will start auto scaling after maximum 30s, but with noise reduction, we expect at least in 300s (ReadyToScaleThresholdSeconds), 
cluster should remain the replica number. And after `ReadyToScaleThresholdSeconds` time, the  cluster should start normal auto scaling and auto scale phase should be back to normal.

### Check List

Tests

 - Unit test
 - E2E test

Code changes

 - Has Go code change


Side effects

n/a

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
```release-note
User now can specify `ReadyToScaleThresholdSeconds` in `TidbClusterAutoScaler`, until cluster keep in ready to auto scale status for `ReadyToScaleThresholdSeconds` seconds, then cluster start auto scaling.
```
