### PR TITLE
don't dump StatefulSet spec on update event

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -361,7 +361,7 @@ func (tcc *Controller) addStatefulSet(obj interface{}) {
 	if tc == nil {
 		return
 	}
-	klog.V(4).Infof("StatefuSet %s/%s created, TidbCluster: %s/%s", ns, setName, ns, tc.Name)
+	klog.V(4).Infof("StatefulSet %s/%s created, TidbCluster: %s/%s", ns, setName, ns, tc.Name)
 	tcc.enqueueTidbCluster(tc)
 }
 
@@ -382,7 +382,7 @@ func (tcc *Controller) updateStatefuSet(old, cur interface{}) {
 	if tc == nil {
 		return
 	}
-	klog.V(4).Infof("StatefulSet %s/%s updated, %+v -> %+v.", ns, setName, oldSet.Spec, curSet.Spec)
+	klog.V(4).Infof("StatefulSet %s/%s updated, TidbCluster: %s/%s", ns, setName, ns, tc.Name)
 	tcc.enqueueTidbCluster(tc)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
it has high frequency and normally not useful in debugging (not human readable), e.g.

```
I0701 03:04:59.820980       1 tidb_cluster_controller.go:384] StatefulSet default/basic-tidb updated, {Replicas:0xc0017e7638 Selector:&LabelSelector{MatchLabels:map[string]string{app.kubernetes.io/component: tidb,app.kubernetes.io/instance: basic,app.kubernetes.io/managed-by: tidb-operator,app.kubernetes.io/name: tidb-cluster,},MatchExpressions:[]LabelSelectorRequirement{},} Template:{ObjectMeta:{Name: GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[app.kubernetes.io/component:tidb app.kubernetes.io/instance:basic app.kubernetes.io/managed-by:tidb-operator app.kubernetes.io/name:tidb-cluster] Annotations:map[prometheus.io/path:/metrics prometheus.io/port:10080 prometheus.io/scrape:true] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{Volumes:[{Name:annotations VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:&DownwardAPIVolumeSource{Items:[]DownwardAPIVolumeFile{DownwardAPIVolumeFile{Path:annotations,FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.annotations,},ResourceFieldRef:nil,Mode:nil,},},DefaultMode:*420,} FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:config VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:&ConfigMapVolumeSource{LocalObjectReference:LocalObjectReference{Name:basic-tidb,},Items:[]KeyToPath{KeyToPath{Key:config-file,Path:tidb.toml,Mode:nil,},},DefaultMode:*420,Optional:nil,} VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:startup-script VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:&ConfigMapVolumeSource{LocalObjectReference:LocalObjectReference{Name:basic-tidb,},Items:[]KeyToPath{KeyToPath{Key:startup-script,Path:tidb_start_script.sh,Mode:nil,},},DefaultMode:*420,Optional:nil,} VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:slowlog VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}}] InitContainers:[] Containers:[{Name:slowlog Image:busybox:1.26.2 Command:[sh -c touch /var/log/tidb/slowlog; tail -n0 -F /var/log/tidb/slowlog;] Args:[] WorkingDir: Ports:[] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:slowlog ReadOnly:false MountPath:/var/log/tidb SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:tidb Image:pingcap/tidb:v4.0.0 Command:[/bin/sh /usr/local/bin/tidb_start_script.sh] Args:[] WorkingDir: Ports:[{Name:server HostPort:0 ContainerPort:4000 Protocol:TCP HostIP:} {Name:status HostPort:0 ContainerPort:10080 Protocol:TCP HostIP:}] EnvFrom:[] Env:[{Name:CLUSTER_NAME Value:basic ValueFrom:nil} {Name:TZ Value:UTC ValueFrom:nil} {Name:BINLOG_ENABLED Value:false ValueFrom:nil} {Name:SLOW_LOG_FILE Value:/var/log/tidb/slowlog ValueFrom:nil} {Name:POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:NAMESPACE Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.namespace,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:HEADLESS_SERVICE_NAME Value:basic-tidb-peer ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:annotations ReadOnly:true MountPath:/etc/podinfo SubPath: MountPropagation:<nil> SubPathExpr:} {Name:config ReadOnly:true MountPath:/etc/tidb SubPath: MountPropagation:<nil> SubPathExpr:} {Name:startup-script ReadOnly:true MountPath:/usr/local/bin SubPath: MountPropagation:<nil> SubPathExpr:} {Name:slowlog ReadOnly:false MountPath:/var/log/tidb SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:&Probe{Handler:Handler{Exec:nil,HTTPGet:nil,TCPSocket:&TCPSocketAction{Port:{0 4000 },Host:,},},InitialDelaySeconds:10,TimeoutSeconds:1,PeriodSeconds:10,SuccessThreshold:1,FailureThreshold:3,} StartupProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy:Always TerminationGracePeriodSeconds:0xc0017e79c0 ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[]Sysctl{},WindowsOptions:nil,} ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName:default-scheduler Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[]}} VolumeClaimTemplates:[] ServiceName:basic-tidb-peer PodManagementPolicy:Parallel UpdateStrategy:{Type:RollingUpdate RollingUpdate:&RollingUpdateStatefulSetStrategy{Partition:*1,}} RevisionHistoryLimit:0xc0017e7a34} -> {Replicas:0xc00092fa08 Selector:&LabelSelector{MatchLabels:map[string]string{app.kubernetes.io/component: tidb,app.kubernetes.io/instance: basic,app.kubernetes.io/managed-by: tidb-operator,app.kubernetes.io/name: tidb-cluster,},MatchExpressions:[]LabelSelectorRequirement{},} Template:{ObjectMeta:{Name: GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[app.kubernetes.io/component:tidb app.kubernetes.io/instance:basic app.kubernetes.io/managed-by:tidb-operator app.kubernetes.io/name:tidb-cluster] Annotations:map[prometheus.io/path:/metrics prometheus.io/port:10080 prometheus.io/scrape:true] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{Volumes:[{Name:annotations VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:&DownwardAPIVolumeSource{Items:[]DownwardAPIVolumeFile{DownwardAPIVolumeFile{Path:annotations,FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.annotations,},ResourceFieldRef:nil,Mode:nil,},},DefaultMode:*420,} FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:config VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:&ConfigMapVolumeSource{LocalObjectReference:LocalObjectReference{Name:basic-tidb,},Items:[]KeyToPath{KeyToPath{Key:config-file,Path:tidb.toml,Mode:nil,},},DefaultMode:*420,Optional:nil,} VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:startup-script VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:&ConfigMapVolumeSource{LocalObjectReference:LocalObjectReference{Name:basic-tidb,},Items:[]KeyToPath{KeyToPath{Key:startup-script,Path:tidb_start_script.sh,Mode:nil,},},DefaultMode:*420,Optional:nil,} VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}} {Name:slowlog VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil}}] InitContainers:[] Containers:[{Name:slowlog Image:busybox:1.26.2 Command:[sh -c touch /var/log/tidb/slowlog; tail -n0 -F /var/log/tidb/slowlog;] Args:[] WorkingDir: Ports:[] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:slowlog ReadOnly:false MountPath:/var/log/tidb SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:tidb Image:pingcap/tidb:v4.0.0 Command:[/bin/sh /usr/local/bin/tidb_start_script.sh] Args:[] WorkingDir: Ports:[{Name:server HostPort:0 ContainerPort:4000 Protocol:TCP HostIP:} {Name:status HostPort:0 ContainerPort:10080 Protocol:TCP HostIP:}] EnvFrom:[] Env:[{Name:CLUSTER_NAME Value:basic ValueFrom:nil} {Name:TZ Value:UTC ValueFrom:nil} {Name:BINLOG_ENABLED Value:false ValueFrom:nil} {Name:SLOW_LOG_FILE Value:/var/log/tidb/slowlog ValueFrom:nil} {Name:POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:NAMESPACE Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.namespace,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:HEADLESS_SERVICE_NAME Value:basic-tidb-peer ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:annotations ReadOnly:true MountPath:/etc/podinfo SubPath: MountPropagation:<nil> SubPathExpr:} {Name:config ReadOnly:true MountPath:/etc/tidb SubPath: MountPropagation:<nil> SubPathExpr:} {Name:startup-script ReadOnly:true MountPath:/usr/local/bin SubPath: MountPropagation:<nil> SubPathExpr:} {Name:slowlog ReadOnly:false MountPath:/var/log/tidb SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:&Probe{Handler:Handler{Exec:nil,HTTPGet:nil,TCPSocket:&TCPSocketAction{Port:{0 4000 },Host:,},},InitialDelaySeconds:10,TimeoutSeconds:1,PeriodSeconds:10,SuccessThreshold:1,FailureThreshold:3,} StartupProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy:Always TerminationGracePeriodSeconds:0xc000d36170 ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[]Sysctl{},WindowsOptions:nil,} ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName:default-scheduler Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[]}} VolumeClaimTemplates:[] ServiceName:basic-tidb-peer PodManagementPolicy:Parallel UpdateStrategy:{Type:RollingUpdate RollingUpdate:&RollingUpdateStatefulSetStrategy{Partition:*1,}} RevisionHistoryLimit:0xc000d36254}.
```
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
