### PR TITLE
Support tidbmonitor monitor multiple cluster.

### DIFF
--- a/examples/heterogeneous/tidb-monitor.yaml
+++ b/examples/heterogeneous/tidb-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: pingcap.com/v1alpha1
+kind: TidbMonitor
+metadata:
+  name: heterogeneous
+spec:
+  clusters:
+    - name: basic
+    - name: heterogeneous
+  prometheus:
+    baseImage: prom/prometheus
+    version: v2.11.1
+  grafana:
+    baseImage: grafana/grafana
+    version: 6.1.6
+  initializer:
+    baseImage: pingcap/tidb-monitor-initializer
+    version: v4.0.4
+  reloader:
+    baseImage: pingcap/tidb-monitor-reloader
+    version: v1.0.1
+  imagePullPolicy: IfNotPresent

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -16,9 +16,6 @@ package monitor
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"strconv"
-
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -33,6 +30,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 func GetMonitorObjectName(monitor *v1alpha1.TidbMonitor) string {
@@ -48,11 +48,14 @@ func buildTidbMonitorLabel(name string) map[string]string {
 func getMonitorConfigMap(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) (*core.ConfigMap, error) {
 
 	var releaseNamespaces []string
+	var releaseClusters []string
 	for _, cluster := range monitor.Spec.Clusters {
 		releaseNamespaces = append(releaseNamespaces, cluster.Namespace)
+		releaseClusters = append(releaseClusters, cluster.Name)
 	}
 
-	targetPattern, err := config.NewRegexp(tc.Name)
+	relabelConfigsRegex := strings.Join(releaseClusters, "|")
+	targetPattern, err := config.NewRegexp(relabelConfigsRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -16,6 +16,10 @@ package monitor
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/label"
@@ -30,9 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 func GetMonitorObjectName(monitor *v1alpha1.TidbMonitor) string {


### PR DESCRIPTION

### What problem does this PR solve? 
#3062 
### What is changed and how does it work?
Prometheus configuration relabel_configs regex use multiple cluster name join.
### Check List <!--REMOVE the items that are not applicable-->

Tests 

 - Unit test
 - E2E test
 - Stability test

Code changes

 - Has Go code change


Side effects

 - None
