### PR TITLE
Unified use of public method TidbCluster.IsTLSClusterEnabled.

### DIFF
--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -305,7 +305,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	backupLabel := label.NewBackup().Instance(backup.GetInstanceName()).BackupJob().Backup(name)
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
-	if tc.Spec.TLSCluster != nil && tc.Spec.TLSCluster.Enabled {
+	if tc.IsTLSClusterEnabled() {
 		args = append(args, "--cluster-tls=true")
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      util.ClusterClientVolName,

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -289,7 +289,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 	restoreLabel := label.NewBackup().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
-	if tc.Spec.TLSCluster != nil && tc.Spec.TLSCluster.Enabled {
+	if tc.IsTLSClusterEnabled() {
 		args = append(args, "--cluster-tls=true")
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      util.ClusterClientVolName,


### PR DESCRIPTION
# What problem does this PR solve? <!--add and issue link with summary if exists-->
None
### What is changed and how does it work?
Unified use of public method  `TidbCluster.IsTLSClusterEnabled`.

