### PR TITLE
Fix TidbMonitor e2e check error

### DIFF
--- a/tests/monitor.go
+++ b/tests/monitor.go
@@ -227,7 +227,15 @@ func checkGrafanaDataCommon(name, namespace string, grafanaClient *metrics.Clien
 		addr = fmt.Sprintf("%s.%s.svc.cluster.local:3000", svcName, namespace)
 	}
 
-	datasourceID, err := getDatasourceID(addr)
+	var datasourceID int
+	err := wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		datasourceID, err = getDatasourceID(addr)
+		if err != nil {
+			klog.Error(err)
+			return false, err
+		}
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
When checking grafana functionality, we should use wait function instead of throwing error directly.


https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/operator_ghpr_e2e_test_kind/detail/operator_ghpr_e2e_test_kind/6675/pipeline


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
