### PR TITLE
do not print rclone conf file

### DIFF
--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -57,8 +57,6 @@ else
 	EXEC_COMMAND="/usr/local/bin/shush exec --"
 fi
 
-cat /tmp/rclone.conf
-
 # exec command
 case "$1" in
     backup)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
do not print rclone conf file in the entrypoint
### What is changed and how does it work?
do not print rclone conf file in the entrypoint
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Do not print rclone config in the Pod logs
```
