### PR TITLE
fix tidb-operator helm hook-delete-policy.

### DIFF
--- a/charts/tidb-operator/templates/admission/pre-delete-job.yaml
+++ b/charts/tidb-operator/templates/admission/pre-delete-job.yaml
@@ -14,7 +14,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -31,7 +31,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
@@ -53,7 +53,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}
@@ -79,7 +79,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
   template:
     metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fails to install or uninstall tidb-operator again if last `helm uninstall` was interrupted by `ctrl + c`. 
Related issue: [https://github.com/helm/helm/issues/8640](https://github.com/helm/helm/issues/8640)

### What is changed and how does it work?
Add the default `before-hook-creation` to `helm.sh/hook-delete-policy`. This configuration delete the previous resource before a new hook is launched.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Stop `helm uninstall` abruptly by `ctrl + c`.
![image](https://user-images.githubusercontent.com/44308864/90957590-fb592a80-e4c0-11ea-9c39-f4c0f47ec7f4.png)
2. Successfully execute `helm uninstall` again.
![image](https://user-images.githubusercontent.com/44308864/90957610-2cd1f600-e4c1-11ea-8c03-8fb4d9a85f18.png)


Code changes

 - Has CI related scripts change

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
