### PR TITLE
fix  helm install question included in e2e shell under mac system

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -174,7 +174,7 @@ function e2e::setup_helm_server() {
     if hack::version_ge $(e2e::get_kube_version) "v1.16.0"; then
         # workaround for https://github.com/helm/helm/issues/6374
         # TODO remove this when we can upgrade to helm 2.15+, see https://github.com/helm/helm/pull/6462
-        # \'$'\n  regex is used to be compatible with BSD sed (Darwin)
+        # \'$'\n is used to be compatible with BSD sed (Darwin)
         $HELM_BIN init --service-account tiller --output yaml \
             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
             | sed 's@  replicas: 1@  replicas: 1\'$'\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -174,18 +174,11 @@ function e2e::setup_helm_server() {
     if hack::version_ge $(e2e::get_kube_version) "v1.16.0"; then
         # workaround for https://github.com/helm/helm/issues/6374
         # TODO remove this when we can upgrade to helm 2.15+, see https://github.com/helm/helm/pull/6462
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # mac system
-            $HELM_BIN init --service-account tiller --output yaml \
+        # \'$'\n  regex is used to be compatible with BSD sed (Darwin)
+        $HELM_BIN init --service-account tiller --output yaml \
             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
             | sed 's@  replicas: 1@  replicas: 1\'$'\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
             | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
-        else
-            $HELM_BIN init --service-account tiller --output yaml \
-            | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
-            | sed 's@  replicas: 1@  replicas: 1\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
-            | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
-        fi
         echo "info: wait for tiller to be ready"
         e2e::__wait_for_deploy kube-system tiller-deploy
     else

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -174,10 +174,18 @@ function e2e::setup_helm_server() {
     if hack::version_ge $(e2e::get_kube_version) "v1.16.0"; then
         # workaround for https://github.com/helm/helm/issues/6374
         # TODO remove this when we can upgrade to helm 2.15+, see https://github.com/helm/helm/pull/6462
-        $HELM_BIN init --service-account tiller --output yaml \
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # mac system
+            $HELM_BIN init --service-account tiller --output yaml \
+            | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
+            | sed 's@  replicas: 1@  replicas: 1\'$'\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
+            | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
+        else
+            $HELM_BIN init --service-account tiller --output yaml \
             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
             | sed 's@  replicas: 1@  replicas: 1\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
             | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
+        fi
         echo "info: wait for tiller to be ready"
         e2e::__wait_for_deploy kube-system tiller-deploy
     else


### PR DESCRIPTION
### What is changed and how does it work?
Under mac system,I cannot run e2e test  normally.

command：

`
./output/bin/helm init --service-account tiller --output yaml             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@'             | sed 's@  replicas: 1@  replicas: 1\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@'             | kubectl  apply -f -
`
error:
`
error: error parsing STDIN: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
`

I find `\n` nextline character not work in mac , so we can replace with `\'$'\n`.

### Check List 

Tests 

 - E2E test

Code changes

 - Has CI related scripts change




