### PR TITLE
separate tikv and tiflash tombstone stores

### DIFF
--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -686,6 +686,9 @@ func (tfmm *tiflashMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster
 		return err
 	}
 	for _, store := range tombstoneStoresInfo.Stores {
+		if store.Store != nil && !pattern.Match([]byte(store.Store.Address)) {
+			continue
+		}
 		status := tfmm.getTiFlashStore(store)
 		if status == nil {
 			continue

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -31,7 +31,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,333 +38,9 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
 )
 
-func TestTiKVMemberManagerSyncCreate(t *testing.T) {
-	g := NewGomegaWithT(t)
-	type testcase struct {
-		name                         string
-		prepare                      func(cluster *v1alpha1.TidbCluster)
-		errWhenCreateStatefulSet     bool
-		errWhenCreateTiKVPeerService bool
-		errWhenGetStores             bool
-		err                          bool
-		tikvPeerSvcCreated           bool
-		setCreated                   bool
-		pdStores                     *pdapi.StoresInfo
-		tombstoneStores              *pdapi.StoresInfo
-	}
-
-	testFn := func(test *testcase, t *testing.T) {
-		t.Log(test.name)
-
-		tc := newTidbClusterForPD()
-		tc.Status.PD.Members = map[string]v1alpha1.PDMember{
-			"pd-0": {Name: "pd-0", Health: true},
-			"pd-1": {Name: "pd-1", Health: true},
-			"pd-2": {Name: "pd-2", Health: true},
-		}
-		tc.Status.PD.StatefulSet = &apps.StatefulSetStatus{ReadyReplicas: 3}
-
-		ns := tc.Namespace
-		tcName := tc.Name
-		oldSpec := tc.Spec
-		if test.prepare != nil {
-			test.prepare(tc)
-		}
-
-		tkmm, fakeSetControl, fakeSvcControl, pdClient, _, _ := newFakeTiKVMemberManager(tc)
-		pdClient.AddReaction(pdapi.GetConfigActionType, func(action *pdapi.Action) (interface{}, error) {
-			return &v1alpha1.PDConfig{
-				Replication: &v1alpha1.PDReplicationConfig{
-					LocationLabels: []string{"region", "zone", "rack", "host"},
-				},
-			}, nil
-		})
-		if test.errWhenGetStores {
-			pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return nil, fmt.Errorf("failed to get stores from tikv cluster")
-			})
-		} else {
-			pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return test.pdStores, nil
-			})
-			pdClient.AddReaction(pdapi.GetTombStoneStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return test.tombstoneStores, nil
-			})
-			pdClient.AddReaction(pdapi.SetStoreLabelsActionType, func(action *pdapi.Action) (interface{}, error) {
-				return true, nil
-			})
-		}
-
-		if test.errWhenCreateStatefulSet {
-			fakeSetControl.SetCreateStatefulSetError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
-		}
-		if test.errWhenCreateTiKVPeerService {
-			fakeSvcControl.SetCreateServiceError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
-		}
-
-		err := tkmm.Sync(tc)
-		if test.err {
-			g.Expect(err).To(HaveOccurred())
-		} else {
-			g.Expect(err).NotTo(HaveOccurred())
-		}
-
-		g.Expect(tc.Spec).To(Equal(oldSpec))
-
-		svc, err := tkmm.svcLister.Services(ns).Get(controller.TiKVPeerMemberName(tcName))
-		if test.tikvPeerSvcCreated {
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(svc).NotTo(Equal(nil))
-		} else {
-			expectErrIsNotFound(g, err)
-		}
-
-		tc1, err := tkmm.setLister.StatefulSets(ns).Get(controller.TiKVMemberName(tcName))
-		if test.setCreated {
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(tc1).NotTo(Equal(nil))
-		} else {
-			expectErrIsNotFound(g, err)
-		}
-	}
-
-	tests := []testcase{
-		{
-			name:                         "normal",
-			prepare:                      nil,
-			errWhenCreateStatefulSet:     false,
-			errWhenCreateTiKVPeerService: false,
-			err:                          false,
-			tikvPeerSvcCreated:           true,
-			setCreated:                   true,
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-		},
-		{
-			name: "pd is not available",
-			prepare: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.PD.Members = map[string]v1alpha1.PDMember{}
-			},
-			errWhenCreateStatefulSet:     false,
-			errWhenCreateTiKVPeerService: false,
-			err:                          true,
-			tikvPeerSvcCreated:           false,
-			setCreated:                   false,
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-		},
-		{
-			name:                         "error when create statefulset",
-			prepare:                      nil,
-			errWhenCreateStatefulSet:     true,
-			errWhenCreateTiKVPeerService: false,
-			err:                          true,
-			tikvPeerSvcCreated:           true,
-			setCreated:                   false,
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-		},
-		{
-			name:                         "error when create tikv peer service",
-			prepare:                      nil,
-			errWhenCreateStatefulSet:     false,
-			errWhenCreateTiKVPeerService: true,
-			err:                          true,
-			tikvPeerSvcCreated:           false,
-			setCreated:                   false,
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-		},
-	}
-
-	for i := range tests {
-		testFn(&tests[i], t)
-	}
-}
-
-func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
-	g := NewGomegaWithT(t)
-	type testcase struct {
-		name                         string
-		modify                       func(cluster *v1alpha1.TidbCluster)
-		pdStores                     *pdapi.StoresInfo
-		tombstoneStores              *pdapi.StoresInfo
-		errWhenUpdateStatefulSet     bool
-		errWhenUpdateTiKVPeerService bool
-		errWhenGetStores             bool
-		statusChange                 func(*apps.StatefulSet)
-		err                          bool
-		expectTiKVPeerServiceFn      func(*GomegaWithT, *corev1.Service, error)
-		expectStatefulSetFn          func(*GomegaWithT, *apps.StatefulSet, error)
-		expectTidbClusterFn          func(*GomegaWithT, *v1alpha1.TidbCluster)
-	}
-
-	testFn := func(test *testcase, t *testing.T) {
-		t.Log(test.name)
-
-		tc := newTidbClusterForPD()
-		tc.Status.PD.Members = map[string]v1alpha1.PDMember{
-			"pd-0": {Name: "pd-0", Health: true},
-			"pd-1": {Name: "pd-1", Health: true},
-			"pd-2": {Name: "pd-2", Health: true},
-		}
-		tc.Status.PD.StatefulSet = &apps.StatefulSetStatus{ReadyReplicas: 3}
-
-		ns := tc.Namespace
-		tcName := tc.Name
-
-		tkmm, fakeSetControl, fakeSvcControl, pdClient, _, _ := newFakeTiKVMemberManager(tc)
-		pdClient.AddReaction(pdapi.GetConfigActionType, func(action *pdapi.Action) (interface{}, error) {
-			return &pdapi.PDConfigFromAPI{
-				Replication: &pdapi.PDReplicationConfig{
-					LocationLabels: []string{"region", "zone", "rack", "host"},
-				},
-			}, nil
-		})
-		if test.errWhenGetStores {
-			pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return nil, fmt.Errorf("failed to get stores from pd cluster")
-			})
-		} else {
-			pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return test.pdStores, nil
-			})
-			pdClient.AddReaction(pdapi.GetTombStoneStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-				return test.tombstoneStores, nil
-			})
-			pdClient.AddReaction(pdapi.SetStoreLabelsActionType, func(action *pdapi.Action) (interface{}, error) {
-				return true, nil
-			})
-		}
-
-		if test.statusChange == nil {
-			fakeSetControl.SetStatusChange(func(set *apps.StatefulSet) {
-				set.Status.Replicas = *set.Spec.Replicas
-				set.Status.CurrentRevision = "pd-1"
-				set.Status.UpdateRevision = "pd-1"
-				observedGeneration := int64(1)
-				set.Status.ObservedGeneration = observedGeneration
-			})
-		} else {
-			fakeSetControl.SetStatusChange(test.statusChange)
-		}
-
-		err := tkmm.Sync(tc)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		_, err = tkmm.svcLister.Services(ns).Get(controller.TiKVPeerMemberName(tcName))
-		g.Expect(err).NotTo(HaveOccurred())
-		_, err = tkmm.setLister.StatefulSets(ns).Get(controller.TiKVMemberName(tcName))
-		g.Expect(err).NotTo(HaveOccurred())
-
-		tc1 := tc.DeepCopy()
-		test.modify(tc1)
-
-		if test.errWhenUpdateTiKVPeerService {
-			fakeSvcControl.SetUpdateServiceError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
-		}
-		if test.errWhenUpdateStatefulSet {
-			fakeSetControl.SetUpdateStatefulSetError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
-		}
-
-		err = tkmm.Sync(tc1)
-		if test.err {
-			g.Expect(err).To(HaveOccurred())
-		} else {
-			g.Expect(err).NotTo(HaveOccurred())
-		}
-
-		if test.expectTiKVPeerServiceFn != nil {
-			svc, err := tkmm.svcLister.Services(ns).Get(controller.TiKVPeerMemberName(tcName))
-			test.expectTiKVPeerServiceFn(g, svc, err)
-		}
-		if test.expectStatefulSetFn != nil {
-			set, err := tkmm.setLister.StatefulSets(ns).Get(controller.TiKVMemberName(tcName))
-			test.expectStatefulSetFn(g, set, err)
-		}
-		if test.expectTidbClusterFn != nil {
-			test.expectTidbClusterFn(g, tc1)
-		}
-	}
-
-	tests := []testcase{
-		{
-			name: "normal",
-			modify: func(tc *v1alpha1.TidbCluster) {
-				tc.Spec.TiKV.Replicas = 5
-				tc.Spec.Services = []v1alpha1.Service{
-					{Name: "tikv", Type: string(corev1.ServiceTypeNodePort)},
-				}
-				tc.Status.PD.Phase = v1alpha1.NormalPhase
-			},
-			// TODO add unit test for status sync
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			errWhenUpdateStatefulSet:     false,
-			errWhenUpdateTiKVPeerService: false,
-			errWhenGetStores:             false,
-			err:                          false,
-			expectTiKVPeerServiceFn:      nil,
-			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(int(*set.Spec.Replicas)).To(Equal(4))
-			},
-			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.ObservedGeneration).To(Equal(int64(1)))
-				g.Expect(tc.Status.TiKV.Stores).To(Equal(map[string]v1alpha1.TiKVStore{}))
-				g.Expect(tc.Status.TiKV.TombstoneStores).To(Equal(map[string]v1alpha1.TiKVStore{}))
-			},
-		},
-		{
-			name: "error when update statefulset",
-			modify: func(tc *v1alpha1.TidbCluster) {
-				tc.Spec.TiKV.Replicas = 5
-				tc.Status.PD.Phase = v1alpha1.NormalPhase
-			},
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			errWhenUpdateStatefulSet:     true,
-			errWhenUpdateTiKVPeerService: false,
-			err:                          true,
-			expectTiKVPeerServiceFn:      nil,
-			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-			},
-		},
-		{
-			name: "error when sync tikv status",
-			modify: func(tc *v1alpha1.TidbCluster) {
-				tc.Spec.TiKV.Replicas = 5
-				tc.Status.PD.Phase = v1alpha1.NormalPhase
-			},
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			errWhenUpdateStatefulSet:     false,
-			errWhenUpdateTiKVPeerService: false,
-			errWhenGetStores:             true,
-			err:                          true,
-			expectTiKVPeerServiceFn:      nil,
-			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(int(*set.Spec.Replicas)).To(Equal(3))
-			},
-			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(0))
-			},
-		},
-	}
-
-	for i := range tests {
-		t.Logf("begin: %s", tests[i].name)
-		testFn(&tests[i], t)
-		t.Logf("end: %s", tests[i].name)
-	}
-}
-
-func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
+func TestTiFlashMemberManagerTiFlashStatefulSetIsUpgrading(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
 		name            string
@@ -377,8 +52,8 @@ func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
 	}
 	testFn := func(test *testcase, t *testing.T) {
 		tc := newTidbClusterForPD()
-		pmm, _, _, _, podIndexer, _ := newFakeTiKVMemberManager(tc)
-		tc.Status.TiKV.StatefulSet = &apps.StatefulSetStatus{
+		pmm, _, _, _, podIndexer, _ := newFakeTiFlashMemberManager(tc)
+		tc.Status.TiFlash.StatefulSet = &apps.StatefulSetStatus{
 			UpdateRevision: "v3",
 		}
 
@@ -395,10 +70,10 @@ func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
 		if test.hasPod {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 0),
+					Name:        ordinalPodName(v1alpha1.TiFlashMemberType, tc.GetName(), 0),
 					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{},
-					Labels:      label.New().Instance(tc.GetInstanceName()).TiKV().Labels(),
+					Labels:      label.New().Instance(tc.GetInstanceName()).TiFlash().Labels(),
 				},
 			}
 			if test.updatePod != nil {
@@ -406,7 +81,7 @@ func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
 			}
 			podIndexer.Add(pod)
 		}
-		b, err := pmm.tikvStatefulSetIsUpgradingFn(pmm.podLister, pmm.pdControl, set, tc)
+		b, err := pmm.tiflashStatefulSetIsUpgradingFn(pmm.podLister, pmm.pdControl, set, tc)
 		if test.errExpectFn != nil {
 			test.errExpectFn(g, err)
 		}
@@ -465,7 +140,7 @@ func TestTiKVMemberManagerTiKVStatefulSetIsUpgrading(t *testing.T) {
 	}
 }
 
-func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
+func TestTiFlashMemberManagerSetStoreLabelsForTiFlash(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
 		name             string
@@ -479,7 +154,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 	}
 	testFn := func(test *testcase, t *testing.T) {
 		tc := newTidbClusterForPD()
-		pmm, _, _, pdClient, podIndexer, nodeIndexer := newFakeTiKVMemberManager(tc)
+		pmm, _, _, pdClient, podIndexer, nodeIndexer := newFakeTiFlashMemberManager(tc)
 		pdClient.AddReaction(pdapi.GetConfigActionType, func(action *pdapi.Action) (interface{}, error) {
 			return &pdapi.PDConfigFromAPI{
 				Replication: &pdapi.PDReplicationConfig{
@@ -514,7 +189,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 		if test.hasPod {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-tikv-1",
+					Name:      "test-tiflash-1",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: corev1.PodSpec{
@@ -533,7 +208,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 			})
 		}
 
-		setCount, err := pmm.setStoreLabelsForTiKV(tc)
+		setCount, err := pmm.setStoreLabelsForTiFlash(tc)
 		if test.errExpectFn != nil {
 			test.errExpectFn(g, err)
 		}
@@ -612,7 +287,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -641,7 +316,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -669,7 +344,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -715,7 +390,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -749,7 +424,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 								Labels: []*metapb.StoreLabel{
 									{
 										Key:   "region",
@@ -782,7 +457,7 @@ func TestTiKVMemberManagerSetStoreLabelsForTiKV(t *testing.T) {
 	}
 }
 
-func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
+func TestTiFlashMemberManagerSyncTidbClusterStatus(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
 		name                      string
@@ -808,10 +483,10 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 		if test.updateTC != nil {
 			test.updateTC(tc)
 		}
-		pmm, _, _, pdClient, _, _ := newFakeTiKVMemberManager(tc)
+		pmm, _, _, pdClient, _, _ := newFakeTiFlashMemberManager(tc)
 
 		if test.upgradingFn != nil {
-			pmm.tikvStatefulSetIsUpgradingFn = test.upgradingFn
+			pmm.tiflashStatefulSetIsUpgradingFn = test.upgradingFn
 		}
 		if test.errWhenGetStores {
 			pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
@@ -856,7 +531,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 				g.Expect(strings.Contains(err.Error(), "whether upgrading failed")).To(BeTrue())
 			},
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiFlash.StatefulSet.Replicas).To(Equal(int32(3)))
 			},
 		},
 		{
@@ -871,8 +546,8 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tombstoneStoreInfo:        nil,
 			errExpectFn:               nil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(tc.Status.TiFlash.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
 			},
 		},
 		{
@@ -889,8 +564,8 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tombstoneStoreInfo:        nil,
 			errExpectFn:               nil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.TiFlash.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
 			},
 		},
 		{
@@ -905,8 +580,8 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tombstoneStoreInfo:        nil,
 			errExpectFn:               nil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.TiFlash.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.NormalPhase))
 			},
 		},
 		{
@@ -924,8 +599,8 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 				g.Expect(strings.Contains(err.Error(), "failed to get stores")).To(BeTrue())
 			},
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Synced).To(BeFalse())
+				g.Expect(tc.Status.TiFlash.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeFalse())
 			},
 		},
 		{
@@ -944,9 +619,9 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(0))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(0))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
@@ -969,9 +644,9 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(0))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(0))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
@@ -994,16 +669,16 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(0))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(0))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "LastHeartbeatTS is zero, TidbClulster LastHeartbeatTS is not zero",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastHeartbeatTime: now,
 				}
 			},
@@ -1018,7 +693,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1029,11 +704,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1045,17 +721,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(time.Time{}.IsZero()).To(BeTrue())
-				g.Expect(tc.Status.TiKV.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeFalse())
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeFalse())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "LastHeartbeatTS is zero, TidbClulster LastHeartbeatTS is zero",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastHeartbeatTime: metav1.Time{Time: time.Time{}},
 				}
 			},
@@ -1069,7 +745,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1080,11 +756,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1096,17 +773,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(time.Time{}.IsZero()).To(BeTrue())
-				g.Expect(tc.Status.TiKV.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeTrue())
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "LastHeartbeatTS is not zero, TidbClulster LastHeartbeatTS is zero",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastHeartbeatTime: metav1.Time{Time: time.Time{}},
 				}
 			},
@@ -1120,7 +797,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1131,11 +808,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1147,17 +825,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(time.Time{}.IsZero()).To(BeTrue())
-				g.Expect(tc.Status.TiKV.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeFalse())
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastHeartbeatTime.Time.IsZero()).To(BeFalse())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "set LastTransitionTime first time",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				// tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				// tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{}
 			},
 			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
 				return false, nil
@@ -1169,7 +847,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 						},
 						Status: &pdapi.StoreStatus{
@@ -1180,11 +858,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1195,17 +874,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(tc.Status.TiKV.Stores["333"].LastTransitionTime.Time.IsZero()).To(BeFalse())
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastTransitionTime.Time.IsZero()).To(BeFalse())
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "state not change, LastTransitionTime not change",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastTransitionTime: now,
 					State:              v1alpha1.TiKVStateUp,
 				}
@@ -1220,7 +899,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1232,11 +911,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1247,17 +927,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(tc.Status.TiKV.Stores["333"].LastTransitionTime).To(Equal(now))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastTransitionTime).To(Equal(now))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "state change, LastTransitionTime change",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastTransitionTime: now,
 					State:              v1alpha1.TiKVStateUp,
 				}
@@ -1272,7 +952,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Down",
 						},
@@ -1284,11 +964,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1299,17 +980,17 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(tc.Status.TiKV.Stores["333"].LastTransitionTime).NotTo(Equal(now))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(tc.Status.TiFlash.Stores["333"].LastTransitionTime).NotTo(Equal(now))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 		{
 			name: "get tombstone stores failed",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-				tc.Status.TiKV.Stores["333"] = v1alpha1.TiKVStore{
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{}
+				tc.Status.TiFlash.Stores["333"] = v1alpha1.TiKVStore{
 					LastTransitionTime: now,
 					State:              v1alpha1.TiKVStateUp,
 				}
@@ -1324,7 +1005,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1336,11 +1017,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1354,9 +1036,9 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 				g.Expect(strings.Contains(err.Error(), "failed to get tombstone stores")).To(BeTrue())
 			},
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(0))
-				g.Expect(tc.Status.TiKV.Synced).To(BeFalse())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(0))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeFalse())
 			},
 		},
 		{
@@ -1372,7 +1054,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Up",
 						},
@@ -1384,11 +1066,12 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
+							StateName: "Up",
 						},
 						Status: &pdapi.StoreStatus{
-							LastHeartbeatTS: time.Time{},
+							LastHeartbeatTS: time.Now(),
 						},
 					},
 				},
@@ -1400,7 +1083,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      333,
-								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Tombstone",
 						},
@@ -1412,7 +1095,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 						Store: &pdapi.MetaStore{
 							Store: &metapb.Store{
 								Id:      330,
-								Address: fmt.Sprintf("%s-tiflash-1.%s-tiflash-peer.%s.svc:20160", "test", "test", "default"),
+								Address: fmt.Sprintf("%s-tikv-1.%s-tikv-peer.%s.svc:20160", "test", "test", "default"),
 							},
 							StateName: "Tombstone",
 						},
@@ -1424,9 +1107,9 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(1))
-				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(1))
-				g.Expect(tc.Status.TiKV.Synced).To(BeTrue())
+				g.Expect(len(tc.Status.TiFlash.Stores)).To(Equal(1))
+				g.Expect(len(tc.Status.TiFlash.TombstoneStores)).To(Equal(1))
+				g.Expect(tc.Status.TiFlash.Synced).To(BeTrue())
 			},
 		},
 	}
@@ -1437,8 +1120,8 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 	}
 }
 
-func newFakeTiKVMemberManager(tc *v1alpha1.TidbCluster) (
-	*tikvMemberManager, *controller.FakeStatefulSetControl,
+func newFakeTiFlashMemberManager(tc *v1alpha1.TidbCluster) (
+	*tiflashMemberManager, *controller.FakeStatefulSetControl,
 	*controller.FakeServiceControl, *pdapi.FakePDClient, cache.Indexer, cache.Indexer) {
 	cli := fake.NewSimpleClientset()
 	kubeCli := kubefake.NewSimpleClientset()
@@ -1452,27 +1135,27 @@ func newFakeTiKVMemberManager(tc *v1alpha1.TidbCluster) (
 	svcControl := controller.NewFakeServiceControl(svcInformer, epsInformer, tcInformer)
 	podInformer := kubeinformers.NewSharedInformerFactory(kubeCli, 0).Core().V1().Pods()
 	nodeInformer := kubeinformers.NewSharedInformerFactory(kubeCli, 0).Core().V1().Nodes()
-	tikvScaler := NewFakeTiKVScaler()
-	tikvUpgrader := NewFakeTiKVUpgrader()
+	tiflashScaler := NewFakeTiFlashScaler()
+	tiflashUpgrader := NewFakeTiFlashUpgrader()
 	genericControl := controller.NewFakeGenericControl()
 
-	tmm := &tikvMemberManager{
-		pdControl:    pdControl,
-		podLister:    podInformer.Lister(),
-		nodeLister:   nodeInformer.Lister(),
-		setControl:   setControl,
-		svcControl:   svcControl,
-		typedControl: controller.NewTypedControl(genericControl),
-		setLister:    setInformer.Lister(),
-		svcLister:    svcInformer.Lister(),
-		tikvScaler:   tikvScaler,
-		tikvUpgrader: tikvUpgrader,
+	tmm := &tiflashMemberManager{
+		pdControl:       pdControl,
+		podLister:       podInformer.Lister(),
+		nodeLister:      nodeInformer.Lister(),
+		setControl:      setControl,
+		svcControl:      svcControl,
+		typedControl:    controller.NewTypedControl(genericControl),
+		setLister:       setInformer.Lister(),
+		svcLister:       svcInformer.Lister(),
+		tiflashScaler:   tiflashScaler,
+		tiflashUpgrader: tiflashUpgrader,
 	}
-	tmm.tikvStatefulSetIsUpgradingFn = tikvStatefulSetIsUpgrading
+	tmm.tiflashStatefulSetIsUpgradingFn = tiflashStatefulSetIsUpgrading
 	return tmm, setControl, svcControl, pdClient, podInformer.Informer().GetIndexer(), nodeInformer.Informer().GetIndexer()
 }
 
-func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
+func TestGetNewServiceForTidbCluster(t *testing.T) {
 	tests := []struct {
 		name      string
 		tc        v1alpha1.TidbCluster
@@ -1491,18 +1174,18 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 				Name:       "peer",
 				Port:       20160,
 				Headless:   true,
-				SvcLabel:   func(l label.Label) label.Label { return l.TiKV() },
-				MemberName: controller.TiKVPeerMemberName,
+				SvcLabel:   func(l label.Label) label.Label { return l.TiFlash() },
+				MemberName: controller.TiFlashPeerMemberName,
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-tikv-peer",
+					Name:      "foo-tiflash-peer",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "tikv",
+						"app.kubernetes.io/component":  "tiflash",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1533,7 +1216,7 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "tikv",
+						"app.kubernetes.io/component":  "tiflash",
 					},
 					PublishNotReadyAddresses: true,
 				},
@@ -1551,7 +1234,7 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 	}
 }
 
-func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
+func TestGetNewTiFlashSetForTidbCluster(t *testing.T) {
 	enable := true
 	tests := []struct {
 		name    string
@@ -1560,26 +1243,48 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 		testSts func(sts *apps.StatefulSet)
 	}{
 		{
-			name: "tikv network is not host",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-			},
-			testSts: testHostNetwork(t, false, ""),
-		},
-		{
-			name: "tikv network is host",
+			name: "tiflash network is not host",
 			tc: v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tc",
 					Namespace: "ns",
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
+					TiFlash: &v1alpha1.TiFlashSpec{
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			testSts: testHostNetwork(t, false, ""),
+		},
+		{
+			name: "tiflash network is host",
+			tc: v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tc",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiFlash: &v1alpha1.TiFlashSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
 							HostNetwork: &enable,
+						},
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1587,7 +1292,7 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 			testSts: testHostNetwork(t, true, v1.DNSClusterFirstWithHostNet),
 		},
 		{
-			name: "tikv network is not host when pd is host",
+			name: "tiflash network is not host when pd is host",
 			tc: v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tc",
@@ -1599,12 +1304,23 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 							HostNetwork: &enable,
 						},
 					},
+					TiFlash: &v1alpha1.TiFlashSpec{
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			testSts: testHostNetwork(t, false, ""),
 		},
 		{
-			name: "tikv network is not host when tidb is host",
+			name: "tiflash network is not host when tidb is host",
 			tc: v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tc",
@@ -1616,35 +1332,57 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 							HostNetwork: &enable,
 						},
 					},
+					TiFlash: &v1alpha1.TiFlashSpec{
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			testSts: testHostNetwork(t, false, ""),
 		},
 		{
-			name: "tikv delete slots",
+			name: "tiflash delete slots",
 			tc: v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tc",
 					Namespace: "ns",
 					Annotations: map[string]string{
-						label.AnnTiKVDeleteSlots: "[0,1]",
+						label.AnnTiFlashDeleteSlots: "[0,1]",
 					},
 				},
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: v1alpha1.TiDBSpec{},
+					TiFlash: &v1alpha1.TiFlashSpec{
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			testSts: testAnnotations(t, map[string]string{"delete-slots": "[0,1]"}),
 		},
 		{
-			name: "tikv should respect resources config",
+			name: "tiflash should respect resources config",
 			tc: v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tc",
 					Namespace: "ns",
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
+					TiFlash: &v1alpha1.TiFlashSpec{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:              resource.MustParse("1"),
@@ -1659,6 +1397,15 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 								corev1.ResourceStorage:          resource.MustParse("100Gi"),
 							},
 						},
+						StorageClaims: []v1alpha1.StorageClaim{
+							{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("100Gi"),
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1670,8 +1417,8 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 					},
 				}))
 				nameToContainer := MapContainers(&sts.Spec.Template.Spec)
-				tikvContainer := nameToContainer[v1alpha1.TiKVMemberType.String()]
-				g.Expect(tikvContainer.Resources).To(Equal(corev1.ResourceRequirements{
+				tiflashContainer := nameToContainer[v1alpha1.TiFlashMemberType.String()]
+				g.Expect(tiflashContainer.Resources).To(Equal(corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("2Gi"),
@@ -1684,16 +1431,16 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 					},
 				}))
 				var capacityEnvVar corev1.EnvVar
-				for i := range tikvContainer.Env {
-					if tikvContainer.Env[i].Name == "CAPACITY" {
-						capacityEnvVar = tikvContainer.Env[i]
+				for i := range tiflashContainer.Env {
+					if tiflashContainer.Env[i].Name == "CAPACITY" {
+						capacityEnvVar = tiflashContainer.Env[i]
 						break
 					}
 				}
 				g.Expect(capacityEnvVar).To(Equal(corev1.EnvVar{
 					Name:  "CAPACITY",
 					Value: "100GB",
-				}), "Expected the CAPACITY of tikv is properly set")
+				}), "Expected the CAPACITY of tiflash is properly set")
 			},
 		},
 		// TODO add more tests
@@ -1701,376 +1448,11 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sts, err := getNewTiKVSetForTidbCluster(&tt.tc, nil)
+			sts, err := getNewStatefulSet(&tt.tc, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.testSts(sts)
-		})
-	}
-}
-
-func TestTiKVInitContainers(t *testing.T) {
-	privileged := true
-	asRoot := false
-	tests := []struct {
-		name             string
-		tc               v1alpha1.TidbCluster
-		wantErr          bool
-		expectedInit     []corev1.Container
-		expectedSecurity *corev1.PodSecurityContext
-	}{
-		{
-			name: "no init container",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							PodSecurityContext: &corev1.PodSecurityContext{
-								RunAsNonRoot: &asRoot,
-								Sysctls: []corev1.Sysctl{
-									{
-										Name:  "net.core.somaxconn",
-										Value: "32768",
-									},
-									{
-										Name:  "net.ipv4.tcp_syncookies",
-										Value: "0",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_time",
-										Value: "300",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_intvl",
-										Value: "75",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedInit: nil,
-			expectedSecurity: &corev1.PodSecurityContext{
-				RunAsNonRoot: &asRoot,
-				Sysctls: []corev1.Sysctl{
-					{
-						Name:  "net.core.somaxconn",
-						Value: "32768",
-					},
-					{
-						Name:  "net.ipv4.tcp_syncookies",
-						Value: "0",
-					},
-					{
-						Name:  "net.ipv4.tcp_keepalive_time",
-						Value: "300",
-					},
-					{
-						Name:  "net.ipv4.tcp_keepalive_intvl",
-						Value: "75",
-					},
-				},
-			},
-		},
-		{
-			name: "sysctl with init container",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							Annotations: map[string]string{
-								"tidb.pingcap.com/sysctl-init": "true",
-							},
-							PodSecurityContext: &corev1.PodSecurityContext{
-								RunAsNonRoot: &asRoot,
-								Sysctls: []corev1.Sysctl{
-									{
-										Name:  "net.core.somaxconn",
-										Value: "32768",
-									},
-									{
-										Name:  "net.ipv4.tcp_syncookies",
-										Value: "0",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_time",
-										Value: "300",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_intvl",
-										Value: "75",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedInit: []corev1.Container{
-				{
-					Name:  "init",
-					Image: "busybox:1.26.2",
-					Command: []string{
-						"sh",
-						"-c",
-						"sysctl -w net.core.somaxconn=32768 net.ipv4.tcp_syncookies=0 net.ipv4.tcp_keepalive_time=300 net.ipv4.tcp_keepalive_intvl=75",
-					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: &privileged,
-					},
-				},
-			},
-			expectedSecurity: &corev1.PodSecurityContext{
-				RunAsNonRoot: &asRoot,
-				Sysctls:      []corev1.Sysctl{},
-			},
-		},
-		{
-			name: "sysctl with init container",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							Annotations: map[string]string{
-								"tidb.pingcap.com/sysctl-init": "true",
-							},
-							PodSecurityContext: &corev1.PodSecurityContext{
-								RunAsNonRoot: &asRoot,
-							},
-						},
-					},
-				},
-			},
-			expectedInit: nil,
-			expectedSecurity: &corev1.PodSecurityContext{
-				RunAsNonRoot: &asRoot,
-			},
-		},
-		{
-			name: "sysctl with init container",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							Annotations: map[string]string{
-								"tidb.pingcap.com/sysctl-init": "true",
-							},
-							PodSecurityContext: nil,
-						},
-					},
-				},
-			},
-			expectedInit:     nil,
-			expectedSecurity: nil,
-		},
-		{
-			name: "sysctl without init container due to invalid annotation",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							Annotations: map[string]string{
-								"tidb.pingcap.com/sysctl-init": "false",
-							},
-							PodSecurityContext: &corev1.PodSecurityContext{
-								RunAsNonRoot: &asRoot,
-								Sysctls: []corev1.Sysctl{
-									{
-										Name:  "net.core.somaxconn",
-										Value: "32768",
-									},
-									{
-										Name:  "net.ipv4.tcp_syncookies",
-										Value: "0",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_time",
-										Value: "300",
-									},
-									{
-										Name:  "net.ipv4.tcp_keepalive_intvl",
-										Value: "75",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedInit: nil,
-			expectedSecurity: &corev1.PodSecurityContext{
-				RunAsNonRoot: &asRoot,
-				Sysctls: []corev1.Sysctl{
-					{
-						Name:  "net.core.somaxconn",
-						Value: "32768",
-					},
-					{
-						Name:  "net.ipv4.tcp_syncookies",
-						Value: "0",
-					},
-					{
-						Name:  "net.ipv4.tcp_keepalive_time",
-						Value: "300",
-					},
-					{
-						Name:  "net.ipv4.tcp_keepalive_intvl",
-						Value: "75",
-					},
-				},
-			},
-		},
-		{
-			name: "no init container no securityContext",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tc",
-					Namespace: "ns",
-				},
-			},
-			expectedInit:     nil,
-			expectedSecurity: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sts, err := getNewTiKVSetForTidbCluster(&tt.tc, nil)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("error %v, wantErr %v", err, tt.wantErr)
-			}
-			if diff := cmp.Diff(tt.expectedInit, sts.Spec.Template.Spec.InitContainers); diff != "" {
-				t.Errorf("unexpected InitContainers in Statefulset (-want, +got): %s", diff)
-			}
-			if tt.expectedSecurity == nil {
-				if sts.Spec.Template.Spec.SecurityContext != nil {
-					t.Errorf("unexpected SecurityContext in Statefulset (want nil, got %#v)", *sts.Spec.Template.Spec.SecurityContext)
-				}
-			} else if sts.Spec.Template.Spec.SecurityContext == nil {
-				t.Errorf("unexpected SecurityContext in Statefulset (want %#v, got nil)", *tt.expectedSecurity)
-			} else if diff := cmp.Diff(*(tt.expectedSecurity), *(sts.Spec.Template.Spec.SecurityContext)); diff != "" {
-				t.Errorf("unexpected SecurityContext in Statefulset (-want, +got): %s", diff)
-			}
-		})
-	}
-}
-
-func TestGetTiKVConfigMap(t *testing.T) {
-	g := NewGomegaWithT(t)
-	updateStrategy := v1alpha1.ConfigUpdateStrategyInPlace
-	testCases := []struct {
-		name     string
-		tc       v1alpha1.TidbCluster
-		expected *corev1.ConfigMap
-	}{
-		{
-			name: "TiKV config is nil",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "ns",
-				},
-			},
-			expected: nil,
-		},
-		{
-			name: "basic",
-			tc: v1alpha1.TidbCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "ns",
-				},
-				Spec: v1alpha1.TidbClusterSpec{
-					TiKV: v1alpha1.TiKVSpec{
-						ComponentSpec: v1alpha1.ComponentSpec{
-							ConfigUpdateStrategy: &updateStrategy,
-						},
-						Config: &v1alpha1.TiKVConfig{
-							Raftstore: &v1alpha1.TiKVRaftstoreConfig{
-								SyncLog:              pointer.BoolPtr(false),
-								RaftBaseTickInterval: pointer.StringPtr("1s"),
-							},
-							Server: &v1alpha1.TiKVServerConfig{
-								GrpcKeepaliveTimeout: pointer.StringPtr("30s"),
-							},
-						},
-					},
-				},
-			},
-			expected: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-tikv",
-					Namespace: "ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/name":       "tidb-cluster",
-						"app.kubernetes.io/managed-by": "tidb-operator",
-						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "tikv",
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "pingcap.com/v1alpha1",
-							Kind:       "TidbCluster",
-							Name:       "foo",
-							UID:        "",
-							Controller: func(b bool) *bool {
-								return &b
-							}(true),
-							BlockOwnerDeletion: func(b bool) *bool {
-								return &b
-							}(true),
-						},
-					},
-				},
-				Data: map[string]string{
-					"startup-script": "",
-					"config-file": `[server]
-  grpc-keepalive-timeout = "30s"
-
-[raftstore]
-  sync-log = false
-  raft-base-tick-interval = "1s"
-`,
-				},
-			},
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			cm, err := getTikVConfigMap(&tt.tc)
-			g.Expect(err).To(Succeed())
-			if tt.expected == nil {
-				g.Expect(cm).To(BeNil())
-				return
-			}
-			// startup-script is better to be tested in e2e
-			cm.Data["startup-script"] = ""
-			if diff := cmp.Diff(*tt.expected, *cm); diff != "" {
-				t.Errorf("unexpected plugin configuration (-want, +got): %s", diff)
-			}
 		})
 	}
 }

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -629,6 +629,9 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 		return err
 	}
 	for _, store := range tombstoneStoresInfo.Stores {
+		if store.Store != nil && !pattern.Match([]byte(store.Store.Address)) {
+			continue
+		}
 		status := tkmm.getTiKVStore(store)
 		if status == nil {
 			continue


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #2458 
### What is changed and how does it work?
Separate the tikv and tiflash tombstone stores
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Delete some tikv and tiflash stores, check the tidbcluster status that status.tikv.tombstoneStores only includes tikv tombstone stores and status.tiflash.tombstoneStores only includes tiflash tombstone stores
```
  tiflash:
    image: pingcap/tiflash:v3.1.0-rc
    phase: Normal
    statefulSet:
      collisionCount: 0
      currentReplicas: 5
      currentRevision: test310-tiflash-64684cfbdb
      observedGeneration: 9
      readyReplicas: 5
      replicas: 5
      updateRevision: test310-tiflash-64684cfbdb
      updatedReplicas: 5
    stores:
      "157":
        id: "157"
        ip: test310-tiflash-1.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:07Z"
        lastTransitionTime: "2020-05-14T11:11:40Z"
        leaderCount: 0
        podName: test310-tiflash-1
        state: Up
      "1026":
        id: "1026"
        ip: test310-tiflash-2.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:11Z"
        lastTransitionTime: "2020-05-14T09:24:42Z"
        leaderCount: 0
        podName: test310-tiflash-2
        state: Up
      "1029":
        id: "1029"
        ip: test310-tiflash-3.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:11Z"
        lastTransitionTime: "2020-05-14T06:44:04Z"
        leaderCount: 0
        podName: test310-tiflash-3
        state: Up
      "1030":
        id: "1030"
        ip: test310-tiflash-4.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:07Z"
        lastTransitionTime: "2020-05-14T07:00:47Z"
        leaderCount: 0
        podName: test310-tiflash-4
        state: Up
    synced: true
    tombstoneStores:
      "152":
        id: "152"
        ip: test310-tiflash-0.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: null
        lastTransitionTime: null
        leaderCount: 0
        podName: test310-tiflash-0
        state: Tombstone
      "1034":
        id: "1034"
        ip: test310-tiflash-5.test310-tiflash-peer.test310.svc
        lastHeartbeatTime: null
        lastTransitionTime: null
        leaderCount: 0
        podName: test310-tiflash-5
        state: Tombstone
  tikv:
    image: pingcap/tikv:v3.1.0-rc
    phase: Upgrade
    statefulSet:
      collisionCount: 0
      currentReplicas: 1
      currentRevision: test310-tikv-bcbb454bc
      observedGeneration: 2
      readyReplicas: 4
      replicas: 4
      updateRevision: test310-tikv-bcbb454bc
      updatedReplicas: 1
    stores:
      "1":
        id: "1"
        ip: test310-tikv-1.test310-tikv-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:05Z"
        lastTransitionTime: "2020-05-14T09:27:20Z"
        leaderCount: 20
        podName: test310-tikv-1
        state: Up
      "5":
        id: "5"
        ip: test310-tikv-2.test310-tikv-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:05Z"
        lastTransitionTime: "2020-05-14T09:27:20Z"
        leaderCount: 15
        podName: test310-tikv-2
        state: Up
      "1045":
        id: "1045"
        ip: test310-tikv-3.test310-tikv-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T13:04:03Z"
        lastTransitionTime: "2020-05-14T09:49:00Z"
        leaderCount: 11
        podName: test310-tikv-3
        state: Up
    synced: true
    tombstoneStores:
      "4":
        id: "4"
        ip: test310-tikv-0.test310-tikv-peer.test310.svc
        lastHeartbeatTime: "2020-05-14T11:47:58Z"
        lastTransitionTime: null
        leaderCount: 0
        podName: test310-tikv-0
        state: Tombstone
```

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
