### PR TITLE
webhook: Register Strategy AdmissionHook at a separate API endpoint

### DIFF
--- a/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
+++ b/charts/tidb-operator/templates/admission/admission-webhook-registration.yaml
@@ -117,7 +117,7 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: "/apis/admission.tidb.pingcap.com/v1alpha1/admissionreviews"
+        path: "/apis/admission.tidb.pingcap.com/v1alpha1/pingcapresourcevalidations"
       {{- if .Values.admissionWebhook.cabundle }}
       caBundle: {{ .Values.admissionWebhook.cabundle }}
       {{- else }}
@@ -148,7 +148,7 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: "/apis/admission.tidb.pingcap.com/v1alpha1/mutatingreviews"
+        path: "/apis/admission.tidb.pingcap.com/v1alpha1/pingcapresourcemutations"
       {{- if .Values.admissionWebhook.cabundle }}
       caBundle: {{ .Values.admissionWebhook.cabundle }}
       {{- else }}

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/version"
 	"github.com/pingcap/tidb-operator/pkg/webhook"
 	"github.com/pingcap/tidb-operator/pkg/webhook/pod"
+	"github.com/pingcap/tidb-operator/pkg/webhook/strategy"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 )
@@ -74,5 +75,7 @@ func main() {
 	}
 	pod.AstsControllerServiceAccounts = fmt.Sprintf("system:serviceaccount:%s:advanced-statefulset-controller", ns)
 
-	cmd.RunAdmissionServer(ah)
+	strategyAdmissionHook := strategy.NewStrategyAdmissionHook(&strategy.Registry)
+
+	cmd.RunAdmissionServer(ah, strategyAdmissionHook)
 }

--- a/pkg/webhook/admission_hooks.go
+++ b/pkg/webhook/admission_hooks.go
@@ -18,39 +18,43 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/generic-admission-server/pkg/apiserver"
+	asappsv1 "github.com/pingcap/advanced-statefulset/client/apis/apps/v1"
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
+	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions"
 	"github.com/pingcap/tidb-operator/pkg/features"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	"github.com/pingcap/tidb-operator/pkg/webhook/pod"
-	"github.com/pingcap/tidb-operator/pkg/webhook/strategy"
+	"github.com/pingcap/tidb-operator/pkg/webhook/statefulset"
 	"github.com/pingcap/tidb-operator/pkg/webhook/util"
 	admission "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	eventv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
-
-	asappsv1 "github.com/pingcap/advanced-statefulset/client/apis/apps/v1"
-	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
-	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
-	"github.com/pingcap/tidb-operator/pkg/webhook/statefulset"
 )
 
+// AdmissionHook implements both ValidatingAdmissionHook and
+// MutatingAdmissionHook interface.
 type AdmissionHook struct {
 	lock                     sync.RWMutex
 	initialized              bool
 	podAC                    *pod.PodAdmissionControl
 	stsAC                    *statefulset.StatefulSetAdmissionControl
-	strategyAC               *strategy.AdmissionWebhook
 	ResyncDuration           time.Duration
 	ExtraServiceAccounts     string
 	EvictRegionLeaderTimeout time.Duration
 }
+
+var _ apiserver.ValidatingAdmissionHook = &AdmissionHook{}
+var _ apiserver.MutatingAdmissionHook = &AdmissionHook{}
 
 func (a *AdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	return schema.GroupVersionResource{
@@ -62,16 +66,14 @@ func (a *AdmissionHook) ValidatingResource() (plural schema.GroupVersionResource
 }
 
 func (a *AdmissionHook) Validate(ar *admission.AdmissionRequest) *admission.AdmissionResponse {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
 	if !a.initialized {
 		return &admission.AdmissionResponse{
 			Allowed: false,
 		}
 	}
-	resp := a.strategyAC.Validate(ar)
-	if !resp.Allowed {
-		return resp
-	}
-	// see if other ACs are interested in this resource
+
 	switch ar.Kind.Kind {
 	case "Pod":
 		if "" != ar.Kind.Group {
@@ -88,7 +90,7 @@ func (a *AdmissionHook) Validate(ar *admission.AdmissionRequest) *admission.Admi
 		}
 		return a.stsAC.AdmitStatefulSets(ar)
 	default:
-		return resp
+		return a.unknownAdmissionRequest(ar)
 	}
 }
 
@@ -102,16 +104,14 @@ func (a *AdmissionHook) MutatingResource() (plural schema.GroupVersionResource, 
 }
 
 func (a *AdmissionHook) Admit(ar *admission.AdmissionRequest) *admission.AdmissionResponse {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
 	name := ar.Name
 	namespace := ar.Namespace
 	kind := ar.Kind.Kind
 	klog.V(4).Infof("receive mutation request for %s[%s/%s]", kind, namespace, name)
 
-	resp := a.strategyAC.Mutate(ar)
-	if !resp.Allowed {
-		return resp
-	}
-	// see if other ACs are interested in this resource
 	switch ar.Kind.Kind {
 	case "Pod":
 		if "" != ar.Kind.Group {
@@ -119,15 +119,13 @@ func (a *AdmissionHook) Admit(ar *admission.AdmissionRequest) *admission.Admissi
 		}
 		return a.podAC.MutatePods(ar)
 	default:
-		return resp
+		return a.unknownAdmissionRequest(ar)
 	}
 }
 
-// any special initialization goes here
+// Initialize implements AdmissionHook.Initialize interface. It's is called as
+// a post-start hook.
 func (a *AdmissionHook) Initialize(cfg *rest.Config, stopCh <-chan struct{}) error {
-	if a.initialized {
-		return nil
-	}
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -155,25 +153,31 @@ func (a *AdmissionHook) Initialize(cfg *rest.Config, stopCh <-chan struct{}) err
 	// init pdControl
 	pdControl := pdapi.NewDefaultPDControl(kubeCli)
 
-	//init recorder
+	// init recorder
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&eventv1.EventSinkImpl{
 		Interface: eventv1.New(kubeCli.CoreV1().RESTClient()).Events("")})
 	recorder := eventBroadcaster.NewRecorder(v1alpha1.Scheme, corev1.EventSource{Component: "tidb-admission-controller"})
 
-	var informerFactory informers.SharedInformerFactory
-	var options []informers.SharedInformerOption
-	informerFactory = informers.NewSharedInformerFactoryWithOptions(cli, a.ResyncDuration, options...)
+	// informer factory
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(cli, a.ResyncDuration)
 
-	pc := pod.NewPodAdmissionControl(kubeCli, cli, pdControl, strings.Split(a.ExtraServiceAccounts, ","), a.EvictRegionLeaderTimeout, informerFactory, recorder)
-	informerFactory.Start(stopCh)
-	a.podAC = pc
+	a.podAC = pod.NewPodAdmissionControl(kubeCli, cli, pdControl, strings.Split(a.ExtraServiceAccounts, ","), a.EvictRegionLeaderTimeout, informerFactory, recorder)
 	klog.Info("pod admission webhook initialized successfully")
 	a.stsAC = statefulset.NewStatefulSetAdmissionControl(cli)
 	klog.Info("statefulset admission webhook initialized successfully")
-	a.strategyAC = strategy.NewAdmissionWebhook(&strategy.Registry)
-	klog.Info("strategy based admission webhook initialized successfully")
+
+	// Start informer factories after all controller are initialized.
+	informerFactory.Start(stopCh)
+
+	// Wait for all started informers' cache were synced.
+	for v, synced := range informerFactory.WaitForCacheSync(wait.NeverStop) {
+		if !synced {
+			klog.Fatalf("error syncing informer for %v", v)
+		}
+	}
+
 	a.initialized = true
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/3046
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
