### PR TITLE
Bump dm version to v2.0.0-beta.1

### DIFF
--- a/manifests/dm/master/dm-master.yaml
+++ b/manifests/dm/master/dm-master.yaml
@@ -51,7 +51,7 @@ spec:
           value: dm-master
         - name: TZ
           value: UTC
-        image: pingcap/dm:ha-alpha
+        image: pingcap/dm:v2.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -145,4 +145,3 @@ spec:
   publishNotReadyAddresses: true
   sessionAffinity: None
   type: ClusterIP
-

--- a/manifests/dm/worker/base/dm-worker.yaml
+++ b/manifests/dm/worker/base/dm-worker.yaml
@@ -47,7 +47,7 @@ spec:
           value: dm-worker
         - name: TZ
           value: UTC
-        image: pingcap/dm:ha-alpha
+        image: pingcap/dm:v2.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -118,4 +118,3 @@ spec:
   publishNotReadyAddresses: true
   sessionAffinity: None
   type: ClusterIP
-


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR bumps dm version to latest HA version: v2.0.0-beta.1

### What is changed and how does it work?

DM image version is bumped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

- DM manifests

Related changes

 - Need to cherry-pick to the release branch: release-1.1


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Bump dm version to v2.0.0-beta.1
```
