### PR TITLE
add humanreadable backup size

### DIFF
--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -315,6 +316,7 @@ func (bm *Manager) performBackup(backup *v1alpha1.Backup, db *sql.DB) error {
 	backup.Status.TimeStarted = metav1.Time{Time: started}
 	backup.Status.TimeCompleted = metav1.Time{Time: finish}
 	backup.Status.BackupSize = size
+	backup.Status.BackupSizeReadable = humanize.Bytes(uint64(size))
 	backup.Status.CommitTs = fmt.Sprintf("%d", commitTs)
 
 	return bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -336,6 +337,7 @@ func (bm *BackupManager) performBackup(backup *v1alpha1.Backup, db *sql.DB) erro
 	backup.Status.TimeStarted = metav1.Time{Time: started}
 	backup.Status.TimeCompleted = metav1.Time{Time: finish}
 	backup.Status.BackupSize = size
+	backup.Status.BackupSizeReadable = humanize.Bytes(uint64(size))
 	backup.Status.CommitTs = commitTs
 
 	return bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2409,6 +2409,18 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
+<code>backupSizeReadable</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>BackupSizeReadable is the data size of the backup.
+the difference with BackupSize is that its format is human readable</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>backupSize</code></br>
 <em>
 int64

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4668,10 +4668,10 @@ spec:
     description: The full path of backup data
     name: BackupPath
     type: string
-  - JSONPath: .status.backupSize
+  - JSONPath: .status.backupSizeReadable
     description: The data size of the backup
     name: BackupSize
-    type: integer
+    type: string
   - JSONPath: .status.commitTs
     description: The commit ts of tidb cluster dump
     name: CommitTS

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1182,6 +1182,9 @@ type BackupStatus struct {
 	TimeStarted metav1.Time `json:"timeStarted"`
 	// TimeCompleted is the time at which the backup was completed.
 	TimeCompleted metav1.Time `json:"timeCompleted"`
+	// BackupSizeReadable is the data size of the backup.
+	// the difference with BackupSize is that its format is human readable
+	BackupSizeReadable string `json:"backupSizeReadable"`
 	// BackupSize is the data size of the backup.
 	BackupSize int64 `json:"backupSize"`
 	// CommitTs is the snapshot time point of tidb cluster.

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -110,9 +110,9 @@ var (
 	}
 	backupBackupSizeColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "BackupSize",
-		Type:        "integer",
+		Type:        "string",
 		Description: "The data size of the backup",
-		JSONPath:    ".status.backupSize",
+		JSONPath:    ".status.backupSizeReadable",
 	}
 	backupCommitTSColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "CommitTS",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fixes https://github.com/pingcap/tidb-operator/issues/2634

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ]  - Unit test
- [ ]  - E2E test
- [ ]  - Stability test
- [x]  - Manual test (add detailed scripts or steps below)
- [ ]  - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
