### PR TITLE
update PD config API schema and use evictSchedulerLeader config API

### DIFF
--- a/pkg/pdapi/pd_config.go
+++ b/pkg/pdapi/pd_config.go
@@ -193,7 +193,7 @@ type PDScheduleConfig struct {
 	Schedulers *PDSchedulerConfigs `toml:"schedulers,omitempty" json:"schedulers-v2,omitempty"` // json v2 is for the sake of compatible upgrade
 
 	// Only used to display
-	SchedulersPayload map[string]string `toml:"schedulers-payload" json:"schedulers-payload,omitempty"`
+	SchedulersPayload map[string]interface{} `toml:"schedulers-payload" json:"schedulers-payload,omitempty"`
 
 	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into the next region of it.
 	// Imported from v3.1.0
@@ -262,4 +262,12 @@ func (s *StringSlice) UnmarshalJSON(text []byte) error {
 	}
 	*s = strings.Split(data, ",")
 	return nil
+}
+
+// evictLeaderSchedulerConfig holds configuration for evict leader
+// https://github.com/pingcap/pd/blob/b21855a3aeb787c71b0819743059e432be217dcd/server/schedulers/evict_leader.go#L81-L86
+// note that we use `interface{}` as the type of value because we don't care
+// about the value for now
+type evictLeaderSchedulerConfig struct {
+	StoreIDWithRanges map[uint64]interface{} `json:"store-id-ranges"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #2805 
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
ACTION REQUIRED: PD v4.0.2 introduced a breaking change in config API, please upgrade tidb-operator tor v1.1.2 when deploying the TiDB after v4.0.2
```
