### PR TITLE
fix goroutine leak when tls enabled

### DIFF
--- a/pkg/autoscaler/autoscaler/query/external.go
+++ b/pkg/autoscaler/autoscaler/query/external.go
@@ -88,7 +88,8 @@ func getClient(endpoint *v1alpha1.ExternalEndpoint, kubecli kubernetes.Interface
 			return nil, err
 		}
 		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
+			TLSClientConfig:   tlsConfig,
+			DisableKeepAlives: true,
 		}
 		client = &http.Client{
 			Timeout:   defaultTimeout,

--- a/pkg/controller/http_client.go
+++ b/pkg/controller/http_client.go
@@ -61,7 +61,7 @@ func (hc *httpClient) getHTTPClient(tc *v1alpha1.TidbCluster) (*http.Client, err
 		RootCAs:      rootCAs,
 		Certificates: []tls.Certificate{tlsCert},
 	}
-	httpClient.Transport = &http.Transport{TLSClientConfig: config}
+	httpClient.Transport = &http.Transport{TLSClientConfig: config, DisableKeepAlives: true}
 
 	return httpClient, nil
 }

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -88,13 +88,13 @@ func (tdc *defaultTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) 
 		return nil, err
 	}
 	defer httputil.DeferClose(res.Body)
-	if res.StatusCode != http.StatusOK {
-		errMsg := fmt.Errorf(fmt.Sprintf("Error response %v URL: %s", res.StatusCode, url))
-		return nil, errMsg
-	}
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		errMsg := fmt.Errorf(fmt.Sprintf("Error response %s:%v URL: %s", string(body), res.StatusCode, url))
+		return nil, errMsg
 	}
 	info := DBInfo{}
 	err = json.Unmarshal(body, &info)
@@ -121,13 +121,13 @@ func (tdc *defaultTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int
 		return nil, err
 	}
 	defer httputil.DeferClose(res.Body)
-	if res.StatusCode != http.StatusOK {
-		errMsg := fmt.Errorf(fmt.Sprintf("Error response %v URL: %s", res.StatusCode, url))
-		return nil, errMsg
-	}
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		errMsg := fmt.Errorf(fmt.Sprintf("Error response %s:%v URL: %s", string(body), res.StatusCode, url))
+		return nil, errMsg
 	}
 	info := config.Config{}
 	err = json.Unmarshal(body, &info)
@@ -142,16 +142,16 @@ func getBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode >= 400 {
-		errMsg := fmt.Errorf(fmt.Sprintf("Error response %v URL %s", res.StatusCode, apiURL))
-		return nil, errMsg
-	}
-
 	defer httputil.DeferClose(res.Body)
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
+	if res.StatusCode >= 400 {
+		errMsg := fmt.Errorf(fmt.Sprintf("Error response %s:%v URL %s", string(body), res.StatusCode, apiURL))
+		return nil, errMsg
+	}
+
 	return body, err
 }
 

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -114,11 +114,15 @@ type pdClient struct {
 
 // NewPDClient returns a new PDClient
 func NewPDClient(url string, timeout time.Duration, tlsConfig *tls.Config) PDClient {
+	var disableKeepalive bool
+	if tlsConfig != nil {
+		disableKeepalive = true
+	}
 	return &pdClient{
 		url: url,
 		httpClient: &http.Client{
 			Timeout:   timeout,
-			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			Transport: &http.Transport{TLSClientConfig: tlsConfig, DisableKeepAlives: disableKeepalive},
 		},
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #3079 
### What is changed and how does it work?
Disable keepalive for TLS connections, more detail refer to https://github.com/elastic/cloud-on-k8s/issues/854#issuecomment-491773323
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
     - Deploy, upgrade, scaling TiDB Cluster with TLS enabled (find one bug with upgrading #3078)
     - Deploy, upgrade, scaling TiDB Cluster with TLS disabled

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix goroutine leak when TLS enabled
```
