### PR TITLE
e2e: fix namespace creation conflict

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,6 +22,11 @@ import (
 	"time"
 
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -52,6 +57,57 @@ func init() {
 	})
 }
 
+// See https://github.com/kubernetes/kubernetes/pull/90591
+func createTestingNS(baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error) {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["e2e-run"] = string(framework.RunID)
+
+	// We don't use ObjectMeta.GenerateName feature, as in case of API call
+	// failure we don't know whether the namespace was created and what is its
+	// name.
+	name := fmt.Sprintf("%v-%v", baseName, framework.RandomSuffix())
+
+	namespaceObj := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+			Labels:    labels,
+		},
+		Status: v1.NamespaceStatus{},
+	}
+	// Be robust about making the namespace creation call.
+	var got *v1.Namespace
+	if err := wait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
+		var err error
+		got, err = c.CoreV1().Namespaces().Create(namespaceObj)
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// regenerate on conflict
+				framework.Logf("Namespace name %q was already taken, generate a new name and retry", namespaceObj.Name)
+				namespaceObj.Name = fmt.Sprintf("%v-%v", baseName, framework.RandomSuffix())
+			} else {
+				framework.Logf("Unexpected error while creating namespace: %v", err)
+			}
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if framework.TestContext.VerifyServiceAccount {
+		if err := framework.WaitForDefaultServiceAccountInNamespace(c, got.Name); err != nil {
+			// Even if we fail to create serviceAccount in the namespace,
+			// we have successfully create a namespace.
+			// So, return the created namespace.
+			return got, err
+		}
+	}
+	return got, nil
+}
+
 func TestMain(m *testing.M) {
 	// Register test flags, then parse flags.
 	handleFlags()
@@ -74,6 +130,9 @@ func TestMain(m *testing.M) {
 	if framework.TestContext.RepoRoot != "" {
 		testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
 	}
+
+	// See https://github.com/pingcap/tidb-operator/issues/2339
+	framework.TestContext.CreateTestingNS = createTestingNS
 
 	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #2339
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
