### PR TITLE
update grafana version to v6.1.6

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -533,7 +533,7 @@ monitor:
       #  memory: 64Mi
   grafana:
     create: true
-    image: grafana/grafana:6.0.1
+    image: grafana/grafana:6.1.6
     imagePullPolicy: IfNotPresent
     logLevel: info
     resources:

--- a/deploy/aliyun/manifests/db-monitor.yaml.example
+++ b/deploy/aliyun/manifests/db-monitor.yaml.example
@@ -34,7 +34,7 @@ spec:
       annotations:
         service.beta.kubernetes.io/alicloud-loadbalancer-address-type: internet
     username: admin
-    version: 6.0.1
+    version: 6.1.6
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/deploy/aws/manifests/db-monitor.yaml.example
+++ b/deploy/aws/manifests/db-monitor.yaml.example
@@ -32,7 +32,7 @@ spec:
       portName: http-grafana
       type: LoadBalancer
     username: admin
-    version: 6.0.1
+    version: 6.1.6
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/deploy/gcp/manifests/db-monitor.yaml.example
+++ b/deploy/gcp/manifests/db-monitor.yaml.example
@@ -32,7 +32,7 @@ spec:
       portName: http-grafana
       type: LoadBalancer
     username: admin
-    version: 6.0.1
+    version: 6.1.6
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/auto-scale/tidb-monitor.yaml
+++ b/examples/auto-scale/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v4.0.0

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
   initializer:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-initializer
     version: v4.0.1

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v4.0.0

--- a/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
@@ -20,7 +20,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v4.0.0

--- a/examples/monitor-with-thanos/tidb-monitor.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v3.0.13

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
     service:
       type: NodePort
   initializer:

--- a/manifests/monitor/tidb-monitor.yaml
+++ b/manifests/monitor/tidb-monitor.yaml
@@ -23,7 +23,7 @@ spec:
       portName: http-prometheus 
   grafana:
     baseImage: grafana/grafana
-    version: 6.0.1
+    version: 6.1.6
     imagePullPolicy: IfNotPresent
     logLevel: info
     resources: {}

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -38,7 +38,7 @@ const (
 	TiDBMonitorInitializerImage   = "pingcap/tidb-monitor-initializer"
 	TiDBMonitorInitializerVersion = "v3.0.8"
 	GrafanaImage                  = "grafana/grafana"
-	GrafanaVersion                = "6.0.1"
+	GrafanaVersion                = "6.1.6"
 )
 
 func ListImages() []string {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix https://github.com/pingcap/tidb-operator/issues/2797

### What is changed and how does it work?
replace grafana version from v6.0.1 to v6.1.6

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Update used grafana version from v6.0.1 to v6.1.6
```
