### PR TITLE
backup: TLS Support for Backup&Restore with dumpling&lightning

### DIFF
--- a/cmd/backup-manager/app/cmd/export.go
+++ b/cmd/backup-manager/app/cmd/export.go
@@ -45,6 +45,7 @@ func NewExportCommand() *cobra.Command {
 	cmd.Flags().StringVar(&bo.Namespace, "namespace", "", "Backup CR's namespace")
 	cmd.Flags().StringVar(&bo.ResourceName, "backupName", "", "Backup CRD object name")
 	cmd.Flags().StringVar(&bo.Bucket, "bucket", "", "Bucket in which to store the backup data")
+	cmd.Flags().BoolVar(&bo.TLSClient, "client-tls", false, "Whether client tls is enabled")
 	cmd.Flags().StringVar(&bo.StorageType, "storageType", "", "Backend storage type")
 	return cmd
 }

--- a/cmd/backup-manager/app/cmd/import.go
+++ b/cmd/backup-manager/app/cmd/import.go
@@ -44,6 +44,7 @@ func NewImportCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&ro.Namespace, "namespace", "", "Restore CR's namespace")
 	cmd.Flags().StringVar(&ro.ResourceName, "restoreName", "", "Restore CRD object name")
+	cmd.Flags().BoolVar(&ro.TLSClient, "client-tls", false, "Whether client tls is enabled")
 	cmd.Flags().StringVar(&ro.BackupPath, "backupPath", "", "The location of the backup")
 	return cmd
 }

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -111,8 +111,7 @@ func (bm *BackupManager) ProcessBackup() error {
 	var db *sql.DB
 	var dsn string
 	err = wait.PollImmediate(constants.PollInterval, constants.CheckTimeout, func() (done bool, err error) {
-		// TLS is not currently supported
-		dsn, err = bm.GetDSN(false)
+		dsn, err = bm.GetDSN(bm.TLSClient)
 		if err != nil {
 			klog.Errorf("can't get dsn of tidb cluster %s, err: %s", bm, err)
 			return false, err

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -91,8 +91,8 @@ func (rm *RestoreManager) ProcessRestore() error {
 	var db *sql.DB
 	var dsn string
 	err = wait.PollImmediate(constants.PollInterval, constants.CheckTimeout, func() (done bool, err error) {
-		// TLS is not currently supported
-		dsn, err = rm.GetDSN(false)
+		// TODO: for local backend mode, lightning will use both pd and mysql client. We should set both tls configurations in that mode
+		dsn, err = rm.GetDSN(rm.TLSClient)
 		if err != nil {
 			klog.Errorf("can't get dsn of tidb cluster %s, err: %s", rm, err)
 			return false, err

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -184,6 +184,26 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 		fmt.Sprintf("--backupPath=%s", backupPath),
 	}
 
+	volumeMounts := []corev1.VolumeMount{}
+	volumes := []corev1.Volume{}
+	if restore.Spec.To.TLSClientSecretName != nil {
+		args = append(args, "--client-tls=true")
+		clientSecretName := *restore.Spec.To.TLSClientSecretName
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "tidb-client-tls",
+			ReadOnly:  true,
+			MountPath: util.TiDBClientTLSPath,
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "tidb-client-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: clientSecretName,
+				},
+			},
+		})
+	}
+
 	restoreLabel := label.NewBackup().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
 	serviceAccount := constants.DefaultServiceAccountName
 	if restore.Spec.ServiceAccount != "" {
@@ -204,9 +224,9 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 					Image:           controller.TidbBackupManagerImage,
 					Args:            args,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					VolumeMounts: []corev1.VolumeMount{
+					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: label.RestoreJobLabelVal, MountPath: constants.BackupRootPath},
-					},
+					}, volumeMounts...),
 					Env:       util.AppendEnvIfPresent(envVars, "TZ"),
 					Resources: restore.Spec.ResourceRequirements,
 				},
@@ -214,7 +234,7 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 			RestartPolicy: corev1.RestartPolicyNever,
 			Affinity:      restore.Spec.Affinity,
 			Tolerations:   restore.Spec.Tolerations,
-			Volumes: []corev1.Volume{
+			Volumes: append([]corev1.Volume{
 				{
 					Name: label.RestoreJobLabelVal,
 					VolumeSource: corev1.VolumeSource{
@@ -223,7 +243,7 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 						},
 					},
 				},
-			},
+			}, volumes...),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
resolve https://github.com/pingcap/tidb-operator/issues/3094
dumpling and lightning have already supported tls but tidb-operator don't use the configs.

### What is changed and how does it work?
Add tls configs for lightning&dumpling in tidb-operator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
Manually test dumpling&lightning for tidb cluster.

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Support TLS for Backup&Restore with dumpling&lightning.
```
