### PR TITLE
Update prometheus operator tikv example

### DIFF
--- a/examples/prometheus-operator/tikv-serviceMonitor.yaml
+++ b/examples/prometheus-operator/tikv-serviceMonitor.yaml
@@ -10,7 +10,12 @@ spec:
   - interval: 15s
     scrapeTimeout: 10s
     path: /metrics
-    targetPort: 20180
+    relabelings:
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      targetLabel: __address__
+      replacement: $1:$2
+      action: replace
     metricRelabelings:
     - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
       action: keep
@@ -25,12 +30,6 @@ spec:
       action: replace
       targetLabel: __metrics_path__
       regex: (.+)
-    - sourceLabels: [__meta_kubernetes_pod_name, __meta_kubernetes_pod_label_app_kubernetes_io_instance,
-                      __meta_kubernetes_pod_annotation_prometheus_io_port]
-      regex: (.+);(.+);(.+)
-      targetLabel: __address__
-      replacement: $1.$2-tikv-peer:$3
-      action: replace
     - sourceLabels: [__meta_kubernetes_namespace]
       action: replace
       targetLabel: kubernetes_namespace


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>



### What problem does this PR solve? <!--add and issue link with summary if exists-->

The current tikv service monitor example doesn't work with prometheus operator because tikv doesn't open 20180 explicitly.

This example works for me. Verification

![image](https://user-images.githubusercontent.com/25150124/81889087-bb54e400-9570-11ea-82c8-3540b2e8f482.png)
