### PR TITLE
Fix labelselector error in reclaimPolicyManager

### DIFF
--- a/pkg/controller/pv_control.go
+++ b/pkg/controller/pv_control.go
@@ -69,17 +69,9 @@ func (rpc *realPVControl) PatchPVReclaimPolicy(obj runtime.Object, pv *corev1.Pe
 
 	name := metaObj.GetName()
 	pvName := pv.GetName()
-
-	latestPV, err := rpc.kubeCli.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	if string(latestPV.Spec.PersistentVolumeReclaimPolicy) == string(reclaimPolicy) {
-		return nil
-	}
 	patchBytes := []byte(fmt.Sprintf(`{"spec":{"persistentVolumeReclaimPolicy":"%s"}}`, reclaimPolicy))
-	
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		_, err := rpc.kubeCli.CoreV1().PersistentVolumes().Patch(pvName, types.StrategicMergePatchType, patchBytes)
 		return err
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
The label selector logic is wrong in `reclaimPolicyManager`'s `sync` function which would cause TidbMonitor covered TidbCluster's reclaimPolicy, this request fix it.

fix https://github.com/pingcap/tidb-operator/issues/2697


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the pv syncing error when `TidbMonitor` and `TidbCluster` have different value in `reclaimPolicy`
```
