### PR TITLE
optimize pvc resizer logic

### DIFF
--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -166,11 +166,12 @@ func (p *pvcResizer) patchPVCs(ns string, selector labels.Selector, storageReque
 		if err != nil {
 			return err
 		}
-		if !volumeExpansionSupported {
-			klog.Warningf("Storage Class %q used by PVC %s/%s does not support volume expansion, skipped", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
-			continue
-		}
+
 		if currentRequest, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; !ok || storageRequest.Cmp(currentRequest) > 0 {
+			if !volumeExpansionSupported {
+				klog.Warningf("Storage Class %q used by PVC %s/%s does not support volume expansion, skipped", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
+				continue
+			}
 			_, err = p.kubeCli.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(pvc.Name, types.MergePatchType, mergePatch)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
With the current implementation, there will be too many noisy logs even if there is no change to the `storage` if the sc does not support expansion:
```
W0820 11:06:53.210573       1 pvc_resizer.go:170] Storage Class "local-storage" used by PVC ns1/tikv-ns1-tikv-1 does not support volume expansion, skipped
W0820 11:06:53.210581       1 pvc_resizer.go:170] Storage Class "local-storage" used by PVC ns1/tikv-ns1-tikv-4 does not support volume expansion, skipped
W0820 11:06:53.210590       1 pvc_resizer.go:170] Storage Class "local-storage" used by PVC ns1/tikv-ns1-tikv-3 does not support volume expansion, skipped
```
### What is changed and how does it work?
Check if expansion is supported only when we need to patch the PVC.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
   Deploy TiDB Cluster with local-storage

Code changes

 - Has Go code change




Related changes

 - Need to cherry-pick to the release branch


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
