### PR TITLE
Fixed scheduling errors when based on zone scheduling

### DIFF
--- a/pkg/scheduler/predicates/test_helper.go
+++ b/pkg/scheduler/predicates/test_helper.go
@@ -168,6 +168,26 @@ func fakeTwoNodes() []apiv1.Node {
 	}
 }
 
+func fakeSkipNodes(nodeTopologyMap map[string]string) func() []apiv1.Node {
+	return func() []apiv1.Node {
+		nodes := make([]apiv1.Node, 0)
+		for nodeName, nodeTopology := range nodeTopologyMap {
+			nodes = append(nodes, apiv1.Node{
+				TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"kubernetes.io/hostname": nodeName,
+						"zone":                   nodeTopology,
+					},
+				},
+			})
+		}
+
+		return nodes
+	}
+}
+
 func fakeOneNode() []apiv1.Node {
 	return []apiv1.Node{
 		{
@@ -185,6 +205,25 @@ func fakeOneNode() []apiv1.Node {
 
 func fakeZeroNode() []apiv1.Node {
 	return []apiv1.Node{}
+}
+
+func fakeZeroScheduledNode(nodeName string) (*apiv1.Node, error) {
+	return &apiv1.Node{}, nil
+}
+
+func fakeScheduledNode(scheduledNodeName, zone string) func(string) (*apiv1.Node, error) {
+	return func(nodeName string) (*apiv1.Node, error) {
+		return &apiv1.Node{
+			TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: scheduledNodeName,
+				Labels: map[string]string{
+					"kubernetes.io/hostname": scheduledNodeName,
+					"zone":                   zone,
+				},
+			},
+		}, nil
+	}
 }
 
 func CollectEvents(source <-chan string) []string {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix: #2638

### What is changed and how does it work?
When scheduling a pod based on zone, firstly, gets all the nodes that have scheduled the pod by traversing pods, and then, gets all zones that have scheduled pods by querying node information from `kubecli`, finally, computes available zones.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
