### PR TITLE
autoscaler: construct pd strategy request according to autoscaler spec

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1826,13 +1826,14 @@ TidbAutoScalerSpec
 <code>resources</code></br>
 <em>
 <a href="#autoresource">
-[]AutoResource
+map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.AutoResource
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Resources represent the resource type definitions that can be used for TiDB/TiKV</p>
+<p>Resources represent the resource type definitions that can be used for TiDB/TiKV
+The key is resource_type name of the resource</p>
 </td>
 </tr>
 </table>
@@ -2373,17 +2374,6 @@ TidbMonitorStatus
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>resource_type</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ResourceType identifies a specific resource type</p>
-</td>
-</tr>
 <tr>
 <td>
 <code>cpu</code></br>
@@ -18084,13 +18074,14 @@ TidbAutoScalerSpec
 <code>resources</code></br>
 <em>
 <a href="#autoresource">
-[]AutoResource
+map[string]github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.AutoResource
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Resources represent the resource type definitions that can be used for TiDB/TiKV</p>
+<p>Resources represent the resource type definitions that can be used for TiDB/TiKV
+The key is resource_type name of the resource</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -17982,18 +17982,7 @@ spec:
               - name
               type: object
             resources:
-              items:
-                properties:
-                  count:
-                    format: int32
-                    type: integer
-                  cpu: {}
-                  memory: {}
-                  resource_type:
-                    type: string
-                  storage: {}
-                type: object
-              type: array
+              type: object
             tidb:
               properties:
                 external:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -430,13 +430,6 @@ func schema_pkg_apis_pingcap_v1alpha1_AutoResource(ref common.ReferenceCallback)
 				Description: "AutoResource describes the resource type definitions",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"resource_type": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ResourceType identifies a specific resource type",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"cpu": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CPU defines the CPU of this resource type",
@@ -463,6 +456,7 @@ func schema_pkg_apis_pingcap_v1alpha1_AutoResource(ref common.ReferenceCallback)
 						},
 					},
 				},
+				Required: []string{"cpu", "memory"},
 			},
 		},
 		Dependencies: []string{
@@ -10468,9 +10462,10 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbClusterAutoScalerSpec(ref common.Refer
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources represent the resource type definitions that can be used for TiDB/TiKV",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
+							Description: "Resources represent the resource type definitions that can be used for TiDB/TiKV The key is resource_type name of the resource",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Ref: ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.AutoResource"),

--- a/pkg/apis/pingcap/v1alpha1/tidbclusterautoscaler_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbclusterautoscaler_types.go
@@ -84,19 +84,18 @@ type TidbClusterAutoScalerSpec struct {
 	TiDB *TidbAutoScalerSpec `json:"tidb,omitempty"`
 
 	// Resources represent the resource type definitions that can be used for TiDB/TiKV
+	// The key is resource_type name of the resource
 	// +optional
-	Resources []AutoResource `json:"resources,omitempty"`
+	Resources map[string]AutoResource `json:"resources,omitempty"`
 }
 
 // +k8s:openapi-gen=true
 // AutoResource describes the resource type definitions
 type AutoResource struct {
-	// ResourceType identifies a specific resource type
-	ResourceType string `json:"resource_type,omitempty"`
 	// CPU defines the CPU of this resource type
-	CPU resource.Quantity `json:"cpu,omitempty"`
+	CPU resource.Quantity `json:"cpu"`
 	// Memory defines the memory of this resource type
-	Memory resource.Quantity `json:"memory,omitempty"`
+	Memory resource.Quantity `json:"memory"`
 	// Storage defines the storage of this resource type
 	Storage resource.Quantity `json:"storage,omitempty"`
 	// Count defines the max availabel count of this resource type

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -7442,9 +7442,9 @@ func (in *TidbClusterAutoScalerSpec) DeepCopyInto(out *TidbClusterAutoScalerSpec
 	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
-		*out = make([]AutoResource, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = make(map[string]AutoResource, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 	return

--- a/pkg/autoscaler/autoscaler/util.go
+++ b/pkg/autoscaler/autoscaler/util.go
@@ -20,11 +20,16 @@ import (
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
+
+var zeroQuantity = resource.MustParse("0")
 
 // checkStsAutoScalingPrerequisites would check the sts status to ensure wouldn't happen during
 // upgrading, scaling
@@ -88,36 +93,109 @@ func limitTargetReplicas(targetReplicas int32, tac *v1alpha1.TidbClusterAutoScal
 	return targetReplicas
 }
 
+func defaultResources(tc *v1alpha1.TidbCluster, tac *v1alpha1.TidbClusterAutoScaler, component v1alpha1.MemberType) {
+	if tac.Spec.Resources == nil {
+		tac.Spec.Resources = map[string]v1alpha1.AutoResource{}
+	}
+	typ := fmt.Sprintf("default_%s", component.String())
+	resource := v1alpha1.AutoResource{}
+	var requests corev1.ResourceList
+	switch component {
+	case v1alpha1.TiDBMemberType:
+		requests = tc.Spec.TiDB.Requests
+	case v1alpha1.TiKVMemberType:
+		requests = tc.Spec.TiKV.Requests
+	}
+	for res, v := range requests {
+		switch res {
+		case corev1.ResourceCPU:
+			resource.CPU = v
+		case corev1.ResourceMemory:
+			resource.Memory = v
+		case corev1.ResourceStorage:
+			resource.Storage = v
+		}
+	}
+	tac.Spec.Resources[typ] = resource
+}
+
+func defaultResourceTypes(tac *v1alpha1.TidbClusterAutoScaler, rule *v1alpha1.AutoRule, component v1alpha1.MemberType) {
+	if len(rule.ResourceTypes) == 0 {
+		for typ, res := range tac.Spec.Resources {
+			if component == v1alpha1.TiKVMemberType {
+				// The resource has no storage for TiKV
+				if res.Storage.Cmp(zeroQuantity) == 0 {
+					continue
+				}
+			}
+			rule.ResourceTypes = append(rule.ResourceTypes, typ)
+		}
+	}
+}
+
+func getBasicAutoScalerSpec(tac *v1alpha1.TidbClusterAutoScaler, component v1alpha1.MemberType) *v1alpha1.BasicAutoScalerSpec {
+	switch component {
+	case v1alpha1.TiDBMemberType:
+		return &tac.Spec.TiDB.BasicAutoScalerSpec
+	case v1alpha1.TiKVMemberType:
+		return &tac.Spec.TiKV.BasicAutoScalerSpec
+	}
+	return nil
+}
+
+func defaultBasicAutoScaler(tac *v1alpha1.TidbClusterAutoScaler, component v1alpha1.MemberType) {
+	spec := getBasicAutoScalerSpec(tac, component)
+
+	if spec.MinReplicas == nil {
+		spec.MinReplicas = pointer.Int32Ptr(1)
+	}
+	if spec.ScaleOutIntervalSeconds == nil {
+		spec.ScaleOutIntervalSeconds = pointer.Int32Ptr(300)
+	}
+	if spec.ScaleInIntervalSeconds == nil {
+		spec.ScaleInIntervalSeconds = pointer.Int32Ptr(500)
+	}
+	// If ExternalEndpoint is not provided, we would set default metrics
+	if spec.External == nil && spec.MetricsTimeDuration == nil {
+		spec.MetricsTimeDuration = pointer.StringPtr("3m")
+	}
+
+	for res, rule := range spec.Rules {
+		if res == corev1.ResourceCPU {
+			if rule.MinThreshold == nil {
+				rule.MinThreshold = pointer.Float64Ptr(0.1)
+			}
+		}
+		defaultResourceTypes(tac, &rule, component)
+		spec.Rules[res] = rule
+	}
+}
+
 // If the minReplicas not set, the default value would be 1
 // If the Metrics not set, the default metric will be set to 80% average CPU utilization.
 // defaultTAC would default the omitted value
-func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler) {
+func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler, tc *v1alpha1.TidbCluster) {
 	if tac.Annotations == nil {
 		tac.Annotations = map[string]string{}
 	}
 
-	def := func(spec *v1alpha1.BasicAutoScalerSpec) {
-		if spec.MinReplicas == nil {
-			spec.MinReplicas = pointer.Int32Ptr(1)
+	if len(tac.Spec.Resources) == 0 {
+		// Construct default resource
+		if tac.Spec.TiKV != nil {
+			defaultResources(tc, tac, v1alpha1.TiKVMemberType)
 		}
-		if spec.ScaleOutIntervalSeconds == nil {
-			spec.ScaleOutIntervalSeconds = pointer.Int32Ptr(300)
-		}
-		if spec.ScaleInIntervalSeconds == nil {
-			spec.ScaleInIntervalSeconds = pointer.Int32Ptr(500)
-		}
-		// If ExternalEndpoint is not provided, we would set default metrics
-		if spec.External == nil && spec.MetricsTimeDuration == nil {
-			spec.MetricsTimeDuration = pointer.StringPtr("3m")
+
+		if tac.Spec.TiDB != nil {
+			defaultResources(tc, tac, v1alpha1.TiDBMemberType)
 		}
 	}
 
 	if tidb := tac.Spec.TiDB; tidb != nil {
-		def(&tidb.BasicAutoScalerSpec)
+		defaultBasicAutoScaler(tac, v1alpha1.TiDBMemberType)
 	}
 
 	if tikv := tac.Spec.TiKV; tikv != nil {
-		def(&tikv.BasicAutoScalerSpec)
+		defaultBasicAutoScaler(tac, v1alpha1.TiKVMemberType)
 		for id, m := range tikv.Metrics {
 			if m.Resource == nil || m.Resource.Name != corev1.ResourceStorage {
 				continue
@@ -137,6 +215,86 @@ func defaultTAC(tac *v1alpha1.TidbClusterAutoScaler) {
 	}
 }
 
+func validateBasicAutoScalerSpec(tac *v1alpha1.TidbClusterAutoScaler, component v1alpha1.MemberType) error {
+	spec := getBasicAutoScalerSpec(tac, component)
+
+	if len(spec.Rules) == 0 {
+		return fmt.Errorf("no rules defined for component %s in %s/%s", component.String(), tac.Namespace, tac.Name)
+	}
+
+	acceptableResources := map[corev1.ResourceName]struct{}{
+		corev1.ResourceCPU:     {},
+		corev1.ResourceStorage: {},
+	}
+
+	checkCommon := func(res corev1.ResourceName, rule v1alpha1.AutoRule) error {
+		if _, ok := acceptableResources[res]; !ok {
+			return fmt.Errorf("unknown resource type %s of %s in %s/%s", res.String(), component.String(), tac.Namespace, tac.Name)
+		}
+		if rule.MaxThreshold > 1.0 || rule.MaxThreshold < 0.0 {
+			return fmt.Errorf("max_threshold (%v) should be between 0 and 1 for rule %s of %s in %s/%s", rule.MaxThreshold, res, component.String(), tac.Namespace, tac.Name)
+		}
+		if len(rule.ResourceTypes) == 0 {
+			return fmt.Errorf("no resources provided for rule %s of %s in %s/%s", res, component.String(), tac.Namespace, tac.Name)
+		}
+		for _, resType := range rule.ResourceTypes {
+			if _, ok := tac.Spec.Resources[resType]; !ok {
+				return fmt.Errorf("unknown resource %s for %s in %s/%s", resType, component.String(), tac.Namespace, tac.Name)
+			}
+		}
+		return nil
+	}
+
+	for res, rule := range spec.Rules {
+		if err := checkCommon(res, rule); err != nil {
+			return err
+		}
+
+		switch res {
+		case corev1.ResourceCPU:
+			if *rule.MinThreshold > 1.0 || *rule.MinThreshold < 0.0 {
+				return fmt.Errorf("min_threshold (%v) should be between 0 and 1 for rule %s of %s in %s/%s", *rule.MinThreshold, res, component.String(), tac.Namespace, tac.Name)
+			}
+			if *rule.MinThreshold > rule.MaxThreshold {
+				return fmt.Errorf("min_threshold (%v) > max_threshold (%v) for cpu rule of %s in %s/%s", *rule.MinThreshold, rule.MaxThreshold, component.String(), tac.Namespace, tac.Name)
+			}
+		case corev1.ResourceStorage:
+			for _, resType := range rule.ResourceTypes {
+				if res, ok := tac.Spec.Resources[resType]; ok {
+					if res.Storage.Cmp(zeroQuantity) == 0 {
+						return fmt.Errorf("resource %s specified for storage rule for %s in %s/%s does not have storage", resType, component.String(), tac.Namespace, tac.Name)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// TODO: add tests for this function
+func validateTAC(tac *v1alpha1.TidbClusterAutoScaler) error {
+	if len(tac.Spec.Resources) == 0 {
+		return fmt.Errorf("no resources provided for %s/%s", tac.Namespace, tac.Name)
+	}
+
+	if tidb := tac.Spec.TiDB; tidb != nil {
+		err := validateBasicAutoScalerSpec(tac, v1alpha1.TiDBMemberType)
+		if err != nil {
+			return err
+		}
+	}
+
+	if tikv := tac.Spec.TiKV; tikv != nil {
+		err := validateBasicAutoScalerSpec(tac, v1alpha1.TiKVMemberType)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func genMetricsEndpoint(tac *v1alpha1.TidbClusterAutoScaler) (string, error) {
 	if tac.Spec.MetricsUrl == nil && tac.Spec.Monitor == nil {
 		return "", fmt.Errorf("tac[%s/%s] metrics url or monitor should be defined explicitly", tac.Namespace, tac.Name)
@@ -145,4 +303,61 @@ func genMetricsEndpoint(tac *v1alpha1.TidbClusterAutoScaler) (string, error) {
 		return *tac.Spec.MetricsUrl, nil
 	}
 	return fmt.Sprintf("http://%s-prometheus.%s.svc:9090", tac.Spec.Monitor.Name, tac.Spec.Monitor.Namespace), nil
+}
+
+func autoscalerToStrategy(tac *v1alpha1.TidbClusterAutoScaler) *pdapi.Strategy {
+	strategy := &pdapi.Strategy{
+		Resources: make([]*pdapi.Resource, 0, len(tac.Spec.Resources)),
+	}
+
+	for typ, res := range tac.Spec.Resources {
+		resource := &pdapi.Resource{
+			CPU:          res.CPU.AsDec().UnscaledBig().Uint64(),
+			Memory:       res.Memory.AsDec().UnscaledBig().Uint64(),
+			Storage:      res.Storage.AsDec().UnscaledBig().Uint64(),
+			ResourceType: typ,
+		}
+		if res.Count != nil {
+			count := uint64(*res.Count)
+			resource.Count = &count
+		}
+		strategy.Resources = append(strategy.Resources, resource)
+	}
+
+	if tac.Spec.TiDB != nil {
+		strategy.Rules = append(strategy.Rules, autoRulesToStrategyRule(v1alpha1.TiDBMemberType.String(), tac.Spec.TiDB.Rules))
+	}
+
+	if tac.Spec.TiKV != nil {
+		strategy.Rules = append(strategy.Rules, autoRulesToStrategyRule(v1alpha1.TiKVMemberType.String(), tac.Spec.TiKV.Rules))
+	}
+
+	return strategy
+}
+
+func autoRulesToStrategyRule(component string, rules map[corev1.ResourceName]v1alpha1.AutoRule) *pdapi.Rule {
+	result := &pdapi.Rule{
+		Component: component,
+	}
+	for res, rule := range rules {
+		switch res {
+		case corev1.ResourceCPU:
+			// For CPU rule, users should both specify max_threshold and min_threshold
+			// Defaulting and validating make sure that the min_threshold is set
+			result.CPURule = &pdapi.CPURule{
+				MaxThreshold:  rule.MaxThreshold,
+				MinThreshold:  *rule.MinThreshold,
+				ResourceTypes: rule.ResourceTypes,
+			}
+		case corev1.ResourceStorage:
+			// For storage rule, users need only set the max_threshold and we convert it to min_threshold for PD
+			result.StorageRule = &pdapi.StorageRule{
+				MinThreshold:  1.0 - rule.MaxThreshold,
+				ResourceTypes: rule.ResourceTypes,
+			}
+		default:
+			klog.Warningf("unknown resource type %v", res.String())
+		}
+	}
+	return result
 }

--- a/pkg/autoscaler/autoscaler/util_test.go
+++ b/pkg/autoscaler/autoscaler/util_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 )
 
@@ -255,6 +257,7 @@ func TestLimitTargetReplicas(t *testing.T) {
 
 func TestDefaultTac(t *testing.T) {
 	g := NewGomegaWithT(t)
+	tc := newTidbCluster()
 	tac := newTidbClusterAutoScaler()
 	tac.Spec.TiDB = nil
 	tac.Spec.TiKV.MinReplicas = nil
@@ -262,11 +265,25 @@ func TestDefaultTac(t *testing.T) {
 	tac.Spec.TiKV.MetricsTimeDuration = nil
 	tac.Spec.TiKV.ScaleOutIntervalSeconds = nil
 	tac.Spec.TiKV.ScaleInIntervalSeconds = nil
-	defaultTAC(tac)
+	tac.Spec.TiKV.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold: 0.8,
+		},
+	}
+	defaultTAC(tac, tc)
 	g.Expect(*tac.Spec.TiKV.MinReplicas).Should(Equal(int32(1)))
 	g.Expect(*tac.Spec.TiKV.MetricsTimeDuration).Should(Equal("3m"))
 	g.Expect(*tac.Spec.TiKV.ScaleOutIntervalSeconds).Should(Equal(int32(300)))
 	g.Expect(*tac.Spec.TiKV.ScaleInIntervalSeconds).Should(Equal(int32(500)))
+	g.Expect(tac.Spec.Resources).Should(Equal(map[string]v1alpha1.AutoResource{
+		"default_tikv": {
+			CPU:     tc.Spec.TiKV.Requests.Cpu().DeepCopy(),
+			Memory:  tc.Spec.TiKV.Requests.Memory().DeepCopy(),
+			Storage: tc.Spec.TiKV.Requests[corev1.ResourceStorage].DeepCopy(),
+		},
+	}))
+	g.Expect(*tac.Spec.TiKV.Rules[corev1.ResourceCPU].MinThreshold).Should(BeNumerically("==", 0.1))
+	g.Expect(tac.Spec.TiKV.Rules[corev1.ResourceCPU].ResourceTypes).Should(ConsistOf([]string{"default_tikv"}))
 
 	tac = newTidbClusterAutoScaler()
 	tac.Spec.TiKV = nil
@@ -275,12 +292,76 @@ func TestDefaultTac(t *testing.T) {
 	tac.Spec.TiDB.MetricsTimeDuration = nil
 	tac.Spec.TiDB.ScaleOutIntervalSeconds = nil
 	tac.Spec.TiDB.ScaleInIntervalSeconds = nil
-	defaultTAC(tac)
+	tac.Spec.TiDB.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold: 0.8,
+		},
+	}
+	defaultTAC(tac, tc)
 	g.Expect(*tac.Spec.TiDB.MinReplicas).Should(Equal(int32(1)))
 	g.Expect(*tac.Spec.TiDB.MetricsTimeDuration).Should(Equal("3m"))
 	g.Expect(*tac.Spec.TiDB.ScaleOutIntervalSeconds).Should(Equal(int32(300)))
 	g.Expect(*tac.Spec.TiDB.ScaleInIntervalSeconds).Should(Equal(int32(500)))
+	g.Expect(tac.Spec.Resources).Should(Equal(map[string]v1alpha1.AutoResource{
+		"default_tidb": {
+			CPU:     tc.Spec.TiDB.Requests.Cpu().DeepCopy(),
+			Memory:  tc.Spec.TiDB.Requests.Memory().DeepCopy(),
+			Storage: tc.Spec.TiDB.Requests[corev1.ResourceStorage].DeepCopy(),
+		},
+	}))
+	g.Expect(*tac.Spec.TiDB.Rules[corev1.ResourceCPU].MinThreshold).Should(BeNumerically("==", 0.1))
+	g.Expect(tac.Spec.TiDB.Rules[corev1.ResourceCPU].ResourceTypes).Should(ConsistOf([]string{"default_tidb"}))
 
+	tac = newTidbClusterAutoScaler()
+	tac.Spec.TiDB = nil
+	tac.Spec.TiKV.MinReplicas = nil
+	tac.Spec.TiKV.Metrics = []v1alpha1.CustomMetric{}
+	tac.Spec.TiKV.MetricsTimeDuration = nil
+	tac.Spec.TiKV.ScaleOutIntervalSeconds = nil
+	tac.Spec.TiKV.ScaleInIntervalSeconds = nil
+	tac.Spec.TiKV.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceStorage: {
+			MaxThreshold: 0.8,
+		},
+	}
+	tac.Spec.Resources = map[string]v1alpha1.AutoResource{
+		"compute": {
+			CPU:    resource.MustParse("1000m"),
+			Memory: resource.MustParse("2Gi"),
+		},
+		"storage": {
+			CPU:     resource.MustParse("1000m"),
+			Memory:  resource.MustParse("2Gi"),
+			Storage: resource.MustParse("200Gi"),
+		},
+	}
+	defaultTAC(tac, tc)
+	g.Expect(tac.Spec.TiKV.Rules[corev1.ResourceStorage].ResourceTypes).Should(ConsistOf([]string{"storage"}))
+
+	tac = newTidbClusterAutoScaler()
+	tac.Spec.TiDB.MinReplicas = nil
+	tac.Spec.TiDB.Metrics = []v1alpha1.CustomMetric{}
+	tac.Spec.TiDB.MetricsTimeDuration = nil
+	tac.Spec.TiDB.ScaleOutIntervalSeconds = nil
+	tac.Spec.TiDB.ScaleInIntervalSeconds = nil
+	tac.Spec.TiKV.MinReplicas = nil
+	tac.Spec.TiKV.Metrics = []v1alpha1.CustomMetric{}
+	tac.Spec.TiKV.MetricsTimeDuration = nil
+	tac.Spec.TiKV.ScaleOutIntervalSeconds = nil
+	tac.Spec.TiKV.ScaleInIntervalSeconds = nil
+	tac.Spec.TiDB.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold: 0.8,
+		},
+	}
+	tac.Spec.TiKV.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceStorage: {
+			MaxThreshold: 0.8,
+		},
+	}
+	defaultTAC(tac, tc)
+	g.Expect(tac.Spec.TiKV.Rules[corev1.ResourceStorage].ResourceTypes).Should(ConsistOf([]string{"default_tikv"}))
+	g.Expect(tac.Spec.TiDB.Rules[corev1.ResourceCPU].ResourceTypes).Should(ConsistOf([]string{"default_tidb", "default_tikv"}))
 }
 
 func TestGenMetricsEndpoint(t *testing.T) {
@@ -305,6 +386,178 @@ func TestGenMetricsEndpoint(t *testing.T) {
 	r, err = genMetricsEndpoint(tac)
 	g.Expect(err).Should(BeNil())
 	g.Expect(r).Should(Equal(u))
+}
+
+func TestAutoscalerToStrategy(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tac := newTidbClusterAutoScaler()
+	tac.Spec.Resources = map[string]v1alpha1.AutoResource{
+		"resource_a": {
+			CPU:     resource.MustParse("1000m"),
+			Memory:  resource.MustParse("8Gi"),
+			Storage: resource.MustParse("1000Gi"),
+			Count:   pointer.Int32Ptr(2),
+		},
+		"resource_b": {
+			CPU:     resource.MustParse("2000m"),
+			Memory:  resource.MustParse("4Gi"),
+			Storage: resource.MustParse("2000Gi"),
+			Count:   pointer.Int32Ptr(4),
+		},
+		"compute": {
+			CPU:    resource.MustParse("8000m"),
+			Memory: resource.MustParse("16Gi"),
+		},
+	}
+	tac.Spec.TiDB.Rules = make(map[corev1.ResourceName]v1alpha1.AutoRule)
+	tac.Spec.TiKV.Rules = make(map[corev1.ResourceName]v1alpha1.AutoRule)
+	tac.Spec.TiDB.Rules[corev1.ResourceCPU] = v1alpha1.AutoRule{
+		MaxThreshold:  0.8,
+		MinThreshold:  pointer.Float64Ptr(0.2),
+		ResourceTypes: []string{"resource_a"},
+	}
+	tac.Spec.TiKV.Rules[corev1.ResourceCPU] = v1alpha1.AutoRule{
+		MaxThreshold:  0.8,
+		MinThreshold:  pointer.Float64Ptr(0.2),
+		ResourceTypes: []string{"resource_a", "resource_b"},
+	}
+	tac.Spec.TiKV.Rules[corev1.ResourceStorage] = v1alpha1.AutoRule{
+		MaxThreshold:  0.8,
+		ResourceTypes: []string{"resource_a"},
+	}
+	strategy := autoscalerToStrategy(tac)
+	g.Expect(len(strategy.Resources)).Should(Equal(3))
+	g.Expect(len(strategy.Rules)).Should(Equal(2))
+}
+
+func TestValidateTidbClusterAutoScaler(t *testing.T) {
+	g := NewGomegaWithT(t)
+	minThreshold := 0.1
+	invalidMinThreshold := 2.0
+
+	tac := newTidbClusterAutoScaler()
+	tac.Spec.TiKV = nil
+	tac.Spec.Resources = map[string]v1alpha1.AutoResource{
+		"compute": {
+			Memory: resource.MustParse("2Gi"),
+			CPU:    resource.MustParse("1000m"),
+		},
+	}
+
+	// Case 1: Invalid max_threshold
+	tac.Spec.TiDB.BasicAutoScalerSpec.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold:  2,
+			MinThreshold:  &minThreshold,
+			ResourceTypes: []string{"compute"},
+		},
+	}
+	err := validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("max_threshold (%v) should be between 0 and 1 for rule cpu of tidb in %s/%s", 2, tac.Namespace, tac.Name)))
+
+	// Case 2: Invalid min_theshold
+	tac.Spec.TiDB.BasicAutoScalerSpec.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold:  1,
+			MinThreshold:  &invalidMinThreshold,
+			ResourceTypes: []string{"compute"},
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("min_threshold (%v) should be between 0 and 1 for rule cpu of tidb in %s/%s", invalidMinThreshold, tac.Namespace, tac.Name)))
+
+	// Case 3: No resources
+	tac.Spec.TiDB.BasicAutoScalerSpec.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold: 1,
+			MinThreshold: &minThreshold,
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("no resources provided for rule cpu of tidb in %s/%s", tac.Namespace, tac.Name)))
+
+	// Case 4: Resource not in Spec
+	tac.Spec.TiDB.BasicAutoScalerSpec.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold:  1,
+			MinThreshold:  &minThreshold,
+			ResourceTypes: []string{"non_exist"},
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("unknown resource non_exist for tidb in %s/%s", tac.Namespace, tac.Name)))
+
+	// Case 5: min_threshold > max_threshold for cpu rule
+	tac.Spec.TiDB.BasicAutoScalerSpec.Rules = map[corev1.ResourceName]v1alpha1.AutoRule{
+		corev1.ResourceCPU: {
+			MaxThreshold:  0.05,
+			MinThreshold:  &minThreshold,
+			ResourceTypes: []string{"compute"},
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("min_threshold (%v) > max_threshold (%v) for cpu rule of tidb in %s/%s", minThreshold, 0.05, tac.Namespace, tac.Name)))
+
+	// Case 6: Resource does not have storage for storage rule
+	tac.Spec.TiDB = nil
+	tac.Spec.TiKV = &v1alpha1.TikvAutoScalerSpec{
+		BasicAutoScalerSpec: v1alpha1.BasicAutoScalerSpec{
+			Rules: map[corev1.ResourceName]v1alpha1.AutoRule{
+				corev1.ResourceStorage: {
+					MaxThreshold:  0.8,
+					ResourceTypes: []string{"compute"},
+				},
+			},
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("resource compute specified for storage rule for tikv in %s/%s does not have storage", tac.Namespace, tac.Name)))
+
+	// Case 7: No storage resources provided and no resources specified for TiKV, no resources after defaulting
+	tac.Spec.TiKV.BasicAutoScalerSpec.Rules[corev1.ResourceStorage] = v1alpha1.AutoRule{
+		MaxThreshold: 0.8,
+	}
+	defaultTAC(tac, newTidbCluster())
+	err = validateTAC(tac)
+	g.Expect(err).Should(MatchError(fmt.Errorf("no resources provided for rule storage of tikv in %s/%s", tac.Namespace, tac.Name)))
+
+	// Case 8: Valid spec
+	tac = newTidbClusterAutoScaler()
+	tac.Spec.Resources = map[string]v1alpha1.AutoResource{
+		"compute": {
+			Memory: resource.MustParse("2Gi"),
+			CPU:    resource.MustParse("1000m"),
+		},
+		"storage": {
+			Memory:  resource.MustParse("2Gi"),
+			CPU:     resource.MustParse("1000m"),
+			Storage: resource.MustParse("1000Gi"),
+		},
+	}
+	tac.Spec.TiDB.BasicAutoScalerSpec = v1alpha1.BasicAutoScalerSpec{
+		Rules: map[corev1.ResourceName]v1alpha1.AutoRule{
+			corev1.ResourceCPU: {
+				MaxThreshold:  0.8,
+				MinThreshold:  &minThreshold,
+				ResourceTypes: []string{"compute"},
+			},
+		},
+	}
+	tac.Spec.TiKV.BasicAutoScalerSpec = v1alpha1.BasicAutoScalerSpec{
+		Rules: map[corev1.ResourceName]v1alpha1.AutoRule{
+			corev1.ResourceCPU: {
+				MaxThreshold:  0.8,
+				MinThreshold:  &minThreshold,
+				ResourceTypes: []string{"compute"},
+			},
+			corev1.ResourceStorage: {
+				MaxThreshold:  0.8,
+				ResourceTypes: []string{"storage"},
+			},
+		},
+	}
+	err = validateTAC(tac)
+	g.Expect(err).Should(BeNil())
 }
 
 func newTidbClusterAutoScaler() *v1alpha1.TidbClusterAutoScaler {
@@ -336,4 +589,32 @@ func newSts() *appsv1.StatefulSet {
 			Replicas:        2,
 		},
 	}
+}
+
+func newTidbCluster() *v1alpha1.TidbCluster {
+	tc := &v1alpha1.TidbCluster{}
+	tc.Name = "tc"
+	tc.Namespace = "default"
+	computeResource := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1000m"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+	storageResource := corev1.ResourceList{
+		corev1.ResourceCPU:     resource.MustParse("1000m"),
+		corev1.ResourceMemory:  resource.MustParse("2Gi"),
+		corev1.ResourceStorage: resource.MustParse("1000Gi"),
+	}
+	tc.Spec.TiDB = &v1alpha1.TiDBSpec{
+		ResourceRequirements: corev1.ResourceRequirements{
+			Requests: computeResource,
+			Limits:   computeResource,
+		},
+	}
+	tc.Spec.TiKV = &v1alpha1.TiKVSpec{
+		ResourceRequirements: corev1.ResourceRequirements{
+			Requests: storageResource,
+			Limits:   storageResource,
+		},
+	}
+	return tc
 }


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? 

https://github.com/pingcap/tidb-operator/issues/3159 Task#2

### What is changed and how does it work?

Construct pd strategy according to autoscaler spec

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has Go code change

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
