### PR TITLE
Automated cherry pick of #3016: Enable goimports, unused, deadcode, and varcheck linters in

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,10 @@ run:
 
 linters:
   enable:
-    - gofmt
+    - goimports
   disable:
     # Enable once related errors are fixed or ignored explicitly 
     - staticcheck
-    - unused
     - gosimple
     - structcheck
     - errcheck
-    - deadcode
-    - varcheck

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -16,6 +16,7 @@ export GO111MODULE=on
 GOBIN ?= $(shell go env GOPATH)/bin
 DEP_PROGS=\
 	$(GOBIN)/misspell\
+	$(GOBIN)/goimports\
 	$(GOBIN)/golangci-lint
 
 .PHONY: all
@@ -38,3 +39,6 @@ $(GOBIN)/golangci-lint: deps
 
 $(GOBIN)/misspell: deps
 	go install github.com/client9/misspell/cmd/misspell
+
+$(GOBIN)/goimports: deps
+	go install golang.org/x/tools/cmd/goimports

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.29.0
+	golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305 // indirect
 )

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -546,6 +546,8 @@ golang.org/x/tools v0.0.0-20200625211823-6506e20df31f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200710042808-f1c4188a97a1 h1:rD1FcWVsRaMY+l8biE9jbWP5MS/CJJ/90a9TMkMgNrM=
 golang.org/x/tools v0.0.0-20200710042808-f1c4188a97a1/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305 h1:yaM5S0KcY0lIoZo7Fl+oi91b/DdlU2zuWpfHrpWbCS0=
+golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/update-goimports.sh
+++ b/hack/update-goimports.sh
@@ -20,9 +20,10 @@ set -o pipefail
 ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 cd $ROOT
 
-hack/update-codegen.sh
-hack/update-test-codegen.sh
-hack/update-openapi-spec.sh
-hack/update-crd-groups.sh
-hack/update-EOF.sh
-hack/update-goimports.sh
+pushd "${ROOT}/hack/tools" >/dev/null
+    GO111MODULE=on go install golang.org/x/tools/cmd/goimports
+popd >/dev/null
+
+find . -type f -name '*.go' -not \( \
+    -path '*/vendor/*' \
+    \) | xargs goimports -w

--- a/misc/cmd/debug-launcher/main.go
+++ b/misc/cmd/debug-launcher/main.go
@@ -14,9 +14,10 @@
 package main
 
 import (
-	"github.com/pingcap/tidb-operator/pkg/tkctl/debug"
 	"log"
 	"os"
+
+	"github.com/pingcap/tidb-operator/pkg/tkctl/debug"
 )
 
 func main() {

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster_test.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster_test.go
@@ -14,9 +14,10 @@
 package defaulting
 
 import (
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
-	"testing"
 )
 
 func TestSetTidbSpecDefault(t *testing.T) {

--- a/pkg/apis/pingcap/v1alpha1/pd_config.go
+++ b/pkg/apis/pingcap/v1alpha1/pd_config.go
@@ -25,11 +25,6 @@ package v1alpha1
 
 // initially copied from PD v3.0.6
 
-const (
-	defaultEnableTelemetry  = true
-	defaultDisableTelemetry = false
-)
-
 // PDConfig is the configuration of pd-server
 // +k8s:openapi-gen=true
 type PDConfig struct {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -26,13 +26,11 @@ import (
 
 const (
 	// defaultHelperImage is default image of helper
-	defaultHelperImage      = "busybox:1.26.2"
-	defaultTimeZone         = "UTC"
-	defaultEnableTLSCluster = false
-	defaultEnableTLSClient  = false
-	defaultExposeStatus     = true
-	defaultSeparateSlowLog  = true
-	defaultEnablePVReclaim  = false
+	defaultHelperImage     = "busybox:1.26.2"
+	defaultTimeZone        = "UTC"
+	defaultExposeStatus    = true
+	defaultSeparateSlowLog = true
+	defaultEnablePVReclaim = false
 )
 
 var (

--- a/pkg/apiserver/storage/key.go
+++ b/pkg/apiserver/storage/key.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -93,12 +92,6 @@ func (o *objKey) objectMeta() metav1.ObjectMeta {
 		Name:   o.fullName(),
 		Labels: o.labelMap(),
 	}
-}
-
-func (o *objKey) selector() (labels.Selector, error) {
-	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: o.labelMap(),
-	})
 }
 
 func (o *objKey) labelSelectorStr() string {

--- a/pkg/apiserver/storage/store.go
+++ b/pkg/apiserver/storage/store.go
@@ -24,8 +24,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	clientv1alpha1 "github.com/pingcap/tidb-operator/pkg/client/clientset/versioned/typed/pingcap/v1alpha1"
-	informerv1alpha1 "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
-	listerv1alpha1 "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -39,8 +37,6 @@ import (
 
 // store implements a ConfigMap backed storage.Interface
 type store struct {
-	lister    listerv1alpha1.DataResourceLister
-	informer  informerv1alpha1.DataResourceInformer
 	client    clientv1alpha1.DataResourceInterface
 	codec     runtime.Codec
 	versioner storage.Versioner

--- a/pkg/apiserver/storage/watcher.go
+++ b/pkg/apiserver/storage/watcher.go
@@ -27,3 +27,5 @@ func (w *informerBasedWatcher) ResultChan() <-chan watch.Event {
 	// TODO: implementation
 	return w.resultChan
 }
+
+var _ = &informerBasedWatcher{}

--- a/pkg/autoscaler/autoscaler/calculate/calculate_test.go
+++ b/pkg/autoscaler/autoscaler/calculate/calculate_test.go
@@ -14,8 +14,9 @@
 package calculate
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestCalculate(t *testing.T) {

--- a/pkg/autoscaler/autoscaler/util.go
+++ b/pkg/autoscaler/autoscaler/util.go
@@ -171,17 +171,3 @@ func genMetricsEndpoint(tac *v1alpha1.TidbClusterAutoScaler) (string, error) {
 	}
 	return fmt.Sprintf("http://%s-prometheus.%s.svc:9090", tac.Spec.Monitor.Name, tac.Spec.Monitor.Namespace), nil
 }
-
-func emptyStorageMetricsStatus(tac *v1alpha1.TidbClusterAutoScaler) {
-	for id, m := range tac.Status.TiKV.MetricsStatusList {
-		if m.Name == string(corev1.ResourceStorage) {
-			m.StoragePressure = nil
-			m.StoragePressureStartTime = nil
-			m.CapacityStorage = nil
-			m.AvailableStorage = nil
-			m.BaselineAvailableStorage = nil
-			tac.Status.TiKV.MetricsStatusList[id] = m
-			return
-		}
-	}
-}

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
@@ -83,7 +83,6 @@ func (tac *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 func (tac *Controller) worker() {
 	for tac.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -129,7 +129,6 @@ func (bkc *Controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
 func (bkc *Controller) worker() {
 	for bkc.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/backup_schedule_status_updater.go
+++ b/pkg/controller/backup_schedule_status_updater.go
@@ -15,19 +15,16 @@ package controller
 
 import (
 	"fmt"
-	"strings"
-
-	"k8s.io/klog"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
 )
 
 // BackupScheduleStatusUpdaterInterface is an interface used to update the BackupScheduleStatus associated with a BackupSchedule.
@@ -82,21 +79,6 @@ func (bss *realBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(
 		return updateErr
 	})
 	return err
-}
-
-func (bss *realBackupScheduleStatusUpdater) recordBackupScheduleEvent(verb string, bs *v1alpha1.BackupSchedule, err error) {
-	bsName := bs.GetName()
-	if err == nil {
-		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s BackupSchedule %s successful",
-			strings.ToLower(verb), bsName)
-		bss.recorder.Event(bs, corev1.EventTypeNormal, reason, msg)
-	} else {
-		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s BackupSchedule %s failed error: %s",
-			strings.ToLower(verb), bsName, err)
-		bss.recorder.Event(bs, corev1.EventTypeWarning, reason, msg)
-	}
 }
 
 var _ BackupScheduleStatusUpdaterInterface = &realBackupScheduleStatusUpdater{}

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -15,7 +15,6 @@ package controller
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/klog"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -78,21 +76,6 @@ func (bcu *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition
 		return nil
 	})
 	return err
-}
-
-func (bcu *realBackupConditionUpdater) recordBackupEvent(verb string, backup *v1alpha1.Backup, err error) {
-	backupName := backup.GetName()
-	if err == nil {
-		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s Backup %s successful",
-			strings.ToLower(verb), backupName)
-		bcu.recorder.Event(backup, corev1.EventTypeNormal, reason, msg)
-	} else {
-		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s Backup %s failed error: %s",
-			strings.ToLower(verb), backupName, err)
-		bcu.recorder.Event(backup, corev1.EventTypeWarning, reason, msg)
-	}
 }
 
 var _ BackupConditionUpdaterInterface = &realBackupConditionUpdater{}

--- a/pkg/controller/backupschedule/backup_schedule_controller.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller.go
@@ -124,7 +124,6 @@ func (bsc *Controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
 func (bsc *Controller) worker() {
 	for bsc.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/configmap_control.go
+++ b/pkg/controller/configmap_control.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ConfigMapControlInterface manages configmaps used by TiDB clusters
@@ -43,7 +42,6 @@ type ConfigMapControlInterface interface {
 }
 
 type realConfigMapControl struct {
-	client   client.Client
 	kubeCli  kubernetes.Interface
 	recorder record.EventRecorder
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -70,11 +70,6 @@ var (
 	PodWebhookEnabled bool
 )
 
-const (
-	// defaultTiDBSlowLogImage is default image of tidb log tailer
-	defaultTiDBLogTailerImage = "busybox:1.26.2"
-)
-
 // RequeueError is used to requeue the item, this error type should't be considered as a real error
 type RequeueError struct {
 	s string

--- a/pkg/controller/pv_control.go
+++ b/pkg/controller/pv_control.go
@@ -15,13 +15,13 @@ package controller
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -128,7 +128,6 @@ func (rsc *Controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
 func (rsc *Controller) worker() {
 	for rsc.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -15,7 +15,6 @@ package controller
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/klog"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -78,21 +76,6 @@ func (rcu *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condit
 		return nil
 	})
 	return err
-}
-
-func (rcu *realRestoreConditionUpdater) recordRestoreEvent(verb string, restore *v1alpha1.Restore, err error) {
-	restoreName := restore.GetName()
-	if err == nil {
-		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s Restore %s successful",
-			strings.ToLower(verb), restoreName)
-		rcu.recorder.Event(restore, corev1.EventTypeNormal, reason, msg)
-	} else {
-		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s Restore %s failed error: %s",
-			strings.ToLower(verb), restoreName, err)
-		rcu.recorder.Event(restore, corev1.EventTypeWarning, reason, msg)
-	}
 }
 
 var _ RestoreConditionUpdaterInterface = &realRestoreConditionUpdater{}

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -280,7 +280,6 @@ func (tcc *Controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
 func (tcc *Controller) worker() {
 	for tcc.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/tidbcluster_control.go
+++ b/pkg/controller/tidbcluster_control.go
@@ -15,13 +15,11 @@ package controller
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	tcinformers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -84,21 +82,6 @@ func (rtc *realTidbClusterControl) UpdateTidbCluster(tc *v1alpha1.TidbCluster, n
 		klog.Errorf("failed to update TidbCluster: [%s/%s], error: %v", ns, tcName, err)
 	}
 	return updateTC, err
-}
-
-func (rtc *realTidbClusterControl) recordTidbClusterEvent(verb string, tc *v1alpha1.TidbCluster, err error) {
-	tcName := tc.GetName()
-	if err == nil {
-		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s TidbCluster %s successful",
-			strings.ToLower(verb), tcName)
-		rtc.recorder.Event(tc, corev1.EventTypeNormal, reason, msg)
-	} else {
-		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
-		msg := fmt.Sprintf("%s TidbCluster %s failed error: %s",
-			strings.ToLower(verb), tcName, err)
-		rtc.recorder.Event(tc, corev1.EventTypeWarning, reason, msg)
-	}
 }
 
 func deepEqualExceptHeartbeatTime(newStatus *v1alpha1.TidbClusterStatus, oldStatus *v1alpha1.TidbClusterStatus) bool {

--- a/pkg/controller/tidbinitializer/tidb_initializer_controller.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_controller.go
@@ -114,7 +114,6 @@ func (tic *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 func (tic *Controller) worker() {
 	for tic.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -101,7 +101,6 @@ func (tmc *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 func (tmc *Controller) worker() {
 	for tmc.processNextWorkItem() {
-		// revive:disable:empty-block
 	}
 }
 

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -47,8 +47,6 @@ const (
 	clusterCertPath = "/var/lib/tidb-tls"
 	// serverCertPath is where the tidb-server cert stored (if any)
 	serverCertPath = "/var/lib/tidb-server-tls"
-	// serviceAccountCAPath is where is CABundle of serviceaccount locates
-	serviceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// tlsSecretRootCAKey is the key used in tls secret for the root CA.
 	// When user use self-signed certificates, the root CA must be provided. We
 	// following the same convention used in Kubernetes service token.

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -1777,7 +1777,6 @@ func TestTiDBMemberManagerScaleToZeroReplica(t *testing.T) {
 		name                     string
 		setStatus                func(cluster *v1alpha1.TidbCluster)
 		errWhenUpdateStatefulSet bool
-		statusChange             func(*apps.StatefulSet)
 		err                      bool
 		expectStatefulSetFn      func(*GomegaWithT, *apps.StatefulSet, *v1alpha1.TidbCluster, error)
 	}

--- a/pkg/manager/member/tidbcluster_status_manager.go
+++ b/pkg/manager/member/tidbcluster_status_manager.go
@@ -30,9 +30,7 @@ import (
 const (
 	prometheusComponent = "prometheus"
 	grafanaComponent    = "grafana"
-	//TODO support AlertManager, move to UCP
-	alertmanager    = "alertmanager"
-	componentPrefix = "/topology"
+	componentPrefix     = "/topology"
 )
 
 type TidbClusterStatusManager struct {

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -39,9 +39,6 @@ import (
 )
 
 const (
-	// tiflashClusterCertPath is where the cert for inter-cluster communication stored (if any)
-	tiflashClusterCertPath = "/var/lib/tiflash-tls"
-
 	//find a better way to manage store only managed by tiflash in Operator
 	tiflashStoreLimitPattern = `%s-tiflash-\d+\.%s-tiflash-peer\.%s\.svc\:\d+`
 )

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -149,16 +149,6 @@ func setUpgradePartition(set *apps.StatefulSet, upgradeOrdinal int32) {
 	klog.Infof("set %s/%s partition to %d", set.GetNamespace(), set.GetName(), upgradeOrdinal)
 }
 
-func imagePullFailed(pod *corev1.Pod) bool {
-	for _, container := range pod.Status.ContainerStatuses {
-		if container.State.Waiting != nil && container.State.Waiting.Reason != "" &&
-			(container.State.Waiting.Reason == ImagePullBackOff || container.State.Waiting.Reason == ErrImagePull) {
-			return true
-		}
-	}
-	return false
-}
-
 func MemberPodName(tcName string, ordinal int32, memberType v1alpha1.MemberType) string {
 	return fmt.Sprintf("%s-%s-%d", tcName, memberType.String(), ordinal)
 }
@@ -319,10 +309,6 @@ func updateStatefulSet(setCtl controller.StatefulSetControlInterface, tc *v1alph
 	}
 
 	return nil
-}
-
-func clusterSecretName(tc *v1alpha1.TidbCluster, component string) string {
-	return fmt.Sprintf("%s-%s-cluster-secret", tc.Name, component)
 }
 
 // filter targetContainer by  containerName, If not find, then return nil

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -619,23 +619,6 @@ func (pc *pdClient) TransferPDLeader(memberName string) error {
 	return fmt.Errorf("failed %v to transfer pd leader to %s,error: %v", res.StatusCode, memberName, err2)
 }
 
-func (pc *pdClient) getBodyOK(apiURL string) ([]byte, error) {
-	res, err := pc.httpClient.Get(apiURL)
-	if err != nil {
-		return nil, err
-	}
-	defer httputil.DeferClose(res.Body)
-	if res.StatusCode >= 400 {
-		errMsg := fmt.Errorf(fmt.Sprintf("Error response %v URL %s", res.StatusCode, apiURL))
-		return nil, errMsg
-	}
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	return body, err
-}
-
 func getLeaderEvictSchedulerInfo(storeID uint64) *schedulerInfo {
 	return &schedulerInfo{"evict-leader-scheduler", storeID}
 }

--- a/pkg/pdapi/pdapi_test.go
+++ b/pkg/pdapi/pdapi_test.go
@@ -660,13 +660,6 @@ func checkNoError(t *testing.T, results []reflect.Value) {
 	}
 }
 
-func checkError(t *testing.T, results []reflect.Value) {
-	lastVal := results[len(results)-1].Interface()
-	if v, ok := lastVal.(error); !ok || v == nil {
-		t.Errorf("expects error, got nil")
-	}
-}
-
 // TestGeneric is a generic test to test methods of PD Client.
 func TestGeneric(t *testing.T) {
 	tests := []struct {

--- a/pkg/scheduler/predicates/ha_test.go
+++ b/pkg/scheduler/predicates/ha_test.go
@@ -431,7 +431,6 @@ func TestHAFilter(t *testing.T) {
 		podFn              func(string, string, int32) *apiv1.Pod
 		nodesFn            func() []apiv1.Node
 		podListFn          func(string, string, string) (*apiv1.PodList, error)
-		podGetFn           func(string, string) (*apiv1.Pod, error)
 		pvcGetFn           func(string, string) (*apiv1.PersistentVolumeClaim, error)
 		tcGetFn            func(string, string) (*v1alpha1.TidbCluster, error)
 		scheduledNodeGetFn func(string) (*apiv1.Node, error)

--- a/pkg/tkctl/cmd/ctop/ctop.go
+++ b/pkg/tkctl/cmd/ctop/ctop.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/executor"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/pkg/tkctl/cmd/debug/debug.go
+++ b/pkg/tkctl/cmd/debug/debug.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/executor"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/pkg/tkctl/cmd/diagnose/diagnose.go
+++ b/pkg/tkctl/cmd/diagnose/diagnose.go
@@ -66,7 +66,6 @@ using 'tkctl use to set tidb cluster first.'`
 )
 
 type diagnoseInfoOptions struct {
-	kubeContext     string
 	namespace       string
 	tidbClusterName string
 

--- a/pkg/tkctl/cmd/get/get.go
+++ b/pkg/tkctl/cmd/get/get.go
@@ -16,16 +16,16 @@ package get
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/tidb-operator/pkg/tkctl/alias"
 	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/tkctl/alias"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/readable"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/tkctl/cmd/info/info.go
+++ b/pkg/tkctl/cmd/info/info.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/tkctl/readable"
 	"github.com/pingcap/tidb-operator/pkg/tkctl/util"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/pkg/tkctl/cmd/pdctl/pdctl.go
+++ b/pkg/tkctl/cmd/pdctl/pdctl.go
@@ -15,10 +15,11 @@ package pdctl
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pingcap/tidb-operator/pkg/tkctl/config"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"os"
 )
 
 // TODO: implementation

--- a/pkg/tkctl/cmd/upinfo/upinfo.go
+++ b/pkg/tkctl/cmd/upinfo/upinfo.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/util"
 	"github.com/spf13/cobra"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/tkctl/config/types.go
+++ b/pkg/tkctl/config/types.go
@@ -14,8 +14,9 @@
 package config
 
 import (
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 // TidbClusterConfig indicates which tidb cluster to use.

--- a/pkg/tkctl/debug/hijack.go
+++ b/pkg/tkctl/debug/hijack.go
@@ -16,7 +16,6 @@ package debug
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb-operator/pkg/tkctl/streams"
 	"io"
 	"runtime"
 	"sync"
@@ -25,6 +24,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
+	"github.com/pingcap/tidb-operator/pkg/tkctl/streams"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/tkctl/debug/launcher.go
+++ b/pkg/tkctl/debug/launcher.go
@@ -16,14 +16,15 @@ package debug
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/cobra"
-	"io"
-	"strings"
 )
 
 const (

--- a/pkg/tkctl/readable/printers.go
+++ b/pkg/tkctl/readable/printers.go
@@ -53,10 +53,6 @@ type podBasicColumns struct {
 	CPUInfo string
 }
 
-type tikvExtraInfoColumn struct {
-	StoreId string
-}
-
 func AddHandlers(h printers.PrintHandler) {
 	tidbClusterColumns := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -405,14 +401,6 @@ func translateTimestampSince(timestamp metav1.Time) string {
 	}
 
 	return duration.HumanDuration(time.Since(timestamp.Time))
-}
-
-// extra Component Tikv Data
-func extraTikvDataColumn(pod *v1.Pod) *tikvExtraInfoColumn {
-	storeId := pod.Labels[label.StoreIDLabelKey]
-	return &tikvExtraInfoColumn{
-		StoreId: storeId,
-	}
 }
 
 // localPrinter prints object with local handlers.

--- a/pkg/tkctl/util/util_test.go
+++ b/pkg/tkctl/util/util_test.go
@@ -14,8 +14,9 @@
 package util
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestMakeDockerSocketMount(t *testing.T) {

--- a/pkg/webhook/pod/pd_deleter_test.go
+++ b/pkg/webhook/pod/pd_deleter_test.go
@@ -19,17 +19,14 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	pdUtils "github.com/pingcap/tidb-operator/pkg/manager/member"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
-	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	admission "k8s.io/api/admission/v1beta1"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8sTesting "k8s.io/client-go/testing"
@@ -298,13 +295,4 @@ func newOwnerStatefulSetForPDPodAdmissionControl() *apps.StatefulSet {
 	sts.Status.CurrentRevision = "1"
 	sts.Status.UpdateRevision = "1"
 	return &sts
-}
-
-func newPVCForDeletePod() *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatorUtils.OrdinalPVCName(v1alpha1.PDMemberType, pdStsName, deletePDPodOrdinal),
-			Namespace: namespace,
-		},
-	}
 }

--- a/pkg/webhook/pod/pod_mutater.go
+++ b/pkg/webhook/pod/pod_mutater.go
@@ -16,6 +16,7 @@ package pod
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/features"

--- a/pkg/webhook/pod/tikv_deleter_test.go
+++ b/pkg/webhook/pod/tikv_deleter_test.go
@@ -24,12 +24,10 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/label"
 	memberUtils "github.com/pingcap/tidb-operator/pkg/manager/member"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
-	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	admission "k8s.io/api/admission/v1beta1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8sTesting "k8s.io/client-go/testing"
@@ -302,15 +300,6 @@ func newOwnerStatefulsetForTikv() *apps.StatefulSet {
 	sts.Status.CurrentRevision = "1"
 	sts.Status.UpdateRevision = "1"
 	return &sts
-}
-
-func newPVCForTikv(ordinal int32) *core.PersistentVolumeClaim {
-	return &core.PersistentVolumeClaim{
-		ObjectMeta: meta.ObjectMeta{
-			Name:      operatorUtils.OrdinalPVCName(v1alpha1.TiKVMemberType, tiKVStsName, ordinal),
-			Namespace: namespace,
-		},
-	}
 }
 
 func newTiKVStoresInfo() *pdapi.StoresInfo {

--- a/pkg/webhook/pod/util_test.go
+++ b/pkg/webhook/pod/util_test.go
@@ -15,11 +15,11 @@ package pod
 
 import (
 	"fmt"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	memberUtils "github.com/pingcap/tidb-operator/pkg/manager/member"

--- a/tests/pkg/fault-trigger/api/server.go
+++ b/tests/pkg/fault-trigger/api/server.go
@@ -214,30 +214,6 @@ func (s *Server) vmAction(
 	}
 }
 
-func (s *Server) kubeProxyAction(
-	req *restful.Request,
-	resp *restful.Response,
-	res *Response,
-	nodeName string,
-	fn func(nodeName string) error,
-	method string,
-) {
-	if err := fn(nodeName); err != nil {
-		res.message(fmt.Sprintf("failed to invoke %s, nodeName: %s, error: %v", method, nodeName, err)).
-			statusCode(http.StatusInternalServerError)
-		if err = resp.WriteEntity(res); err != nil {
-			klog.Errorf("failed to response, methods: %s, error: %v", method, err)
-		}
-		return
-	}
-
-	res.message("OK").statusCode(http.StatusOK)
-
-	if err := resp.WriteEntity(res); err != nil {
-		klog.Errorf("failed to response, method: %s, error: %v", method, err)
-	}
-}
-
 func (s *Server) getVM(name string) (*manager.VM, error) {
 	vms, err := s.mgr.ListVMs()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #3016 on release-1.1.

#3016: Enable goimports, unused, deadcode, and varcheck linters in