### PR TITLE
e2e: clean eks/gke if job is unsuccessful

### DIFF
--- a/ci/e2e_eks.groovy
+++ b/ci/e2e_eks.groovy
@@ -168,7 +168,7 @@ pipeline {
                 junit testResults: "*.xml", allowEmptyResults: true
             }
         }
-        failure {
+        unsuccessful {
             sh """
             export CLUSTER=${params.CLUSTER}
             echo "info: cleaning eks cluster \$CLUSTER"

--- a/ci/e2e_gke.groovy
+++ b/ci/e2e_gke.groovy
@@ -176,6 +176,22 @@ pipeline {
                 junit testResults: "*.xml", allowEmptyResults: true
             }
         }
+        unsuccessful {
+            withCredentials([
+                file(credentialsId: 'TIDB_OPERATOR_GCP_CREDENTIALS', variable: 'GCP_CREDENTIALS'),
+                file(credentialsId: 'TIDB_OPERATOR_GCP_SSH_PRIVATE_KEY', variable: 'GCP_SSH_PRIVATE_KEY'),
+                file(credentialsId: 'TIDB_OPERATOR_GCP_SSH_PUBLIC_KEY', variable: 'GCP_SSH_PUBLIC_KEY'),
+            ]) {
+                sh """
+                export PROVIDER=gke
+                export CLUSTER=${params.CLUSTER}
+                export GCP_ZONE=${params.GCP_ZONE}
+                export GCP_PROJECT=${params.GCP_PROJECT}
+                echo "info: try to clean the cluster created previously"
+                SKIP_BUILD=y SKIP_IMAGE_BUILD=y SKIP_UP=y SKIP_TEST=y SKIP_DUMP=y ./hack/e2e.sh
+                """
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
