### PR TITLE
statefulsets are updated during each sync even if no changes to the config

### DIFF
--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -101,7 +101,7 @@ func GetLastAppliedConfig(set *apps.StatefulSet) (*apps.StatefulSetSpec, *corev1
 // statefulSetEqual compares the new Statefulset's spec with old Statefulset's last applied config
 func statefulSetEqual(new apps.StatefulSet, old apps.StatefulSet) bool {
 	// The annotations in old sts may include LastAppliedConfigAnnotation
-	var tmpAnno map[string]string
+	tmpAnno := map[string]string{}
 	for k, v := range old.Annotations {
 		if k != LastAppliedConfigAnnotation {
 			tmpAnno[k] = v
@@ -120,11 +120,7 @@ func statefulSetEqual(new apps.StatefulSet, old apps.StatefulSet) bool {
 		// oldConfig.Template.Annotations may include LastAppliedConfigAnnotation to keep backward compatiability
 		// Please check detail in https://github.com/pingcap/tidb-operator/pull/1489
 		tmpTemplate := oldConfig.Template.DeepCopy()
-		if tmpTemplate.Annotations != nil {
-			if _, ok := tmpTemplate.Annotations[LastAppliedConfigAnnotation]; ok {
-				delete(tmpTemplate.Annotations, LastAppliedConfigAnnotation)
-			}
-		}
+		delete(tmpTemplate.Annotations, LastAppliedConfigAnnotation)
 		return apiequality.Semantic.DeepEqual(oldConfig.Replicas, new.Spec.Replicas) &&
 			apiequality.Semantic.DeepEqual(*tmpTemplate, new.Spec.Template) &&
 			apiequality.Semantic.DeepEqual(oldConfig.UpdateStrategy, new.Spec.UpdateStrategy)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
statefulsets are updated during each sync even if no changes to the config
### What is changed and how does it work?
Fix the equality check logic
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Check tidb-controller-manager logs that statefulsets are not updated without changes to the config

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue that statefulsets are updated during each sync even if no changes to the config
```
