### PR TITLE
replace Errorf with Error and Infof with Info

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -86,14 +86,14 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) error {
 			errMsg += line
 		}
 
-		klog.Infof(strings.Replace(line, "\n", "", -1))
+		klog.Info(strings.Replace(line, "\n", "", -1))
 		if err != nil || io.EOF == err {
 			break
 		}
 	}
 	tmpErr, _ := ioutil.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
-		klog.Infof(string(tmpErr))
+		klog.Info(string(tmpErr))
 		errMsg += string(tmpErr)
 	}
 	err = cmd.Wait()

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -66,11 +66,11 @@ func (ro *Options) downloadBackupData(localPath string, opts []string) error {
 	var errMsg string
 	tmpOut, _ := ioutil.ReadAll(stdOut)
 	if len(tmpOut) > 0 {
-		klog.Infof(string(tmpOut))
+		klog.Info(string(tmpOut))
 	}
 	tmpErr, _ := ioutil.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
-		klog.Infof(string(tmpErr))
+		klog.Info(string(tmpErr))
 		errMsg = string(tmpErr)
 	}
 

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -83,14 +83,14 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 		if strings.Contains(line, "[ERROR]") {
 			errMsg += line
 		}
-		klog.Infof(strings.Replace(line, "\n", "", -1))
+		klog.Info(strings.Replace(line, "\n", "", -1))
 		if err != nil || io.EOF == err {
 			break
 		}
 	}
 	tmpErr, _ := ioutil.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
-		klog.Infof(string(tmpErr))
+		klog.Info(string(tmpErr))
 		errMsg += string(tmpErr)
 	}
 

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -168,7 +168,7 @@ func main() {
 				}
 			}
 		}
-		klog.Infof("cache of informer factories sync successfully")
+		klog.Info("cache of informer factories sync successfully")
 
 		// Start syncLoop for all controllers
 		for _, controller := range controllers {

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -171,7 +171,7 @@ func getLastScheduledTime(bs *v1alpha1.BackupSchedule) (*time.Time, error) {
 				bs.Status.AllBackupCleanTime = &metav1.Time{Time: time.Now()}
 				return nil, controller.RequeueErrorf("recovery backup schedule %s/%s from pause status, refresh AllBackupCleanTime.", ns, bsName)
 			}
-			klog.Errorf("Too many missed start backup schedule time (> 100). Check the clock.")
+			klog.Error("Too many missed start backup schedule time (> 100). Check the clock.")
 			return nil, nil
 		}
 	}

--- a/pkg/controller/periodicity/periodicity_controller.go
+++ b/pkg/controller/periodicity/periodicity_controller.go
@@ -46,8 +46,8 @@ func NewController(deps *controller.Dependencies) *Controller {
 }
 
 func (c *Controller) Run(_ int, stopCh <-chan struct{}) {
-	klog.Infof("Staring periodicity controller")
-	defer klog.Infof("Shutting down periodicity controller")
+	klog.Info("Staring periodicity controller")
+	defer klog.Info("Shutting down periodicity controller")
 	wait.Until(c.run, time.Minute, stopCh)
 }
 

--- a/pkg/manager/member/scaler.go
+++ b/pkg/manager/member/scaler.go
@@ -83,7 +83,7 @@ func (s *generalScaler) deleteDeferDeletingPVC(controller runtime.Object,
 	pvcs, err := s.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
 	if err != nil {
 		msg := fmt.Sprintf("%s %s/%s list pvc failed, selector: %s, err: %v", kind, ns, meta.GetName(), selector, err)
-		klog.Errorf(msg)
+		klog.Error(msg)
 		return skipReason, fmt.Errorf(msg)
 	}
 	if len(pvcs) == 0 {
@@ -128,12 +128,12 @@ func (s *generalScaler) updateDeferDeletingPVC(tc *v1alpha1.TidbCluster,
 	pvcs, err := s.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
 	if err != nil {
 		msg := fmt.Sprintf("Cluster %s/%s list pvc failed, selector: %s, err: %v", ns, tc.Name, selector, err)
-		klog.Errorf(msg)
+		klog.Error(msg)
 		return fmt.Errorf(msg)
 	}
 	if len(pvcs) == 0 {
 		msg := fmt.Sprintf("Cluster %s/%s list pvc not found, selector: %s", ns, tc.Name, selector)
-		klog.Errorf(msg)
+		klog.Error(msg)
 		return fmt.Errorf(msg)
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,7 +35,7 @@ func PrintVersionInfo() {
 
 // LogVersionInfo print version info at startup
 func LogVersionInfo() {
-	klog.Infof("Welcome to TiDB Operator.")
+	klog.Info("Welcome to TiDB Operator.")
 	klog.Infof("TiDB Operator Version: %#v", Get())
 }
 

--- a/pkg/webhook/statefulset/statefulset.go
+++ b/pkg/webhook/statefulset/statefulset.go
@@ -106,7 +106,7 @@ func (sc *StatefulSetAdmissionControl) Validate(ar *admission.AdmissionRequest) 
 	tc, err := sc.operatorCli.PingcapV1alpha1().TidbClusters(namespace).Get(tcName, metav1.GetOptions{})
 	if err != nil {
 		err := fmt.Errorf("get tidbcluster %s/%s failed, statefulset %s, err %v", namespace, tcName, name, err)
-		klog.Errorf(err.Error())
+		klog.Error(err.Error())
 		return util.ARFail(err)
 	}
 
@@ -123,7 +123,7 @@ func (sc *StatefulSetAdmissionControl) Validate(ar *admission.AdmissionRequest) 
 	partition, err := strconv.ParseInt(partitionStr, 10, 32)
 	if err != nil {
 		err := fmt.Errorf("statefulset %s/%s, convert partition str %s to int failed, err: %v", namespace, name, partitionStr, err)
-		klog.Errorf(err.Error())
+		klog.Error(err.Error())
 		return util.ARFail(err)
 	}
 

--- a/tests/fault.go
+++ b/tests/fault.go
@@ -295,7 +295,7 @@ func (fa *faultTriggerActions) StopKubeProxyOrDie() {
 
 // StartKubeProxy starts the kube-proxy service.
 func (fa *faultTriggerActions) StartKubeProxy() error {
-	klog.Infof("starting all kube-proxy pods")
+	klog.Info("starting all kube-proxy pods")
 	nodes := getAllK8sNodes(fa.cfg)
 	ds, err := fa.kubeCli.AppsV1().DaemonSets(metav1.NamespaceSystem).Get("kube-proxy", metav1.GetOptions{})
 	if err != nil {

--- a/tests/slack/slack.go
+++ b/tests/slack/slack.go
@@ -175,5 +175,5 @@ func NotifyAndCompletedf(format string, args ...interface{}) {
 	if sendErr != nil {
 		klog.Warningf("failed to notify slack[%s] the massage: %s,error: %v", WebhookURL, msg, sendErr)
 	}
-	klog.Infof(msg)
+	klog.Info(msg)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Some BR logs are printed incorrectly. (For example, `%!](MISSING)`)
```log
I1012 09:45:55.314821       1 backup.go:91] [2020/10/12 09:45:55.314 +00:00] [INFO] [progress.go:114] [progress] [step="Full backup"] [progress=100.00%!](MISSING) [count="1 / 1"] [speed="? p/s"] [elapsed=1s] [remaining=1s]
```

### What is changed and how does it work?
replace `Errorf` with `Error` and `Infof` with `Info`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
  Test Backup with new operator:
```log
I1012 09:50:47.385423       1 backup.go:91] [2020/10/12 09:50:47.385 +00:00] [INFO] [progress.go:114] [progress] [step="Full backup"] [progress=100.00%] [count="1 / 1"] [speed="? p/s"] [elapsed=0s] [remaining=0s]
```

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
