### PR TITLE
fix backup and restore time column

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4664,39 +4664,39 @@ metadata:
   name: backups.pingcap.com
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.backupPath
-      description: The full path of backup data
-      name: BackupPath
-      type: string
-    - JSONPath: .status.backupSize
-      description: The data size of the backup
-      name: BackupSize
-      type: integer
-    - JSONPath: .status.commitTs
-      description: The commit ts of tidb cluster dump
-      name: CommitTS
-      type: string
-    - JSONPath: .status.timeStarted
-      description: The time at which the backup was started
-      format: date-time
-      name: Started
-      priority: 1
-      type: string
-    - JSONPath: .status.timeCompleted
-      description: The time at which the backup was completed
-      format: date-time
-      name: Completed
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
+  - JSONPath: .status.backupPath
+    description: The full path of backup data
+    name: BackupPath
+    type: string
+  - JSONPath: .status.backupSize
+    description: The data size of the backup
+    name: BackupSize
+    type: integer
+  - JSONPath: .status.commitTs
+    description: The commit ts of tidb cluster dump
+    name: CommitTS
+    type: string
+  - JSONPath: .status.timeStarted
+    description: The time at which the backup was started
+    format: date-time
+    name: Started
+    priority: 1
+    type: string
+  - JSONPath: .status.timeCompleted
+    description: The time at which the backup was completed
+    format: date-time
+    name: Completed
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: Backup
     plural: backups
     shortNames:
-      - bk
+    - bk
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -4728,8 +4728,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -4744,8 +4744,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                             type: object
@@ -4753,8 +4753,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - preference
+                        - weight
+                        - preference
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4774,8 +4774,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -4790,14 +4790,14 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                             type: object
                           type: array
                       required:
-                        - nodeSelectorTerms
+                      - nodeSelectorTerms
                       type: object
                   type: object
                 podAffinity:
@@ -4821,8 +4821,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -4835,14 +4835,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - podAffinityTerm
+                        - weight
+                        - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4862,8 +4862,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -4876,7 +4876,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                          - topologyKey
+                        - topologyKey
                         type: object
                       type: array
                   type: object
@@ -4901,8 +4901,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -4915,14 +4915,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - podAffinityTerm
+                        - weight
+                        - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4942,8 +4942,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -4956,7 +4956,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                          - topologyKey
+                        - topologyKey
                         type: object
                       type: array
                   type: object
@@ -4992,7 +4992,7 @@ spec:
                 timeAgo:
                   type: string
               required:
-                - cluster
+              - cluster
               type: object
             from:
               properties:
@@ -5008,8 +5008,8 @@ spec:
                 user:
                   type: string
               required:
-                - host
-                - secretName
+              - host
+              - secretName
               type: object
             gcs:
               properties:
@@ -5032,8 +5032,8 @@ spec:
                 storageClass:
                   type: string
               required:
-                - projectId
-                - secretName
+              - projectId
+              - secretName
               type: object
             imagePullSecrets:
               items:
@@ -5085,7 +5085,7 @@ spec:
                 storageClass:
                   type: string
               required:
-                - provider
+              - provider
               type: object
             serviceAccount:
               type: string
@@ -5124,25 +5124,25 @@ metadata:
   name: restores.pingcap.com
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.timeStarted
-      description: The time at which the backup was started
-      format: date-time
-      name: Started
-      type: string
-    - JSONPath: .status.timeCompleted
-      description: The time at which the restore was completed
-      format: date-time
-      name: Completed
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
+  - JSONPath: .status.timeStarted
+    description: The time at which the backup was started
+    format: date-time
+    name: Started
+    type: string
+  - JSONPath: .status.timeCompleted
+    description: The time at which the restore was completed
+    format: date-time
+    name: Completed
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: pingcap.com
   names:
     kind: Restore
     plural: restores
     shortNames:
-      - rt
+    - rt
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -5174,8 +5174,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -5190,8 +5190,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                             type: object
@@ -5199,8 +5199,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - preference
+                        - weight
+                        - preference
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5220,8 +5220,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -5236,14 +5236,14 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                             type: object
                           type: array
                       required:
-                        - nodeSelectorTerms
+                      - nodeSelectorTerms
                       type: object
                   type: object
                 podAffinity:
@@ -5267,8 +5267,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -5281,14 +5281,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - podAffinityTerm
+                        - weight
+                        - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5308,8 +5308,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -5322,7 +5322,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                          - topologyKey
+                        - topologyKey
                         type: object
                       type: array
                   type: object
@@ -5347,8 +5347,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -5361,14 +5361,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                          - weight
-                          - podAffinityTerm
+                        - weight
+                        - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5388,8 +5388,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                    - key
-                                    - operator
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -5402,7 +5402,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                          - topologyKey
+                        - topologyKey
                         type: object
                       type: array
                   type: object
@@ -5438,7 +5438,7 @@ spec:
                 timeAgo:
                   type: string
               required:
-                - cluster
+              - cluster
               type: object
             gcs:
               properties:
@@ -5461,8 +5461,8 @@ spec:
                 storageClass:
                   type: string
               required:
-                - projectId
-                - secretName
+              - projectId
+              - secretName
               type: object
             imagePullSecrets:
               items:
@@ -5505,7 +5505,7 @@ spec:
                 storageClass:
                   type: string
               required:
-                - provider
+              - provider
               type: object
             serviceAccount:
               type: string
@@ -5529,8 +5529,8 @@ spec:
                 user:
                   type: string
               required:
-                - host
-                - secretName
+              - host
+              - secretName
               type: object
             tolerations:
               items:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4664,37 +4664,39 @@ metadata:
   name: backups.pingcap.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.backupPath
-    description: The full path of backup data
-    name: BackupPath
-    type: string
-  - JSONPath: .status.backupSize
-    description: The data size of the backup
-    name: BackupSize
-    type: integer
-  - JSONPath: .status.commitTs
-    description: The commit ts of tidb cluster dump
-    name: CommitTS
-    type: string
-  - JSONPath: .status.timeStarted
-    description: The time at which the backup was started
-    name: Started
-    priority: 1
-    type: date
-  - JSONPath: .status.timeCompleted
-    description: The time at which the backup was completed
-    name: Completed
-    priority: 1
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
+    - JSONPath: .status.backupPath
+      description: The full path of backup data
+      name: BackupPath
+      type: string
+    - JSONPath: .status.backupSize
+      description: The data size of the backup
+      name: BackupSize
+      type: integer
+    - JSONPath: .status.commitTs
+      description: The commit ts of tidb cluster dump
+      name: CommitTS
+      type: string
+    - JSONPath: .status.timeStarted
+      description: The time at which the backup was started
+      format: date-time
+      name: Started
+      priority: 1
+      type: string
+    - JSONPath: .status.timeCompleted
+      description: The time at which the backup was completed
+      format: date-time
+      name: Completed
+      priority: 1
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   group: pingcap.com
   names:
     kind: Backup
     plural: backups
     shortNames:
-    - bk
+      - bk
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -4726,8 +4728,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -4742,8 +4744,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
@@ -4751,8 +4753,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - preference
+                          - weight
+                          - preference
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4772,8 +4774,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -4788,14 +4790,14 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                        - nodeSelectorTerms
                       type: object
                   type: object
                 podAffinity:
@@ -4819,8 +4821,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -4833,14 +4835,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - podAffinityTerm
+                          - weight
+                          - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4860,8 +4862,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -4874,7 +4876,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -4899,8 +4901,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -4913,14 +4915,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - podAffinityTerm
+                          - weight
+                          - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -4940,8 +4942,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -4954,7 +4956,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -4990,7 +4992,7 @@ spec:
                 timeAgo:
                   type: string
               required:
-              - cluster
+                - cluster
               type: object
             from:
               properties:
@@ -5006,8 +5008,8 @@ spec:
                 user:
                   type: string
               required:
-              - host
-              - secretName
+                - host
+                - secretName
               type: object
             gcs:
               properties:
@@ -5030,8 +5032,8 @@ spec:
                 storageClass:
                   type: string
               required:
-              - projectId
-              - secretName
+                - projectId
+                - secretName
               type: object
             imagePullSecrets:
               items:
@@ -5083,7 +5085,7 @@ spec:
                 storageClass:
                   type: string
               required:
-              - provider
+                - provider
               type: object
             serviceAccount:
               type: string
@@ -5122,23 +5124,25 @@ metadata:
   name: restores.pingcap.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.timeStarted
-    description: The time at which the backup was started
-    name: Started
-    type: date
-  - JSONPath: .status.timeCompleted
-    description: The time at which the restore was completed
-    name: Completed
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
+    - JSONPath: .status.timeStarted
+      description: The time at which the backup was started
+      format: date-time
+      name: Started
+      type: string
+    - JSONPath: .status.timeCompleted
+      description: The time at which the restore was completed
+      format: date-time
+      name: Completed
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   group: pingcap.com
   names:
     kind: Restore
     plural: restores
     shortNames:
-    - rt
+      - rt
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -5170,8 +5174,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -5186,8 +5190,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
@@ -5195,8 +5199,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - preference
+                          - weight
+                          - preference
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5216,8 +5220,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -5232,14 +5236,14 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                        - nodeSelectorTerms
                       type: object
                   type: object
                 podAffinity:
@@ -5263,8 +5267,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -5277,14 +5281,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - podAffinityTerm
+                          - weight
+                          - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5304,8 +5308,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -5318,7 +5322,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -5343,8 +5347,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -5357,14 +5361,14 @@ spec:
                               topologyKey:
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             format: int32
                             type: integer
                         required:
-                        - weight
-                        - podAffinityTerm
+                          - weight
+                          - podAffinityTerm
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -5384,8 +5388,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -5398,7 +5402,7 @@ spec:
                           topologyKey:
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -5434,7 +5438,7 @@ spec:
                 timeAgo:
                   type: string
               required:
-              - cluster
+                - cluster
               type: object
             gcs:
               properties:
@@ -5457,8 +5461,8 @@ spec:
                 storageClass:
                   type: string
               required:
-              - projectId
-              - secretName
+                - projectId
+                - secretName
               type: object
             imagePullSecrets:
               items:
@@ -5501,7 +5505,7 @@ spec:
                 storageClass:
                   type: string
               required:
-              - provider
+                - provider
               type: object
             serviceAccount:
               type: string
@@ -5525,8 +5529,8 @@ spec:
                 user:
                   type: string
               required:
-              - host
-              - secretName
+                - host
+                - secretName
               type: object
             tolerations:
               items:

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -122,14 +122,16 @@ var (
 	}
 	backupStartedColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Started",
-		Type:        "date",
+		Type:        "string",
+		Format:      "date-time",
 		Description: "The time at which the backup was started",
 		Priority:    1,
 		JSONPath:    ".status.timeStarted",
 	}
 	backupCompletedColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Completed",
-		Type:        "date",
+		Type:        "string",
+		Format:      "date-time",
 		Description: "The time at which the backup was completed",
 		Priority:    1,
 		JSONPath:    ".status.timeCompleted",
@@ -137,13 +139,15 @@ var (
 	restoreAdditionalPrinterColumns []extensionsobj.CustomResourceColumnDefinition
 	restoreStartedColumn            = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Started",
-		Type:        "date",
+		Type:        "string",
+		Format:      "date-time",
 		Description: "The time at which the backup was started",
 		JSONPath:    ".status.timeStarted",
 	}
 	restoreCompletedColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Completed",
-		Type:        "date",
+		Type:        "string",
+		Format:      "date-time",
 		Description: "The time at which the restore was completed",
 		JSONPath:    ".status.timeCompleted",
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix https://github.com/pingcap/tidb-operator/issues/2659
### What is changed and how does it work?
previous: 
```
➜  ~ kubectl get bk -o wide
NAME              BACKUPPATH   BACKUPSIZE   COMMITTS   STARTED   COMPLETED   AGE
demo1-backup-s3                0                       14m       14m         14m
```
now:
```
➜  ~ kubectl get bk -o wide
NAME              BACKUPPATH   BACKUPSIZE   COMMITTS   STARTED                COMPLETED              AGE
demo1-backup-s3                0                       2020-06-16T10:20:28Z   2020-06-16T10:20:28Z   9m51s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ]  - Unit test
- [ ]  - E2E test
- [ ]  - Stability test
- [x]  - Manual test (add detailed scripts or steps below)
- [ ]  - No code

Code changes

- [x]  - Has Go code change
- [ ]  - Has CI related scripts change
- [ ]  - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
