### PR TITLE
add tls support between drainer and downstream database server

### DIFF
--- a/charts/tidb-drainer/templates/_helpers.tpl
+++ b/charts/tidb-drainer/templates/_helpers.tpl
@@ -37,11 +37,13 @@ config-file: |-
   cert-allowed-cn = {{ .Values.tlsSyncer.certAllowedCN | toJson }}
   {{- end -}}
     {{- end -}}
-    {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+    {{- if .Values.tlsSyncer.checkpoint }}
+  {{- if .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
   [syncer.to.checkpoint.security]
   ssl-ca = "/var/lib/drainer-syncer-checkpoint-tls/ca.crt"
   ssl-cert = "/var/lib/drainer-syncer-checkpoint-tls/tls.crt"
   ssl-key = "/var/lib/drainer-syncer-checkpoint-tls/tls.key"
+  {{- end -}}
   {{- if .Values.tlsSyncer.checkpoint.certAllowedCN }}
   cert-allowed-cn = {{ .Values.tlsSyncer.checkpoint.certAllowedCN | toJson }}
   {{- end -}}

--- a/charts/tidb-drainer/templates/_helpers.tpl
+++ b/charts/tidb-drainer/templates/_helpers.tpl
@@ -27,6 +27,15 @@ config-file: |-
   cert-allowed-cn = {{ .Values.tlsCluster.certAllowedCN | toJson }}
   {{- end -}}
     {{- end -}}
+    {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+  [syncer.to.security]
+  ssl-ca = "/var/lib/drainer-syncer-tls/ca.crt"
+  ssl-cert = "/var/lib/drainer-syncer-tls/tls.crt"
+  ssl-key = "/var/lib/drainer-syncer-tls/tls.key"
+  {{- if .Values.tlsSyncer.certAllowedCN }}
+  cert-allowed-cn = {{ .Values.tlsSyncer.certAllowedCN | toJson }}
+  {{- end -}}
+    {{- end -}}
 {{- end -}}
 
 {{- define "drainer-configmap.name" -}}

--- a/charts/tidb-drainer/templates/_helpers.tpl
+++ b/charts/tidb-drainer/templates/_helpers.tpl
@@ -27,7 +27,8 @@ config-file: |-
   cert-allowed-cn = {{ .Values.tlsCluster.certAllowedCN | toJson }}
   {{- end -}}
     {{- end -}}
-    {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+  {{- if .Values.tlsSyncer }}
+    {{- if .Values.tlsSyncer.tlsClientSecretName }}
   [syncer.to.security]
   ssl-ca = "/var/lib/drainer-syncer-tls/ca.crt"
   ssl-cert = "/var/lib/drainer-syncer-tls/tls.crt"
@@ -36,6 +37,16 @@ config-file: |-
   cert-allowed-cn = {{ .Values.tlsSyncer.certAllowedCN | toJson }}
   {{- end -}}
     {{- end -}}
+    {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+  [syncer.to.checkpoint.security]
+  ssl-ca = "/var/lib/drainer-syncer-checkpoint-tls/ca.crt"
+  ssl-cert = "/var/lib/drainer-syncer-checkpoint-tls/tls.crt"
+  ssl-key = "/var/lib/drainer-syncer-checkpoint-tls/tls.key"
+  {{- if .Values.tlsSyncer.checkpoint.certAllowedCN }}
+  cert-allowed-cn = {{ .Values.tlsSyncer.checkpoint.certAllowedCN | toJson }}
+  {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "drainer-configmap.name" -}}

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -61,10 +61,12 @@ spec:
           mountPath: /var/lib/drainer-syncer-tls
           readOnly: true
       {{- end }}
-      {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+      {{- if .Values.tlsSyncer.checkpoint }}
+        {{- if .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
         - name: drainer-syncer-checkpoint-tls
           mountPath: /var/lib/drainer-syncer-checkpoint-tls
           readOnly: true
+        {{- end }}
       {{- end }}
       {{- end }}
       {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
@@ -92,10 +94,12 @@ spec:
         secret:
           secretName: {{ .Values.tlsSyncer.tlsClientSecretName }}
     {{- end }}
-    {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+    {{- if .Values.tlsSyncer.checkpoint }}
+      {{- if .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
       - name: drainer-syncer-checkpoint-tls
         secret:
           secretName: {{ .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+      {{- end }}
     {{- end }}
     {{- end }}
     {{- with .Values.nodeSelector }}

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -55,6 +55,11 @@ spec:
           mountPath: /var/lib/drainer-tls
           readOnly: true
       {{- end }}
+      {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+        - name: drainer-syncer-tls
+          mountPath: /var/lib/drainer-syncer-tls
+          readOnly: true
+      {{- end }}
       {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
         env:
         - name: TZ
@@ -73,6 +78,11 @@ spec:
       - name: drainer-tls
         secret:
           secretName: {{ include "drainer.tlsSecretName" . }}
+    {{- end }}
+    {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+      - name: drainer-syncer-tls
+        secret:
+          secretName: {{ .Values.tlsSyncer.tlsClientSecretName }}
     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
           readOnly: true
       {{- end }}
       {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
-        - name: drainer-syncer-tls
+        - name: drainer-syncer-checkpoint-tls
           mountPath: /var/lib/drainer-syncer-checkpoint-tls
           readOnly: true
       {{- end }}

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -55,10 +55,17 @@ spec:
           mountPath: /var/lib/drainer-tls
           readOnly: true
       {{- end }}
-      {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+      {{- if .Values.tlsSyncer }}
+      {{- if .Values.tlsSyncer.tlsClientSecretName }}
         - name: drainer-syncer-tls
           mountPath: /var/lib/drainer-syncer-tls
           readOnly: true
+      {{- end }}
+      {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+        - name: drainer-syncer-tls
+          mountPath: /var/lib/drainer-syncer-checkpoint-tls
+          readOnly: true
+      {{- end }}
       {{- end }}
       {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
         env:
@@ -79,10 +86,17 @@ spec:
         secret:
           secretName: {{ include "drainer.tlsSecretName" . }}
     {{- end }}
-    {{- if and .Values.tlsSyncer .Values.tlsSyncer.tlsClientSecretName }}
+    {{- if .Values.tlsSyncer }}
+    {{- if .Values.tlsSyncer.tlsClientSecretName }}
       - name: drainer-syncer-tls
         secret:
           secretName: {{ .Values.tlsSyncer.tlsClientSecretName }}
+    {{- end }}
+    {{- if and .Values.tlsSyncer.checkpoint .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+      - name: drainer-syncer-checkpoint-tls
+        secret:
+          secretName: {{ .Values.tlsSyncer.checkpoint.tlsClientSecretName }}
+    {{- end }}
     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -48,20 +48,34 @@ tlsCluster:
   certAllowedCN: []
   #  - TiDB
 
-# The tls config between drainer and the downstream database server (MySQL/TiDB)
-tlsSyncer:
-  tlsClientSecretName:
+# The TLS config between drainer and the downstream database server (MySQL/TiDB)
+tlsSyncer: {}
+  # The steps to enable this feature:
+  #   1. Generate MySQL Client certificate.
+  #      There are documents help to generate these certificates:
+  #        - enable TLS for the MySQL Client through cfssl or cert-manager: https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client
+  #        - check and enble TLS for the MySQL Client: https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers
+  #   2. Create one secret object for Drainer which contains the certificates created above.
+  #      Suggest the name of this Secret is <downstream_database_secret_name>.
+  #        For Drainer: kubectl create secret generic ${downstream_database_secret_name} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
+  #   3. Then create the Drainer cluster with `tlsSyncer.tlsClientSecretName` set to `<downstream_database_secret_name>`.
+  # tlsClientSecretName: demo-tidb-client-secret
 
   # certAllowedCN is the Common Name that allowed
-  certAllowedCN: []
+  # certAllowedCN: []
   #  - TiDB
 
-  # checkpoint is the tls config for the database we save binlog checkpoint
-  # Omit this part if you just want to save checkpoint in downstream database
-  checkpoint:
-    tlsClientSecretName:
+  # checkpoint is the TLS config for the database we save binlog checkpoint
+  # In most cases, you needn't to specify [syncer.to.checkpoint.type].
+  # Drainer will use downstream to save binlog checkpoint and you can just left this field commented.
+  # You have to fill this field only if you want to save binlog checkpoint to ** another database which has enabled TLS **.
+  # The steps to enable this feature is similar like enable tlsSyncer.tlsClientSecretName,
+  # which means you need to Generate MySQL Client certificate, create one secret object and then set tlsClientSecretName
+  # to your checkpoint database secret name like above.
+  # checkpoint: {}
+  # tlsClientSecretName: checkpoint-tidb-client-secret
   # certAllowedCN is the Common Name that allowed
-    certAllowedCN: []
+  # certAllowedCN: []
   #  - TiDB
 
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -48,6 +48,15 @@ tlsCluster:
   certAllowedCN: []
   #  - TiDB
 
+# The tls config between drainer and the downstream database server (MySQL/TiDB)
+tlsSyncer:
+  # tlsClientSecretName:
+
+  # certAllowedCN is the Common Name that allowed
+  # certAllowedCN: []
+  #  - TiDB
+
+
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml
 # [security] section will be generated automatically if tlsCluster.enabled is set to true so users do not need to configure it.
 config: |

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -50,16 +50,18 @@ tlsCluster:
 
 # The tls config between drainer and the downstream database server (MySQL/TiDB)
 tlsSyncer:
-  # tlsClientSecretName:
+  tlsClientSecretName:
 
   # certAllowedCN is the Common Name that allowed
-  # certAllowedCN: []
+  certAllowedCN: []
   #  - TiDB
 
-  # checkpoint:
-  #  tlsClientSecretName:
-  #
-  #  certAllowedCN: []
+  # checkpoint is the tls config for the database we save binlog checkpoint
+  # Omit this part if you just want to save checkpoint in downstream database
+  checkpoint:
+    tlsClientSecretName:
+  # certAllowedCN is the Common Name that allowed
+    certAllowedCN: []
   #  - TiDB
 
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -51,31 +51,27 @@ tlsCluster:
 # The TLS config between drainer and the downstream database server (MySQL/TiDB)
 tlsSyncer: {}
   # The steps to enable this feature:
-  #   1. Generate MySQL Client certificate.
-  #      There are documents help to generate these certificates:
-  #        - enable TLS for the MySQL Client through cfssl or cert-manager: https://docs.pingcap.com/tidb-in-kubernetes/stable/enable-tls-for-mysql-client
-  #        - check and enble TLS for the MySQL Client: https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers
-  #   2. Create one secret object for Drainer which contains the certificates created above.
-  #      Suggest the name of this Secret is <downstream_database_secret_name>.
-  #        For Drainer: kubectl create secret generic ${downstream_database_secret_name} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
-  #   3. Then create the Drainer cluster with `tlsSyncer.tlsClientSecretName` set to `<downstream_database_secret_name>`.
-  # tlsClientSecretName: demo-tidb-client-secret
-
+  #   1. Create one secret object which contains the certificates for the downstream database server.
+  #      For example: kubectl create secret generic ${downstream_database_secret_name} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
+  #   2. Then set `tlsSyncer.tlsClientSecretName` to `${downstream_database_secret_name}`.
+  # tlsClientSecretName: ${downstream_database_secret_name}
   # certAllowedCN is the Common Name that allowed
-  # certAllowedCN: []
+  # certAllowedCN:
   #  - TiDB
 
-  # checkpoint is the TLS config for the database we save binlog checkpoint
-  # In most cases, you needn't to specify [syncer.to.checkpoint.type].
-  # Drainer will use downstream to save binlog checkpoint and you can just left this field commented.
-  # You have to fill this field only if you want to save binlog checkpoint to ** another database which has enabled TLS **.
-  # The steps to enable this feature is similar like enable tlsSyncer.tlsClientSecretName,
-  # which means you need to Generate MySQL Client certificate, create one secret object and then set tlsClientSecretName
-  # to your checkpoint database secret name like above.
-  # checkpoint: {}
-  # tlsClientSecretName: checkpoint-tidb-client-secret
+  # checkpoint is the TLS config for the database you save binlog checkpoint.
+  # By default, Drainer will use downstream to save binlog checkpoint,
+  # so you do not need to configure [syncer.to.checkpoint.type] and
+  # you do not need to configure the `checkpoint` below.
+  # You have to configure this field only if you want to save binlog checkpoint
+  # to ** another database which has enabled TLS **.
+  # The steps to enable this feature is similar with those to enable tlsSyncer.tlsClientSecretName,
+  # which means you need to create one secret object containing the certificates for
+  # the checkpoint database and then set `checkpoint.tlsClientSecretName`.
+  # checkpoint:
+  #   tlsClientSecretName: ${checkpoint_tidb_client_secret}
   # certAllowedCN is the Common Name that allowed
-  # certAllowedCN: []
+  # certAllowedCN:
   #  - TiDB
 
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -56,6 +56,11 @@ tlsSyncer:
   # certAllowedCN: []
   #  - TiDB
 
+  # checkpoint:
+  #  tlsClientSecretName:
+  #
+  #  certAllowedCN: []
+  #  - TiDB
 
 # Refer to https://github.com/pingcap/tidb-binlog/blob/master/cmd/drainer/drainer.toml
 # [security] section will be generated automatically if tlsCluster.enabled is set to true so users do not need to configure it.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
resolve https://github.com/pingcap/tidb-operator/issues/2969
add tls support between drainer and downstream database server.

### What is changed and how does it work?
add tls syncer part for drainer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
    * Write to downstream database without tls.
    * Write to downstream database with only downstream tls specified.
    * Write to downstream but checkpoint to another database with/without tls enabled.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add TLS support between drainer and downstream database server
```
