### PR TITLE
fix empty version issue

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -49,7 +49,11 @@ func (tc *TidbCluster) PDImage() string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return image
 }
@@ -73,7 +77,11 @@ func (tc *TidbCluster) TiKVImage() string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return image
 }
@@ -105,7 +113,11 @@ func (tc *TidbCluster) TiFlashImage() string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return image
 }
@@ -119,7 +131,11 @@ func (tc *TidbCluster) TiCDCImage() string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return image
 }
@@ -141,7 +157,11 @@ func (tc *TidbCluster) TiDBImage() string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return image
 }
@@ -158,7 +178,11 @@ func (tc *TidbCluster) PumpImage() *string {
 		if version == nil {
 			version = &tc.Spec.Version
 		}
-		image = fmt.Sprintf("%s:%s", baseImage, *version)
+		if *version == "" {
+			image = baseImage
+		} else {
+			image = fmt.Sprintf("%s:%s", baseImage, *version)
+		}
 	}
 	return &image
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix https://github.com/pingcap/tidb-operator/issues/3050
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
   - Configure baseImage for PD/TiDB/TiKV/TiFlash/Pump/TiCDC with image tag and set `spec.version: ""`, `spec.<component>.spec: ""`

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
