### PR TITLE
add label to identify individual services

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -231,8 +231,8 @@ func (l Label) UsedBy(name string) Label {
 	return l
 }
 
-// UsedByInternal adds used-by=internal label
-func (l Label) UsedByInternal() Label {
+// UsedByPeer adds used-by=peer label
+func (l Label) UsedByPeer() Label {
 	l[UsedByLabelKey] = "peer"
 	return l
 }

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -24,11 +24,6 @@ import (
 const (
 	// The following labels are recommended by kubernetes https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 
-	// ResourceNameLabelKey is the unique identifier of the resource, its value is the same as metadata.name
-	ResourceNameLabelKey string = "kubernetes.io/name"
-	// UsedByLabelKey indicate where it is used. for example, tidb has two services,
-	// one for internal component access and the other for end-user
-	UsedByLabelKey string = "app.kubernetes.io/used-by"
 	// ManagedByLabelKey is Kubernetes recommended label key, it represents the tool being used to manage the operation of an application
 	// For resources managed by TiDB Operator, its value is always tidb-operator
 	ManagedByLabelKey string = "app.kubernetes.io/managed-by"
@@ -43,7 +38,11 @@ const (
 
 	// NamespaceLabelKey is label key used in PV for easy querying
 	NamespaceLabelKey string = "app.kubernetes.io/namespace"
-
+	// ResourceNameLabelKey is the unique identifier of the resource, its value is the same as metadata.name
+	ResourceNameLabelKey string = "kubernetes.io/name"
+	// UsedByLabelKey indicate where it is used. for example, tidb has two services,
+	// one for internal component access and the other for end-user
+	UsedByLabelKey string = "app.kubernetes.io/used-by"
 	// ClusterIDLabelKey is cluster id label key
 	ClusterIDLabelKey string = "tidb.pingcap.com/cluster-id"
 	// StoreIDLabelKey is store id label key
@@ -236,7 +235,7 @@ func (l Label) UsedBy(name string) Label {
 
 // UsedByInternal adds used-by=internal label
 func (l Label) UsedByInternal() Label {
-	l[UsedByLabelKey] = "internal"
+	l[UsedByLabelKey] = "peer"
 	return l
 }
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -24,6 +24,11 @@ import (
 const (
 	// The following labels are recommended by kubernetes https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 
+	// ResourceNameLabelKey is the unique identifier of the resource, its value is the same as metadata.name
+	ResourceNameLabelKey string = "kubernetes.io/name"
+	// UsedByLabelKey indicate where it is used. for example, tidb has two services,
+	// one for internal component access and the other for end-user
+	UsedByLabelKey string = "app.kubernetes.io/used-by"
 	// ManagedByLabelKey is Kubernetes recommended label key, it represents the tool being used to manage the operation of an application
 	// For resources managed by TiDB Operator, its value is always tidb-operator
 	ManagedByLabelKey string = "app.kubernetes.io/managed-by"
@@ -223,6 +228,30 @@ func (l Label) Instance(name string) Label {
 	return l
 }
 
+// UserBy adds use-by kv pair to label
+func (l Label) UsedBy(name string) Label {
+	l[UsedByLabelKey] = name
+	return l
+}
+
+// UsedByInternal adds used-by=internal label
+func (l Label) UsedByInternal() Label {
+	l[UsedByLabelKey] = "internal"
+	return l
+}
+
+// UsedByEndUser adds use-by=end-user label
+func (l Label) UsedByEndUser() Label {
+	l[UsedByLabelKey] = "end-user"
+	return l
+}
+
+// ResourceName adds resource name kv pair to label
+func (l Label) ResourceName(name string) Label {
+	l[ResourceNameLabelKey] = name
+	return l
+}
+
 // Namespace adds namespace kv pair to label
 func (l Label) Namespace(name string) Label {
 	l[NamespaceLabelKey] = name
@@ -367,6 +396,15 @@ func (l Label) LabelSelector() *metav1.LabelSelector {
 // Labels converts label to map[string]string
 func (l Label) Labels() map[string]string {
 	return l
+}
+
+// Copy copy the value of label to avoid pointer copy
+func (l Label) Copy() Label {
+	copyLabel := make(Label)
+	for k, v := range l {
+		copyLabel[k] = v
+	}
+	return copyLabel
 }
 
 // String converts label to a string

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -38,8 +38,6 @@ const (
 
 	// NamespaceLabelKey is label key used in PV for easy querying
 	NamespaceLabelKey string = "app.kubernetes.io/namespace"
-	// ResourceNameLabelKey is the unique identifier of the resource, its value is the same as metadata.name
-	ResourceNameLabelKey string = "kubernetes.io/name"
 	// UsedByLabelKey indicate where it is used. for example, tidb has two services,
 	// one for internal component access and the other for end-user
 	UsedByLabelKey string = "app.kubernetes.io/used-by"
@@ -242,12 +240,6 @@ func (l Label) UsedByInternal() Label {
 // UsedByEndUser adds use-by=end-user label
 func (l Label) UsedByEndUser() Label {
 	l[UsedByLabelKey] = "end-user"
-	return l
-}
-
-// ResourceName adds resource name kv pair to label
-func (l Label) ResourceName(name string) Label {
-	l[ResourceNameLabelKey] = name
 	return l
 }
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -420,13 +420,14 @@ func (pmm *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbClust
 	tcName := tc.Name
 	svcName := controller.PDMemberName(tcName)
 	instanceName := tc.GetInstanceName()
-	pdLabel := label.New().Instance(instanceName).PD().Labels()
+	pdSelector := label.New().Instance(instanceName).PD()
+	pdLabels := pdSelector.Copy().UsedByEndUser().ResourceName(svcName).Labels()
 
 	pdService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            svcName,
 			Namespace:       ns,
-			Labels:          pdLabel,
+			Labels:          pdLabels,
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -439,7 +440,7 @@ func (pmm *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbClust
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
-			Selector: pdLabel,
+			Selector: pdSelector.Labels(),
 		},
 	}
 	// if set pd service type ,overwrite global variable services
@@ -467,13 +468,14 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 	tcName := tc.Name
 	svcName := controller.PDPeerMemberName(tcName)
 	instanceName := tc.GetInstanceName()
-	pdLabel := label.New().Instance(instanceName).PD().Labels()
+	pdSelector := label.New().Instance(instanceName).PD()
+	pdLabels := pdSelector.Copy().UsedByInternal().ResourceName(svcName).Labels()
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            svcName,
 			Namespace:       ns,
-			Labels:          pdLabel,
+			Labels:          pdLabels,
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -486,7 +488,7 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
-			Selector:                 pdLabel,
+			Selector:                 pdSelector.Labels(),
 			PublishNotReadyAddresses: true,
 		},
 	}

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -469,7 +469,7 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 	svcName := controller.PDPeerMemberName(tcName)
 	instanceName := tc.GetInstanceName()
 	pdSelector := label.New().Instance(instanceName).PD()
-	pdLabels := pdSelector.Copy().UsedByInternal().Labels()
+	pdLabels := pdSelector.Copy().UsedByPeer().Labels()
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -421,7 +421,7 @@ func (pmm *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbClust
 	svcName := controller.PDMemberName(tcName)
 	instanceName := tc.GetInstanceName()
 	pdSelector := label.New().Instance(instanceName).PD()
-	pdLabels := pdSelector.Copy().UsedByEndUser().ResourceName(svcName).Labels()
+	pdLabels := pdSelector.Copy().UsedByEndUser().Labels()
 
 	pdService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -469,7 +469,7 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 	svcName := controller.PDPeerMemberName(tcName)
 	instanceName := tc.GetInstanceName()
 	pdSelector := label.New().Instance(instanceName).PD()
-	pdLabels := pdSelector.Copy().UsedByInternal().ResourceName(svcName).Labels()
+	pdLabels := pdSelector.Copy().UsedByInternal().Labels()
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -847,7 +847,7 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
-						"app.kubernetes.io/used-by":    "internal",
+						"app.kubernetes.io/used-by":    "peer",
 						"kubernetes.io/name":           "foo-pd-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -848,7 +848,6 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "peer",
-						"kubernetes.io/name":           "foo-pd-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1560,7 +1559,6 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1622,7 +1620,6 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1685,7 +1682,6 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1749,7 +1745,6 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1815,7 +1810,6 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -847,6 +847,8 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "internal",
+						"kubernetes.io/name":           "foo-pd-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1557,6 +1559,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1617,6 +1621,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1678,6 +1684,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1740,6 +1748,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1804,6 +1814,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "pd",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-pd",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -438,7 +438,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 	instanceName := tc.GetInstanceName()
 	tidbSelector := label.New().Instance(instanceName).TiDB()
 	svcName := controller.TiDBMemberName(tcName)
-	tidbLabels := tidbSelector.Copy().UsedByEndUser().ResourceName(svcName).Labels()
+	tidbLabels := tidbSelector.Copy().UsedByEndUser().Labels()
 	portName := "mysql-client"
 	if svcSpec.PortName != nil {
 		portName = *svcSpec.PortName
@@ -497,7 +497,7 @@ func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.S
 	instanceName := tc.GetInstanceName()
 	svcName := controller.TiDBPeerMemberName(tcName)
 	tidbSelector := label.New().Instance(instanceName).TiDB()
-	tidbLabel := tidbSelector.Copy().UsedByInternal().ResourceName(svcName).Labels()
+	tidbLabel := tidbSelector.Copy().UsedByInternal().Labels()
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -497,7 +497,7 @@ func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.S
 	instanceName := tc.GetInstanceName()
 	svcName := controller.TiDBPeerMemberName(tcName)
 	tidbSelector := label.New().Instance(instanceName).TiDB()
-	tidbLabel := tidbSelector.Copy().UsedByInternal().Labels()
+	tidbLabel := tidbSelector.Copy().UsedByPeer().Labels()
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -881,7 +881,7 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
-						"app.kubernetes.io/used-by":    "internal",
+						"app.kubernetes.io/used-by":    "peer",
 						"kubernetes.io/name":           "foo-tidb-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -881,6 +881,8 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
+						"app.kubernetes.io/used-by":    "internal",
+						"kubernetes.io/name":           "foo-tidb-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1390,6 +1392,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1448,6 +1452,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1520,6 +1526,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
+						"app.kubernetes.io/used-by":    "end-user",
+						"kubernetes.io/name":           "foo-tidb",
 					},
 					Annotations: map[string]string{
 						"lb-type": "testlb",

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -882,7 +882,6 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 						"app.kubernetes.io/used-by":    "peer",
-						"kubernetes.io/name":           "foo-tidb-peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1393,7 +1392,6 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1453,7 +1451,6 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-tidb",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1527,7 +1524,6 @@ func TestGetNewTiDBService(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tidb",
 						"app.kubernetes.io/used-by":    "end-user",
-						"kubernetes.io/name":           "foo-tidb",
 					},
 					Annotations: map[string]string{
 						"lb-type": "testlb",

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -1187,7 +1187,6 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tiflash",
 						"app.kubernetes.io/used-by":    "peer",
-						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -1186,7 +1186,7 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tiflash",
-						"app.kubernetes.io/used-by":    "internal",
+						"app.kubernetes.io/used-by":    "peer",
 						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -1186,6 +1186,8 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tiflash",
+						"app.kubernetes.io/used-by":    "internal",
+						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -275,13 +275,19 @@ func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) 
 	tcName := tc.Name
 	instanceName := tc.GetInstanceName()
 	svcName := svcConfig.MemberName(tcName)
-	svcLabel := svcConfig.SvcLabel(label.New().Instance(instanceName)).Labels()
+	svcSelector := svcConfig.SvcLabel(label.New().Instance(instanceName))
+	svcLabel := svcSelector.Copy().ResourceName("svcName")
+	if svcConfig.Headless {
+		svcLabel = svcLabel.UsedByInternal()
+	} else {
+		svcLabel = svcLabel.UsedByEndUser()
+	}
 
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            svcName,
 			Namespace:       ns,
-			Labels:          svcLabel,
+			Labels:          svcLabel.Labels(),
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -293,7 +299,7 @@ func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) 
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
-			Selector:                 svcLabel,
+			Selector:                 svcSelector.Labels(),
 			PublishNotReadyAddresses: true,
 		},
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -278,7 +278,7 @@ func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) 
 	svcSelector := svcConfig.SvcLabel(label.New().Instance(instanceName))
 	svcLabel := svcSelector.Copy()
 	if svcConfig.Headless {
-		svcLabel = svcLabel.UsedByInternal()
+		svcLabel = svcLabel.UsedByPeer()
 	} else {
 		svcLabel = svcLabel.UsedByEndUser()
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -276,7 +276,7 @@ func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) 
 	instanceName := tc.GetInstanceName()
 	svcName := svcConfig.MemberName(tcName)
 	svcSelector := svcConfig.SvcLabel(label.New().Instance(instanceName))
-	svcLabel := svcSelector.Copy().ResourceName("svcName")
+	svcLabel := svcSelector.Copy()
 	if svcConfig.Headless {
 		svcLabel = svcLabel.UsedByInternal()
 	} else {

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -1503,6 +1503,8 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
+						"app.kubernetes.io/used-by":    "internal",
+						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -1504,7 +1504,6 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
 						"app.kubernetes.io/used-by":    "peer",
-						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -1503,7 +1503,7 @@ func TestGetNewTiFlashServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
 						"app.kubernetes.io/component":  "tikv",
-						"app.kubernetes.io/used-by":    "internal",
+						"app.kubernetes.io/used-by":    "peer",
 						"kubernetes.io/name":           "svcName",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -666,8 +666,8 @@ func getMonitorService(monitor *v1alpha1.TidbMonitor) []*core.Service {
 
 	prometheusName := prometheusName(monitor)
 	monitorLabel := label.NewMonitor().Instance(monitor.Name).Monitor()
-	promeLabel := monitorLabel.Copy().UsedBy("prometheus").ResourceName(prometheusName)
-	grafanaLabel := monitorLabel.Copy().UsedBy("grafana").ResourceName(grafanaName(monitor))
+	promeLabel := monitorLabel.Copy().UsedBy("prometheus")
+	grafanaLabel := monitorLabel.Copy().UsedBy("grafana")
 	prometheusService := &core.Service{
 		ObjectMeta: meta.ObjectMeta{
 			Name:            prometheusName,

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -51,6 +51,8 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/managed-by": "tidb-operator",
 							"app.kubernetes.io/instance":   "foo",
 							"app.kubernetes.io/component":  "monitor",
+							"app.kubernetes.io/used-by":    "prometheus",
+							"kubernetes.io/name":           "foo-prometheus",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -165,6 +167,8 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/managed-by": "tidb-operator",
 							"app.kubernetes.io/instance":   "foo",
 							"app.kubernetes.io/component":  "monitor",
+							"app.kubernetes.io/used-by":    "prometheus",
+							"kubernetes.io/name":           "foo-prometheus",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -52,7 +52,6 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/instance":   "foo",
 							"app.kubernetes.io/component":  "monitor",
 							"app.kubernetes.io/used-by":    "prometheus",
-							"kubernetes.io/name":           "foo-prometheus",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -168,7 +167,6 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/instance":   "foo",
 							"app.kubernetes.io/component":  "monitor",
 							"app.kubernetes.io/used-by":    "prometheus",
-							"kubernetes.io/name":           "foo-prometheus",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -281,7 +279,6 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/instance":   "foo",
 							"app.kubernetes.io/component":  "monitor",
 							"app.kubernetes.io/used-by":    "prometheus",
-							"kubernetes.io/name":           "foo-prometheus",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -377,7 +374,6 @@ func TestGetMonitorService(t *testing.T) {
 							"app.kubernetes.io/managed-by": "tidb-operator",
 							"app.kubernetes.io/name":       "tidb-cluster",
 							"app.kubernetes.io/used-by":    "grafana",
-							"kubernetes.io/name":           "foo-grafana",
 						},
 					},
 					Spec: core.ServiceSpec{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fixes https://github.com/pingcap/tidb-operator/issues/2622

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```bash
➜  tidb-operator git:(add-labels-for-service) ✗ kubectl get svc -n pingcap-dev
NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
basic-discovery          ClusterIP   10.107.212.188   <none>        10261/TCP            2m3s
basic-grafana            ClusterIP   10.111.254.210   <none>        3000/TCP             2m2s
basic-monitor-reloader   ClusterIP   10.97.149.92     <none>        9089/TCP             2m2s
basic-pd                 ClusterIP   10.110.120.114   <none>        2379/TCP             2m2s
basic-pd-peer            ClusterIP   None             <none>        2380/TCP             2m2s
basic-prometheus         ClusterIP   10.103.60.68     <none>        9090/TCP             2m3s
basic-tidb               ClusterIP   10.110.92.244    <none>        4000/TCP,10080/TCP   12s
basic-tidb-peer          ClusterIP   None             <none>        10080/TCP            12s
basic-tikv-peer          ClusterIP   None             <none>        20160/TCP            60s
➜  tidb-operator git:(add-labels-for-service) ✗ kubectl get svc -n pingcap-dev -l app.kubernetes.io/used-by=end-user
NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
basic-pd     ClusterIP   10.110.120.114   <none>        2379/TCP             2m15s
basic-tidb   ClusterIP   10.110.92.244    <none>        4000/TCP,10080/TCP   25s
➜  tidb-operator git:(add-labels-for-service) ✗ kubectl get svc -n pingcap-dev -l app.kubernetes.io/used-by=internal
NAME              TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)     AGE
basic-pd-peer     ClusterIP   None         <none>        2380/TCP    2m21s
basic-tidb-peer   ClusterIP   None         <none>        10080/TCP   31s
basic-tikv-peer   ClusterIP   None         <none>        20160/TCP   79s
➜  tidb-operator git:(add-labels-for-service) ✗ kubectl get svc -n pingcap-dev -l app.kubernetes.io/used-by=grafana
NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
basic-grafana   ClusterIP   10.111.254.210   <none>        3000/TCP   2m28s
➜  tidb-operator git:(add-labels-for-service) ✗ kubectl get svc -n pingcap-dev -l app.kubernetes.io/used-by=prometheus
NAME               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
basic-prometheus   ClusterIP   10.103.60.68   <none>        9090/TCP   2m35s
```

Code changes

 - Has Go code change



### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
