### PR TITLE
Move compatible filterLeaderEvictScheduler in pdapi

### DIFF
--- a/pkg/webhook/pod/tikv_creater.go
+++ b/pkg/webhook/pod/tikv_creater.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	tikvNotBootstrapped  = `TiKV cluster not bootstrapped, please start TiKV first"`
+	tikvNotBootstrapped = `TiKV cluster not bootstrapped, please start TiKV first"`
 )
 
 func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, tc *v1alpha1.TidbCluster, pdClient pdapi.PDClient) *admission.AdmissionResponse {

--- a/pkg/webhook/pod/tikv_creater.go
+++ b/pkg/webhook/pod/tikv_creater.go
@@ -14,7 +14,6 @@
 package pod
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -29,13 +28,7 @@ import (
 
 const (
 	tikvNotBootstrapped  = `TiKV cluster not bootstrapped, please start TiKV first"`
-	evictSchedulerLeader = "evict-leader-scheduler"
 )
-
-// Payload only used to unmarshal the data from pdapi
-type Payload struct {
-	StoreIdRanges map[string]interface{} `json:"store-id-ranges"`
-}
 
 func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, tc *v1alpha1.TidbCluster, pdClient pdapi.PDClient) *admission.AdmissionResponse {
 
@@ -67,9 +60,10 @@ func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, tc *v1alpha1.Ti
 		return util.ARSuccess()
 	}
 
-	schedulerIds, err := filterLeaderEvictScheduler(evictLeaderSchedulers, pdClient)
-	if err != nil {
-		return util.ARFail(err)
+	schedulerIds := sets.String{}
+	for _, s := range evictLeaderSchedulers {
+		id := strings.Split(s, "-")[3]
+		schedulerIds.Insert(id)
 	}
 
 	// if the pod which is going to be created already have a store and was in evictLeaderSchedulers,
@@ -88,35 +82,4 @@ func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, tc *v1alpha1.Ti
 	}
 
 	return util.ARSuccess()
-}
-
-// This method is to make compatible between old pdapi version and 4.0 pdapi version.
-// To get more detail, see: https://github.com/pingcap/tidb-operator/pull/1831
-func filterLeaderEvictScheduler(evictLeaderSchedulers []string, pdClient pdapi.PDClient) (sets.String, error) {
-	schedulerIds := sets.String{}
-	if len(evictLeaderSchedulers) == 1 && evictLeaderSchedulers[0] == evictSchedulerLeader {
-		c, err := pdClient.GetConfig()
-		if err != nil {
-			return schedulerIds, err
-		}
-		if c.Schedule != nil && c.Schedule.SchedulersPayload != nil {
-			v, ok := c.Schedule.SchedulersPayload[evictSchedulerLeader]
-			if ok {
-				payload := &Payload{}
-				err := json.Unmarshal([]byte(v), payload)
-				if err != nil {
-					return schedulerIds, err
-				}
-				for k := range payload.StoreIdRanges {
-					schedulerIds.Insert(k)
-				}
-			}
-		}
-	} else {
-		for _, s := range evictLeaderSchedulers {
-			id := strings.Split(s, "-")[3]
-			schedulerIds.Insert(id)
-		}
-	}
-	return schedulerIds, nil
 }

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	TiDBV3Version                 = "v3.0.8"
-	TiDBV3UpgradeVersion          = "v3.0.9"
+	TiDBV3Version                 = "v3.1.1"
+	TiDBV3UpgradeVersion          = "v3.1.2"
 	TiDBV4Version                 = "v4.0.0-rc.2"
 	TiDBV4UpgradeVersion          = "v4.0.0"
 	PrometheusImage               = "prom/prometheus"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Move `filterLeaderEvictScheduler` into pdapi function to make `GetEvictLeaderSchedulers` function common used both for PD 3.0.x and 4.0.x

fixes https://github.com/pingcap/tidb-operator/issues/2761

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
