### PR TITLE
Upgrade e2e 4.0 version and fix 1.12 env error

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -310,15 +310,15 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		builds["E2E v1.12"] = {
 			build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12 ./hack/e2e.sh -- --preload-images")
 		}
-// 		builds["E2E v1.18"] = {
-// 			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
-// 		}
-// 		builds["E2E v1.18 AdvancedStatefulSet"] = {
-// 			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
-// 		}
-// 		builds["E2E v1.18 Serial"] = {
-// 			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
-// 		}
+		builds["E2E v1.18"] = {
+			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
+		}
+		builds["E2E v1.18 AdvancedStatefulSet"] = {
+			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
+		}
+		builds["E2E v1.18 Serial"] = {
+			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
+		}
 		builds.failFast = false
 		parallel builds
 

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -310,15 +310,15 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		builds["E2E v1.12"] = {
 			build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12 ./hack/e2e.sh -- --preload-images")
 		}
-		builds["E2E v1.18"] = {
-			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
-		}
-		builds["E2E v1.18 AdvancedStatefulSet"] = {
-			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
-		}
-		builds["E2E v1.18 Serial"] = {
-			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
-		}
+// 		builds["E2E v1.18"] = {
+// 			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
+// 		}
+// 		builds["E2E v1.18 AdvancedStatefulSet"] = {
+// 			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
+// 		}
+// 		builds["E2E v1.18 Serial"] = {
+// 			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
+// 		}
 		builds.failFast = false
 		parallel builds
 

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -30,7 +30,7 @@ const (
 	TiDBV3Version                 = "v3.0.8"
 	TiDBV3UpgradeVersion          = "v3.0.9"
 	TiDBV4Version                 = "v4.0.0-rc"
-	TiDBV4UpgradeVersion          = "nightly"
+	TiDBV4UpgradeVersion          = "v4.0.0-rc.2"
 	PrometheusImage               = "prom/prometheus"
 	PrometheusVersion             = "v2.11.1"
 	TiDBMonitorReloaderImage      = "pingcap/tidb-monitor-reloader"

--- a/tests/e2e/util/util.go
+++ b/tests/e2e/util/util.go
@@ -41,7 +41,7 @@ func WaitForAPIServicesAvaiable(client aggregatorclientset.Interface, selector l
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(5*time.Second, 30*time.Minute, func() (bool, error) {
 		apiServiceList, err := client.ApiregistrationV1().APIServices().List(metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})

--- a/tests/e2e/util/util.go
+++ b/tests/e2e/util/util.go
@@ -41,7 +41,7 @@ func WaitForAPIServicesAvaiable(client aggregatorclientset.Interface, selector l
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 30*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
 		apiServiceList, err := client.ApiregistrationV1().APIServices().List(metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
upgrade 4.0 upgrade version from `nightly` to `4.0.0-rc.2` in e2e and make wait timeout for installing operator from 3min to 10min.


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
