### PR TITLE
Set `reserve-space = 0MB` for TiKV 4.0+ in e2e tests

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -13399,6 +13399,22 @@ TiKVBlockCacheConfig
 <em>(Optional)</em>
 </td>
 </tr>
+<tr>
+<td>
+<code>reserve-space</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The size of the temporary file that preoccupies the extra space when
+TiKV is started. The name of temporary file is <code>space_placeholder_file</code>,
+located in the <code>storage.data-dir</code> directory. When TiKV runs out of disk
+space and cannot be started normally, you can delete this file as an
+emergency intervention and set it to <code>0MB</code>. Default value is 2GB.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tikvstoragereadpoolconfig">TiKVStorageReadPoolConfig</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4424,6 +4424,8 @@ spec:
                         max-key-size:
                           format: int64
                           type: integer
+                        reserve-space:
+                          type: string
                         scheduler-concurrency:
                           format: int64
                           type: integer

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -7156,6 +7156,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVStorageConfig(ref common.ReferenceCall
 							Ref: ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVBlockCacheConfig"),
 						},
 					},
+					"reserve-space": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The size of the temporary file that preoccupies the extra space when TiKV is started. The name of temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV runs out of disk space and cannot be started normally, you can delete this file as an emergency intervention and set it to `0MB`. Default value is 2GB.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/tikv_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tikv_config.go
@@ -539,6 +539,13 @@ type TiKVStorageConfig struct {
 	SchedulerPendingWriteThreshold *string `json:"scheduler-pending-write-threshold,omitempty" toml:"scheduler-pending-write-threshold,omitempty"`
 	// +optional
 	BlockCache *TiKVBlockCacheConfig `json:"block-cache,omitempty" toml:"block-cache,omitempty"`
+	// The size of the temporary file that preoccupies the extra space when
+	// TiKV is started. The name of temporary file is `space_placeholder_file`,
+	// located in the `storage.data-dir` directory. When TiKV runs out of disk
+	// space and cannot be started normally, you can delete this file as an
+	// emergency intervention and set it to `0MB`. Default value is 2GB.
+	// +optional
+	ReserveSpace *string `json:"reserve-space,omitempty" toml:"reserve-space,omitempty"`
 }
 
 // TiKVBlockCacheConfig is the config of a block cache

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -5888,6 +5888,11 @@ func (in *TiKVStorageConfig) DeepCopyInto(out *TiKVStorageConfig) {
 		*out = new(TiKVBlockCacheConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ReserveSpace != nil {
+		in, out := &in.ReserveSpace, &out.ReserveSpace
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -16,6 +16,7 @@ package fixture
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
@@ -65,8 +66,24 @@ func WithStorage(r corev1.ResourceRequirements, size string) corev1.ResourceRequ
 	return r
 }
 
+var (
+	// the first version which introduces storage.reserve-space config
+	// https://github.com/tikv/tikv/pull/6321
+	tikvV4Beta = semver.MustParse("v4.0.0-beta")
+)
+
 // GetTidbCluster returns a TidbCluster resource configured for testing
 func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
+	tikvStorageConfig := &v1alpha1.TiKVStorageConfig{
+		// Don't reserve space in e2e tests, see
+		// https://github.com/pingcap/tidb-operator/issues/2509.
+		ReserveSpace: pointer.StringPtr("0MB"),
+	}
+	// We assume all unparsable versions are greater or equal to v4.0.0-beta,
+	// e.g. nightly.
+	if v, err := semver.NewVersion(version); err == nil && v.LessThan(tikvV4Beta) {
+		tikvStorageConfig = nil
+	}
 	return &v1alpha1.TidbCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -102,6 +119,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 				Config: &v1alpha1.TiKVConfig{
 					LogLevel: pointer.StringPtr("info"),
 					Server:   &v1alpha1.TiKVServerConfig{},
+					Storage:  tikvStorageConfig,
 				},
 			},
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #2509 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
