### PR TITLE
Added "path" to S3StorageProvider API doc

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -7883,6 +7883,17 @@ string
 </tr>
 <tr>
 <td>
+<code>path</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Full path to file in S3, in the format s3://bucket/prefix/backup-date-time.tgz</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bucket</code></br>
 <em>
 string
@@ -7945,7 +7956,7 @@ string
 </em>
 </td>
 <td>
-<p>Prefix of the data path.</p>
+<p>Prefix (subdirectory) for the backup file.</p>
 </td>
 </tr>
 <tr>
@@ -7967,7 +7978,7 @@ string
 </em>
 </td>
 <td>
-<p>Options Rclone options for backup and restore with mydumper and lightning.</p>
+<p>rclone options for backup and restore with mydumper and Lightning.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

The "path" item was missing from the API docs for S3StorageProvider.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
