### PR TITLE
fix panic for heterogeneous tikv cluster

### DIFF
--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -258,7 +258,7 @@ func (tkmm *tikvMemberManager) syncTiKVConfigMap(tc *v1alpha1.TidbCluster, set *
 		})
 	}
 
-	err = updateConfigMapIfNeed(tkmm.deps.ConfigMapLister, tc.BaseTiDBSpec().ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(tkmm.deps.ConfigMapLister, tc.BaseTiKVSpec().ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Operator will panic if a TiKV hete tc is created.

```
E1014 05:55:37.530457       1 runtime.go:78] Observed a panic: \"invalid memory address or nil pointer dereference\" (runtime error: invalid memory address or nil pointer dereference)
goroutine 756 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1aa2220, 0x2fae9b0)
	k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1aa2220, 0x2fae9b0)
	runtime/panic.go:679 +0x1b2
github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.(*TidbCluster).BaseTiDBSpec(...)
	github.com/pingcap/tidb-operator@/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go:242
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).syncTiKVConfigMap(0xc00057d940, 0xc00113c900, 0x0, 0x0, 0x0, 0xc0002d7d60)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:261 +0x97
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).syncStatefulSetForTidbCluster(0xc00057d940, 0xc00113c900, 0x1d2b2ca, 0x4)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:179 +0x544
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).Sync(0xc00057d940, 0xc00113c900, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:111 +0x1c7
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*defaultTidbClusterControl).updateTidbCluster(0xc00016ee00, 0xc00113c900, 0xc000c23c01, 0x12edabd)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_control.go:185 +0x34e
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*defaultTidbClusterControl).UpdateTidbCluster(0xc00016ee00, 0xc00113c900, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_control.go:106 +0xc8
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).syncTidbCluster(...)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:156
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).sync(0xc000667dd0, 0xc00093a0a0, 0x1a, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:152 +0x1f0
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).processNextWorkItem(0xc000667dd0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:119 +0x100
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).worker(0xc000667dd0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:107 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000c04c90)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000c04c90, 0x3b9aca00, 0x0, 0x1, 0xc000c6a2a0)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000c04c90, 0x3b9aca00, 0xc000c6a2a0)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:88 +0x4d
created by github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).Run
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:99 +0x1d9
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1736337]

goroutine 756 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:55 +0x105
panic(0x1aa2220, 0x2fae9b0)
	runtime/panic.go:679 +0x1b2
github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.(*TidbCluster).BaseTiDBSpec(...)
	github.com/pingcap/tidb-operator@/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go:242
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).syncTiKVConfigMap(0xc00057d940, 0xc00113c900, 0x0, 0x0, 0x0, 0xc0002d7d60)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:261 +0x97
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).syncStatefulSetForTidbCluster(0xc00057d940, 0xc00113c900, 0x1d2b2ca, 0x4)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:179 +0x544
github.com/pingcap/tidb-operator/pkg/manager/member.(*tikvMemberManager).Sync(0xc00057d940, 0xc00113c900, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/manager/member/tikv_member_manager.go:111 +0x1c7
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*defaultTidbClusterControl).updateTidbCluster(0xc00016ee00, 0xc00113c900, 0xc000c23c01, 0x12edabd)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_control.go:185 +0x34e
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*defaultTidbClusterControl).UpdateTidbCluster(0xc00016ee00, 0xc00113c900, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_control.go:106 +0xc8
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).syncTidbCluster(...)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:156
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).sync(0xc000667dd0, 0xc00093a0a0, 0x1a, 0x0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:152 +0x1f0
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).processNextWorkItem(0xc000667dd0, 0x0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:119 +0x100
github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).worker(0xc000667dd0)
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:107 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000c04c90)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000c04c90, 0x3b9aca00, 0x0, 0x1, 0xc000c6a2a0)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000c04c90, 0x3b9aca00, 0xc000c6a2a0)
	k8s.io/apimachinery@v0.0.0/pkg/util/wait/wait.go:88 +0x4d
created by github.com/pingcap/tidb-operator/pkg/controller/tidbcluster.(*Controller).Run
	github.com/pingcap/tidb-operator@/pkg/controller/tidbcluster/tidb_cluster_controller.go:99 +0x1d9
```

### What is changed and how does it work?

Fix wrong field accessed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
