### PR TITLE
E2e CI job use memory storage for etcd

### DIFF
--- a/ci/e2e_kind.groovy
+++ b/ci/e2e_kind.groovy
@@ -199,6 +199,7 @@ pipeline {
                 export DELETE_NAMESPACE_ON_FAILURE=${params.DELETE_NAMESPACE_ON_FAILURE}
                 export ARTIFACTS=${ARTIFACTS}
                 export GINKGO_NO_COLOR=y
+                export ETCD_STORAGE_TYPE=memory
                 echo "info: begin to run e2e"
                 ./hack/e2e.sh -- ${params.E2E_ARGS}
                 """

--- a/ci/e2e_kind.groovy
+++ b/ci/e2e_kind.groovy
@@ -199,7 +199,6 @@ pipeline {
                 export DELETE_NAMESPACE_ON_FAILURE=${params.DELETE_NAMESPACE_ON_FAILURE}
                 export ARTIFACTS=${ARTIFACTS}
                 export GINKGO_NO_COLOR=y
-                export ETCD_STORAGE_TYPE=memory
                 echo "info: begin to run e2e"
                 ./hack/e2e.sh -- ${params.E2E_ARGS}
                 """

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -63,6 +63,8 @@ spec:
     # legacy docker path for cr.io/k8s-testimages/kubekins-e2e
     - name: docker-graph
       mountPath: /docker-graph
+	- name: etcd-data-dir
+	  mountPath: /mnt/tmpfs/etcd
   volumes:
   - name: modules
     hostPath:
@@ -76,6 +78,9 @@ spec:
     emptyDir: {}
   - name: docker-graph
     emptyDir: {}
+  - name: etcd-data-dir
+    emptyDir:
+      medium: Memory
   tolerations:
   - effect: NoSchedule
     key: tidb-operator
@@ -301,7 +306,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		}
 		}
 
-		def GLOBALS = "SKIP_BUILD=y SKIP_IMAGE_BUILD=y DOCKER_REPO=hub.pingcap.net/tidb-operator-e2e IMAGE_TAG=${GITHASH} DELETE_NAMESPACE_ON_FAILURE=true GINKGO_NO_COLOR=y"
+		def GLOBALS = "KIND_ETCD_DATADIR=/mnt/tmpfs/etcd SKIP_BUILD=y SKIP_IMAGE_BUILD=y DOCKER_REPO=hub.pingcap.net/tidb-operator-e2e IMAGE_TAG=${GITHASH} DELETE_NAMESPACE_ON_FAILURE=true GINKGO_NO_COLOR=y"
 		def builds = [:]
 		// We must not enable operator killer for Kubernetes before 1.15 in
 		// which webhook configuration does not support objectSelector. Webhook

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -307,14 +307,8 @@ def call(BUILD_BRANCH, CREDENTIALS_ID, CODECOV_CREDENTIALS_ID) {
 		// which webhook configuration does not support objectSelector. Webhook
 		// pod cann't be recovered when it's deleted because we hooked pod
 		// CREATE/DELETE event.
-		builds["E2E v1.12"] = {
-			build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12 ./hack/e2e.sh -- --preload-images")
-		}
 		builds["E2E v1.18"] = {
 			build("v1.18", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- -preload-images --operator-killer")
-		}
-		builds["E2E v1.18 AdvancedStatefulSet"] = {
-			build("v1.18-advanced-statefulset", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --operator-features AdvancedStatefulSet=true --operator-killer")
 		}
 		builds["E2E v1.18 Serial"] = {
 			build("v1.18-serial", "${GLOBALS} KUBE_VERSION=v1.18 ./hack/e2e.sh -- --preload-images --ginkgo.focus='\\[Serial\\]' --install-operator=false", e2eSerialResources)

--- a/ci/pingcap_tidb_operator_build_kind.groovy
+++ b/ci/pingcap_tidb_operator_build_kind.groovy
@@ -63,8 +63,9 @@ spec:
     # legacy docker path for cr.io/k8s-testimages/kubekins-e2e
     - name: docker-graph
       mountPath: /docker-graph
-	- name: etcd-data-dir
-	  mountPath: /mnt/tmpfs/etcd
+    # use memory storage for etcd hostpath in kind cluster
+    - name: etcd-data-dir
+      mountPath: /mnt/tmpfs/etcd
   volumes:
   - name: modules
     hostPath:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -370,7 +370,7 @@ nodes:
 - role: control-plane
 EOF
     # check $ETCD_STORAGE_TYPE in [disk, memory]
-    if [[$ETCD_STORAGE_TYPE == "disk" || $ETCD_STORAGE_TYPE == "memory"]]; then
+    if [[ "$ETCD_STORAGE_TYPE" == "disk" || $ETCD_STORAGE_TYPE == "memory" ]]; then
         # check $KIND_DATA_HOSTPATH
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
             if [ ! -d "$KIND_DATA_HOSTPATH" ]; then

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -29,12 +29,10 @@ source "${ROOT}/hack/lib.sh"
 # check bash version
 BASH_MAJOR_VERSION=$(echo "$BASH_VERSION" | cut -d '.' -f 1)
 # we need bash version >= 4
-if [ $BASH_MAJOR_VERSION -lt 4 ]
-then
-  echo "error: e2e.sh could not work with bash version earlier than 4 for now, please upgrade your bash"
-  exit 1
+if [ $BASH_MAJOR_VERSION -lt 4 ]; then
+    echo "error: e2e.sh could not work with bash version earlier than 4 for now, please upgrade your bash"
+    exit 1
 fi
-
 
 function usage() {
     cat <<'EOF'
@@ -163,7 +161,7 @@ EOF
 
 while getopts "h?" opt; do
     case "$opt" in
-    h|\?)
+    h | \?)
         usage
         exit 0
         ;;
@@ -270,9 +268,9 @@ function e2e::__restart_docker() {
     local MAX_WAIT=5
     while true; do
         # docker ps -q should only work if the daemon is ready
-        docker ps -q > /dev/null 2>&1 && break
+        docker ps -q >/dev/null 2>&1 && break
         if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
-            WAIT_N=$((WAIT_N+1))
+            WAIT_N=$((WAIT_N + 1))
             echo "info; Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
             sleep ${WAIT_N}
         else
@@ -285,7 +283,7 @@ function e2e::__restart_docker() {
 
 function e2e::__configure_docker_mirror_for_dind() {
     echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
-cat <<EOF > /etc/docker/daemon.json.tmp
+    cat <<EOF >/etc/docker/daemon.json.tmp
 {
     "registry-mirrors": ["$DOCKER_IO_MIRROR"]
 }
@@ -301,7 +299,7 @@ EOF
 
 function e2e::create_kindconfig() {
     local tmpfile=${1}
-    cat <<EOF > $tmpfile
+    cat <<EOF >$tmpfile
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
@@ -341,31 +339,31 @@ kubeadmConfigPatches:
     v: "4"
 EOF
     if [ -n "$DOCKER_IO_MIRROR" -o -n "$GCR_IO_MIRROR" -o -n "$QUAY_IO_MIRROR" ]; then
-cat <<EOF >> $tmpfile
+        cat <<EOF >>$tmpfile
 containerdConfigPatches:
 - |-
 EOF
         if [ -n "$DOCKER_IO_MIRROR" ]; then
-cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
     endpoint = ["$DOCKER_IO_MIRROR"]
 EOF
         fi
         if [ -n "$GCR_IO_MIRROR" ]; then
-cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
     endpoint = ["$GCR_IO_MIRROR"]
 EOF
         fi
         if [ -n "$QUAY_IO_MIRROR" ]; then
-cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
     endpoint = ["$QUAY_IO_MIRROR"]
 EOF
         fi
     fi
     # control-plane
-    cat <<EOF >> $tmpfile
+    cat <<EOF >>$tmpfile
 nodes:
 - role: control-plane
 EOF
@@ -384,7 +382,7 @@ EOF
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
             # set custom KIND_DATA_HOSTPATH and KIND_ETCD_DATADIR
-            cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"
@@ -394,13 +392,13 @@ EOF
 EOF
         else
             # set custom KIND_ETCD_DATADIR
-            cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   extraMounts:
   - containerPath: /var/lib/etcd
     hostPath: "$KIND_ETCD_DATADIR"
 EOF
         fi
-    else 
+    else
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
             if [ ! -d "$KIND_DATA_HOSTPATH" ]; then
                 echo "error: '$KIND_DATA_HOSTPATH' is not a directory"
@@ -409,16 +407,17 @@ EOF
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
             # set custom KIND_DATA_HOSTPATH
-            cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"
     propagation: HostToContainer
 EOF
+        fi
     fi
     # workers
     for ((i = 1; i <= $KUBE_WORKERS; i++)) {
-        cat <<EOF >> $tmpfile
+        cat <<EOF >>$tmpfile
 - role: worker
 EOF
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
@@ -428,7 +427,7 @@ EOF
             fi
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/worker${i}"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
-            cat <<EOF >> $tmpfile
+            cat <<EOF >>$tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -29,10 +29,12 @@ source "${ROOT}/hack/lib.sh"
 # check bash version
 BASH_MAJOR_VERSION=$(echo "$BASH_VERSION" | cut -d '.' -f 1)
 # we need bash version >= 4
-if [ $BASH_MAJOR_VERSION -lt 4 ]; then
-    echo "error: e2e.sh could not work with bash version earlier than 4 for now, please upgrade your bash"
-    exit 1
+if [ $BASH_MAJOR_VERSION -lt 4 ]
+then
+  echo "error: e2e.sh could not work with bash version earlier than 4 for now, please upgrade your bash"
+  exit 1
 fi
+
 
 function usage() {
     cat <<'EOF'
@@ -161,7 +163,7 @@ EOF
 
 while getopts "h?" opt; do
     case "$opt" in
-    h | \?)
+    h|\?)
         usage
         exit 0
         ;;
@@ -268,9 +270,9 @@ function e2e::__restart_docker() {
     local MAX_WAIT=5
     while true; do
         # docker ps -q should only work if the daemon is ready
-        docker ps -q >/dev/null 2>&1 && break
+        docker ps -q > /dev/null 2>&1 && break
         if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
-            WAIT_N=$((WAIT_N + 1))
+            WAIT_N=$((WAIT_N+1))
             echo "info; Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
             sleep ${WAIT_N}
         else
@@ -283,7 +285,7 @@ function e2e::__restart_docker() {
 
 function e2e::__configure_docker_mirror_for_dind() {
     echo "info: configure docker.io mirror '$DOCKER_IO_MIRROR' for DinD"
-    cat <<EOF >/etc/docker/daemon.json.tmp
+cat <<EOF > /etc/docker/daemon.json.tmp
 {
     "registry-mirrors": ["$DOCKER_IO_MIRROR"]
 }
@@ -299,7 +301,7 @@ EOF
 
 function e2e::create_kindconfig() {
     local tmpfile=${1}
-    cat <<EOF >$tmpfile
+    cat <<EOF > $tmpfile
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
@@ -339,31 +341,31 @@ kubeadmConfigPatches:
     v: "4"
 EOF
     if [ -n "$DOCKER_IO_MIRROR" -o -n "$GCR_IO_MIRROR" -o -n "$QUAY_IO_MIRROR" ]; then
-        cat <<EOF >>$tmpfile
+cat <<EOF >> $tmpfile
 containerdConfigPatches:
 - |-
 EOF
         if [ -n "$DOCKER_IO_MIRROR" ]; then
-            cat <<EOF >>$tmpfile
+cat <<EOF >> $tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
     endpoint = ["$DOCKER_IO_MIRROR"]
 EOF
         fi
         if [ -n "$GCR_IO_MIRROR" ]; then
-            cat <<EOF >>$tmpfile
+cat <<EOF >> $tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
     endpoint = ["$GCR_IO_MIRROR"]
 EOF
         fi
         if [ -n "$QUAY_IO_MIRROR" ]; then
-            cat <<EOF >>$tmpfile
+cat <<EOF >> $tmpfile
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
     endpoint = ["$QUAY_IO_MIRROR"]
 EOF
         fi
     fi
     # control-plane
-    cat <<EOF >>$tmpfile
+    cat <<EOF >> $tmpfile
 nodes:
 - role: control-plane
 EOF
@@ -382,7 +384,7 @@ EOF
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
             # set custom KIND_DATA_HOSTPATH and KIND_ETCD_DATADIR
-            cat <<EOF >>$tmpfile
+            cat <<EOF >> $tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"
@@ -392,13 +394,13 @@ EOF
 EOF
         else
             # set custom KIND_ETCD_DATADIR
-            cat <<EOF >>$tmpfile
+            cat <<EOF >> $tmpfile
   extraMounts:
   - containerPath: /var/lib/etcd
     hostPath: "$KIND_ETCD_DATADIR"
 EOF
         fi
-    else
+    else 
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
             if [ ! -d "$KIND_DATA_HOSTPATH" ]; then
                 echo "error: '$KIND_DATA_HOSTPATH' is not a directory"
@@ -407,17 +409,16 @@ EOF
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
             # set custom KIND_DATA_HOSTPATH
-            cat <<EOF >>$tmpfile
+            cat <<EOF >> $tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"
     propagation: HostToContainer
 EOF
-        fi
     fi
     # workers
     for ((i = 1; i <= $KUBE_WORKERS; i++)) {
-        cat <<EOF >>$tmpfile
+        cat <<EOF >> $tmpfile
 - role: worker
 EOF
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
@@ -427,7 +428,7 @@ EOF
             fi
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/worker${i}"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
-            cat <<EOF >>$tmpfile
+            cat <<EOF >> $tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -64,7 +64,7 @@ Environments:
     GCR_IO_MIRROR         configure mirror for gcr.io
     QUAY_IO_MIRROR        configure mirror for quay.io
     KIND_DATA_HOSTPATH    (kind only) the host path of data directory for kind cluster, defaults: none
-    ETCD_STORAGE_TYPE     (kind only) the etcd storage type [disk, memory], default: disk
+    KIND_ETCD_DATADIR     (kind only) the host path of etcd data directory for kind cluster, defaults: none
     GCP_PROJECT           (gke only) the GCP project to run in
     GCP_CREDENTIALS       (gke only) the GCP service account to use
     GCP_REGION            (gke only) the GCP region, if specified a regional cluster is creaetd
@@ -188,7 +188,7 @@ SKIP_TEST=${SKIP_TEST:-}
 SKIP_DUMP=${SKIP_DUMP:-}
 REUSE_CLUSTER=${REUSE_CLUSTER:-}
 KIND_DATA_HOSTPATH=${KIND_DATA_HOSTPATH:-none}
-ETCD_STORAGE_TYPE=${ETCD_STORAGE_TYPE:-disk}
+KIND_ETCD_DATADIR=${KIND_ETCD_DATADIR:-none}
 GCP_PROJECT=${GCP_PROJECT:-}
 GCP_CREDENTIALS=${GCP_CREDENTIALS:-}
 GCP_REGION=${GCP_REGION:-}
@@ -221,7 +221,7 @@ echo "SKIP_DOWN: $SKIP_DOWN"
 echo "SKIP_TEST: $SKIP_TEST"
 echo "SKIP_DUMP: $SKIP_DUMP"
 echo "KIND_DATA_HOSTPATH: $KIND_DATA_HOSTPATH"
-echo "ETCD_STORAGE_TYPE: $ETCD_STORAGE_TYPE"
+echo "KIND_ETCD_DATADIR: $KIND_ETCD_DATADIR"
 echo "GCP_PROJECT: $GCP_PROJECT"
 echo "GCP_CREDENTIALS: $GCP_CREDENTIALS"
 echo "GCP_REGION: $GCP_REGION"
@@ -369,9 +369,38 @@ EOF
 nodes:
 - role: control-plane
 EOF
-    # check $ETCD_STORAGE_TYPE in [disk, memory]
-    if [[ "$ETCD_STORAGE_TYPE" == "disk" || $ETCD_STORAGE_TYPE == "memory" ]]; then
+    # check $KIND_ETCD_DATADIR
+    if [[ "$KIND_ETCD_DATADIR" != "none" ]]; then
         # check $KIND_DATA_HOSTPATH
+        if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
+            if [ ! -d "$KIND_DATA_HOSTPATH" ]; then
+                echo "error: '$KIND_DATA_HOSTPATH' is not a directory"
+                exit 1
+            fi
+            if [ ! -d "$KIND_ETCD_DATADIR" ]; then
+                echo "error: '$KIND_ETCD_DATADIR' is not a directory"
+                exit 1
+            fi
+            local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
+            test -d $hostWorkerPath || mkdir $hostWorkerPath
+            # set custom KIND_DATA_HOSTPATH and KIND_ETCD_DATADIR
+            cat <<EOF >> $tmpfile
+  extraMounts:
+  - containerPath: /mnt/disks/
+    hostPath: "$hostWorkerPath"
+    propagation: HostToContainer
+  - containerPath: /var/lib/etcd
+    hostPath: "$KIND_ETCD_DATADIR"
+EOF
+        else
+            # set custom KIND_ETCD_DATADIR
+            cat <<EOF >> $tmpfile
+  extraMounts:
+  - containerPath: /var/lib/etcd
+    hostPath: "$KIND_ETCD_DATADIR"
+EOF
+        fi
+    else 
         if [[ "$KIND_DATA_HOSTPATH" != "none" ]]; then
             if [ ! -d "$KIND_DATA_HOSTPATH" ]; then
                 echo "error: '$KIND_DATA_HOSTPATH' is not a directory"
@@ -379,42 +408,13 @@ EOF
             fi
             local hostWorkerPath="${KIND_DATA_HOSTPATH}/control-plane"
             test -d $hostWorkerPath || mkdir $hostWorkerPath
-            # set custom KIND_DATA_HOSTPATH and ETCD_STORAGE_TYPE in disk
-            if [[ "$ETCD_STORAGE_TYPE" == "disk" ]]; then
-                cat <<EOF >> $tmpfile
+            # set custom KIND_DATA_HOSTPATH
+            cat <<EOF >> $tmpfile
   extraMounts:
   - containerPath: /mnt/disks/
     hostPath: "$hostWorkerPath"
     propagation: HostToContainer
 EOF
-            # set custom KIND_DATA_HOSTPATH and ETCD_STORAGE_TYPE in memory
-            elif [[ "$ETCD_STORAGE_TYPE" == "memory" ]]; then
-                mkdir /tmp/etcd
-                mount -t tmpfs  /tmp/etcd
-                cat <<EOF >> $tmpfile
-  extraMounts:
-  - containerPath: /mnt/disks/
-    hostPath: "$hostWorkerPath"
-    propagation: HostToContainer
-  - containerPath: /var/lib/etcd
-    hostPath: /tmp/etcd
-EOF
-            fi
-        else
-            # set ETCD_STORAGE_TYPE in memory
-            if [[ "$ETCD_STORAGE_TYPE" == "memory" ]]; then
-                mkdir /tmp/etcd
-                mount -t tmpfs  /tmp/etcd
-                cat <<EOF >> $tmpfile
-  extraMounts:
-  - containerPath: /var/lib/etcd
-    hostPath: /tmp/etcd
-EOF
-            fi
-        fi
-    else 
-        echo "error: '$ETCD_STORAGE_TYPE' is incorrect, must be [disk, memory]"
-        exit 1
     fi
     # workers
     for ((i = 1; i <= $KUBE_WORKERS; i++)) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #2619 

### What is changed and how does it work?
Add an option environment `ETCD_STORAGE_TYPE` , default is `disk`, if set it as `memory` will
running etcd use memory storage.
Reference:
https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-529154066


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Code changes

 - Has CI related scripts change


Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
None
```
