### PR TITLE
tidb-scheduler: implement kube-scheduler extender preempt verb

### DIFF
--- a/charts/tidb-operator/templates/config/_scheduler-policy-json.tpl
+++ b/charts/tidb-operator/templates/config/_scheduler-policy-json.tpl
@@ -34,6 +34,7 @@
     {
       "urlPrefix": "http://127.0.0.1:10262/scheduler",
       "filterVerb": "filter",
+      "preemptVerb": "preempt",
       "weight": 1,
       "httpTimeout": 30000000000,
       "enableHttps": false

--- a/hack/local-up-operator.sh
+++ b/hack/local-up-operator.sh
@@ -169,11 +169,15 @@ echo "info: installing crds"
 $KUBECTL_BIN apply -f manifests/crd.yaml
 
 echo "info: deploying tidb-operator"
+KUBE_VERSION=$($KUBECTL_BIN version --short | awk '/Server Version:/ {print $3}')
 helm_args=(
     template
+    --kube-version "$KUBE_VERSION"
     --name tidb-operator-dev
     --namespace "$NAMESPACE"
-    --set operatorImage=$DOCKER_REGISTRY/pingcap/tidb-operator:${IMAGE_TAG}
+    --set-string operatorImage=$DOCKER_REGISTRY/pingcap/tidb-operator:${IMAGE_TAG}
+    --set-string controllerManager.logLevel=4
+    --set-string scheduler.logLevel=4
 )
  
 $HELM_BIN ${helm_args[@]} ./charts/tidb-operator/ | kubectl -n "$NAMESPACE" apply -f  -

--- a/pkg/scheduler/predicates/fake.go
+++ b/pkg/scheduler/predicates/fake.go
@@ -1,0 +1,44 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+type FakePredicate struct {
+	FakeName string
+	Nodes    []v1.Node
+	Err      error
+}
+
+var _ Predicate = &FakePredicate{}
+
+func NewFakePredicate(name string, nodes []v1.Node, err error) *FakePredicate {
+	return &FakePredicate{}
+}
+
+func (f *FakePredicate) Name() string {
+	return f.FakeName
+}
+
+func (f *FakePredicate) Filter(_ string, _ *v1.Pod, nodes []v1.Node) ([]v1.Node, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	if f.Nodes != nil {
+		return f.Nodes, nil
+	}
+	return nodes, nil
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	schedulerapiv1 "k8s.io/kubernetes/pkg/scheduler/api/v1"
 )
 
@@ -272,11 +273,11 @@ func TestSchedulerPriority(t *testing.T) {
 }
 
 func TestSchedulerPreempt(t *testing.T) {
-	victims := &schedulerapiv1.Victims{
+	victims := &schedulerapi.Victims{
 		Pods: []*apiv1.Pod{},
 	}
-	metaVictims := &schedulerapiv1.MetaVictims{
-		Pods: []*schedulerapiv1.MetaPod{},
+	metaVictims := &schedulerapi.MetaVictims{
+		Pods: []*schedulerapi.MetaPod{},
 	}
 	nodeA := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -312,24 +313,24 @@ func TestSchedulerPreempt(t *testing.T) {
 	tests := []struct {
 		name       string
 		nodes      []*apiv1.Node
-		args       *schedulerapiv1.ExtenderPreemptionArgs
+		args       *schedulerapi.ExtenderPreemptionArgs
 		predicates map[string][]predicates.Predicate
-		wantResult *schedulerapiv1.ExtenderPreemptionResult
+		wantResult *schedulerapi.ExtenderPreemptionResult
 		wantErr    string
 	}{
 		{
 			name:  "unrelated pod",
 			nodes: []*apiv1.Node{nodeA, nodeB, nodeC},
-			args: &schedulerapiv1.ExtenderPreemptionArgs{
+			args: &schedulerapi.ExtenderPreemptionArgs{
 				Pod: unrelatedPod,
-				NodeNameToVictims: map[string]*schedulerapiv1.Victims{
+				NodeNameToVictims: map[string]*schedulerapi.Victims{
 					"node-a": victims,
 					"node-b": victims,
 					"node-c": victims,
 				},
 			},
-			wantResult: &schedulerapiv1.ExtenderPreemptionResult{
-				NodeNameToMetaVictims: map[string]*schedulerapiv1.MetaVictims{
+			wantResult: &schedulerapi.ExtenderPreemptionResult{
+				NodeNameToMetaVictims: map[string]*schedulerapi.MetaVictims{
 					"node-a": metaVictims,
 					"node-b": metaVictims,
 					"node-c": metaVictims,
@@ -344,9 +345,9 @@ func TestSchedulerPreempt(t *testing.T) {
 					&predicates.FakePredicate{},
 				},
 			},
-			args: &schedulerapiv1.ExtenderPreemptionArgs{
+			args: &schedulerapi.ExtenderPreemptionArgs{
 				Pod: pdPod,
-				NodeNameToVictims: map[string]*schedulerapiv1.Victims{
+				NodeNameToVictims: map[string]*schedulerapi.Victims{
 					"node-a": victims,
 					"node-b": victims,
 					"node-c": victims,
@@ -367,16 +368,16 @@ func TestSchedulerPreempt(t *testing.T) {
 					},
 				},
 			},
-			args: &schedulerapiv1.ExtenderPreemptionArgs{
+			args: &schedulerapi.ExtenderPreemptionArgs{
 				Pod: pdPod,
-				NodeNameToVictims: map[string]*schedulerapiv1.Victims{
+				NodeNameToVictims: map[string]*schedulerapi.Victims{
 					"node-a": victims,
 					"node-b": victims,
 					"node-c": victims,
 				},
 			},
-			wantResult: &schedulerapiv1.ExtenderPreemptionResult{
-				NodeNameToMetaVictims: map[string]*schedulerapiv1.MetaVictims{
+			wantResult: &schedulerapi.ExtenderPreemptionResult{
+				NodeNameToMetaVictims: map[string]*schedulerapi.MetaVictims{
 					"node-a": metaVictims,
 				},
 			},
@@ -391,16 +392,16 @@ func TestSchedulerPreempt(t *testing.T) {
 					},
 				},
 			},
-			args: &schedulerapiv1.ExtenderPreemptionArgs{
+			args: &schedulerapi.ExtenderPreemptionArgs{
 				Pod: pdPod,
-				NodeNameToVictims: map[string]*schedulerapiv1.Victims{
+				NodeNameToVictims: map[string]*schedulerapi.Victims{
 					"node-a": victims,
 					"node-b": victims,
 					"node-c": victims,
 				},
 			},
-			wantResult: &schedulerapiv1.ExtenderPreemptionResult{
-				NodeNameToMetaVictims: map[string]*schedulerapiv1.MetaVictims{},
+			wantResult: &schedulerapi.ExtenderPreemptionResult{
+				NodeNameToMetaVictims: map[string]*schedulerapi.MetaVictims{},
 			},
 		},
 		{
@@ -417,16 +418,16 @@ func TestSchedulerPreempt(t *testing.T) {
 					},
 				},
 			},
-			args: &schedulerapiv1.ExtenderPreemptionArgs{
+			args: &schedulerapi.ExtenderPreemptionArgs{
 				Pod: pdPod,
-				NodeNameToVictims: map[string]*schedulerapiv1.Victims{
+				NodeNameToVictims: map[string]*schedulerapi.Victims{
 					"node-a": victims,
 					"node-b": victims,
 					"node-c": victims,
 				},
 			},
-			wantResult: &schedulerapiv1.ExtenderPreemptionResult{
-				NodeNameToMetaVictims: map[string]*schedulerapiv1.MetaVictims{
+			wantResult: &schedulerapi.ExtenderPreemptionResult{
+				NodeNameToMetaVictims: map[string]*schedulerapi.MetaVictims{
 					"node-a": metaVictims,
 					"node-b": metaVictims,
 					"node-c": metaVictims,

--- a/pkg/scheduler/server/mux.go
+++ b/pkg/scheduler/server/mux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/scheduler"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	schedulerapiv1 "k8s.io/kubernetes/pkg/scheduler/api/v1"
 )
 
@@ -55,7 +56,7 @@ func StartServer(kubeCli kubernetes.Interface, cli versioned.Interface, port int
 	ws.Route(ws.POST("/preempt").To(svr.preemptNode).
 		Doc("preempt nodes").
 		Operation("preemptNodes").
-		Writes(schedulerapiv1.ExtenderPreemptionResult{}))
+		Writes(schedulerapi.ExtenderPreemptionResult{}))
 
 	ws.Route(ws.POST("/prioritize").To(svr.prioritizeNode).
 		Doc("prioritize nodes").
@@ -93,7 +94,7 @@ func (svr *server) preemptNode(req *restful.Request, resp *restful.Response) {
 	svr.lock.Lock()
 	defer svr.lock.Unlock()
 
-	args := &schedulerapiv1.ExtenderPreemptionArgs{}
+	args := &schedulerapi.ExtenderPreemptionArgs{}
 	if err := req.ReadEntity(args); err != nil {
 		errorResponse(resp, errFailToRead)
 		return


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #1968 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Support preemption in `tidb-scheduler`
```
