### PR TITLE
update design for across kubernetes deploy

### DIFF
--- a/docs/design-proposals/2020-08-03-deploy-tidb-cluster-across-mulitple-kubernetes-clusters.md
+++ b/docs/design-proposals/2020-08-03-deploy-tidb-cluster-across-mulitple-kubernetes-clusters.md
@@ -29,18 +29,28 @@ Users may want to deploy one TiDB cluster across multiple regions on public clou
 * Deploy a TidbCluster in each Kubernetes cluster.
 * The distribution of the PD replicas in each Kubernetes cluster should ensure that the major members are not located in one Kubernetes cluster.
   For example, if there are 3 Kubernetes clusters, the distribution of PD replicas can be `1,1,1` or `2,2,1`, etc.
-* The Discovery component which is responsible for the PD startup is started only in one of the TidbCluster and a headless service is created for it.
-* No Discovery component is created in the other clusters. The other TidbClusters configure the Discovery headless service name. The PD Pods in these clusters retrieve the Discovery Pod IP through the Discovery headless service and access the Discovery component to get startup parameters.
+* Update `spec.cluster` in TidbCluster CR and add `spec.cluster.domain`.
+* Discovery component is created in each cluster. The PD Pods in each cluster access the Discovery in the same cluster.
+* Update the Discovery component
+  * if `spec.cluster` is configured, Discovery get the members from the PD of the `spec.cluster`
+    * if `spec.cluster.domain` is not configured, access the PD with service name
+    * if `spec.cluster.domain` is configured, access the PD with the headless service name
+    * if the PD of the `spec.cluster` is not available, try to access its own PD service
+  * if `spec.cluster` is not configured, follow the current way   
 * TiDB Operator, TiDB, TiKV, and other components in one cluster connect to the PD via the PD service in its own cluster.
 * Applications in one cluster connect to the TiDB via the TiDB Service in its own cluster.
 
 ## Design Details
 
 * TidbCluster CR supports configuring service domain
-  For example, `serviceDomain: test.local`, the address of each component in the cluster should be ns0-pd-0.ns0-pd-peer.ns0.svc.test.local, ns0-tikv-0.ns0-tikv-peer.ns0.svc.test.local
-* Support creating a headless service for Discovery
-  For example, ns0-discovery-peer, if the service domain is configured, the full name would be ns0-discovery-peer.ns0.svc.test.local
-* TidbCluster CR supports the configuration of the Discovery address. If the Discovery address is configured, the Discovery component is no longer created for this TidbCluster and the PD Pods retrieve the startup parameters through the Discovery component address
+  For example, `domain: test.local`, the address of each component in the cluster should be ns0-pd-0.ns0-pd-peer.ns0.svc.test.local, ns0-tikv-0.ns0-tikv-peer.ns0.svc.test.local
+* Update `spec.cluster` in TidbCluster CR and add `spec.cluster.domain`
+* Update the Discovery component
+  * if `spec.cluster` is configured, Discovery get the members from the PD of the `spec.cluster`
+    * if `spec.cluster.domain` is not configured, access the PD with service name
+    * if `spec.cluster.domain` is configured, access the PD with the headless service name
+    * if the PD of the `spec.cluster` is not available, try to access its own PD service
+  * if `spec.cluster` is not configured, follow the current way
 * TLS support for the TidbClusters across Kubernetes clusters
 * The status of each TidbCluster should only include the components managed by this TidbCluster so that the Failover process works as expected
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
After more discussion with community members, we agreed that we can reuse the `spec.cluster` added in the heterogeneous design and update the discovery component to get PD members from the PD cluster of `spec.cluster`, if it's unavailable, get PD members from its own PD service, which makes the TiDB Clusters more equipotent and no "master" cluster concept anymore, one cluster can be down without affecting the other clusters.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
