### PR TITLE
Simplify some code in pkg/autoscaler

### DIFF
--- a/pkg/autoscaler/autoscaler/util.go
+++ b/pkg/autoscaler/autoscaler/util.go
@@ -112,6 +112,10 @@ func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler) {
 		}
 	}
 
+	if tidb := tac.Spec.TiDB; tidb != nil {
+		def(&tidb.BasicAutoScalerSpec)
+	}
+
 	if tikv := tac.Spec.TiKV; tikv != nil {
 		def(&tikv.BasicAutoScalerSpec)
 		for id, m := range tikv.Metrics {
@@ -128,14 +132,8 @@ func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler) {
 		}
 	}
 
-	if tidb := tac.Spec.TiDB; tidb != nil {
-		def(&tidb.BasicAutoScalerSpec)
-	}
-
-	if tac.Spec.Monitor != nil {
-		if len(tac.Spec.Monitor.Namespace) < 1 {
-			tac.Spec.Monitor.Namespace = tac.Namespace
-		}
+	if monitor := tac.Spec.Monitor; monitor != nil && len(monitor.Namespace) < 1 {
+		monitor.Namespace = tac.Namespace
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

1. Use `tcLister` to retrieve the TidbCluster instance instead of fetching it from apiserver directly.
2. Simplify some code in `pkg/autoscaler`, I think nested `if` statement will make the code not straightforward.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test

```release-note
NONE
```
