### PR TITLE
Use crd to manage tidbcluster in stability

### DIFF
--- a/tests/actions.go
+++ b/tests/actions.go
@@ -953,7 +953,7 @@ func (oa *operatorActions) CleanTidbClusterOrDie(info *TidbClusterConfig) {
 func (oa *operatorActions) CheckTidbClusterStatus(info *TidbClusterConfig) error {
 	klog.Infof("checking tidb cluster [%s/%s] status", info.Namespace, info.ClusterName)
 	if info.Clustrer != nil {
-		return oa.crdUtil.WaitForTidbClusterReady(info.Clustrer, 30*time.Minute, 5*time.Second)
+		return oa.crdUtil.WaitForTidbClusterReady(info.Clustrer, 120*time.Minute, 1*time.Minute)
 	}
 
 	ns := info.Namespace

--- a/tests/backup.go
+++ b/tests/backup.go
@@ -63,12 +63,14 @@ func (t *BackupTarget) GetDrainerConfig(source *TidbClusterConfig, ts string) *D
 }
 
 func (oa *operatorActions) BackupAndRestoreToMultipleClusters(source *TidbClusterConfig, targets []BackupTarget) error {
-	err := oa.DeployAndCheckPump(source)
-	if err != nil {
-		return err
+	if source.Clustrer == nil {
+		err := oa.DeployAndCheckPump(source)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = oa.DeployAdHocBackup(source)
+	err := oa.DeployAdHocBackup(source)
 	if err != nil {
 		klog.Errorf("cluster:[%s] deploy happen error: %v", source.ClusterName, err)
 		return err

--- a/tests/backup.go
+++ b/tests/backup.go
@@ -63,14 +63,12 @@ func (t *BackupTarget) GetDrainerConfig(source *TidbClusterConfig, ts string) *D
 }
 
 func (oa *operatorActions) BackupAndRestoreToMultipleClusters(source *TidbClusterConfig, targets []BackupTarget) error {
-	if source.Clustrer == nil {
-		err := oa.DeployAndCheckPump(source)
-		if err != nil {
-			return err
-		}
+	err := oa.DeployAndCheckPump(source)
+	if err != nil {
+		return err
 	}
 
-	err := oa.DeployAdHocBackup(source)
+	err = oa.DeployAdHocBackup(source)
 	if err != nil {
 		klog.Errorf("cluster:[%s] deploy happen error: %v", source.ClusterName, err)
 		return err

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -194,25 +194,6 @@ func run() {
 		}
 		klog.Infof("clusters DisasterTolerance checked")
 
-		// TODO: Use Backup and Restore CRD instead
-		//backup and restore
-		//for i := range backupTargets {
-		//	tc := backupTargets[i].TargetCluster.Clustrer
-		//	crdUil.CreateTidbClusterOrDie(tc)
-		//	addDeployedClusterFn(backupTargets[i].TargetCluster)
-		//	secret := buildSecret(backupTargets[i].TargetCluster)
-		//	crdUil.CreateSecretOrDie(secret)
-		//	crdUil.CheckDisasterToleranceOrDie(tc)
-		//}
-		//clusterZero := clusters[0].Clustrer
-		//clusterZero = crdUil.GetTidbClusterOrDie(clusterZero.Name, clusterZero.Namespace)
-		//clusterZero = fixture.AddPumpForTidbCluster(clusterZero)
-		//crdUil.UpdateTidbClusterOrDie(clusterZero)
-		//crdUil.WaitTidbClusterReadyOrDie(clusterZero, 30*time.Minute)
-		//oa.BackupAndRestoreToMultipleClustersOrDie(clusters[0], backupTargets)
-		//klog.Infof("clusters backup and restore checked")
-		//slack.NotifyAndCompletedf("stability test: clusters backup and restore checked")
-
 		//stop node
 		physicalNode, node, faultTime := fta.StopNodeOrDie()
 		oa.EmitEvent(nil, fmt.Sprintf("StopNode: %s on %s", node, physicalNode))
@@ -319,7 +300,7 @@ func run() {
 				fta.StartKubeAPIServerOrDie(vNode.IP)
 			}
 		}
-		//klog.Infof("clusters stop all kube-apiserver and restart")
+		klog.Infof("clusters stop all kube-apiserver and restart")
 		time.Sleep(time.Minute)
 	}
 

--- a/tests/cmd/stability/main.go
+++ b/tests/cmd/stability/main.go
@@ -236,6 +236,7 @@ func run() {
 		// truncate tikv sst file
 		oa.TruncateSSTFileThenCheckFailoverOrDie(clusters[0], 5*time.Minute)
 		klog.Infof("clusters truncate sst file and checked failover")
+		slack.NotifyAndCompletedf("stability test: clusters truncate sst file and checked failover")
 
 		// delete pd data
 		oa.DeletePDDataThenCheckFailoverOrDie(clusters[0], 5*time.Minute)

--- a/tests/crd_test_util.go
+++ b/tests/crd_test_util.go
@@ -96,14 +96,14 @@ func (ctu *CrdTestUtil) UpdateTidbClusterOrDie(tc *v1alpha1.TidbCluster) {
 }
 
 func (ctu *CrdTestUtil) CheckDisasterToleranceOrDie(tc *v1alpha1.TidbCluster) {
-	err := checkDisasterTolerance(ctu.kubeCli, tc)
+	err := ctu.CheckDisasterTolerance(tc)
 	if err != nil {
 		slack.NotifyAndPanic(err)
 	}
 }
 
-func checkDisasterTolerance(kubeCli kubernetes.Interface, cluster *v1alpha1.TidbCluster) error {
-	pds, err := kubeCli.CoreV1().Pods(cluster.Namespace).List(
+func (ctu *CrdTestUtil) CheckDisasterTolerance(cluster *v1alpha1.TidbCluster) error {
+	pds, err := ctu.kubeCli.CoreV1().Pods(cluster.Namespace).List(
 		metav1.ListOptions{LabelSelector: labels.SelectorFromSet(
 			label.New().Instance(cluster.Name).PD().Labels(),
 		).String()})
@@ -115,7 +115,7 @@ func checkDisasterTolerance(kubeCli kubernetes.Interface, cluster *v1alpha1.Tidb
 		return err
 	}
 
-	tikvs, err := kubeCli.CoreV1().Pods(cluster.Namespace).List(
+	tikvs, err := ctu.kubeCli.CoreV1().Pods(cluster.Namespace).List(
 		metav1.ListOptions{LabelSelector: labels.SelectorFromSet(
 			label.New().Instance(cluster.Name).TiKV().Labels(),
 		).String()})
@@ -127,7 +127,7 @@ func checkDisasterTolerance(kubeCli kubernetes.Interface, cluster *v1alpha1.Tidb
 		return err
 	}
 
-	tidbs, err := kubeCli.CoreV1().Pods(cluster.Namespace).List(
+	tidbs, err := ctu.kubeCli.CoreV1().Pods(cluster.Namespace).List(
 		metav1.ListOptions{LabelSelector: labels.SelectorFromSet(
 			label.New().Instance(cluster.Name).TiDB().Labels(),
 		).String()})
@@ -168,13 +168,13 @@ func (ctu *CrdTestUtil) DeleteTidbClusterOrDie(tc *v1alpha1.TidbCluster) {
 }
 
 func (ctu *CrdTestUtil) WaitTidbClusterReadyOrDie(tc *v1alpha1.TidbCluster, timeout time.Duration) {
-	err := ctu.waitForTidbClusterReady(tc, timeout, 5*time.Second)
+	err := ctu.WaitForTidbClusterReady(tc, timeout, 5*time.Second)
 	if err != nil {
 		slack.NotifyAndPanic(err)
 	}
 }
 
-func (ctu *CrdTestUtil) waitForTidbClusterReady(tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) error {
+func (ctu *CrdTestUtil) WaitForTidbClusterReady(tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) error {
 	if tc == nil {
 		return fmt.Errorf("tidbcluster is nil, cannot call WaitForTidbClusterReady")
 	}

--- a/tests/crd_test_util.go
+++ b/tests/crd_test_util.go
@@ -14,43 +14,77 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
 	"time"
 
+	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
+	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
+	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
+	utilstatefulset "github.com/pingcap/tidb-operator/tests/e2e/util/statefulset"
 	"github.com/pingcap/tidb-operator/tests/slack"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/klog"
 )
 
-func GetTidbClusterOrDie(cli versioned.Interface, name, namespace string) *v1alpha1.TidbCluster {
-	tc, err := cli.PingcapV1alpha1().TidbClusters(namespace).Get(name, metav1.GetOptions{})
+type CrdTestUtil struct {
+	cli         versioned.Interface
+	kubeCli     kubernetes.Interface
+	tcStsGetter typedappsv1.StatefulSetsGetter
+	asCli       asclientset.Interface
+}
+
+func NewCrdTestUtil(cli versioned.Interface, kubeCli kubernetes.Interface, asCli asclientset.Interface, astsEnabled bool) *CrdTestUtil {
+	var tcStsGetter typedappsv1.StatefulSetsGetter
+	if astsEnabled {
+		tcStsGetter = helper.NewHijackClient(kubeCli, asCli).AppsV1()
+	} else {
+		tcStsGetter = kubeCli.AppsV1()
+	}
+
+	return &CrdTestUtil{
+		cli:         cli,
+		kubeCli:     kubeCli,
+		tcStsGetter: tcStsGetter,
+		asCli:       asCli,
+	}
+}
+
+func (ctu *CrdTestUtil) GetTidbClusterOrDie(name, namespace string) *v1alpha1.TidbCluster {
+	tc, err := ctu.cli.PingcapV1alpha1().TidbClusters(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		slack.NotifyAndPanic(err)
 	}
 	return tc
 }
 
-func CreateTidbClusterOrDie(cli versioned.Interface, tc *v1alpha1.TidbCluster) {
-	_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+func (ctu *CrdTestUtil) CreateTidbClusterOrDie(tc *v1alpha1.TidbCluster) {
+	_, err := ctu.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 	if err != nil {
 		slack.NotifyAndPanic(err)
 	}
 }
 
-func UpdateTidbClusterOrDie(cli versioned.Interface, tc *v1alpha1.TidbCluster) {
+func (ctu *CrdTestUtil) UpdateTidbClusterOrDie(tc *v1alpha1.TidbCluster) {
 	err := wait.Poll(5*time.Second, 3*time.Minute, func() (done bool, err error) {
-		latestTC, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, metav1.GetOptions{})
+		latestTC, err := ctu.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 		latestTC.Spec = tc.Spec
-		_, err = cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Update(latestTC)
+		_, err = ctu.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Update(latestTC)
 		if err != nil {
 			return false, nil
 		}
@@ -61,8 +95,8 @@ func UpdateTidbClusterOrDie(cli versioned.Interface, tc *v1alpha1.TidbCluster) {
 	}
 }
 
-func CheckDisasterToleranceOrDie(kubeCli kubernetes.Interface, tc *v1alpha1.TidbCluster) {
-	err := checkDisasterTolerance(kubeCli, tc)
+func (ctu *CrdTestUtil) CheckDisasterToleranceOrDie(tc *v1alpha1.TidbCluster) {
+	err := checkDisasterTolerance(ctu.kubeCli, tc)
 	if err != nil {
 		slack.NotifyAndPanic(err)
 	}
@@ -121,4 +155,464 @@ func checkPodsDisasterTolerance(allPods []corev1.Pod) error {
 		}
 	}
 	return nil
+}
+
+func (ctu *CrdTestUtil) DeleteTidbClusterOrDie(tc *v1alpha1.TidbCluster) {
+	err := ctu.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Delete(tc.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return
+		}
+		slack.NotifyAndPanic(err)
+	}
+}
+
+func (ctu *CrdTestUtil) WaitTidbClusterReadyOrDie(tc *v1alpha1.TidbCluster, timeout time.Duration) {
+	err := ctu.waitForTidbClusterReady(tc, timeout, 5*time.Second)
+	if err != nil {
+		slack.NotifyAndPanic(err)
+	}
+}
+
+func (ctu *CrdTestUtil) waitForTidbClusterReady(tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) error {
+	if tc == nil {
+		return fmt.Errorf("tidbcluster is nil, cannot call WaitForTidbClusterReady")
+	}
+	return wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		var local *v1alpha1.TidbCluster
+		var err error
+		if local, err = ctu.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, metav1.GetOptions{}); err != nil {
+			klog.Errorf("failed to get tidbcluster: %s/%s, %v", tc.Namespace, tc.Name, err)
+			return false, nil
+		}
+
+		if b, err := ctu.pdMembersReadyFn(local); !b && err == nil {
+			return false, nil
+		}
+		if b, err := ctu.tikvMembersReadyFn(local); !b && err == nil {
+			return false, nil
+		}
+		if b, err := ctu.tidbMembersReadyFn(local); !b && err == nil {
+			return false, nil
+		}
+		if tc.Spec.TiFlash != nil && tc.Spec.TiFlash.Replicas > int32(0) {
+			if b, err := ctu.tiflashMembersReadyFn(local); !b && err == nil {
+				return false, nil
+			}
+		}
+		if tc.Spec.Pump != nil {
+			if b, err := ctu.pumpMembersReadyFn(local); !b && err == nil {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+func (ctu *CrdTestUtil) pdMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, error) {
+	tcName := tc.GetName()
+	ns := tc.GetNamespace()
+	pdSetName := controller.PDMemberName(tcName)
+
+	pdSet, err := ctu.tcStsGetter.StatefulSets(ns).Get(pdSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get statefulset: %s/%s, %v", ns, pdSetName, err)
+		return false, nil
+	}
+
+	if pdSet.Status.CurrentRevision != pdSet.Status.UpdateRevision {
+		return false, nil
+	}
+
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(ctu.kubeCli, ctu.asCli), pdSet) {
+		return false, nil
+	}
+
+	if tc.Status.PD.StatefulSet == nil {
+		klog.Infof("tidbcluster: %s/%s .status.PD.StatefulSet is nil", ns, tcName)
+		return false, nil
+	}
+	failureCount := len(tc.Status.PD.FailureMembers)
+	replicas := tc.Spec.PD.Replicas + int32(failureCount)
+	if *pdSet.Spec.Replicas != replicas {
+		klog.Infof("statefulset: %s/%s .spec.Replicas(%d) != %d",
+			ns, pdSetName, *pdSet.Spec.Replicas, replicas)
+		return false, nil
+	}
+	if pdSet.Status.ReadyReplicas != tc.Spec.PD.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != %d",
+			ns, pdSetName, pdSet.Status.ReadyReplicas, tc.Spec.PD.Replicas)
+		return false, nil
+	}
+	if len(tc.Status.PD.Members) != int(tc.Spec.PD.Replicas) {
+		klog.Infof("tidbcluster: %s/%s .status.PD.Members count(%d) != %d",
+			ns, tcName, len(tc.Status.PD.Members), tc.Spec.PD.Replicas)
+		return false, nil
+	}
+	if pdSet.Status.ReadyReplicas != pdSet.Status.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != .status.Replicas(%d)",
+			ns, pdSetName, pdSet.Status.ReadyReplicas, pdSet.Status.Replicas)
+		return false, nil
+	}
+
+	c, found := getMemberContainer(ctu.kubeCli, ctu.tcStsGetter, ns, tc.Name, label.PDLabelVal)
+	if !found {
+		klog.Infof("statefulset: %s/%s not found containers[name=pd] or pod %s-0",
+			ns, pdSetName, pdSetName)
+		return false, nil
+	}
+
+	if tc.PDImage() != c.Image {
+		klog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=pd].image(%s) != %s",
+			ns, pdSetName, c.Image, tc.PDImage())
+		return false, nil
+	}
+
+	for _, member := range tc.Status.PD.Members {
+		if !member.Health {
+			klog.Infof("tidbcluster: %s/%s pd member(%s/%s) is not health",
+				ns, tcName, member.ID, member.Name)
+			return false, nil
+		}
+	}
+
+	pdServiceName := controller.PDMemberName(tcName)
+	pdPeerServiceName := controller.PDPeerMemberName(tcName)
+	if _, err := ctu.kubeCli.CoreV1().Services(ns).Get(pdServiceName, metav1.GetOptions{}); err != nil {
+		klog.Errorf("failed to get service: %s/%s", ns, pdServiceName)
+		return false, nil
+	}
+	if _, err := ctu.kubeCli.CoreV1().Services(ns).Get(pdPeerServiceName, metav1.GetOptions{}); err != nil {
+		klog.Errorf("failed to get peer service: %s/%s", ns, pdPeerServiceName)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ctu *CrdTestUtil) tikvMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, error) {
+	tcName := tc.GetName()
+	ns := tc.GetNamespace()
+	tikvSetName := controller.TiKVMemberName(tcName)
+
+	tikvSet, err := ctu.tcStsGetter.StatefulSets(ns).Get(tikvSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get statefulset: %s/%s, %v", ns, tikvSetName, err)
+		return false, nil
+	}
+
+	if tikvSet.Status.CurrentRevision != tikvSet.Status.UpdateRevision {
+		return false, nil
+	}
+
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(ctu.kubeCli, ctu.asCli), tikvSet) {
+		return false, nil
+	}
+
+	if tc.Status.TiKV.StatefulSet == nil {
+		klog.Infof("tidbcluster: %s/%s .status.TiKV.StatefulSet is nil", ns, tcName)
+		return false, nil
+	}
+	failureCount := len(tc.Status.TiKV.FailureStores)
+	replicas := tc.Spec.TiKV.Replicas + int32(failureCount)
+	if *tikvSet.Spec.Replicas != replicas {
+		klog.Infof("statefulset: %s/%s .spec.Replicas(%d) != %d",
+			ns, tikvSetName, *tikvSet.Spec.Replicas, replicas)
+		return false, nil
+	}
+	if tikvSet.Status.ReadyReplicas != replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != %d",
+			ns, tikvSetName, tikvSet.Status.ReadyReplicas, replicas)
+		return false, nil
+	}
+	if len(tc.Status.TiKV.Stores) != int(replicas) {
+		klog.Infof("tidbcluster: %s/%s .status.TiKV.Stores.count(%d) != %d",
+			ns, tcName, len(tc.Status.TiKV.Stores), replicas)
+		return false, nil
+	}
+	if tikvSet.Status.ReadyReplicas != tikvSet.Status.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != .status.Replicas(%d)",
+			ns, tikvSetName, tikvSet.Status.ReadyReplicas, tikvSet.Status.Replicas)
+		return false, nil
+	}
+
+	c, found := getMemberContainer(ctu.kubeCli, ctu.tcStsGetter, ns, tc.Name, label.TiKVLabelVal)
+	if !found {
+		klog.Infof("statefulset: %s/%s not found containers[name=tikv] or pod %s-0",
+			ns, tikvSetName, tikvSetName)
+		return false, nil
+	}
+
+	if tc.TiKVImage() != c.Image {
+		klog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=tikv].image(%s) != %s",
+			ns, tikvSetName, c.Image, tc.TiKVImage())
+		return false, nil
+	}
+
+	for _, store := range tc.Status.TiKV.Stores {
+		if store.State != v1alpha1.TiKVStateUp {
+			klog.Infof("tidbcluster: %s/%s's store(%s) state != %s", ns, tcName, store.ID, v1alpha1.TiKVStateUp)
+			return false, nil
+		}
+	}
+
+	tikvPeerServiceName := controller.TiKVPeerMemberName(tcName)
+	if _, err := ctu.kubeCli.CoreV1().Services(ns).Get(tikvPeerServiceName, metav1.GetOptions{}); err != nil {
+		klog.Errorf("failed to get peer service: %s/%s", ns, tikvPeerServiceName)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ctu *CrdTestUtil) tidbMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, error) {
+	tcName := tc.GetName()
+	ns := tc.GetNamespace()
+	tidbSetName := controller.TiDBMemberName(tcName)
+
+	tidbSet, err := ctu.tcStsGetter.StatefulSets(ns).Get(tidbSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get statefulset: %s/%s, %v", ns, tidbSetName, err)
+		return false, nil
+	}
+
+	if tidbSet.Status.CurrentRevision != tidbSet.Status.UpdateRevision {
+		return false, nil
+	}
+
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(ctu.kubeCli, ctu.asCli), tidbSet) {
+		return false, nil
+	}
+
+	if tc.Status.TiDB.StatefulSet == nil {
+		klog.Infof("tidbcluster: %s/%s .status.TiDB.StatefulSet is nil", ns, tcName)
+		return false, nil
+	}
+	failureCount := len(tc.Status.TiDB.FailureMembers)
+	replicas := tc.Spec.TiDB.Replicas + int32(failureCount)
+	if *tidbSet.Spec.Replicas != replicas {
+		klog.Infof("statefulset: %s/%s .spec.Replicas(%d) != %d",
+			ns, tidbSetName, *tidbSet.Spec.Replicas, replicas)
+		return false, nil
+	}
+	if tidbSet.Status.ReadyReplicas != tc.Spec.TiDB.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != %d",
+			ns, tidbSetName, tidbSet.Status.ReadyReplicas, tc.Spec.TiDB.Replicas)
+		return false, nil
+	}
+	if len(tc.Status.TiDB.Members) != int(tc.Spec.TiDB.Replicas) {
+		klog.Infof("tidbcluster: %s/%s .status.TiDB.Members count(%d) != %d",
+			ns, tcName, len(tc.Status.TiDB.Members), tc.Spec.TiDB.Replicas)
+		return false, nil
+	}
+	if tidbSet.Status.ReadyReplicas != tidbSet.Status.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != .status.Replicas(%d)",
+			ns, tidbSetName, tidbSet.Status.ReadyReplicas, tidbSet.Status.Replicas)
+		return false, nil
+	}
+
+	c, found := getMemberContainer(ctu.kubeCli, ctu.tcStsGetter, ns, tc.Name, label.TiDBLabelVal)
+	if !found {
+		klog.Infof("statefulset: %s/%s not found containers[name=tidb] or pod %s-0",
+			ns, tidbSetName, tidbSetName)
+		return false, nil
+	}
+
+	if tc.TiDBImage() != c.Image {
+		klog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=tidb].image(%s) != %s",
+			ns, tidbSetName, c.Image, tc.TiDBImage())
+		return false, nil
+	}
+
+	_, err = ctu.kubeCli.CoreV1().Services(ns).Get(tidbSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get service: %s/%s", ns, tidbSetName)
+		return false, nil
+	}
+	_, err = ctu.kubeCli.CoreV1().Services(ns).Get(controller.TiDBPeerMemberName(tcName), metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get peer service: %s/%s", ns, controller.TiDBPeerMemberName(tcName))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ctu *CrdTestUtil) tiflashMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, error) {
+	tcName := tc.GetName()
+	ns := tc.GetNamespace()
+	tiflashSetName := controller.TiFlashMemberName(tcName)
+
+	tiflashSet, err := ctu.tcStsGetter.StatefulSets(ns).Get(tiflashSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get statefulset: %s/%s, %v", ns, tiflashSetName, err)
+		return false, nil
+	}
+
+	if tiflashSet.Status.CurrentRevision != tiflashSet.Status.UpdateRevision {
+		return false, nil
+	}
+
+	if !utilstatefulset.IsAllDesiredPodsRunningAndReady(helper.NewHijackClient(ctu.kubeCli, ctu.asCli), tiflashSet) {
+		return false, nil
+	}
+
+	if tc.Status.TiFlash.StatefulSet == nil {
+		klog.Infof("tidbcluster: %s/%s .status.TiFlash.StatefulSet is nil", ns, tcName)
+		return false, nil
+	}
+	failureCount := len(tc.Status.TiFlash.FailureStores)
+	replicas := tc.Spec.TiFlash.Replicas + int32(failureCount)
+	if *tiflashSet.Spec.Replicas != replicas {
+		klog.Infof("statefulset: %s/%s .spec.Replicas(%d) != %d",
+			ns, tiflashSetName, *tiflashSet.Spec.Replicas, replicas)
+		return false, nil
+	}
+	if tiflashSet.Status.ReadyReplicas != replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != %d",
+			ns, tiflashSetName, tiflashSet.Status.ReadyReplicas, replicas)
+		return false, nil
+	}
+	if len(tc.Status.TiFlash.Stores) != int(replicas) {
+		klog.Infof("tidbcluster: %s/%s .status.TiFlash.Stores.count(%d) != %d",
+			ns, tcName, len(tc.Status.TiFlash.Stores), replicas)
+		return false, nil
+	}
+	if tiflashSet.Status.ReadyReplicas != tiflashSet.Status.Replicas {
+		klog.Infof("statefulset: %s/%s .status.ReadyReplicas(%d) != .status.Replicas(%d)",
+			ns, tiflashSetName, tiflashSet.Status.ReadyReplicas, tiflashSet.Status.Replicas)
+		return false, nil
+	}
+
+	c, found := getMemberContainer(ctu.kubeCli, ctu.tcStsGetter, ns, tc.Name, label.TiFlashLabelVal)
+	if !found {
+		klog.Infof("statefulset: %s/%s not found containers[name=tiflash] or pod %s-0",
+			ns, tiflashSetName, tiflashSetName)
+		return false, nil
+	}
+
+	if tc.TiFlashImage() != c.Image {
+		klog.Infof("statefulset: %s/%s .spec.template.spec.containers[name=tiflash].image(%s) != %s",
+			ns, tiflashSetName, c.Image, tc.TiFlashImage())
+		return false, nil
+	}
+
+	for _, store := range tc.Status.TiFlash.Stores {
+		if store.State != v1alpha1.TiKVStateUp {
+			klog.Infof("tidbcluster: %s/%s's store(%s) state != %s", ns, tcName, store.ID, v1alpha1.TiKVStateUp)
+			return false, nil
+		}
+	}
+
+	tiflashPeerServiceName := controller.TiFlashPeerMemberName(tcName)
+	if _, err := ctu.kubeCli.CoreV1().Services(ns).Get(tiflashPeerServiceName, metav1.GetOptions{}); err != nil {
+		klog.Errorf("failed to get peer service: %s/%s", ns, tiflashPeerServiceName)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ctu *CrdTestUtil) pumpMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, error) {
+	klog.Infof("begin to check incremental backup cluster[%s] namespace[%s]", tc.Name, tc.Namespace)
+	pumpStatefulSetName := fmt.Sprintf("%s-pump", tc.Name)
+
+	pumpStatefulSet, err := ctu.kubeCli.AppsV1().StatefulSets(tc.Namespace).Get(pumpStatefulSetName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get jobs %s ,%v", pumpStatefulSetName, err)
+		return false, nil
+	}
+	if pumpStatefulSet.Status.Replicas != pumpStatefulSet.Status.ReadyReplicas {
+		klog.Errorf("pump replicas is not ready, please wait ! %s ", pumpStatefulSetName)
+		return false, nil
+	}
+
+	listOps := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(
+			map[string]string{
+				label.ComponentLabelKey: "pump",
+				label.InstanceLabelKey:  pumpStatefulSet.Labels[label.InstanceLabelKey],
+				label.NameLabelKey:      "tidb-cluster",
+			},
+		).String(),
+	}
+
+	pods, err := ctu.kubeCli.CoreV1().Pods(tc.Namespace).List(listOps)
+	if err != nil {
+		klog.Errorf("failed to get pods via pump labels %s ,%v", pumpStatefulSetName, err)
+		return false, nil
+	}
+
+	for _, pod := range pods.Items {
+		if !ctu.pumpHealth(tc, pod.Name) {
+			klog.Errorf("some pods is not health %s", pumpStatefulSetName)
+			return false, nil
+		}
+
+		klog.Info(pod.Spec.Affinity)
+		if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil || len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+			return true, fmt.Errorf("pump pod %s/%s should have affinity set", pod.Namespace, pod.Name)
+		}
+		klog.Info(pod.Spec.Tolerations)
+		foundKey := false
+		for _, tor := range pod.Spec.Tolerations {
+			if tor.Key == "node-role" {
+				foundKey = true
+				break
+			}
+		}
+		if !foundKey {
+			return true, fmt.Errorf("pump pod %s/%s should have tolerations set", pod.Namespace, pod.Name)
+		}
+	}
+	return true, nil
+}
+
+func (ctu *CrdTestUtil) pumpHealth(tc *v1alpha1.TidbCluster, podName string) bool {
+	var addr string
+	addr = fmt.Sprintf("%s.%s-pump.%s:8250", podName, tc.Name, tc.Namespace)
+	pumpHealthURL := fmt.Sprintf("http://%s/status", addr)
+	res, err := http.Get(pumpHealthURL)
+	if err != nil {
+		klog.Errorf("cluster:[%s] call %s failed,error:%v", tc.Name, pumpHealthURL, err)
+		return false
+	}
+	if res.StatusCode >= 400 {
+		klog.Errorf("Error response %v", res.StatusCode)
+		return false
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		klog.Errorf("cluster:[%s] read response body failed,error:%v", tc.Name, err)
+		return false
+	}
+	healths := pumpStatus{}
+	err = json.Unmarshal(body, &healths)
+	if err != nil {
+		klog.Errorf("cluster:[%s] unmarshal failed,error:%v", tc.Name, err)
+		return false
+	}
+	for _, status := range healths.StatusMap {
+		if status.State != "online" {
+			klog.Errorf("cluster:[%s] pump's state is not online", tc.Name)
+			return false
+		}
+	}
+	return true
+}
+
+func (ctu *CrdTestUtil) CleanResourcesOrDie(resource, namespace string) {
+	cmd := fmt.Sprintf("kubectl delete %s --all -n %s", resource, namespace)
+	data, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("%v, resp: %s", err, data)
+		slack.NotifyAndPanic(err)
+	}
+}
+
+func (ctu *CrdTestUtil) CreateSecretOrDie(secret *corev1.Secret) {
+	_, err := ctu.kubeCli.CoreV1().Secrets(secret.Namespace).Create(secret)
+	if err != nil {
+		slack.NotifyAndPanic(err)
+	}
 }

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -141,8 +141,9 @@ var _ = ginkgo.Describe("[tidb-operator][Serial]", func() {
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 3
 			tc.Spec.TiDB.Replicas = 2
-			tests.CreateTidbClusterOrDie(cli, tc)
-			err := oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
+			tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+			framework.ExpectNoError(err)
+			err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
 			framework.ExpectNoError(err)
 			ginkgo.By(fmt.Sprintf("Upgrading tidb cluster from %s to %s", utilimage.TiDBV3Version, utilimage.TiDBV3UpgradeVersion))
 			err = setPartitionAnnotation(ns, tc.Name, label.TiKVLabelVal, 1)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 				Name:    "basic-v4",
 			},
 		}
-		
+
 		for _, clusterCfg := range clusterCfgs {
 			localCfg := clusterCfg
 			ginkgo.It(fmt.Sprintf("[TiDB Version: %s] %s", localCfg.Version, localCfg.Name), func() {

--- a/tests/failover.go
+++ b/tests/failover.go
@@ -70,7 +70,7 @@ func (oa *operatorActions) DeletePDDataThenCheckFailover(info *TidbClusterConfig
 		return fmt.Errorf("failed to delete pod %s/%s data, %s", ns, podName, string(result))
 	}
 	klog.Infof("delete pod %s/%s data successfully", ns, podName)
-	
+
 	// first we ensured that pd failover new pod, and failure member/pod should be deleted.
 	err = wait.Poll(10*time.Second, 30*time.Minute+failoverTimeout+pdFailoverPeriod, func() (bool, error) {
 		tc, err := oa.cli.PingcapV1alpha1().TidbClusters(ns).Get(tcName, metav1.GetOptions{})

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -151,7 +151,6 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 					Affinity: buildAffinity(name, ns, v1alpha1.TiDBMemberType),
 				},
 			},
-			TiFlash: nil,
 		},
 	}
 }

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
+	tcconfig "github.com/pingcap/tidb-operator/pkg/util/config"
 	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
@@ -150,6 +151,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 					Affinity: buildAffinity(name, ns, v1alpha1.TiDBMemberType),
 				},
 			},
+			TiFlash: nil,
 		},
 	}
 }
@@ -483,4 +485,55 @@ func GetRestoreCRDWithS3(tc *v1alpha1.TidbCluster, toSecretName, restoreType str
 		restore.Spec.S3.Path = fmt.Sprintf("s3://%s/%s", s3config.Bucket, s3config.Path)
 	}
 	return restore
+}
+
+func AddPumpForTidbCluster(tc *v1alpha1.TidbCluster) *v1alpha1.TidbCluster {
+	if tc.Spec.Pump != nil {
+		return tc
+	}
+	policy := corev1.PullIfNotPresent
+	tc.Spec.Pump = &v1alpha1.PumpSpec{
+		BaseImage: "pingcap/tidb-binlog",
+		ComponentSpec: v1alpha1.ComponentSpec{
+			Version:         &tc.Spec.Version,
+			ImagePullPolicy: &policy,
+			Affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								Namespaces:  []string{tc.Namespace},
+								TopologyKey: "rack",
+							},
+							Weight: 50,
+						},
+					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Key:      "node-role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "tidb",
+				},
+			},
+			SchedulerName:        pointer.StringPtr("default-scheduler"),
+			ConfigUpdateStrategy: &tc.Spec.ConfigUpdateStrategy,
+		},
+		Replicas:         1,
+		StorageClassName: pointer.StringPtr("local-storage"),
+		ResourceRequirements: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+		GenericConfig: tcconfig.New(map[string]interface{}{
+			"addr":               "0.0.0.0:8250",
+			"gc":                 7,
+			"data-dir":           "/data",
+			"heartbeat-interval": 2,
+		}),
+	}
+	return tc
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

These request let tidbcluster deployed by CR and fix some stability bugs.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
