### PR TITLE
Refactor the reclaim_policy_manager and fix TiKVGroup.GetName()

### DIFF
--- a/pkg/manager/meta/reclaim_policy_manager.go
+++ b/pkg/manager/meta/reclaim_policy_manager.go
@@ -15,6 +15,8 @@ package meta
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
@@ -65,53 +67,44 @@ func NewReclaimPolicyTiKVGroupManager(pvcLister corelisters.PersistentVolumeClai
 }
 
 func (rpm *reclaimPolicyManager) Sync(tc *v1alpha1.TidbCluster) error {
-	return rpm.sync(v1alpha1.TiDBClusterKind, tc.GetNamespace(), tc.GetInstanceName(), tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy, tc)
+	return rpm.sync(tc, tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy)
 }
 
 func (rpm *reclaimPolicyManager) SyncMonitor(tm *v1alpha1.TidbMonitor) error {
-	return rpm.sync(v1alpha1.TiDBMonitorKind, tm.GetNamespace(), tm.GetName(), false, *tm.Spec.PVReclaimPolicy, tm)
+	return rpm.sync(tm, false, *tm.Spec.PVReclaimPolicy)
 }
 
 func (rpm *reclaimPolicyManager) SyncTiKVGroup(tg *v1alpha1.TiKVGroup, tc *v1alpha1.TidbCluster) error {
-	return rpm.sync(v1alpha1.TiKVGroupKind, tg.GetName(), tg.GetName(), tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy, tc)
+	return rpm.sync(tg, tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy)
 }
 
-func (rpm *reclaimPolicyManager) sync(kind, ns, instanceName string, isPVReclaimEnabled bool, policy corev1.PersistentVolumeReclaimPolicy, obj runtime.Object) error {
-	var pvcs []*corev1.PersistentVolumeClaim
-	if kind == v1alpha1.TiDBClusterKind {
-		selector, err := label.New().Instance(instanceName).Selector()
-		if err != nil {
-			return err
-		}
-		tcPvcs, err := rpm.pvcLister.PersistentVolumeClaims(ns).List(selector)
-		if err != nil {
-			return fmt.Errorf("reclaimPolicyManager.sync: failed to list pvc for cluster %s/%s, selector %s, error: %s", ns, instanceName, selector, err)
-		}
-		for _, pvc := range tcPvcs {
-			l := label.Label(pvc.Labels)
-			if !l.IsPD() && !l.IsTiDB() && !l.IsTiKV() && !l.IsTiFlash() && !l.IsPump() {
-				continue
-			}
-			pvcs = append(pvcs, pvc)
-		}
-	} else if kind == v1alpha1.TiDBMonitorKind {
-		selector, err := label.NewMonitor().Instance(instanceName).Monitor().Selector()
-		if err != nil {
-			return err
-		}
-		pvcs, err = rpm.pvcLister.PersistentVolumeClaims(ns).List(selector)
-		if err != nil {
-			return fmt.Errorf("reclaimPolicyManager.sync: failed to list pvc for cluster %s/%s, selector %s, error: %s", ns, instanceName, selector, err)
-		}
-	} else if kind == v1alpha1.TiKVGroupKind {
-		selector, err := label.NewGroup().Instance(instanceName).TiKV().Selector()
-		if err != nil {
-			return err
-		}
-		pvcs, err = rpm.pvcLister.PersistentVolumeClaims(ns).List(selector)
-		if err != nil {
-			return fmt.Errorf("reclaimPolicyManager.sync: failed to list pvc for tikvgroup %s/%s, selector %s, error: %s", ns, instanceName, selector, err)
-		}
+func (rpm *reclaimPolicyManager) sync(obj runtime.Object, isPVReclaimEnabled bool, policy corev1.PersistentVolumeReclaimPolicy) error {
+	var (
+		kind         = obj.GetObjectKind().GroupVersionKind().Kind
+		meta         = obj.(metav1.ObjectMetaAccessor).GetObjectMeta()
+		ns           = meta.GetNamespace()
+		instanceName = meta.GetName()
+		selector     labels.Selector
+		err          error
+	)
+
+	switch kind {
+	case v1alpha1.TiDBClusterKind:
+		selector, err = label.New().Instance(instanceName).Selector()
+	case v1alpha1.TiDBMonitorKind:
+		selector, err = label.NewMonitor().Instance(instanceName).Monitor().Selector()
+	case v1alpha1.TiKVGroupKind:
+		selector, err = label.NewGroup().Instance(instanceName).TiKV().Selector()
+	default:
+		return fmt.Errorf("unsupported kind %s", kind)
+	}
+	if err != nil {
+		return err
+	}
+
+	pvcs, err := rpm.pvcLister.PersistentVolumeClaims(ns).List(selector)
+	if err != nil {
+		return fmt.Errorf("reclaimPolicyManager.sync: failed to list pvc for %s %s/%s, selector %s, error: %s", kind, ns, instanceName, selector, err)
 	}
 	for _, pvc := range pvcs {
 		if pvc.Spec.VolumeName == "" {
@@ -119,6 +112,9 @@ func (rpm *reclaimPolicyManager) sync(kind, ns, instanceName string, isPVReclaim
 		}
 		if isPVReclaimEnabled && len(pvc.Annotations[label.AnnPVCDeferDeleting]) != 0 {
 			// If the pv reclaim function is turned on, and when pv is the candidate pv to be reclaimed, skip patch this pv.
+			continue
+		}
+		if l := label.Label(pvc.Labels); kind == v1alpha1.TiDBClusterKind && (!l.IsPD() && !l.IsTiDB() && !l.IsTiKV() && !l.IsTiFlash() && !l.IsPump()) {
 			continue
 		}
 		pv, err := rpm.pvLister.Get(pvc.Spec.VolumeName)

--- a/pkg/manager/meta/reclaim_policy_manager.go
+++ b/pkg/manager/meta/reclaim_policy_manager.go
@@ -15,8 +15,6 @@ package meta
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
@@ -24,6 +22,8 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/manager"
 	"github.com/pingcap/tidb-operator/pkg/monitor"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

The previous implementation contains a BUG that wrongly treats `TiKVGroup.GetName()` as `namespace`.

### What is changed and how does it work?

This PR fixes the bug described above and refactor some code to simply the codebase.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test



Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
