### PR TITLE
Support recover from failover for tiflash and tikv

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -12433,6 +12433,18 @@ LogTailerSpec
 <p>LogTailer is the configurations of the log tailers for TiFlash</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>recoverFailover</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RecoverFailover indicates that Operator can recover the failover Pods</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tikvbackupconfig">TiKVBackupConfig</h3>
@@ -16351,6 +16363,18 @@ TiKVConfig
 <td>
 <em>(Optional)</em>
 <p>Config is the Configuration of tikv-servers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>recoverFailover</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RecoverFailover indicates that Operator can recover the failover Pods</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -8612,6 +8612,8 @@ spec:
                   type: string
                 privileged:
                   type: boolean
+                recoverFailover:
+                  type: boolean
                 replicas:
                   format: int32
                   type: integer
@@ -11226,6 +11228,8 @@ spec:
                 priorityClassName:
                   type: string
                 privileged:
+                  type: boolean
+                recoverFailover:
                   type: boolean
                 replicas:
                   format: int32
@@ -21612,6 +21616,8 @@ spec:
             priorityClassName:
               type: string
             privileged:
+              type: boolean
+            recoverFailover:
               type: boolean
             replicas:
               format: int32

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -6678,6 +6678,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiFlashSpec(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.LogTailerSpec"),
 						},
 					},
+					"recoverFailover": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RecoverFailover indicates that Operator can recover the failover Pods",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"replicas", "storageClaims"},
 			},
@@ -7918,6 +7925,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVGroupSpec(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "Config is the Configuration of tikv-servers",
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVConfig"),
+						},
+					},
+					"recoverFailover": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RecoverFailover indicates that Operator can recover the failover Pods",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"clusterName": {
@@ -9202,6 +9216,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Description: "Config is the Configuration of tikv-servers",
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVConfig"),
+						},
+					},
+					"recoverFailover": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RecoverFailover indicates that Operator can recover the failover Pods",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -411,6 +411,10 @@ type TiKVSpec struct {
 	// Config is the Configuration of tikv-servers
 	// +optional
 	Config *TiKVConfig `json:"config,omitempty"`
+
+	// RecoverFailover indicates that Operator can recover the failover Pods
+	// +optional
+	RecoverFailover bool `json:"recoverFailover,omitempty"`
 }
 
 // TiFlashSpec contains details of TiFlash members
@@ -454,6 +458,10 @@ type TiFlashSpec struct {
 	// LogTailer is the configurations of the log tailers for TiFlash
 	// +optional
 	LogTailer *LogTailerSpec `json:"logTailer,omitempty"`
+
+	// RecoverFailover indicates that Operator can recover the failover Pods
+	// +optional
+	RecoverFailover bool `json:"recoverFailover,omitempty"`
 }
 
 // TiCDCSpec contains details of TiCDC members

--- a/pkg/manager/member/failover.go
+++ b/pkg/manager/member/failover.go
@@ -25,4 +25,5 @@ const (
 type Failover interface {
 	Failover(*v1alpha1.TidbCluster) error
 	Recover(*v1alpha1.TidbCluster)
+	RemoveUndesiredFailures(*v1alpha1.TidbCluster)
 }

--- a/pkg/manager/member/pd_failover.go
+++ b/pkg/manager/member/pd_failover.go
@@ -245,6 +245,20 @@ func (pf *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error 
 	return nil
 }
 
+func (pf *pdFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
+	ordinals := tc.PDStsDesiredOrdinals(true)
+	ordinal, err := util.GetOrdinalFromPodName(podName)
+	if err != nil {
+		klog.Errorf("unexpected pod name %q: %v", podName, err)
+		return false
+	}
+	return ordinals.Has(ordinal)
+}
+
+func (pf *pdFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+	return
+}
+
 func setMemberDeleted(tc *v1alpha1.TidbCluster, podName string) {
 	failureMember := tc.Status.PD.FailureMembers[podName]
 	failureMember.MemberDeleted = true
@@ -267,12 +281,6 @@ func (fpf *fakePDFailover) Recover(_ *v1alpha1.TidbCluster) {
 	return
 }
 
-func (pf *pdFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
-	ordinals := tc.PDStsDesiredOrdinals(true)
-	ordinal, err := util.GetOrdinalFromPodName(podName)
-	if err != nil {
-		klog.Errorf("unexpected pod name %q: %v", podName, err)
-		return false
-	}
-	return ordinals.Has(ordinal)
+func (fpf *fakePDFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+	return
 }

--- a/pkg/manager/member/tidb_failover.go
+++ b/pkg/manager/member/tidb_failover.go
@@ -96,6 +96,10 @@ func (tf *tidbFailover) Recover(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiDB.FailureMembers = nil
 }
 
+func (tf *tidbFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+	return
+}
+
 type fakeTiDBFailover struct {
 }
 
@@ -110,4 +114,7 @@ func (ftf *fakeTiDBFailover) Failover(_ *v1alpha1.TidbCluster) error {
 
 func (ftf *fakeTiDBFailover) Recover(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiDB.FailureMembers = nil
+}
+func (ftf *fakeTiDBFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+	return
 }

--- a/pkg/manager/member/tiflash_failover.go
+++ b/pkg/manager/member/tiflash_failover.go
@@ -92,7 +92,7 @@ func (tff *tiflashFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (tff *tiflashFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (tff *tiflashFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 	for key, failureStore := range tc.Status.TiFlash.FailureStores {
 		if !tff.isPodDesired(tc, failureStore.PodName) {
 			// If we delete the pods, e.g. by using advanced statefulset delete
@@ -101,6 +101,11 @@ func (tff *tiflashFailover) Recover(tc *v1alpha1.TidbCluster) {
 			delete(tc.Status.TiFlash.FailureStores, key)
 		}
 	}
+}
+
+func (tff *tiflashFailover) Recover(tc *v1alpha1.TidbCluster) {
+	tc.Status.TiFlash.FailureStores = nil
+	klog.Infof("TiFlash recover: clear FailureStores, %s/%s", tc.GetNamespace(), tc.GetName())
 }
 
 type fakeTiFlashFailover struct{}
@@ -115,5 +120,8 @@ func (ftff *fakeTiFlashFailover) Failover(_ *v1alpha1.TidbCluster) error {
 }
 
 func (ftff *fakeTiFlashFailover) Recover(_ *v1alpha1.TidbCluster) {
+	return
+}
+func (ftff *fakeTiFlashFailover) RemoveUndesiredFailures(_ *v1alpha1.TidbCluster) {
 	return
 }

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -207,6 +207,11 @@ func (tfmm *tiflashMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) erro
 
 	// Recover failed stores if any before generating desired statefulset
 	if len(tc.Status.TiFlash.FailureStores) > 0 {
+		tfmm.tiflashFailover.RemoveUndesiredFailures(tc)
+	}
+	if len(tc.Status.TiFlash.FailureStores) > 0 &&
+		tc.Spec.TiFlash.RecoverFailover &&
+		shouldRecover(tc, label.TiFlashLabelVal, tfmm.podLister) {
 		tfmm.tiflashFailover.Recover(tc)
 	}
 

--- a/pkg/manager/member/tikv_failover.go
+++ b/pkg/manager/member/tikv_failover.go
@@ -92,7 +92,7 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (tf *tikvFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 	for key, failureStore := range tc.Status.TiKV.FailureStores {
 		if !tf.isPodDesired(tc, failureStore.PodName) {
 			// If we delete the pods, e.g. by using advanced statefulset delete
@@ -101,6 +101,11 @@ func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
 			delete(tc.Status.TiKV.FailureStores, key)
 		}
 	}
+}
+
+func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
+	tc.Status.TiKV.FailureStores = nil
+	klog.Infof("TiKV recover: clear FailureStores, %s/%s", tc.GetNamespace(), tc.GetName())
 }
 
 type fakeTiKVFailover struct{}
@@ -115,5 +120,8 @@ func (ftf *fakeTiKVFailover) Failover(_ *v1alpha1.TidbCluster) error {
 }
 
 func (ftf *fakeTiKVFailover) Recover(_ *v1alpha1.TidbCluster) {
+	return
+}
+func (ftf *fakeTiKVFailover) RemoveUndesiredFailures(_ *v1alpha1.TidbCluster) {
 	return
 }

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -216,6 +216,11 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 
 	// Recover failed stores if any before generating desired statefulset
 	if len(tc.Status.TiKV.FailureStores) > 0 {
+		tkmm.tikvFailover.RemoveUndesiredFailures(tc)
+	}
+	if len(tc.Status.TiKV.FailureStores) > 0 &&
+		tc.Spec.TiKV.RecoverFailover &&
+		shouldRecover(tc, label.TiKVLabelVal, tkmm.podLister) {
 		tkmm.tikvFailover.Recover(tc)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #3177
### What is changed and how does it work?
Add `recoverFailover` field to the spec of TiKV and TiFlash, when users set it to `true`, TiDB Operator will try to recover the failure stores for TiKV and TiFlash.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
   - Failover TiKV manually, after the failed Pods is recovered, the newly created Pods will not be removed, update TidbCluster to set `recoverFailover: true`, the newly created Pods will be removed
   - Failover TiFlash manually, after the failed Pods is recovered, the newly created Pods will not be removed, update TidbCluster to set `recoverFailover: true`, the newly created Pods will be removed

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Support recover from failover for TiFlash and TiKV
```
