### PR TITLE
Fix Helm install setting params

### DIFF
--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -310,15 +310,15 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		builds["E2E v1.12"] = {
 			build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12 ./hack/e2e.sh -- --preload-images")
 		}
-// 		builds["E2E v1.18"] = {
-// 			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
-// 		}
-// 		builds["E2E v1.18 AdvancedStatefulSet"] = {
-// 			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
-// 		}
-// 		builds["E2E v1.18 Serial"] = {
-// 			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
-// 		}
+		builds["E2E v1.18"] = {
+			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
+		}
+		builds["E2E v1.18 AdvancedStatefulSet"] = {
+			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
+		}
+		builds["E2E v1.18 Serial"] = {
+			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
+		}
 		builds.failFast = false
 		parallel builds
 

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -310,15 +310,15 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		builds["E2E v1.12"] = {
 			build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12 ./hack/e2e.sh -- --preload-images")
 		}
-		builds["E2E v1.18"] = {
-			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
-		}
-		builds["E2E v1.18 AdvancedStatefulSet"] = {
-			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
-		}
-		builds["E2E v1.18 Serial"] = {
-			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
-		}
+// 		builds["E2E v1.18"] = {
+// 			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
+// 		}
+// 		builds["E2E v1.18 AdvancedStatefulSet"] = {
+// 			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
+// 		}
+// 		builds["E2E v1.18 Serial"] = {
+// 			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)
+// 		}
 		builds.failFast = false
 		parallel builds
 

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -420,7 +420,7 @@ func (oi *OperatorConfig) OperatorHelmSetBoolean() string {
 	for k, v := range set {
 		arr = append(arr, fmt.Sprintf("--set %s=%v", k, v))
 	}
-	return fmt.Sprintf("%s", strings.Join(arr, ","))
+	return fmt.Sprintf("%s", strings.Join(arr, " "))
 }
 
 func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -420,7 +420,7 @@ func (oi *OperatorConfig) OperatorHelmSetBoolean() string {
 	for k, v := range set {
 		arr = append(arr, fmt.Sprintf("--set %s=%v", k, v))
 	}
-	return fmt.Sprintf("\"%s\"", strings.Join(arr, ","))
+	return fmt.Sprintf("%s", strings.Join(arr, ","))
 }
 
 func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -564,6 +564,8 @@ func (oa *operatorActions) DeployOperator(info *OperatorConfig) error {
 	res, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to deploy operator: %v, %s", err, string(res))
+	} else {
+		klog.Infof("deploy operator response: %v\n", string(res))
 	}
 
 	klog.Infof("Wait for all apiesrvices are available")

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -412,6 +412,7 @@ func (oi *OperatorConfig) OperatorHelmSetBoolean() string {
 	set := map[string]bool{
 		"admissionWebhook.create":                      oi.WebhookEnabled,
 		"admissionWebhook.validation.pods":             oi.PodWebhookEnabled,
+		"admissionWebhook.mutation.pods":               oi.PodWebhookEnabled,
 		"admissionWebhook.validation.statefulSets":     oi.StsWebhookEnabled,
 		"admissionWebhook.mutation.pingcapResources":   oi.DefaultingEnabled,
 		"admissionWebhook.validation.pingcapResources": oi.ValidatingEnabled,

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -565,9 +565,8 @@ func (oa *operatorActions) DeployOperator(info *OperatorConfig) error {
 	res, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to deploy operator: %v, %s", err, string(res))
-	} else {
-		klog.Infof("deploy operator response: %v\n", string(res))
 	}
+	klog.Infof("deploy operator response: %v\n", string(res))
 
 	klog.Infof("Wait for all apiesrvices are available")
 	return e2eutil.WaitForAPIServicesAvaiable(oa.aggrCli, labels.Everything())

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -408,18 +408,28 @@ func (tc *TidbClusterConfig) TidbClusterHelmSetString(m map[string]string) strin
 	return strings.Join(arr, ",")
 }
 
+func (oi *OperatorConfig) OperatorHelmSetBoolean() string {
+	set := map[string]bool{
+		"admissionWebhook.create":                      oi.WebhookEnabled,
+		"admissionWebhook.validation.pods":             oi.PodWebhookEnabled,
+		"admissionWebhook.validation.statefulSets":     oi.StsWebhookEnabled,
+		"admissionWebhook.mutation.pingcapResources":   oi.DefaultingEnabled,
+		"admissionWebhook.validation.pingcapResources": oi.ValidatingEnabled,
+	}
+	arr := make([]string, 0, len(set))
+	for k, v := range set {
+		arr = append(arr, fmt.Sprintf("--set %s=%v", k, v))
+	}
+	return fmt.Sprintf("\"%s\"", strings.Join(arr, ","))
+}
+
 func (oi *OperatorConfig) OperatorHelmSetString(m map[string]string) string {
 	set := map[string]string{
-		"operatorImage":                                oi.Image,
-		"tidbBackupManagerImage":                       oi.BackupImage,
-		"scheduler.logLevel":                           "4",
-		"testMode":                                     strconv.FormatBool(oi.TestMode),
-		"admissionWebhook.cabundle":                    oi.Cabundle,
-		"admissionWebhook.create":                      strconv.FormatBool(oi.WebhookEnabled),
-		"admissionWebhook.validation.pods":             strconv.FormatBool(oi.PodWebhookEnabled),
-		"admissionWebhook.validation.statefulSets":     strconv.FormatBool(oi.StsWebhookEnabled),
-		"admissionWebhook.mutation.pingcapResources":   strconv.FormatBool(oi.DefaultingEnabled),
-		"admissionWebhook.validation.pingcapResources": strconv.FormatBool(oi.ValidatingEnabled),
+		"operatorImage":             oi.Image,
+		"tidbBackupManagerImage":    oi.BackupImage,
+		"scheduler.logLevel":        "4",
+		"testMode":                  strconv.FormatBool(oi.TestMode),
+		"admissionWebhook.cabundle": oi.Cabundle,
 	}
 	if oi.LogLevel != "" {
 		set["controllerManager.logLevel"] = oi.LogLevel
@@ -543,10 +553,11 @@ func (oa *operatorActions) DeployOperator(info *OperatorConfig) error {
 		}
 	}
 
-	cmd := fmt.Sprintf(`helm install %s --name %s --namespace %s --set-string %s`,
+	cmd := fmt.Sprintf(`helm install %s --name %s --namespace %s %s --set-string %s`,
 		oa.operatorChartPath(info.Tag),
 		info.ReleaseName,
 		info.Namespace,
+		info.OperatorHelmSetBoolean(),
 		info.OperatorHelmSetString(nil))
 	klog.Info(cmd)
 
@@ -601,8 +612,9 @@ func (oa *operatorActions) UpgradeOperator(info *OperatorConfig) error {
 		}
 	}
 
-	cmd := fmt.Sprintf("helm upgrade %s %s --set-string %s",
+	cmd := fmt.Sprintf("helm upgrade %s %s %s --set-string %s",
 		info.ReleaseName, oa.operatorChartPath(info.Tag),
+		info.OperatorHelmSetBoolean(),
 		info.OperatorHelmSetString(nil))
 
 	res, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix the helm install params error which would cause `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` installed in an unwanted env.

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
