### PR TITLE
chart/tidb-operator: add appVersion & maintainers fields

### DIFF
--- a/charts/tidb-operator/Chart.yaml
+++ b/charts/tidb-operator/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: tidb-operator Helm chart for Kubernetes
 name: tidb-operator
-version: dev
+version: v1-canary
+appVersion: v1-canary
 home: https://github.com/pingcap/tidb-operator
 sources:
   - https://github.com/pingcap/tidb-operator
@@ -12,3 +13,12 @@ keywords:
   - database
   - mysql
   - raft
+maintainers:
+- name: cofyc
+  email: fuyecheng@pingcap.com
+- name: weekface
+  email: changjunchang@pingcap.com
+- name: DanielZhangQD
+  email: zhanghailong@pingcap.com
+- name: lichunzhu
+  email: lichunzhu@pingcap.com

--- a/ci/release_tidb_operator_binary_and_image.groovy
+++ b/ci/release_tidb_operator_binary_and_image.groovy
@@ -54,6 +54,7 @@ def call(BUILD_BRANCH, RELEASE_TAG, CREDENTIALS_ID, CHART_ITEMS) {
 							chartPrefixName=\$chartItem-${RELEASE_TAG}
 							echo "======= release \$chartItem chart ======"
 							sed -i "s/version:.*/version: ${RELEASE_TAG}/g" charts/\$chartItem/Chart.yaml
+							sed -i "s/appVersion:.*/appVersion: ${RELEASE_TAG}/g" charts/\$chartItem/Chart.yaml
                             # update image tag to current release
                             sed -r -i "s#pingcap/(tidb-operator|tidb-backup-manager):.*#pingcap/\\1:${RELEASE_TAG}#g" charts/\$chartItem/values.yaml
 							tar -zcf \${chartPrefixName}.tgz -C charts \$chartItem


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This is necessary to publish via rancher charts.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
