### PR TITLE
e2e/openshift: pin the same version for docker-ce and docker-ce-cli

### DIFF
--- a/hack/e2e-openshift.sh
+++ b/hack/e2e-openshift.sh
@@ -25,6 +25,7 @@ ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 cd $ROOT
 
 PULL_SECRET_FILE=${PULL_SECRET_FILE:-}
+DOCKER_VERSION=${DOCKER_VERSION:-19.03.9}
 
 if [ ! -e "$PULL_SECRET_FILE" ]; then
     echo "error: pull secret file '$PULL_SECRET_FILE' does not exist"
@@ -44,7 +45,10 @@ sudo yum install -y jq git make golang
 sudo yum install -y yum-utils
 sudo yum-config-manager \
     --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum install -y --nobest docker-ce docker-ce-cli containerd.io
+# install required containerd.io manually, see https://linuxconfig.org/how-to-install-docker-in-rhel-8
+sudo yum install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
+# pin the same version for daemon and cli: https://github.com/docker/cli/issues/2533
+sudo yum install -y docker-ce-${DOCKER_VERSION} docker-ce-cli-${DOCKER_VERSION}
 if ! systemctl is-active --quiet docker; then
     sudo systemctl start docker
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
this works around the bug in docker CLI: https://github.com/docker/cli/issues/2533
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
