### PR TITLE
Backup: fix remote file not clean when job is failed

### DIFF
--- a/cmd/backup-manager/app/util/remote.go
+++ b/cmd/backup-manager/app/util/remote.go
@@ -81,24 +81,24 @@ func NewRemoteStorage(backup *v1alpha1.Backup) (*blob.Bucket, error) {
 }
 
 // getRemoteStorage returns the arg for --storage option and the remote path for br
-func getRemoteStorage(provider v1alpha1.StorageProvider) ([]string, string, error) {
+func getRemoteStorage(provider v1alpha1.StorageProvider) ([]string, error) {
 	st := util.GetStorageType(provider)
 	switch st {
 	case v1alpha1.BackupStorageTypeS3:
 		qs := checkS3Config(provider.S3, false)
-		s, path := newS3StorageOption(qs)
-		return s, path, nil
+		s := newS3StorageOption(qs)
+		return s, nil
 	case v1alpha1.BackupStorageTypeGcs:
 		qs := checkGcsConfig(provider.Gcs, false)
-		s, path := newGcsStorageOption(qs)
-		return s, path, nil
+		s := newGcsStorageOption(qs)
+		return s, nil
 	default:
-		return nil, "", fmt.Errorf("storage %s not support yet", st)
+		return nil, fmt.Errorf("storage %s not support yet", st)
 	}
 }
 
 // newS3StorageOption constructs the arg for --storage option and the remote path for br
-func newS3StorageOption(qs *s3Query) ([]string, string) {
+func newS3StorageOption(qs *s3Query) []string {
 	var s3options []string
 	var path string
 	if qs.prefix == "/" {
@@ -125,7 +125,7 @@ func newS3StorageOption(qs *s3Query) ([]string, string) {
 	if qs.storageClass != "" {
 		s3options = append(s3options, fmt.Sprintf("--s3.storage-class=%s", qs.storageClass))
 	}
-	return s3options, path
+	return s3options
 }
 
 // newS3Storage initialize a new s3 storage
@@ -183,7 +183,7 @@ func newGcsStorage(qs *gcsQuery) (*blob.Bucket, error) {
 }
 
 // newGcsStorageOption constructs the arg for --storage option and the remote path for br
-func newGcsStorageOption(qs *gcsQuery) ([]string, string) {
+func newGcsStorageOption(qs *gcsQuery) []string {
 	var gcsoptions []string
 	var path string
 	if qs.prefix == "/" {
@@ -198,7 +198,7 @@ func newGcsStorageOption(qs *gcsQuery) ([]string, string) {
 	if qs.objectAcl != "" {
 		gcsoptions = append(gcsoptions, fmt.Sprintf("--gcs.predefined-acl=%s", qs.objectAcl))
 	}
-	return gcsoptions, path
+	return gcsoptions
 }
 
 // checkS3Config constructs s3Query parameters

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -84,6 +84,37 @@ func EnsureDirectoryExist(dirName string) error {
 	return nil
 }
 
+func GetRemotePath(backup *v1alpha1.Backup) (string, error) {
+	var path, bucket, prefix string
+	st := util.GetStorageType(backup.Spec.StorageProvider)
+	switch st {
+	case v1alpha1.BackupStorageTypeS3:
+		prefix = backup.Spec.StorageProvider.S3.Prefix
+		bucket = backup.Spec.StorageProvider.S3.Bucket
+		prefix = strings.Trim(prefix, "/")
+		prefix += "/"
+		if prefix == "/" {
+			path = fmt.Sprintf("s3://%s%s", bucket, prefix)
+		} else {
+			path = fmt.Sprintf("s3://%s/%s", bucket, prefix)
+		}
+		return path, nil
+	case v1alpha1.BackupStorageTypeGcs:
+		prefix = backup.Spec.StorageProvider.Gcs.Prefix
+		bucket = backup.Spec.StorageProvider.Gcs.Bucket
+		prefix = strings.Trim(prefix, "/")
+		prefix += "/"
+		if prefix == "/" {
+			path = fmt.Sprintf("gcs://%s%s", bucket, prefix)
+		} else {
+			path = fmt.Sprintf("gcs://%s/%s", bucket, prefix)
+		}
+		return path, nil
+	default:
+		return "", fmt.Errorf("storage %s not support yet", st)
+	}
+}
+
 // OpenDB opens db
 func OpenDB(dsn string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", dsn)
@@ -127,16 +158,16 @@ func GetOptionValueFromEnv(option, envPrefix string) string {
 }
 
 // ConstructBRGlobalOptionsForBackup constructs BR global options for backup and also return the remote path.
-func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, string, error) {
+func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, error) {
 	var args []string
 	config := backup.Spec.BR
 	if config == nil {
-		return nil, "", fmt.Errorf("no config for br in backup %s/%s", backup.Namespace, backup.Name)
+		return nil, fmt.Errorf("no config for br in backup %s/%s", backup.Namespace, backup.Name)
 	}
 	args = append(args, constructBRGlobalOptions(config)...)
-	storageArgs, remotePath, err := getRemoteStorage(backup.Spec.StorageProvider)
+	storageArgs, err := getRemoteStorage(backup.Spec.StorageProvider)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	args = append(args, storageArgs...)
 	if (backup.Spec.Type == v1alpha1.BackupTypeDB || backup.Spec.Type == v1alpha1.BackupTypeTable) && config.DB != "" {
@@ -145,7 +176,7 @@ func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, strin
 	if backup.Spec.Type == v1alpha1.BackupTypeTable && config.Table != "" {
 		args = append(args, fmt.Sprintf("--table=%s", config.Table))
 	}
-	return args, remotePath, nil
+	return args, nil
 }
 
 // ConstructMydumperOptionsForBackup constructs mydumper options for backup
@@ -180,7 +211,7 @@ func ConstructBRGlobalOptionsForRestore(restore *v1alpha1.Restore) ([]string, er
 		return nil, fmt.Errorf("no config for br in restore %s/%s", restore.Namespace, restore.Name)
 	}
 	args = append(args, constructBRGlobalOptions(config)...)
-	storageArgs, _, err := getRemoteStorage(restore.Spec.StorageProvider)
+	storageArgs, err := getRemoteStorage(restore.Spec.StorageProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1120,6 +1120,8 @@ const (
 	BackupRetryFailed BackupConditionType = "RetryFailed"
 	// BackupInvalid means invalid backup CR
 	BackupInvalid BackupConditionType = "Invalid"
+	// BackupPrepare means the backup prepare backup process
+	BackupPrepare BackupConditionType = "Prepare"
 )
 
 // BackupCondition describes the observed state of a Backup at a certain point.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
issues: fix https://github.com/pingcap/tidb-operator/issues/2660
If backup job failed, remote file will not clean if delete the backup CRD.
### What is changed and how does it work?
add remote path at the begining of backup 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Manual test (add detailed scripts or steps below)
the step just as issue 

Code changes

 - Has Go code change