### PR TITLE
do not scale or upgrade tikv at the same time

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -199,8 +199,7 @@ func (tc *TidbCluster) TiKVUpgrading() bool {
 }
 
 func (tc *TidbCluster) TiKVScaling() bool {
-	return tc.Status.TiKV.Phase == ScaleOutPhase ||
-		tc.Status.TiKV.Phase == ScaleInPhase
+	return tc.Status.TiKV.Phase == ScalePhase
 }
 
 func (tc *TidbCluster) TiDBUpgrading() bool {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -194,6 +194,10 @@ func (tc *TidbCluster) PDUpgrading() bool {
 	return tc.Status.PD.Phase == UpgradePhase
 }
 
+func (tc *TidbCluster) PDScaling() bool {
+	return tc.Status.PD.Phase == ScalePhase
+}
+
 func (tc *TidbCluster) TiKVUpgrading() bool {
 	return tc.Status.TiKV.Phase == UpgradePhase
 }

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -198,6 +198,11 @@ func (tc *TidbCluster) TiKVUpgrading() bool {
 	return tc.Status.TiKV.Phase == UpgradePhase
 }
 
+func (tc *TidbCluster) TiKVScaling() bool {
+	return tc.Status.TiKV.Phase == ScaleOutPhase ||
+		tc.Status.TiKV.Phase == ScaleInPhase
+}
+
 func (tc *TidbCluster) TiDBUpgrading() bool {
 	return tc.Status.TiDB.Phase == UpgradePhase
 }

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -61,6 +61,10 @@ const (
 	NormalPhase MemberPhase = "Normal"
 	// UpgradePhase represents the upgrade state of TiDB cluster.
 	UpgradePhase MemberPhase = "Upgrade"
+	// ScaleInPhase represents the scaling in state of TiDB cluster.
+	ScaleInPhase MemberPhase = "ScaleIn"
+	// ScaleOutPhase represents the scaling out state of TiDB cluster.
+	ScaleOutPhase MemberPhase = "ScaleOut"
 )
 
 // ConfigUpdateStrategy represents the strategy to update configuration

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -61,10 +61,8 @@ const (
 	NormalPhase MemberPhase = "Normal"
 	// UpgradePhase represents the upgrade state of TiDB cluster.
 	UpgradePhase MemberPhase = "Upgrade"
-	// ScaleInPhase represents the scaling in state of TiDB cluster.
-	ScaleInPhase MemberPhase = "ScaleIn"
-	// ScaleOutPhase represents the scaling out state of TiDB cluster.
-	ScaleOutPhase MemberPhase = "ScaleOut"
+	// ScalePhase represents the scaling state of TiDB cluster.
+	ScalePhase MemberPhase = "Scale"
 )
 
 // ConfigUpdateStrategy represents the strategy to update configuration

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -315,6 +315,8 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 	}
 	if upgrading {
 		tc.Status.PD.Phase = v1alpha1.UpgradePhase
+	} else if tc.PDStsDesiredReplicas() != *set.Spec.Replicas {
+		tc.Status.PD.Phase = v1alpha1.ScalePhase
 	} else {
 		tc.Status.PD.Phase = v1alpha1.NormalPhase
 	}

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -317,7 +317,7 @@ func TestPDMemberManagerSyncUpdate(t *testing.T) {
 			},
 			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.ClusterID).To(Equal("1"))
-				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.ScalePhase))
 				g.Expect(tc.Status.PD.StatefulSet.ObservedGeneration).To(Equal(int64(1)))
 				g.Expect(len(tc.Status.PD.Members)).To(Equal(3))
 				g.Expect(tc.Status.PD.Members["pd1"].Health).To(Equal(true))
@@ -727,7 +727,7 @@ func TestPDMemberManagerSyncPDSts(t *testing.T) {
 				g.Expect(*set.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
 			},
 			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
-				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.ScalePhase))
 			},
 		},
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -633,7 +633,7 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	}
 	if upgrading && tc.Status.PD.Phase != v1alpha1.UpgradePhase {
 		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
-	} else {
+	} else if tc.Status.TiKV.Phase != v1alpha1.ScaleOutPhase && tc.Status.TiKV.Phase != v1alpha1.ScaleInPhase {
 		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
 	}
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -633,7 +633,7 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	}
 	if upgrading && tc.Status.PD.Phase != v1alpha1.UpgradePhase {
 		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
-	} else if tc.Status.TiKV.Phase != v1alpha1.ScaleOutPhase && tc.Status.TiKV.Phase != v1alpha1.ScaleInPhase {
+	} else if !tc.TiKVScaling() {
 		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
 	}
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -633,7 +633,9 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	}
 	if upgrading && tc.Status.PD.Phase != v1alpha1.UpgradePhase {
 		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
-	} else if !tc.TiKVScaling() {
+	} else if tc.TiKVStsDesiredReplicas() != *set.Spec.Replicas {
+		tc.Status.TiKV.Phase = v1alpha1.ScalePhase
+	} else {
 		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
 	}
 

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -911,6 +911,42 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "statefulset is scaling out",
+			updateTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.TiKV.Phase = v1alpha1.ScaleOutPhase
+			},
+			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
+				return false, nil
+			},
+			errWhenGetStores:          false,
+			storeInfo:                 nil,
+			errWhenGetTombstoneStores: false,
+			tombstoneStoreInfo:        nil,
+			errExpectFn:               nil,
+			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
+				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleOutPhase))
+			},
+		},
+		{
+			name: "statefulset is scaling in",
+			updateTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.TiKV.Phase = v1alpha1.ScaleInPhase
+			},
+			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
+				return false, nil
+			},
+			errWhenGetStores:          false,
+			storeInfo:                 nil,
+			errWhenGetTombstoneStores: false,
+			tombstoneStoreInfo:        nil,
+			errExpectFn:               nil,
+			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
+				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleInPhase))
+			},
+		},
+		{
 			name:     "get stores failed",
 			updateTC: nil,
 			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -799,11 +799,15 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 	status := apps.StatefulSetStatus{
 		Replicas: int32(3),
 	}
+	spec := apps.StatefulSetSpec{
+		Replicas: pointer.Int32Ptr(3),
+	}
 	now := metav1.Time{Time: time.Now()}
 	testFn := func(test *testcase, t *testing.T) {
 		tc := newTidbClusterForPD()
 		tc.Status.PD.Phase = v1alpha1.NormalPhase
 		set := &apps.StatefulSet{
+			Spec:   spec,
 			Status: status,
 		}
 		if test.updateTC != nil {
@@ -913,7 +917,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 		{
 			name: "statefulset is scaling out",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Phase = v1alpha1.ScaleOutPhase
+				tc.Spec.TiKV.Replicas = 4
 			},
 			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
 				return false, nil
@@ -925,13 +929,13 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			errExpectFn:               nil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleOutPhase))
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScalePhase))
 			},
 		},
 		{
 			name: "statefulset is scaling in",
 			updateTC: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Phase = v1alpha1.ScaleInPhase
+				tc.Spec.TiKV.Replicas = 2
 			},
 			upgradingFn: func(lister corelisters.PodLister, controlInterface pdapi.PDControlInterface, set *apps.StatefulSet, cluster *v1alpha1.TidbCluster) (bool, error) {
 				return false, nil
@@ -943,7 +947,7 @@ func TestTiKVMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			errExpectFn:               nil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiKV.StatefulSet.Replicas).To(Equal(int32(3)))
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleInPhase))
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScalePhase))
 			},
 		},
 		{

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -50,7 +50,7 @@ func (tsd *tikvScaler) Scale(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet,
 	} else if scaling < 0 {
 		return tsd.ScaleIn(tc, oldSet, newSet)
 	} else {
-		if tc.Status.TiKV.Phase == v1alpha1.ScaleOutPhase || tc.Status.TiKV.Phase == v1alpha1.ScaleInPhase {
+		if tc.TiKVScaling() {
 			tc.Status.TiKV.Phase = v1alpha1.NormalPhase
 		}
 	}

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -55,7 +55,12 @@ func NewTiKVUpgrader(pdControl pdapi.PDControlInterface,
 func (tku *tikvUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
-	if tc.Status.PD.Phase == v1alpha1.UpgradePhase {
+
+	if tc.Status.PD.Phase == v1alpha1.UpgradePhase ||
+		tc.Status.TiKV.Phase == v1alpha1.ScaleOutPhase ||
+		tc.Status.TiKV.Phase == v1alpha1.ScaleInPhase {
+		klog.Infof("TidbCluster: [%s/%s]'s pd status is %v, tikv status is %v, can not upgrade tikv",
+			ns, tcName, tc.Status.PD.Phase, tc.Status.TiKV.Phase)
 		_, podSpec, err := GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -56,9 +56,7 @@ func (tku *tikvUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Stateful
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	if tc.Status.PD.Phase == v1alpha1.UpgradePhase ||
-		tc.Status.TiKV.Phase == v1alpha1.ScaleOutPhase ||
-		tc.Status.TiKV.Phase == v1alpha1.ScaleInPhase {
+	if tc.Status.PD.Phase == v1alpha1.UpgradePhase || tc.TiKVScaling() {
 		klog.Infof("TidbCluster: [%s/%s]'s pd status is %v, tikv status is %v, can not upgrade tikv",
 			ns, tcName, tc.Status.PD.Phase, tc.Status.TiKV.Phase)
 		_, podSpec, err := GetLastAppliedConfig(oldSet)

--- a/pkg/manager/member/tikv_upgrader_test.go
+++ b/pkg/manager/member/tikv_upgrader_test.go
@@ -291,6 +291,50 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
+			name: "tikv can not upgrade when it is scaling in",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiKV.Phase = v1alpha1.ScaleInPhase
+				tc.Status.TiKV.Synced = true
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+			},
+			changePods:          nil,
+			beginEvictLeaderErr: false,
+			endEvictLeaderErr:   false,
+			updatePodErr:        false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleInPhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
+			name: "tikv can not upgrade when it is scaling out",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiKV.Phase = v1alpha1.ScaleOutPhase
+				tc.Status.TiKV.Synced = true
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+			},
+			changePods:          nil,
+			beginEvictLeaderErr: false,
+			endEvictLeaderErr:   false,
+			updatePodErr:        false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleOutPhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
 			name: "get last apply config error",
 			changeFn: func(tc *v1alpha1.TidbCluster) {
 				tc.Status.PD.Phase = v1alpha1.UpgradePhase

--- a/pkg/manager/member/tikv_upgrader_test.go
+++ b/pkg/manager/member/tikv_upgrader_test.go
@@ -291,10 +291,10 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: "tikv can not upgrade when it is scaling in",
+			name: "tikv can not upgrade when it is scaling",
 			changeFn: func(tc *v1alpha1.TidbCluster) {
 				tc.Status.PD.Phase = v1alpha1.NormalPhase
-				tc.Status.TiKV.Phase = v1alpha1.ScaleInPhase
+				tc.Status.TiKV.Phase = v1alpha1.ScalePhase
 				tc.Status.TiKV.Synced = true
 			},
 			changeOldSet: func(oldSet *apps.StatefulSet) {
@@ -308,29 +308,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleInPhase))
-				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
-			},
-		},
-		{
-			name: "tikv can not upgrade when it is scaling out",
-			changeFn: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.PD.Phase = v1alpha1.NormalPhase
-				tc.Status.TiKV.Phase = v1alpha1.ScaleOutPhase
-				tc.Status.TiKV.Synced = true
-			},
-			changeOldSet: func(oldSet *apps.StatefulSet) {
-				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
-			},
-			changePods:          nil,
-			beginEvictLeaderErr: false,
-			endEvictLeaderErr:   false,
-			updatePodErr:        false,
-			errExpectFn: func(g *GomegaWithT, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-			},
-			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
-				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScaleOutPhase))
+				g.Expect(tc.Status.TiKV.Phase).To(Equal(v1alpha1.ScalePhase))
 				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix https://github.com/pingcap/tidb-operator/issues/2631
### What is changed and how does it work?
Cross-check during upgrading and scaling and make sure that upgrading and scaling for tikv do not occur at the same time.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
   - Scale out TiKV and then upgrade TiKV
   - Scale in TiKV and then upgrade TiKV
   - Scale in and upgrade TiKV at the same time
   - Upgrade TidbCluster to newer version and scale in TiKV at the same time

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Do not scale or upgrade tikv at the same time
```
