### PR TITLE
[DNM] Use secret as Grafana credentials

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -3900,6 +3900,20 @@ ServiceSpec
 </tr>
 <tr>
 <td>
+<code>passwordSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>if passwordSecret is omitted, Grafana will use <code>admin</code> as its password by default.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>username</code></br>
 <em>
 string
@@ -3916,6 +3930,8 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>Deprecated</p>
 </td>
 </tr>
 <tr>

--- a/examples/monitor-grafana-secret/grafana-secret.yaml
+++ b/examples/monitor-grafana-secret/grafana-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  password: YWRtaW4=
+kind: Secret
+metadata:
+  name: grafana
+type: Opaque

--- a/examples/monitor-grafana-secret/tidb-monitor.yaml
+++ b/examples/monitor-grafana-secret/tidb-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: basic
 spec:
   clusters:
-  - name: basic
+    - name: basic
   prometheus:
     config:
       configMapRef:
@@ -21,6 +21,10 @@ spec:
   grafana:
     baseImage: grafana/grafana
     version: 6.0.1
+    username: "admin"
+    passwordSecret:
+      name: grafana
+      key: password
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v3.0.13

--- a/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
@@ -121,8 +121,18 @@ type GrafanaSpec struct {
 
 	LogLevel string      `json:"logLevel,omitempty"`
 	Service  ServiceSpec `json:"service,omitempty"`
-	Username string      `json:"username,omitempty"`
-	Password string      `json:"password,omitempty"`
+
+	// +optional
+	// if passwordSecret is omitted, Grafana will use `admin` as its password by default.
+	PasswordSecret *corev1.SecretKeySelector `json:"passwordSecret,omitempty"`
+
+	Username string `json:"username,omitempty"`
+
+	// +optional
+	// Deprecated
+	// +k8s:openapi-gen=false
+	Password string `json:"password,omitempty"`
+
 	// +optional
 	Envs map[string]string `json:"envs,omitempty"`
 

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -1358,6 +1358,11 @@ func (in *GrafanaSpec) DeepCopyInto(out *GrafanaSpec) {
 	*out = *in
 	in.MonitorContainer.DeepCopyInto(&out.MonitorContainer)
 	in.Service.DeepCopyInto(&out.Service)
+	if in.PasswordSecret != nil {
+		in, out := &in.PasswordSecret, &out.PasswordSecret
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Envs != nil {
 		in, out := &in.Envs, &out.Envs
 		*out = make(map[string]string, len(*in))

--- a/pkg/monitor/monitor/monitor_manager.go
+++ b/pkg/monitor/monitor/monitor_manager.go
@@ -217,11 +217,6 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, mo
 		klog.Errorf("tm[%s/%s]'s configmap failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
 	}
-	secret, err := mm.syncTidbMonitorSecret(monitor)
-	if err != nil {
-		klog.Errorf("tm[%s/%s]'s secret failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
-		return err
-	}
 
 	sa, err := mm.syncTidbMonitorRbac(monitor)
 	if err != nil {
@@ -229,7 +224,7 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, mo
 		return err
 	}
 
-	deployment, err := getMonitorDeployment(sa, cm, secret, monitor, tc)
+	deployment, err := getMonitorDeployment(sa, cm, monitor, tc)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s deployment failed to generate,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
@@ -241,14 +236,6 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, mo
 	}
 	klog.V(4).Infof("tm[%s/%s]'s deployment synced", monitor.Namespace, monitor.Name)
 	return nil
-}
-
-func (mm *MonitorManager) syncTidbMonitorSecret(monitor *v1alpha1.TidbMonitor) (*corev1.Secret, error) {
-	if monitor.Spec.Grafana == nil {
-		return nil, nil
-	}
-	newSt := getMonitorSecret(monitor)
-	return mm.typedControl.CreateOrUpdateSecret(monitor, newSt)
 }
 
 func (mm *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) (*corev1.ConfigMap, error) {

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -270,8 +270,6 @@ func NewTidbMonitor(name, namespace string, tc *v1alpha1.TidbCluster, grafanaEna
 				ImagePullPolicy: &imagePullPolicy,
 				Resources:       corev1.ResourceRequirements{},
 			},
-			Username: "admin",
-			Password: "admin",
 			Service: v1alpha1.ServiceSpec{
 				Type:        corev1.ServiceTypeClusterIP,
 				Annotations: map[string]string{},


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fixes #2637 


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Use secretRef for `Grafana` credentials in `TidbMonitor` instead of plain text
```
