### PR TITLE
Bump tidb image versions to v4.0.4

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -108,7 +108,7 @@ pd:
     # annotations: {} "<the default name will be used>"
     # portName: "client"
   replicas: 3
-  image: pingcap/pd:v4.0.0
+  image: pingcap/pd:v4.0.4
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -255,7 +255,7 @@ tikv:
   # we can only set capacity in tikv.resources.limits.storage.
 
   replicas: 3
-  image: pingcap/tikv:v4.0.0
+  image: pingcap/tikv:v4.0.4
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -352,7 +352,7 @@ tidb:
   # initSqlConfigMapName: tidb-initsql
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v4.0.0
+  image: pingcap/tidb:v4.0.4
   # Image pull policy.
   imagePullPolicy: IfNotPresent
 
@@ -506,7 +506,7 @@ monitor:
   storageClassName: local-storage
   storage: 10Gi
   initializer:
-    image: pingcap/tidb-monitor-initializer:v4.0.0
+    image: pingcap/tidb-monitor-initializer:v4.0.4
     imagePullPolicy: IfNotPresent
     config:
       K8S_PROMETHEUS_URL: http://prometheus-k8s.monitoring.svc:9090
@@ -592,7 +592,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v4.0.0
+    image: pingcap/tidb-binlog:v4.0.4
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -661,7 +661,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v4.0.0
+    image: pingcap/tidb-binlog:v4.0.4
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -826,7 +826,7 @@ scheduledBackup:
 
 importer:
   create: false
-  image: pingcap/tidb-lightning:v4.0.0
+  image: pingcap/tidb-lightning:v4.0.4
   imagePullPolicy: IfNotPresent
   storageClassName: local-storage
   storage: 200Gi

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -12,7 +12,7 @@ timezone: UTC
 
 # clusterName is the TiDB cluster name that should backup from or restore to.
 clusterName: demo
-clusterVersion: v4.0.0
+clusterVersion: v4.0.4
 
 baseImage: pingcap/tidb-binlog
 imagePullPolicy: IfNotPresent

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -5,7 +5,7 @@
 # timezone is the default system timzone
 timezone: UTC
 
-image: pingcap/tidb-lightning:v4.0.0
+image: pingcap/tidb-lightning:v4.0.4
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 

--- a/charts/tikv-importer/values.yaml
+++ b/charts/tikv-importer/values.yaml
@@ -8,7 +8,7 @@ timezone: UTC
 # clusterName is the TiDB cluster name, if not specified, the chart release name will be used
 clusterName: demo
 
-image: pingcap/tidb-lightning:v4.0.0
+image: pingcap/tidb-lightning:v4.0.4
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 

--- a/deploy/aliyun/manifests/db-monitor.yaml.example
+++ b/deploy/aliyun/manifests/db-monitor.yaml.example
@@ -46,7 +46,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.0
+    version: v4.0.4
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/aliyun/manifests/db.yaml.example
+++ b/deploy/aliyun/manifests/db.yaml.example
@@ -109,4 +109,4 @@ spec:
   timezone: UTC
   tlsCluster:
     enabled: false
-  version: v4.0.0
+  version: v4.0.4

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -36,7 +36,7 @@ variable "cluster_name" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v4.0.0"
+  default     = "v4.0.4"
 }
 variable "tidb_cluster_chart_version" {
   description = "tidb-cluster chart version"

--- a/deploy/aws/manifests/db-monitor.yaml.example
+++ b/deploy/aws/manifests/db-monitor.yaml.example
@@ -44,7 +44,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.0
+    version: v4.0.4
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/aws/manifests/db.yaml.example
+++ b/deploy/aws/manifests/db.yaml.example
@@ -109,4 +109,4 @@ spec:
   timezone: UTC
   tlsCluster:
     enabled: false
-  version: v4.0.0
+  version: v4.0.4

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -80,7 +80,7 @@ variable "bastion_instance_type" {
 
 # For aws tutorials compatiablity
 variable "default_cluster_version" {
-  default = "v4.0.0"
+  default = "v4.0.4"
 }
 
 variable "default_cluster_pd_count" {

--- a/deploy/gcp/manifests/db-monitor.yaml.example
+++ b/deploy/gcp/manifests/db-monitor.yaml.example
@@ -44,7 +44,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.0
+    version: v4.0.4
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/gcp/manifests/db.yaml.example
+++ b/deploy/gcp/manifests/db.yaml.example
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: CLUSTER_NAME
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Retain
   schedulerName: tidb-scheduler

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -24,7 +24,7 @@ variable "node_locations" {
 
 variable "tidb_version" {
   description = "TiDB version"
-  default     = "v4.0.0"
+  default     = "v4.0.4"
 }
 
 variable "tidb_operator_version" {

--- a/deploy/modules/aliyun/tidb-cluster/variables.tf
+++ b/deploy/modules/aliyun/tidb-cluster/variables.tf
@@ -12,7 +12,7 @@ variable "image_id" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v4.0.0"
+  default     = "v4.0.4"
 }
 
 variable "tidb_cluster_chart_version" {

--- a/deploy/modules/aws/tidb-cluster/variables.tf
+++ b/deploy/modules/aws/tidb-cluster/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v4.0.0"
+  default = "v4.0.4"
 }
 
 variable "ssh_key_name" {

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -9,7 +9,7 @@ variable "tidb_operator_id" {
 variable "cluster_name" {}
 variable "cluster_version" {
   description = "The TiDB cluster version"
-  default     = "v4.0.0"
+  default     = "v4.0.4"
 }
 variable "tidb_cluster_chart_version" {
   description = "The TiDB cluster chart version"

--- a/deploy/modules/share/tidb-cluster-release/variables.tf
+++ b/deploy/modules/share/tidb-cluster-release/variables.tf
@@ -20,7 +20,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v4.0.0"
+  default = "v4.0.4"
 }
 
 variable "pd_count" {

--- a/examples/advanced-statefulset/tidb-cluster-scaled.yaml
+++ b/examples/advanced-statefulset/tidb-cluster-scaled.yaml
@@ -5,7 +5,7 @@ metadata:
     tikv.tidb.pingcap.com/delete-slots: '[1]'
   name: asts
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   pd:

--- a/examples/advanced-statefulset/tidb-cluster.yaml
+++ b/examples/advanced-statefulset/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: asts
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   pd:

--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   # ** Basic Configuration **
   # TiDB cluster version
-  version: "v4.0.0"
+  version: "v4.0.4"
 
   # Time zone of TiDB cluster Pods
   timezone: UTC

--- a/examples/auto-scale/tidb-cluster.yaml
+++ b/examples/auto-scale/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: auto-scaling-demo
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   pd:

--- a/examples/auto-scale/tidb-monitor.yaml
+++ b/examples/auto-scale/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.0
+    version: v4.0.4
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/aws/tidb-cluster.yaml
+++ b/examples/aws/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.3
+  version: v4.0.4
   timezone: UTC
   configUpdateStrategy: RollingUpdate
   pvReclaimPolicy: Retain

--- a/examples/aws/tidb-monitor.yaml
+++ b/examples/aws/tidb-monitor.yaml
@@ -30,7 +30,7 @@ spec:
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     imagePullPolicy: IfNotPresent
-    version: v4.0.3
+    version: v4.0.4
   kubePrometheusURL: ""
   persistent: true
   prometheus:

--- a/examples/basic-cn/tidb-cluster.yaml
+++ b/examples/basic-cn/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.1
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   discovery: {}

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-initializer
-    version: v4.0.1
+    version: v4.0.4
   reloader:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/basic/tidb-cluster.yaml
+++ b/examples/basic/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   discovery: {}

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.0
+    version: v4.0.4
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/heterogeneous/heterogeneous-cluster.yaml
+++ b/examples/heterogeneous/heterogeneous-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: heterogeneous
 spec:
   configUpdateStrategy: RollingUpdate
-  version: v4.0.3
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   discovery: {}

--- a/examples/heterogeneous/tidb-cluster.yaml
+++ b/examples/heterogeneous/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.3
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   imagePullPolicy: IfNotPresent

--- a/examples/initialize/tidb-cluster.yaml
+++ b/examples/initialize/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: initialize-demo
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   pd:

--- a/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
@@ -23,7 +23,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.0
+    version: v4.0.4
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/selfsigned-tls/tidb-cluster.yaml
+++ b/examples/selfsigned-tls/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: tls
 spec:
-  version: v4.0.0
+  version: v4.0.4
   timezone: UTC
   pvReclaimPolicy: Delete
   pd:

--- a/examples/tiflash/tidb-cluster.yaml
+++ b/examples/tiflash/tidb-cluster.yaml
@@ -70,4 +70,4 @@ spec:
       storage: 10Gi
     storageClassName: local-storage
   timezone: UTC
-  version: v4.0.0-rc
+  version: v4.0.4

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -15,7 +15,7 @@ spec:
       type: NodePort
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.0-rc
+    version: v4.0.4
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -2,7 +2,7 @@ FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_V31=v3.1.2
-ARG TOOLKIT_V40=v4.0.3
+ARG TOOLKIT_V40=v4.0.4
 RUN apk update && apk add ca-certificates
 
 RUN wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
resolve https://github.com/pingcap/tidb-operator/issues/3133

### What is changed and how does it work?
Bump tidb image versions to v4.0.4

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
TiDB Operator examples updated to deploy TiDB Cluster 4.0.4 images.
```
