### PR TITLE
Change tidb-discovery strategy type to `Recreate`

### DIFF
--- a/charts/tidb-cluster/templates/discovery-deployment.yaml
+++ b/charts/tidb-cluster/templates/discovery-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/component: discovery
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 spec:
+  strategy:
+    type: Recreate
   # don't modify this replicas
   replicas: 1
   selector:

--- a/pkg/manager/member/tidb_discovery_manager.go
+++ b/pkg/manager/member/tidb_discovery_manager.go
@@ -135,6 +135,7 @@ func getTidbDiscoveryDeployment(tc *v1alpha1.TidbCluster) (*appsv1.Deployment, e
 	d := &appsv1.Deployment{
 		ObjectMeta: meta,
 		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 			Replicas: controller.Int32Ptr(1),
 			Selector: l.LabelSelector(),
 			Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes: https://github.com/pingcap/tidb-operator/issues/2693
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Change tidb-discovery strategy type to `Recreate`
```
