### PR TITLE
Add switch to control the Dashboard Proxy

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -6476,6 +6476,18 @@ string
 which used by Dashboard.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>enableDashboardInternalProxy</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableDashboardInternalProxy would directly set <code>internal-proxy</code> in the <code>PdConfig</code></p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="pdstatus">PDStatus</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -817,6 +817,8 @@ spec:
                   type: string
                 dataSubDir:
                   type: string
+                enableDashboardInternalProxy:
+                  type: boolean
                 env:
                   items:
                     properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -3067,6 +3067,13 @@ func schema_pkg_apis_pingcap_v1alpha1_PDSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"enableDashboardInternalProxy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EnableDashboardInternalProxy would directly set `internal-proxy` in the `PdConfig`",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"replicas"},
 			},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -326,6 +326,10 @@ type PDSpec struct {
 	// which used by Dashboard.
 	// +optional
 	TLSClientSecretName *string `json:"tlsClientSecretName,omitempty"`
+
+	// EnableDashboardInternalProxy would directly set `internal-proxy` in the `PdConfig`
+	// +optional
+	EnableDashboardInternalProxy *bool `json:"enableDashboardInternalProxy,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -2581,6 +2581,11 @@ func (in *PDSpec) DeepCopyInto(out *PDSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EnableDashboardInternalProxy != nil {
+		in, out := &in.EnableDashboardInternalProxy, &out.EnableDashboardInternalProxy
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -763,6 +763,17 @@ func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		config.Dashboard.TiDBKeyPath = pointer.StringPtr(path.Join(tidbClientCertPath, corev1.TLSPrivateKeyKey))
 	}
 
+	if tc.Spec.PD.EnableDashboardInternalProxy != nil {
+		if config.Dashboard != nil {
+			// EnableDashboardInternalProxy has a higher priority to cover the configuration in Dashboard
+			config.Dashboard.InternalProxy = pointer.BoolPtr(*tc.Spec.PD.EnableDashboardInternalProxy)
+		} else {
+			config.Dashboard = &v1alpha1.DashboardConfig{
+				InternalProxy: pointer.BoolPtr(*tc.Spec.PD.EnableDashboardInternalProxy),
+			}
+		}
+	}
+
 	confText, err := MarshalTOML(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Close https://github.com/pingcap/tidb-operator/issues/2650

Add `enableDashboardInternalProxy` to control whether enable `internal-proxy` for pd dashboard.  This would let user directly visit dashboard by discovery-service:10262. 

After this pr finished, we need to update the document about `access dashboard`.

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add `EnableDashboardInternalProxy` in `PDSpec` to let user directly visit PD Dashboard.
```
