### PR TITLE
Fix alert rules lost after rolling upgrade

### DIFF
--- a/charts/tidb-cluster/templates/monitor-deployment.yaml
+++ b/charts/tidb-cluster/templates/monitor-deployment.yaml
@@ -67,7 +67,11 @@ spec:
         - name: PROM_PERSISTENT_DIR
           value: /data
         - name: TIDB_VERSION
+      {{- if .Values.monitor.prometheus.alertManagerRulesVersion }}
+          value: tidb:{{ .Values.monitor.prometheus.alertManagerRulesVersion }}
+      {{- else }}
           value: {{ .Values.tidb.image }}
+      {{- end }}
         - name: GF_K8S_PROMETHEUS_URL
           value: {{ .Values.monitor.initializer.config.K8S_PROMETHEUS_URL }}
         - name: GF_TIDB_PROMETHEUS_URL

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -573,6 +573,11 @@ monitor:
       portName: http-prometheus
     reserveDays: 12
     # alertmanagerURL: ""
+
+    # alertManagerRulesVersion is the version of the tidb cluster that used for alert rules.
+    # default to current tidb cluster version, for example: v3.0.15
+    #
+    # alertManagerRulesVersion: ""
   nodeSelector: {}
     # kind: monitor
     # zone: cn-bj1-01,cn-bj1-02


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Part of: https://github.com/pingcap/tidb-operator/issues/2710

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix alert rules lost after rolling upgrade
```
