### PR TITLE
revert tidb v3 version change

### DIFF
--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	TiDBV3Version                 = "v3.1.1"
-	TiDBV3UpgradeVersion          = "v3.1.2"
+	TiDBV3Version                 = "v3.0.8"
+	TiDBV3UpgradeVersion          = "v3.0.9"
 	TiDBV4Version                 = "v4.0.0-rc.2"
 	TiDBV4UpgradeVersion          = "v4.0.0"
 	PrometheusImage               = "prom/prometheus"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
ref: https://github.com/pingcap/tidb-operator/issues/2761
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
