### PR TITLE
add omitempty for newly added tidb&pd configurations

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/pd_config.go
+++ b/pkg/apis/pingcap/v1alpha1/pd_config.go
@@ -36,7 +36,7 @@ type PDConfig struct {
 
 	// set different tokens to prevent communication between PDs in different clusters.
 	// +optional
-	InitialClusterToken *string `toml:"initial-cluster-token" json:"initial-cluster-token"`
+	InitialClusterToken *string `toml:"initial-cluster-token,omitempty" json:"initial-cluster-token,omitempty"`
 
 	// LeaderLease time, if leader doesn't update its TTL
 	// in etcd after lease time, etcd will expire the leader key
@@ -156,7 +156,7 @@ type DashboardConfig struct {
 	// production.
 	// Optional: Defaults to false
 	// +optional
-	EnableExperimental *bool `toml:"enable-experimental" json:"enable-experimental"`
+	EnableExperimental *bool `toml:"enable-experimental,omitempty" json:"enable-experimental,omitempty"`
 }
 
 // PDLogConfig serializes log related config in toml/json.

--- a/pkg/apis/pingcap/v1alpha1/tidb_config.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config.go
@@ -146,7 +146,7 @@ type TiDBConfig struct {
 	// imported from v4.0.5
 	// SkipRegisterToDashboard tells TiDB don't register itself to the dashboard.
 	// +optional
-	SkipRegisterToDashboard *bool `toml:"skip-register-to-dashboard" json:"skip-register-to-dashboard"`
+	SkipRegisterToDashboard *bool `toml:"skip-register-to-dashboard,omitempty" json:"skip-register-to-dashboard,omitempty"`
 	// When enabled, usage data (for example, instance versions) will be reported to PingCAP periodically for user experience analytics.
 	// If this config is set to `false` on all TiDB servers, telemetry will be always disabled regardless of the value of the global variable `tidb_enable_telemetry`.
 	// See PingCAP privacy policy for details: https://pingcap.com/en/privacy-policy/.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
In https://github.com/pingcap/tidb-operator/pull/3180 we added three new configurations but we forget to label them as `omitempty`.

### What is changed and how does it work?
Add `omitempty` fro these configurations.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Code changes

 - Has Go code change


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
