### PR TITLE
UCP: Make StatefulSet canary release controlled in featureGate

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,6 +31,7 @@ var (
 		StableScheduling:    true,
 		AdvancedStatefulSet: false,
 		AutoScaling:         false,
+		CanaryRelease:       false,
 	}
 	// DefaultFeatureGate is a shared global FeatureGate.
 	DefaultFeatureGate FeatureGate = NewFeatureGate()
@@ -45,6 +46,9 @@ const (
 
 	// AutoScaling controls whether to use TidbClusterAutoScaler to auto scale-in/out pods
 	AutoScaling string = "AutoScaling"
+
+	// CanaryRelease controls whether to use StatefulSet webhook to canary release statefulsets
+	CanaryRelease string = "CanaryRelease"
 )
 
 type FeatureGate interface {

--- a/pkg/webhook/admission_hooks.go
+++ b/pkg/webhook/admission_hooks.go
@@ -116,6 +116,11 @@ func (a *AdmissionHook) Admit(ar *admission.AdmissionRequest) *admission.Admissi
 			return a.unknownAdmissionRequest(ar)
 		}
 		return a.podAC.MutatePods(ar)
+	case "StatefulSet":
+		if features.DefaultFeatureGate.Enabled(features.CanaryRelease) {
+			return a.stsAC.AdmitStatefulSets(ar)
+		}
+		return resp
 	default:
 		return resp
 	}

--- a/pkg/webhook/admission_hooks.go
+++ b/pkg/webhook/admission_hooks.go
@@ -116,11 +116,6 @@ func (a *AdmissionHook) Admit(ar *admission.AdmissionRequest) *admission.Admissi
 			return a.unknownAdmissionRequest(ar)
 		}
 		return a.podAC.MutatePods(ar)
-	case "StatefulSet":
-		if features.DefaultFeatureGate.Enabled(features.CanaryRelease) {
-			return a.stsAC.AdmitStatefulSets(ar)
-		}
-		return resp
 	default:
 		return resp
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
UCP: #2342 
Close: #2342 
### What is changed and how does it work?
1. Add featureGate CanaryRelease
2. Set default CanaryRelease as false

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test


Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
