### PR TITLE
update br to v3.1.1

### DIFF
--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -2,7 +2,7 @@ FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_VERSION=v3.0.13
-ARG TOOLKIT_V31=v3.1.0
+ARG TOOLKIT_V31=v3.1.1
 ARG TOOLKIT_V40=v4.0.0-rc
 RUN apk update && apk add ca-certificates
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/br/issues/241 is fixed in v3.1.1, so we have to update the BR version.
### What is changed and how does it work?
update br to v3.1.1
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Backup and restore with the new tidb-backup-manager image for v3.1.1 TiDB Cluster


Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Update BR to v3.1.1 in the tidb-backup-manager image
```
