### PR TITLE
disable reserve-space in basic examples

### DIFF
--- a/examples/basic-cn/tidb-cluster.yaml
+++ b/examples/basic-cn/tidb-cluster.yaml
@@ -25,7 +25,9 @@ spec:
     # storageClassName: local-storage
     requests:
       storage: "1Gi"
-    config: {}
+    config:
+      # In basic examples, we set this to avoid using too much storage.
+      reserve-space: "0MB"
   tidb:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb
     replicas: 1

--- a/examples/basic/tidb-cluster.yaml
+++ b/examples/basic/tidb-cluster.yaml
@@ -25,7 +25,10 @@ spec:
     # storageClassName: local-storage
     requests:
       storage: "1Gi"
-    config: {}
+    config:
+      storage:
+        # In basic examples, we set this to avoid using too much storage.
+        reserve-space: "0MB"
   tidb:
     baseImage: pingcap/tidb
     replicas: 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
this is because the `tikv-server` creates a 2GB file in its data directory to reserve space since TiKV 4.0.0-beta. we should disable this feature in our basic examples which are expected to work in minimal environments, e.g. minikube, kind.
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
