### PR TITLE
UCP:Support Service LoadBalancerSourceRanges

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -8038,6 +8038,23 @@ string
 <p>PortName is the name of service port</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>loadBalancerSourceRanges</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LoadBalancerSourceRanges is the loadBalancerSourceRanges of service
+If specified and supported by the platform, this will restrict traffic through the cloud-provider
+load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+cloud-provider does not support the feature.&rdquo;
+More info: <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/">https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/</a>
+Optional: Defaults to omitted</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="status">Status</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -940,6 +940,10 @@ spec:
                       type: string
                     loadBalancerIP:
                       type: string
+                    loadBalancerSourceRanges:
+                      items:
+                        type: string
+                      type: array
                     portName:
                       type: string
                     type:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -3946,6 +3946,20 @@ func schema_pkg_apis_pingcap_v1alpha1_ServiceSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"loadBalancerSourceRanges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LoadBalancerSourceRanges is the loadBalancerSourceRanges of service If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.\" More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/ Optional: Defaults to omitted",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -677,6 +677,15 @@ type ServiceSpec struct {
 	// PortName is the name of service port
 	// +optional
 	PortName *string `json:"portName,omitempty"`
+
+	// LoadBalancerSourceRanges is the loadBalancerSourceRanges of service
+	// If specified and supported by the platform, this will restrict traffic through the cloud-provider
+	// load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+	// cloud-provider does not support the feature."
+	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+	// Optional: Defaults to omitted
+	// +optional
+	LoadBalancerSourceRanges *[]string `json:"loadBalancerSourceRanges,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -685,7 +685,7 @@ type ServiceSpec struct {
 	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
 	// Optional: Defaults to omitted
 	// +optional
-	LoadBalancerSourceRanges *[]string `json:"loadBalancerSourceRanges,omitempty"`
+	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
@@ -255,6 +255,11 @@ func TestValidateService(t *testing.T) {
 			err := validateService(svc, field.NewPath("spec"))
 			r := len(err)
 			g.Expect(r).Should(Equal(tt.expectedErrors))
+			if r > 0 {
+				for _, e := range err {
+					g.Expect(e.Detail).To(ContainSubstring("service.Spec.LoadBalancerSourceRanges is not valid. Expecting a list of IP ranges. For example, 10.0.0.0/24."))
+				}
+			}
 		})
 	}
 }
@@ -286,6 +291,11 @@ func TestValidateTidbMonitor(t *testing.T) {
 			err := ValidateTidbMonitor(monitor)
 			r := len(err)
 			g.Expect(r).Should(Equal(tt.expectedErrors))
+			if r > 0 {
+				for _, e := range err {
+					g.Expect(e.Detail).To(ContainSubstring("service.Spec.LoadBalancerSourceRanges is not valid. Expecting a list of IP ranges. For example, 10.0.0.0/24."))
+				}
+			}
 		})
 	}
 }

--- a/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
@@ -230,9 +230,85 @@ func TestValidateRequestsStorage(t *testing.T) {
 	}
 }
 
+func TestValidateService(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []struct {
+		name                     string
+		loadBalancerSourceRanges []string
+		expectedErrors           int
+	}{
+		{
+			name:                     "correct LoadBalancerSourceRanges",
+			loadBalancerSourceRanges: strings.Split("192.168.0.1/32", ","),
+			expectedErrors:           0,
+		},
+		{
+			name:                     "incorrect LoadBalancerSourceRanges",
+			loadBalancerSourceRanges: strings.Split("192.168.0.1", ","),
+			expectedErrors:           1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newService()
+			svc.LoadBalancerSourceRanges = tt.loadBalancerSourceRanges
+			err := validateService(svc, field.NewPath("spec"))
+			r := len(err)
+			g.Expect(r).Should(Equal(tt.expectedErrors))
+		})
+	}
+}
+
+func TestValidateTidbMonitor(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []struct {
+		name                     string
+		loadBalancerSourceRanges []string
+		expectedErrors           int
+	}{
+		{
+			name:                     "correct LoadBalancerSourceRanges",
+			loadBalancerSourceRanges: strings.Split("192.168.0.1/24,192.168.1.1/24", ","),
+			expectedErrors:           0,
+		},
+		{
+			name:                     "incorrect LoadBalancerSourceRanges",
+			loadBalancerSourceRanges: strings.Split("192.168.0.1,192.168.1.1", ","),
+			expectedErrors:           3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monitor := newTidbMonitor()
+			monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges = tt.loadBalancerSourceRanges
+			monitor.Spec.Grafana.Service.LoadBalancerSourceRanges = tt.loadBalancerSourceRanges
+			monitor.Spec.Reloader.Service.LoadBalancerSourceRanges = tt.loadBalancerSourceRanges
+			err := ValidateTidbMonitor(monitor)
+			r := len(err)
+			g.Expect(r).Should(Equal(tt.expectedErrors))
+		})
+	}
+}
+
 func newTidbCluster() *v1alpha1.TidbCluster {
 	tc := &v1alpha1.TidbCluster{}
 	tc.Name = "test-validate-requests-storage"
 	tc.Namespace = "default"
 	return tc
+}
+
+func newService() *v1alpha1.ServiceSpec {
+	svc := &v1alpha1.ServiceSpec{}
+	return svc
+}
+
+func newTidbMonitor() *v1alpha1.TidbMonitor {
+	monitor := &v1alpha1.TidbMonitor{
+		Spec: v1alpha1.TidbMonitorSpec{
+			Grafana:    &v1alpha1.GrafanaSpec{},
+			Prometheus: v1alpha1.PrometheusSpec{},
+			Reloader:   v1alpha1.ReloaderSpec{},
+		},
+	}
+	return monitor
 }

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -3461,12 +3461,8 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 	}
 	if in.LoadBalancerSourceRanges != nil {
 		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -3459,6 +3459,15 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerSourceRanges != nil {
+		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
+	}
 	return
 }
 

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -473,8 +473,13 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 			Selector: tidbLabels,
 		},
 	}
-	if svcSpec.LoadBalancerIP != nil {
-		tidbSvc.Spec.LoadBalancerIP = *svcSpec.LoadBalancerIP
+	if svcSpec.Type == corev1.ServiceTypeLoadBalancer {
+		if svcSpec.LoadBalancerIP != nil {
+			tidbSvc.Spec.LoadBalancerIP = *svcSpec.LoadBalancerIP
+		}
+		if svcSpec.LoadBalancerSourceRanges != nil {
+			tidbSvc.Spec.LoadBalancerSourceRanges = *svcSpec.LoadBalancerSourceRanges
+		}
 	}
 	if svcSpec.ExternalTrafficPolicy != nil {
 		tidbSvc.Spec.ExternalTrafficPolicy = *svcSpec.ExternalTrafficPolicy

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -478,7 +478,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 			tidbSvc.Spec.LoadBalancerIP = *svcSpec.LoadBalancerIP
 		}
 		if svcSpec.LoadBalancerSourceRanges != nil {
-			tidbSvc.Spec.LoadBalancerSourceRanges = *svcSpec.LoadBalancerSourceRanges
+			tidbSvc.Spec.LoadBalancerSourceRanges = svcSpec.LoadBalancerSourceRanges
 		}
 	}
 	if svcSpec.ExternalTrafficPolicy != nil {

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -1503,7 +1503,7 @@ func TestGetNewTiDBService(t *testing.T) {
 								Annotations: map[string]string{
 									"lb-type": "testlb",
 								},
-								LoadBalancerSourceRanges: &loadBalancerSourceRanges,
+								LoadBalancerSourceRanges: loadBalancerSourceRanges,
 							},
 							ExternalTrafficPolicy: &trafficPolicy,
 							ExposeStatus:          pointer.BoolPtr(true),

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -1347,6 +1347,10 @@ func TestTiDBInitContainers(t *testing.T) {
 func TestGetNewTiDBService(t *testing.T) {
 	g := NewGomegaWithT(t)
 	trafficPolicy := corev1.ServiceExternalTrafficPolicyTypeLocal
+	loadBalancerSourceRanges := []string{
+		"10.0.0.0/8",
+		"130.211.204.1/32",
+	}
 	testCases := []struct {
 		name     string
 		tc       v1alpha1.TidbCluster
@@ -1499,6 +1503,7 @@ func TestGetNewTiDBService(t *testing.T) {
 								Annotations: map[string]string{
 									"lb-type": "testlb",
 								},
+								LoadBalancerSourceRanges: &loadBalancerSourceRanges,
 							},
 							ExternalTrafficPolicy: &trafficPolicy,
 							ExposeStatus:          pointer.BoolPtr(true),
@@ -1537,6 +1542,10 @@ func TestGetNewTiDBService(t *testing.T) {
 				Spec: corev1.ServiceSpec{
 					Type:                  corev1.ServiceTypeLoadBalancer,
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					LoadBalancerSourceRanges: []string{
+						"10.0.0.0/8",
+						"130.211.204.1/32",
+					},
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "mysql-client",

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -691,7 +691,7 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 			prometheusService.Spec.LoadBalancerIP = *monitor.Spec.Prometheus.Service.LoadBalancerIP
 		}
 		if monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges != nil {
-			prometheusService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges
+			prometheusService.Spec.LoadBalancerSourceRanges = monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges
 		}
 	}
 
@@ -722,7 +722,7 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 			reloaderService.Spec.LoadBalancerIP = *monitor.Spec.Reloader.Service.LoadBalancerIP
 		}
 		if monitor.Spec.Reloader.Service.LoadBalancerSourceRanges != nil {
-			reloaderService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Reloader.Service.LoadBalancerSourceRanges
+			reloaderService.Spec.LoadBalancerSourceRanges = monitor.Spec.Reloader.Service.LoadBalancerSourceRanges
 		}
 	}
 
@@ -755,7 +755,7 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 				grafanaService.Spec.LoadBalancerIP = *monitor.Spec.Grafana.Service.LoadBalancerIP
 			}
 			if monitor.Spec.Grafana.Service.LoadBalancerSourceRanges != nil {
-				grafanaService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Grafana.Service.LoadBalancerSourceRanges
+				grafanaService.Spec.LoadBalancerSourceRanges = monitor.Spec.Grafana.Service.LoadBalancerSourceRanges
 			}
 		}
 

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -690,6 +690,9 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 		if monitor.Spec.Prometheus.Service.LoadBalancerIP != nil {
 			prometheusService.Spec.LoadBalancerIP = *monitor.Spec.Prometheus.Service.LoadBalancerIP
 		}
+		if monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges != nil {
+			prometheusService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Prometheus.Service.LoadBalancerSourceRanges
+		}
 	}
 
 	reloaderService := &core.Service{
@@ -717,6 +720,9 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 	if monitor.BaseReloaderSpec().ServiceType() == core.ServiceTypeLoadBalancer {
 		if monitor.Spec.Reloader.Service.LoadBalancerIP != nil {
 			reloaderService.Spec.LoadBalancerIP = *monitor.Spec.Reloader.Service.LoadBalancerIP
+		}
+		if monitor.Spec.Reloader.Service.LoadBalancerSourceRanges != nil {
+			reloaderService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Reloader.Service.LoadBalancerSourceRanges
 		}
 	}
 
@@ -747,6 +753,9 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 		if monitor.BaseGrafanaSpec().ServiceType() == core.ServiceTypeLoadBalancer {
 			if monitor.Spec.Grafana.Service.LoadBalancerIP != nil {
 				grafanaService.Spec.LoadBalancerIP = *monitor.Spec.Grafana.Service.LoadBalancerIP
+			}
+			if monitor.Spec.Grafana.Service.LoadBalancerSourceRanges != nil {
+				grafanaService.Spec.LoadBalancerSourceRanges = *monitor.Spec.Grafana.Service.LoadBalancerSourceRanges
 			}
 		}
 

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitor
 
 import (

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -137,7 +137,7 @@ func TestGetMonitorService(t *testing.T) {
 						Service: v1alpha1.ServiceSpec{
 							Type:           corev1.ServiceTypeLoadBalancer,
 							LoadBalancerIP: pointer.StringPtr("78.11.24.19"),
-							LoadBalancerSourceRanges: &[]string{
+							LoadBalancerSourceRanges: []string{
 								"10.0.0.0/8",
 								"130.211.204.1/32",
 							},
@@ -147,7 +147,7 @@ func TestGetMonitorService(t *testing.T) {
 						Service: v1alpha1.ServiceSpec{
 							Type:           corev1.ServiceTypeLoadBalancer,
 							LoadBalancerIP: pointer.StringPtr("78.11.24.19"),
-							LoadBalancerSourceRanges: &[]string{
+							LoadBalancerSourceRanges: []string{
 								"10.0.0.0/8",
 								"130.211.204.1/32",
 							},

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -1,0 +1,255 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	core "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+func TestGetMonitorService(t *testing.T) {
+	g := NewGomegaWithT(t)
+	testCases := []struct {
+		name     string
+		monitor  v1alpha1.TidbMonitor
+		expected []*corev1.Service
+	}{
+		{
+			name: "basic",
+			monitor: v1alpha1.TidbMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "ns",
+				},
+			},
+			expected: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-prometheus",
+						Namespace: "ns",
+						Labels: map[string]string{
+							"app.kubernetes.io/name":       "tidb-cluster",
+							"app.kubernetes.io/managed-by": "tidb-operator",
+							"app.kubernetes.io/instance":   "foo",
+							"app.kubernetes.io/component":  "monitor",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "pingcap.com/v1alpha1",
+								Kind:       "TidbMonitor",
+								Name:       "foo",
+								UID:        "",
+								Controller: func(b bool) *bool {
+									return &b
+								}(true),
+								BlockOwnerDeletion: func(b bool) *bool {
+									return &b
+								}(true),
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http-prometheus",
+								Protocol:   "TCP",
+								Port:       9090,
+								TargetPort: intstr.IntOrString{IntVal: 9090},
+							},
+						},
+						Selector: map[string]string{
+							"app.kubernetes.io/component": "monitor",
+							"app.kubernetes.io/instance":  "foo",
+							"app.kubernetes.io/name":      "tidb-cluster",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-monitor-reloader",
+						Namespace: "ns",
+						Labels: map[string]string{
+							"app.kubernetes.io/component":  "monitor",
+							"app.kubernetes.io/instance":   "foo",
+							"app.kubernetes.io/managed-by": "tidb-operator",
+							"app.kubernetes.io/name":       "tidb-cluster",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "pingcap.com/v1alpha1",
+								Kind:       "TidbMonitor",
+								Name:       "foo",
+								Controller: func(b bool) *bool {
+									return &b
+								}(true),
+								BlockOwnerDeletion: func(b bool) *bool {
+									return &b
+								}(true),
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []core.ServicePort{
+							{
+								Name:       "tcp-reloader",
+								Port:       9089,
+								Protocol:   core.ProtocolTCP,
+								TargetPort: intstr.FromInt(9089),
+							},
+						},
+						Selector: map[string]string{
+							"app.kubernetes.io/component": "monitor",
+							"app.kubernetes.io/instance":  "foo",
+							"app.kubernetes.io/name":      "tidb-cluster",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TidbMonitor service in typical public cloud",
+			monitor: v1alpha1.TidbMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.TidbMonitorSpec{
+					Prometheus: v1alpha1.PrometheusSpec{
+						Service: v1alpha1.ServiceSpec{
+							Type:           corev1.ServiceTypeLoadBalancer,
+							LoadBalancerIP: pointer.StringPtr("78.11.24.19"),
+							LoadBalancerSourceRanges: &[]string{
+								"10.0.0.0/8",
+								"130.211.204.1/32",
+							},
+						},
+					},
+					Reloader: v1alpha1.ReloaderSpec{
+						Service: v1alpha1.ServiceSpec{
+							Type:           corev1.ServiceTypeLoadBalancer,
+							LoadBalancerIP: pointer.StringPtr("78.11.24.19"),
+							LoadBalancerSourceRanges: &[]string{
+								"10.0.0.0/8",
+								"130.211.204.1/32",
+							},
+						},
+					},
+				},
+			},
+			expected: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-prometheus",
+						Namespace: "ns",
+						Labels: map[string]string{
+							"app.kubernetes.io/name":       "tidb-cluster",
+							"app.kubernetes.io/managed-by": "tidb-operator",
+							"app.kubernetes.io/instance":   "foo",
+							"app.kubernetes.io/component":  "monitor",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "pingcap.com/v1alpha1",
+								Kind:       "TidbMonitor",
+								Name:       "foo",
+								UID:        "",
+								Controller: func(b bool) *bool {
+									return &b
+								}(true),
+								BlockOwnerDeletion: func(b bool) *bool {
+									return &b
+								}(true),
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http-prometheus",
+								Protocol:   "TCP",
+								Port:       9090,
+								TargetPort: intstr.IntOrString{IntVal: 9090},
+							},
+						},
+						Selector: map[string]string{
+							"app.kubernetes.io/component": "monitor",
+							"app.kubernetes.io/instance":  "foo",
+							"app.kubernetes.io/name":      "tidb-cluster",
+						},
+						Type:           "LoadBalancer",
+						LoadBalancerIP: "78.11.24.19",
+						LoadBalancerSourceRanges: []string{
+							"10.0.0.0/8",
+							"130.211.204.1/32",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-monitor-reloader",
+						Namespace: "ns",
+						Labels: map[string]string{
+							"app.kubernetes.io/component":  "monitor",
+							"app.kubernetes.io/instance":   "foo",
+							"app.kubernetes.io/managed-by": "tidb-operator",
+							"app.kubernetes.io/name":       "tidb-cluster",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "pingcap.com/v1alpha1",
+								Kind:       "TidbMonitor",
+								Name:       "foo",
+								Controller: func(b bool) *bool {
+									return &b
+								}(true),
+								BlockOwnerDeletion: func(b bool) *bool {
+									return &b
+								}(true),
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []core.ServicePort{
+							{
+								Name:       "tcp-reloader",
+								Port:       9089,
+								Protocol:   core.ProtocolTCP,
+								TargetPort: intstr.FromInt(9089),
+							},
+						},
+						Selector: map[string]string{
+							"app.kubernetes.io/component": "monitor",
+							"app.kubernetes.io/instance":  "foo",
+							"app.kubernetes.io/name":      "tidb-cluster",
+						},
+						Type:           "LoadBalancer",
+						LoadBalancerIP: "78.11.24.19",
+						LoadBalancerSourceRanges: []string{
+							"10.0.0.0/8",
+							"130.211.204.1/32",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := getMonitorService(&tt.monitor)
+			if tt.expected == nil {
+				g.Expect(svc).To(BeNil())
+				return
+			}
+			if diff := cmp.Diff(&tt.expected, &svc); diff != "" {
+				t.Errorf("unexpected plugin configuration (-want, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
UCP: #2586 
Close: #2586 
Resolve: #2564
### What is changed and how does it work?
1. Add `loadBalancerSourceRanges` to `service spec`.
2. Expose it on the `TiDB Service` and `Monitor Service`.
3. Add some unit tests for setting `LoadBalancerSourceRanges` on the `TiDB Service` and `Monitor Service`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Code changes

 - Has Go code change


Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Support LoadBalancerSourceRanges in the ServiceSpec for the TidbCluster and TidbMonitor.
```
