### PR TITLE
Replace controller.Int32Ptr with k8s.io/utils/pointer.Int32Ptr

### DIFF
--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 // BackupCleaner implements the logic for cleaning backup
@@ -163,7 +164,7 @@ func (bc *backupCleaner) makeCleanJob(backup *v1alpha1.Backup) (*batchv1.Job, st
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(constants.DefaultBackoffLimit),
+			BackoffLimit: pointer.Int32Ptr(constants.DefaultBackoffLimit),
 			Template:     *podSpec,
 		},
 	}

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 type backupManager struct {
@@ -254,7 +255,7 @@ func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(0),
+			BackoffLimit: pointer.Int32Ptr(0),
 			Template:     *podSpec,
 		},
 	}
@@ -384,7 +385,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(0),
+			BackoffLimit: pointer.Int32Ptr(0),
 			Template:     *podSpec,
 		},
 	}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 type restoreManager struct {
@@ -240,7 +241,7 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(0),
+			BackoffLimit: pointer.Int32Ptr(0),
 			Template:     *podSpec,
 		},
 	}
@@ -368,7 +369,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(0),
+			BackoffLimit: pointer.Int32Ptr(0),
 			Template:     *podSpec,
 		},
 	}

--- a/pkg/controller/backupschedule/backup_schedule_controller_test.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller_test.go
@@ -18,19 +18,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pingcap/tidb-operator/pkg/backup/constants"
-
-	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/backup/constants"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned/fake"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions"
-	"github.com/pingcap/tidb-operator/pkg/controller"
+
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
 )
 
 func TestBackupScheduleControllerEnqueueBackupSchedule(t *testing.T) {
@@ -179,7 +179,7 @@ func newBackupSchedule() *v1alpha1.BackupSchedule {
 		},
 		Spec: v1alpha1.BackupScheduleSpec{
 			Schedule:   "1 */10 * * *",
-			MaxBackups: controller.Int32Ptr(10),
+			MaxBackups: pointer.Int32Ptr(10),
 			BackupTemplate: v1alpha1.BackupSpec{
 				From: v1alpha1.TiDBAccessConfig{
 					Host:       "10.1.1.2",

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -393,11 +393,6 @@ func setIfNotEmpty(container map[string]string, key, value string) {
 	}
 }
 
-// Int32Ptr returns a pointer to an int32
-func Int32Ptr(i int32) *int32 {
-	return &i
-}
-
 // RequestTracker is used by unit test for mocking request error
 type RequestTracker struct {
 	requests int

--- a/pkg/controller/generic_control_test.go
+++ b/pkg/controller/generic_control_test.go
@@ -18,15 +18,16 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb-operator/pkg/scheme"
+
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	. "github.com/onsi/gomega"
 )
 
 // TODO: more UTs
@@ -75,7 +76,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							DNSPolicy: corev1.DNSClusterFirst,
@@ -86,7 +87,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 			mergeFn: mergeFn,
 			expectFn: func(g *GomegaWithT, c *FakeClientWithTracker, result *appsv1.Deployment, err error) {
 				g.Expect(err).To(Succeed())
-				g.Expect(result.Spec.Replicas).To(Equal(Int32Ptr(1)))
+				g.Expect(result.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 				g.Expect(c.CreateTracker.GetRequests()).To(Equal(1))
 				g.Expect(c.UpdateTracker.GetRequests()).To(Equal(0))
 			},
@@ -99,7 +100,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							DNSPolicy: corev1.DNSClusterFirst,
@@ -113,7 +114,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							DNSPolicy: corev1.DNSClusterFirstWithHostNet,
@@ -124,7 +125,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 			mergeFn: mergeFn,
 			expectFn: func(g *GomegaWithT, c *FakeClientWithTracker, result *appsv1.Deployment, err error) {
 				g.Expect(err).To(Succeed())
-				g.Expect(result.Spec.Replicas).To(Equal(Int32Ptr(2)))
+				g.Expect(result.Spec.Replicas).To(Equal(pointer.Int32Ptr(2)))
 				g.Expect(result.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirstWithHostNet))
 				g.Expect(c.CreateTracker.GetRequests()).To(Equal(1))
 				g.Expect(c.UpdateTracker.GetRequests()).To(Equal(1))
@@ -138,7 +139,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Paused:   true,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -153,7 +154,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 					Paused:   false,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -165,7 +166,7 @@ func TestGenericControlInterface_CreateOrUpdate(t *testing.T) {
 			mergeFn: mergeFn,
 			expectFn: func(g *GomegaWithT, c *FakeClientWithTracker, result *appsv1.Deployment, err error) {
 				g.Expect(err).To(Succeed())
-				g.Expect(result.Spec.Replicas).To(Equal(Int32Ptr(2)))
+				g.Expect(result.Spec.Replicas).To(Equal(pointer.Int32Ptr(2)))
 				g.Expect(result.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirstWithHostNet))
 				g.Expect(result.Spec.Paused).To(BeTrue())
 				g.Expect(c.CreateTracker.GetRequests()).To(Equal(1))
@@ -221,7 +222,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 				"k": "v",
 			}},
-			Replicas: Int32Ptr(1),
+			Replicas: pointer.Int32Ptr(1),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -244,7 +245,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							DNSPolicy: corev1.DNSClusterFirst,
@@ -271,7 +272,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"k": "v",
 					}},
-					Replicas: Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -293,7 +294,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"k2": "v2",
 					}},
-					Replicas: Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -308,7 +309,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, c *FakeClientWithTracker, result *appsv1.Deployment, err error) {
 				g.Expect(err).To(Succeed())
-				g.Expect(result.Spec.Replicas).To(Equal(Int32Ptr(2)))
+				g.Expect(result.Spec.Replicas).To(Equal(pointer.Int32Ptr(2)))
 				g.Expect(result.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirstWithHostNet))
 				g.Expect(result.Spec.Selector.MatchLabels["k"]).To(Equal("v"))
 				g.Expect(result.Spec.Template.Labels["k"]).To(Equal("v"))

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -699,7 +699,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tc.Spec.PD.Replicas + int32(failureReplicas)),
+			Replicas: pointer.Int32Ptr(tc.Spec.PD.Replicas + int32(failureReplicas)),
 			Selector: pdLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -727,7 +727,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: controller.Int32Ptr(tc.Spec.PD.Replicas + int32(failureReplicas)),
+					Partition: pointer.Int32Ptr(tc.Spec.PD.Replicas + int32(failureReplicas)),
 				}},
 		},
 	}

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -31,6 +31,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 )
 
 func TestPDScalerScaleOut(t *testing.T) {
@@ -59,7 +60,7 @@ func TestPDScalerScaleOut(t *testing.T) {
 
 		oldSet := newStatefulSetForPDScale()
 		newSet := oldSet.DeepCopy()
-		newSet.Spec.Replicas = controller.Int32Ptr(7)
+		newSet.Spec.Replicas = pointer.Int32Ptr(7)
 
 		scaler, _, pvcIndexer, pvcControl := newFakePDScaler()
 
@@ -255,7 +256,7 @@ func TestPDScalerScaleIn(t *testing.T) {
 
 		oldSet := newStatefulSetForPDScale()
 		newSet := oldSet.DeepCopy()
-		newSet.Spec.Replicas = controller.Int32Ptr(3)
+		newSet.Spec.Replicas = pointer.Int32Ptr(3)
 
 		scaler, pdControl, pvcIndexer, pvcControl := newFakePDScaler()
 
@@ -442,7 +443,7 @@ func newStatefulSetForPDScale() *apps.StatefulSet {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(5),
+			Replicas: pointer.Int32Ptr(5),
 		},
 	}
 	return set

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -80,7 +80,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 		}
 		SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 
-		newSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(3)
+		newSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(3)
 
 		err := upgrader.Upgrade(tc, oldSet, newSet)
 		test.errExpectFn(g, err)
@@ -101,7 +101,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 		{
@@ -159,7 +159,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(3)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.ScalePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(3)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
 			},
 		},
 		{
@@ -194,7 +194,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(3)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(2)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(2)))
 			},
 		},
 		{
@@ -226,7 +226,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(2)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(2)))
 			},
 		},
 		{
@@ -241,7 +241,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.NormalPhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(3)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			},
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(2)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(2)))
 			},
 		},
 	}
@@ -287,7 +287,7 @@ func newStatefulSetForPDUpgrader() *apps.StatefulSet {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(3),
+			Replicas: pointer.Int32Ptr(3),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -300,7 +300,7 @@ func newStatefulSetForPDUpgrader() *apps.StatefulSet {
 			},
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type:          apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: controller.Int32Ptr(2)},
+				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: pointer.Int32Ptr(2)},
 			},
 		},
 		Status: apps.StatefulSetStatus{

--- a/pkg/manager/member/scaler_test.go
+++ b/pkg/manager/member/scaler_test.go
@@ -34,6 +34,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 func TestGeneralScalerDeleteAllDeferDeletingPVC(t *testing.T) {
@@ -192,13 +193,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 				},
 			},
 			[]scaleOp{
@@ -215,13 +216,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			[]scaleOp{
@@ -238,13 +239,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(8),
+					Replicas: pointer.Int32Ptr(8),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(6),
+					Replicas: pointer.Int32Ptr(6),
 				},
 			},
 			[]scaleOp{
@@ -267,13 +268,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			[]scaleOp{
@@ -296,13 +297,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 				},
 			},
 			[]scaleOp{
@@ -319,13 +320,13 @@ func TestScaleOne(t *testing.T) {
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(3),
+					Replicas: pointer.Int32Ptr(3),
 				},
 			},
 			&apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(5),
+					Replicas: pointer.Int32Ptr(5),
 				},
 			},
 			[]scaleOp{
@@ -353,7 +354,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(5),
+					Replicas: pointer.Int32Ptr(5),
 				},
 			},
 			// 0, 4, 5
@@ -364,7 +365,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(3),
+					Replicas: pointer.Int32Ptr(3),
 				},
 			},
 			[]scaleOp{
@@ -392,7 +393,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 				},
 			},
 			// <none>
@@ -401,7 +402,7 @@ func TestScaleOne(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			[]scaleOp{
@@ -429,7 +430,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 				},
 			},
 			// <none>
@@ -440,7 +441,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			[]scaleOp{
@@ -466,7 +467,7 @@ func TestScaleOne(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			// 1,2
@@ -477,7 +478,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 				},
 			},
 			[]scaleOp{
@@ -505,7 +506,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(3),
+					Replicas: pointer.Int32Ptr(3),
 				},
 			},
 			// 0, 2, 3, 4, 5
@@ -516,7 +517,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(5),
+					Replicas: pointer.Int32Ptr(5),
 				},
 			},
 			[]scaleOp{
@@ -542,7 +543,7 @@ func TestScaleOne(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(0),
+					Replicas: pointer.Int32Ptr(0),
 				},
 			},
 			// 1,2
@@ -553,7 +554,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(2),
+					Replicas: pointer.Int32Ptr(2),
 				},
 			},
 			[]scaleOp{
@@ -581,7 +582,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(4),
+					Replicas: pointer.Int32Ptr(4),
 				},
 			},
 			&apps.StatefulSet{
@@ -591,7 +592,7 @@ func TestScaleOne(t *testing.T) {
 					},
 				},
 				Spec: apps.StatefulSetSpec{
-					Replicas: controller.Int32Ptr(4),
+					Replicas: pointer.Int32Ptr(4),
 				},
 			},
 			[]scaleOp{

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -32,6 +32,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 // ticdcMemberManager implements manager.Manager.
@@ -314,7 +315,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster) (*apps.StatefulSet, error)
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tc.TiCDCDeployDesiredReplicas()),
+			Replicas: pointer.Int32Ptr(tc.TiCDCDeployDesiredReplicas()),
 			Selector: ticdcLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_discovery_manager.go
+++ b/pkg/manager/member/tidb_discovery_manager.go
@@ -26,6 +26,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -136,7 +137,7 @@ func getTidbDiscoveryDeployment(tc *v1alpha1.TidbCluster) (*appsv1.Deployment, e
 		ObjectMeta: meta,
 		Spec: appsv1.DeploymentSpec{
 			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
-			Replicas: controller.Int32Ptr(1),
+			Replicas: pointer.Int32Ptr(1),
 			Selector: l.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tidb_init_manager.go
+++ b/pkg/manager/member/tidb_init_manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"github.com/pingcap/tidb-operator/pkg/util"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -368,7 +369,7 @@ func (tm *tidbInitManager) makeTiDBInitJob(ti *v1alpha1.TidbInitializer) (*batch
 	job := &batchv1.Job{
 		ObjectMeta: meta,
 		Spec: batchv1.JobSpec{
-			BackoffLimit: controller.Int32Ptr(0),
+			BackoffLimit: pointer.Int32Ptr(0),
 			Template:     *podSpec,
 		},
 	}

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -743,7 +743,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tc.TiDBStsDesiredReplicas()),
+			Replicas: pointer.Int32Ptr(tc.TiDBStsDesiredReplicas()),
 			Selector: tidbLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -755,7 +755,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			ServiceName:         controller.TiDBPeerMemberName(tcName),
 			PodManagementPolicy: apps.ParallelPodManagement,
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: controller.Int32Ptr(tc.TiDBStsDesiredReplicas())},
+				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: pointer.Int32Ptr(tc.TiDBStsDesiredReplicas())},
 			},
 		},
 	}

--- a/pkg/manager/member/tidb_upgrader_test.go
+++ b/pkg/manager/member/tidb_upgrader_test.go
@@ -84,7 +84,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			getLastAppliedConfigErr: false,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(0)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(0)))
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			},
 			getLastAppliedConfigErr: false,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			},
 			getLastAppliedConfigErr: false,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 		{
@@ -153,7 +153,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			getLastAppliedConfigErr: false,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			getLastAppliedConfigErr: true,
 			errorExpect:             true,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 		{
@@ -182,7 +182,7 @@ func TestTiDBUpgrader_Upgrade(t *testing.T) {
 			errorExpect:             true,
 			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.UpgradePhase))
-				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(controller.Int32Ptr(1)))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 			},
 		},
 	}
@@ -207,7 +207,7 @@ func newStatefulSetForTiDBUpgrader() *apps.StatefulSet {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(2),
+			Replicas: pointer.Int32Ptr(2),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -220,7 +220,7 @@ func newStatefulSetForTiDBUpgrader() *apps.StatefulSet {
 			},
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: controller.Int32Ptr(1),
+					Partition: pointer.Int32Ptr(1),
 				},
 			},
 		},

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -529,7 +529,7 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tc.TiFlashStsDesiredReplicas()),
+			Replicas: pointer.Int32Ptr(tc.TiFlashStsDesiredReplicas()),
 			Selector: tiflashLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/tikv_group_member_manager.go
+++ b/pkg/manager/member/tikv_group_member_manager.go
@@ -633,7 +633,7 @@ func getNewTiKVSetForTiKVGroup(tg *v1alpha1.TiKVGroup, tc *v1alpha1.TidbCluster,
 			OwnerReferences: []metav1.OwnerReference{controller.GetTiKVGroupOwnerRef(tg)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tg.TiKVStsDesiredReplicas()),
+			Replicas: pointer.Int32Ptr(tg.TiKVStsDesiredReplicas()),
 			Selector: tikvLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -650,7 +650,7 @@ func getNewTiKVSetForTiKVGroup(tg *v1alpha1.TiKVGroup, tc *v1alpha1.TidbCluster,
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: controller.Int32Ptr(tg.TiKVStsDesiredReplicas()),
+					Partition: pointer.Int32Ptr(tg.TiKVStsDesiredReplicas()),
 				},
 			},
 		},

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -38,6 +38,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -486,7 +487,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(tc.TiKVStsDesiredReplicas()),
+			Replicas: pointer.Int32Ptr(tc.TiKVStsDesiredReplicas()),
 			Selector: tikvLabel.LabelSelector(),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -503,7 +504,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: controller.Int32Ptr(tc.TiKVStsDesiredReplicas()),
+					Partition: pointer.Int32Ptr(tc.TiKVStsDesiredReplicas()),
 				},
 			},
 		},

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -29,6 +29,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 )
 
 func TestTiKVScalerScaleOut(t *testing.T) {
@@ -54,7 +55,7 @@ func TestTiKVScalerScaleOut(t *testing.T) {
 
 		oldSet := newStatefulSetForPDScale()
 		newSet := oldSet.DeepCopy()
-		newSet.Spec.Replicas = controller.Int32Ptr(7)
+		newSet.Spec.Replicas = pointer.Int32Ptr(7)
 
 		scaler, _, pvcIndexer, _, pvcControl := newFakeTiKVScaler()
 
@@ -171,7 +172,7 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 
 		oldSet := newStatefulSetForPDScale()
 		newSet := oldSet.DeepCopy()
-		newSet.Spec.Replicas = controller.Int32Ptr(3)
+		newSet.Spec.Replicas = pointer.Int32Ptr(3)
 
 		pod := &corev1.Pod{
 			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},

--- a/pkg/manager/member/tikv_upgrader_test.go
+++ b/pkg/manager/member/tikv_upgrader_test.go
@@ -206,7 +206,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods: func(pods []*corev1.Pod) {
 				for _, pod := range pods {
@@ -347,7 +347,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods:          nil,
 			beginEvictLeaderErr: false,
@@ -375,7 +375,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods: func(pods []*corev1.Pod) {
 				for _, pod := range pods {
@@ -409,7 +409,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods:          nil,
 			beginEvictLeaderErr: true,
@@ -437,7 +437,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods: func(pods []*corev1.Pod) {
 				for _, pod := range pods {
@@ -469,7 +469,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods: func(pods []*corev1.Pod) {
 				for _, pod := range pods {
@@ -501,7 +501,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods:          nil,
 			beginEvictLeaderErr: false,
@@ -527,7 +527,7 @@ func TestTiKVUpgraderUpgrade(t *testing.T) {
 				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
 				oldSet.Status.CurrentReplicas = 2
 				oldSet.Status.UpdatedReplicas = 1
-				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = controller.Int32Ptr(2)
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
 			},
 			changePods: func(pods []*corev1.Pod) {
 				for _, pod := range pods {
@@ -573,7 +573,7 @@ func newStatefulSetForTiKVUpgrader() *apps.StatefulSet {
 			Labels:    label.New().Instance(upgradeInstanceName).TiKV().Labels(),
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: controller.Int32Ptr(3),
+			Replicas: pointer.Int32Ptr(3),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -587,7 +587,7 @@ func newStatefulSetForTiKVUpgrader() *apps.StatefulSet {
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: controller.Int32Ptr(3),
+					Partition: pointer.Int32Ptr(3),
 				}},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Resolve #2836 

### What is changed and how does it work?
Replace controller.Int32Ptr with k8s.io/utils/pointer.Int32Ptr

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
