### PR TITLE
use timestamp to update gcs prefix for scheduled backup

### DIFF
--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -225,6 +225,9 @@ func (bm *backupScheduleManager) createBackup(bs *v1alpha1.BackupSchedule, times
 		if backupSpec.S3 != nil {
 			backupSpec.S3.Prefix = path.Join(backupSpec.S3.Prefix,
 				strings.ReplaceAll(pdAddress, ":", "-")+"-"+timestamp.UTC().Format(constants.TimeFormat))
+		} else if backupSpec.Gcs != nil {
+			backupSpec.Gcs.Prefix = path.Join(backupSpec.Gcs.Prefix,
+				strings.ReplaceAll(pdAddress, ":", "-")+"-"+timestamp.UTC().Format(constants.TimeFormat))
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close https://github.com/pingcap/tidb-operator/issues/3333

### What is changed and how does it work?
Update prefix with timestamp, like we did for s3 storage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
  Test create scheduled backup to GCS. bks can backup to GCS successfully.
![image](https://user-images.githubusercontent.com/21104942/95554363-a490bb80-0a42-11eb-9b13-884bb366b55b.png)


Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Add timestamp to the prefix of scheduled backup on GCS
```
