### PR TITLE
do not enable placement rules automatically

### DIFF
--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -741,17 +741,7 @@ func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		config.Dashboard.TiDBCertPath = path.Join(tidbClientCertPath, corev1.TLSCertKey)
 		config.Dashboard.TiDBKeyPath = path.Join(tidbClientCertPath, corev1.TLSPrivateKeyKey)
 	}
-	// TiFlash requires PD to enable the `replication.enable-placement-rules`
-	// Check detail in https://pingcap.com/docs/stable/reference/tiflash/deploy/
-	if tc.Spec.TiFlash != nil {
-		if config.Replication == nil {
-			config.Replication = &v1alpha1.PDReplicationConfig{}
-		}
-		if config.Replication.EnablePlacementRules == nil {
-			enable := true
-			config.Replication.EnablePlacementRules = &enable
-		}
-	}
+
 	confText, err := MarshalTOML(config)
 	if err != nil {
 		return nil, err

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -107,12 +107,34 @@ func (tfmm *tiflashMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], waiting for PD cluster running", ns, tcName)
 	}
 
+	err := tfmm.enablePlacementRules(tc)
+	if err != nil {
+		klog.Errorf("Enable placement rules failed, error: %v", err)
+		// No need to return err here, just continue to sync tiflash
+	}
 	// Sync TiFlash Headless Service
-	if err := tfmm.syncHeadlessService(tc); err != nil {
+	if err = tfmm.syncHeadlessService(tc); err != nil {
 		return err
 	}
 
 	return tfmm.syncStatefulSet(tc)
+}
+
+func (tfmm *tiflashMemberManager) enablePlacementRules(tc *v1alpha1.TidbCluster) error {
+	pdCli := controller.GetPDClient(tfmm.pdControl, tc)
+	config, err := pdCli.GetConfig()
+	if err != nil {
+		return err
+	}
+	if config.Replication.EnablePlacementRules != nil && (!*config.Replication.EnablePlacementRules) {
+		klog.Infof("Cluster %s/%s enable-placement-rules is %v, set it to true", tc.Namespace, tc.Name, *config.Replication.EnablePlacementRules)
+		enable := true
+		rule := pdapi.PDReplicationConfig{
+			EnablePlacementRules: &enable,
+		}
+		return pdCli.UpdateEnablePlacementRules(rule)
+	}
+	return nil
 }
 
 func (tfmm *tiflashMemberManager) syncHeadlessService(tc *v1alpha1.TidbCluster) error {

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -129,10 +129,10 @@ func (tfmm *tiflashMemberManager) enablePlacementRules(tc *v1alpha1.TidbCluster)
 	if config.Replication.EnablePlacementRules != nil && (!*config.Replication.EnablePlacementRules) {
 		klog.Infof("Cluster %s/%s enable-placement-rules is %v, set it to true", tc.Namespace, tc.Name, *config.Replication.EnablePlacementRules)
 		enable := true
-		rule := pdapi.PDReplicationConfig{
+		rep := pdapi.PDReplicationConfig{
 			EnablePlacementRules: &enable,
 		}
-		return pdCli.UpdateEnablePlacementRules(rule)
+		return pdCli.UpdateReplicationConfig(rep)
 	}
 	return nil
 }

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -154,8 +154,8 @@ type PDClient interface {
 	// storeLabelsEqualNodeLabels compares store labels with node labels
 	// for historic reasons, PD stores TiKV labels as []*StoreLabel which is a key-value pair slice
 	SetStoreLabels(storeID uint64, labels map[string]string) (bool, error)
-	// UpdateEnablePlacementRules updates the enable-placement-rules config
-	UpdateEnablePlacementRules(rule PDReplicationConfig) error
+	// UpdateReplicationConfig updates the replication config
+	UpdateReplicationConfig(config PDReplicationConfig) error
 	// DeleteStore deletes a TiKV store from cluster
 	DeleteStore(storeID uint64) error
 	// SetStoreState sets store to specified state.
@@ -515,9 +515,9 @@ func (pc *pdClient) SetStoreLabels(storeID uint64, labels map[string]string) (bo
 	return false, fmt.Errorf("failed %v to set store labels: %v", res.StatusCode, err2)
 }
 
-func (pc *pdClient) UpdateEnablePlacementRules(rule PDReplicationConfig) error {
+func (pc *pdClient) UpdateReplicationConfig(config PDReplicationConfig) error {
 	apiURL := fmt.Sprintf("%s/%s", pc.url, pdReplicationPrefix)
-	data, err := json.Marshal(rule)
+	data, err := json.Marshal(config)
 	if err != nil {
 		return err
 	}
@@ -529,8 +529,8 @@ func (pc *pdClient) UpdateEnablePlacementRules(rule PDReplicationConfig) error {
 	if res.StatusCode == http.StatusOK {
 		return nil
 	}
-	err2 := httputil.ReadErrorBody(res.Body)
-	return fmt.Errorf("failed %v to update enable-placement-rules: %v", res.StatusCode, err2)
+	err = httputil.ReadErrorBody(res.Body)
+	return fmt.Errorf("failed %v to update replication: %v", res.StatusCode, err)
 }
 
 func (pc *pdClient) BeginEvictLeader(storeID uint64) error {
@@ -718,7 +718,7 @@ const (
 	DeleteMemberByIDActionType         ActionType = "DeleteMemberByID"
 	DeleteMemberActionType             ActionType = "DeleteMember "
 	SetStoreLabelsActionType           ActionType = "SetStoreLabels"
-	UpdatePlacementRulesActionType     ActionType = "UpdateEnablePlacementRules"
+	UpdateReplicationActionType        ActionType = "UpdateReplicationConfig"
 	BeginEvictLeaderActionType         ActionType = "BeginEvictLeader"
 	EndEvictLeaderActionType           ActionType = "EndEvictLeader"
 	GetEvictLeaderSchedulersActionType ActionType = "GetEvictLeaderSchedulers"
@@ -735,10 +735,10 @@ func (nfr *NotFoundReaction) Error() string {
 }
 
 type Action struct {
-	ID     uint64
-	Name   string
-	Labels map[string]string
-	Rule   PDReplicationConfig
+	ID          uint64
+	Name        string
+	Labels      map[string]string
+	Replication PDReplicationConfig
 }
 
 type Reaction func(action *Action) (interface{}, error)
@@ -878,10 +878,10 @@ func (pc *FakePDClient) SetStoreLabels(storeID uint64, labels map[string]string)
 	return true, nil
 }
 
-// UpdateEnablePlacementRules updates the enable-placement-rules
-func (pc *FakePDClient) UpdateEnablePlacementRules(rule PDReplicationConfig) error {
-	if reaction, ok := pc.reactions[UpdatePlacementRulesActionType]; ok {
-		action := &Action{Rule: rule}
+// UpdateReplicationConfig updates the replication config
+func (pc *FakePDClient) UpdateReplicationConfig(config PDReplicationConfig) error {
+	if reaction, ok := pc.reactions[UpdateReplicationActionType]; ok {
+		action := &Action{Replication: config}
 		_, err := reaction(action)
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #2219 

### What is changed and how does it work?
If users enable TiFlash for the existing TiDB Cluster, enable placement rules automatically with pdapi.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Enable TiFlash for the existing TiDB Cluster, enable-placement-rules is set automatically and PD cluster will not be rolling updated.
   - Create cluster with enable-placement-rules set, tiflash will start successfully and the operator will not update the enable-placement-rules config.

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Set `enable-placement-rules` to `true` for PD if TiFlash is enabled in the cluster
```
