### PR TITLE
Add support for max-index-length to TidbCluster CRD

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -9680,6 +9680,18 @@ string
 </tr>
 <tr>
 <td>
+<code>max-index-length</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional: Defaults to 3072</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>mem-quota-query</code></br>
 <em>
 int64

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6548,6 +6548,9 @@ spec:
                     max-server-connections:
                       format: int64
                       type: integer
+                    max-index-length:
+                      format: int64
+                      type: integer
                     mem-quota-query:
                       format: int64
                       type: integer
@@ -15036,6 +15039,9 @@ spec:
                   format: int32
                   type: integer
                 max-server-connections:
+                  format: int64
+                  type: integer
+                max-index-length:
                   format: int64
                   type: integer
                 mem-quota-query:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6545,10 +6545,10 @@ spec:
                     lower-case-table-names:
                       format: int32
                       type: integer
-                    max-server-connections:
+                    max-index-length:
                       format: int64
                       type: integer
-                    max-index-length:
+                    max-server-connections:
                       format: int64
                       type: integer
                     mem-quota-query:
@@ -15038,10 +15038,10 @@ spec:
                 lower-case-table-names:
                   format: int32
                   type: integer
-                max-server-connections:
+                max-index-length:
                   format: int64
                   type: integer
-                max-index-length:
+                max-server-connections:
                   format: int64
                   type: integer
                 mem-quota-query:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -4821,6 +4821,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBConfig(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"max-index-length": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional: Defaults to 3072",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"mem-quota-query": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Optional: Defaults to 34359738368",

--- a/pkg/apis/pingcap/v1alpha1/tidb_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config.go
@@ -57,6 +57,9 @@ type TiDBConfig struct {
 	// Optional: Defaults to log
 	// +optional
 	OOMAction *string `toml:"oom-action,omitempty" json:"oom-action,omitempty"`
+	// Optional: Defaults to 3072
+	// +optional
+	MaxIndexLength *int64 `toml:"max-index-length,omitempty" json:"max-index-length,omitempty"`
 	// Optional: Defaults to 34359738368
 	// +optional
 	MemQuotaQuery *int64 `toml:"mem-quota-query,omitempty" json:"mem-quota-query,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -3988,6 +3988,11 @@ func (in *TiDBConfig) DeepCopyInto(out *TiDBConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxIndexLength != nil {
+		in, out := &in.MaxIndexLength, &out.MaxIndexLength
+		*out = new(int64)
+		**out = **in
+	}
 	if in.MemQuotaQuery != nil {
 		in, out := &in.MemQuotaQuery, &out.MemQuotaQuery
 		*out = new(int64)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fixes https://github.com/pingcap/tidb-operator/issues/3075

### What is changed and how does it work?

Add max-index-length to TidbCluster and TiDBGroup in manifests/crd.yaml, and add MaxIndexLength to tidb_config.go.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

I was able to successfully add max-index-length to the config in TidbCluster and have it applied to nodes in the cluster.

Code changes

 - Has Go code change

Side effects

n/a

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add support for the `max-index-length` (https://docs.pingcap.com/tidb/stable/tidb-configuration-file#max-index-length) TiDB config option to the TidbCluster CRD
```
