### PR TITLE
add advertise status address for tiflash

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tiflash_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tiflash_config.go
@@ -34,8 +34,10 @@ type FlashServerConfig struct {
 	// +optional
 	EngineAddr *string `json:"engine-addr,omitempty" toml:"engine-addr,omitempty"`
 	// +optional
-	StatusAddr       *string `json:"status-addr,omitempty" toml:"status-addr,omitempty"`
-	TiKVServerConfig `json:",inline"`
+	StatusAddr *string `json:"status-addr,omitempty" toml:"status-addr,omitempty"`
+	// +optional
+	AdvertiseStatusAddr *string `json:"advertise-status-addr,omitempty" toml:"advertise-status-addr,omitempty"`
+	TiKVServerConfig    `json:",inline"`
 }
 
 // ProxyConfig is the configuration of TiFlash proxy process.

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -1392,6 +1392,11 @@ func (in *FlashServerConfig) DeepCopyInto(out *FlashServerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AdvertiseStatusAddr != nil {
+		in, out := &in.AdvertiseStatusAddr, &out.AdvertiseStatusAddr
+		*out = new(string)
+		**out = **in
+	}
 	in.TiKVServerConfig.DeepCopyInto(&out.TiKVServerConfig)
 	return
 }

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -191,6 +191,9 @@ func setTiFlashProxyConfigDefault(config *v1alpha1.ProxyConfig, clusterName, ns 
 	if config.Server.StatusAddr == nil {
 		config.Server.StatusAddr = pointer.StringPtr("0.0.0.0:20292")
 	}
+	if config.Server.AdvertiseStatusAddr == nil {
+		config.Server.AdvertiseStatusAddr = pointer.StringPtr(fmt.Sprintf("%s-POD_NUM.%s.%s.svc:20292", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns))
+	}
 }
 
 func setTiFlashCommonConfigDefault(config *v1alpha1.CommonConfig, clusterName, ns string) {

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -123,8 +123,9 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
-				StatusAddr: pointer.StringPtr("0.0.0.0:20292"),
+				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
+				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},
 		},
 	}
@@ -221,8 +222,9 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
-				StatusAddr: pointer.StringPtr("0.0.0.0:20292"),
+				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
+				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},
 		},
 	}
@@ -324,8 +326,9 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
-				StatusAddr: pointer.StringPtr("0.0.0.0:20292"),
+				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
+				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},
 			Security: &v1alpha1.TiKVSecurityConfig{
 				CAPath:   pointer.StringPtr(path.Join(tiflashCertPath, corev1.ServiceAccountRootCAKey)),
@@ -427,8 +430,9 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info1"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
-				StatusAddr: pointer.StringPtr("0.0.0.0:20292"),
+				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
+				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?
Add advertise status address for TiFlash
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
  - Deploy TiFlash with TLS enabled
  - Deploy TiFlash with TLS disabled

Code changes

 - Has Go code change


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
