### PR TITLE
Fix pass *interface{} to json.Unmarshal

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/pd_config_wraper.go
+++ b/pkg/apis/pingcap/v1alpha1/pd_config_wraper.go
@@ -49,7 +49,7 @@ func (c *PDConfigWraper) MarshalJSON() ([]byte, error) {
 // for compatibility, if we use a map[string]interface{} to Unmarshal directly,
 // we can not distinct the type between integer and float for toml.
 func (c *PDConfigWraper) UnmarshalJSON(data []byte) error {
-	var deprecated *PDConfig
+	deprecated := new(PDConfig)
 	var err error
 	c.GenericConfig, err = unmarshalJSON(data, deprecated)
 	return err

--- a/pkg/apis/pingcap/v1alpha1/pd_config_wraper_test.go
+++ b/pkg/apis/pingcap/v1alpha1/pd_config_wraper_test.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -56,12 +57,12 @@ func TestPDConfigWraper(t *testing.T) {
 		var pdConfig PDConfig
 		f.Fuzz(&pdConfig)
 
-		tomlData, err := toml.Marshal(&pdConfig)
-		t.Logf("case %d toml:\n%s", i, string(tomlData))
+		jsonData, err := json.Marshal(&pdConfig)
+		t.Logf("case %d json:\n%s", i, string(jsonData))
 		g.Expect(err).Should(BeNil())
 
 		pdConfigWraper := NewPDConfig()
-		err = pdConfigWraper.UnmarshalTOML(tomlData)
+		err = json.Unmarshal(jsonData, pdConfigWraper)
 		g.Expect(err).Should(BeNil())
 
 		tomlDataBack, err := pdConfigWraper.MarshalTOML()

--- a/pkg/apis/pingcap/v1alpha1/tidb_config_wraper.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config_wraper.go
@@ -51,7 +51,7 @@ func (c *TiDBConfigWraper) MarshalJSON() ([]byte, error) {
 // for compatibility, if we use a map[string]interface{} to Unmarshal directly,
 // we can not distinct the type between integer and float for toml.
 func (c *TiDBConfigWraper) UnmarshalJSON(data []byte) error {
-	var deprecated *TiDBConfig
+	deprecated := new(TiDBConfig)
 	var err error
 	c.GenericConfig, err = unmarshalJSON(data, deprecated)
 	return err
@@ -78,7 +78,11 @@ func unmarshalJSON(data []byte, x interface{}) (g *config.GenericConfig, err err
 	case string:
 		tomlData = []byte(s)
 	case map[string]interface{}:
-		err = json.Unmarshal(data, &x)
+		if x == nil {
+			panic("x should not be nil")
+		}
+
+		err = json.Unmarshal(data, x)
 		if err != nil {
 			return nil, errors.AddStack(err)
 		}

--- a/pkg/apis/pingcap/v1alpha1/tidb_config_wraper.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config_wraper.go
@@ -78,10 +78,6 @@ func unmarshalJSON(data []byte, x interface{}) (g *config.GenericConfig, err err
 	case string:
 		tomlData = []byte(s)
 	case map[string]interface{}:
-		if x == nil {
-			panic("x should not be nil")
-		}
-
 		err = json.Unmarshal(data, x)
 		if err != nil {
 			return nil, errors.AddStack(err)

--- a/pkg/apis/pingcap/v1alpha1/tidb_config_wraper_test.go
+++ b/pkg/apis/pingcap/v1alpha1/tidb_config_wraper_test.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -44,11 +45,11 @@ func TestTiDBConfigWraper(t *testing.T) {
 		var tidbConfig TiDBConfig
 		f.Fuzz(&tidbConfig)
 
-		tomlData, err := toml.Marshal(&tidbConfig)
+		jsonData, err := json.Marshal(&tidbConfig)
 		g.Expect(err).Should(BeNil())
 
 		tidbConfigWraper := NewTiDBConfig()
-		err = tidbConfigWraper.UnmarshalTOML(tomlData)
+		err = json.Unmarshal(jsonData, tidbConfigWraper)
 		g.Expect(err).Should(BeNil())
 
 		tomlDataBack, err := tidbConfigWraper.MarshalTOML()
@@ -59,4 +60,22 @@ func TestTiDBConfigWraper(t *testing.T) {
 		g.Expect(err).Should(BeNil())
 		g.Expect(tidbConfigBack).Should(Equal(tidbConfig))
 	}
+}
+
+func TestUnmarshlJSON(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type Tmp struct {
+		Float float64 `toml:"float"`
+		Int   int     `toml:"int"`
+	}
+
+	data := `{"float": 1, "int": 1}`
+
+	tmp := new(Tmp)
+	config, err := unmarshalJSON([]byte(data), tmp)
+	g.Expect(err).Should(BeNil())
+
+	g.Expect(config.Get("float").MustFloat()).Should(Equal(1.0))
+	g.Expect(config.Get("int").MustInt()).Should(Equal(int64(1)))
 }

--- a/pkg/apis/pingcap/v1alpha1/tikv_config_wraper.go
+++ b/pkg/apis/pingcap/v1alpha1/tikv_config_wraper.go
@@ -49,7 +49,7 @@ func (c *TiKVConfigWraper) MarshalJSON() ([]byte, error) {
 // for compatibility, if we use a map[string]interface{} to Unmarshal directly,
 // we can not distinct the type between integer and float for toml.
 func (c *TiKVConfigWraper) UnmarshalJSON(data []byte) error {
-	var deprecated *TiKVCfConfig
+	deprecated := new(TiKVConfig)
 	var err error
 	c.GenericConfig, err = unmarshalJSON(data, deprecated)
 	return err

--- a/pkg/apis/pingcap/v1alpha1/tikv_config_wraper_test.go
+++ b/pkg/apis/pingcap/v1alpha1/tikv_config_wraper_test.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -44,11 +45,11 @@ func TestTiKVConfigWraper(t *testing.T) {
 		var tikvConfig TiKVConfig
 		f.Fuzz(&tikvConfig)
 
-		tomlData, err := toml.Marshal(&tikvConfig)
+		jsonData, err := json.Marshal(&tikvConfig)
 		g.Expect(err).Should(BeNil())
 
 		tikvConfigWraper := NewTiKVConfig()
-		err = tikvConfigWraper.UnmarshalTOML(tomlData)
+		err = json.Unmarshal(jsonData, tikvConfigWraper)
 		g.Expect(err).Should(BeNil())
 
 		tomlDataBack, err := tikvConfigWraper.MarshalTOML()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

https://github.com/pingcap/tidb-operator/pull/3342/commits/6a23edae1b6a901bda60bb7418cc51e4c9d3e97f in #3342 

introduce an issue.

we pass `&x` (type *interface{}) to `json.Unmarshal`
so type of x will be `map[string]interface{}` after it.
will fail the add test `TestUnmarshlJSON` in this pr.

### What is changed and how does it work?
pass origin `x` interface and improve test.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test




### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
