### PR TITLE
Hide datasource information for backup job

### DIFF
--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -88,11 +88,11 @@ func EnsureDirectoryExist(dirName string) error {
 func OpenDB(dsn string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return nil, fmt.Errorf("open dsn %s failed, err: %v", dsn, err)
+		return nil, fmt.Errorf("open datasource failed, err: %v", err)
 	}
 	if err := db.Ping(); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("cannot connect to mysql: %s, err: %v", dsn, err)
+		return nil, fmt.Errorf("cannot connect to mysql, err: %v", err)
 	}
 	return db, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close https://github.com/pingcap/tidb-operator/issues/2505

As each backup job's target tidbcluster have already been set in its spec. We don't need to expose its datasource connection info in the log.


 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Make datasource information hidden in log for `Backup` and `Restore` job
```
