### PR TITLE
bump cluster version to v4.0.7 & chart version to v1.1.6

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -38,7 +38,7 @@ services:
     type: ClusterIP
 
 discovery:
-  image: pingcap/tidb-operator:v1.1.5
+  image: pingcap/tidb-operator:v1.1.6
   imagePullPolicy: IfNotPresent
   resources:
     limits:
@@ -108,7 +108,7 @@ pd:
     # annotations: {} "<the default name will be used>"
     # portName: "client"
   replicas: 3
-  image: pingcap/pd:v4.0.6
+  image: pingcap/pd:v4.0.7
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -255,7 +255,7 @@ tikv:
   # we can only set capacity in tikv.resources.limits.storage.
 
   replicas: 3
-  image: pingcap/tikv:v4.0.6
+  image: pingcap/tikv:v4.0.7
   # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
   # different classes might map to quality-of-service levels, or to backup policies,
   # or to arbitrary policies determined by the cluster administrators.
@@ -352,7 +352,7 @@ tidb:
   # initSqlConfigMapName: tidb-initsql
   # initSql: |-
   #   create database app;
-  image: pingcap/tidb:v4.0.6
+  image: pingcap/tidb:v4.0.7
   # Image pull policy.
   imagePullPolicy: IfNotPresent
 
@@ -506,7 +506,7 @@ monitor:
   storageClassName: local-storage
   storage: 10Gi
   initializer:
-    image: pingcap/tidb-monitor-initializer:v4.0.6
+    image: pingcap/tidb-monitor-initializer:v4.0.7
     imagePullPolicy: IfNotPresent
     config:
       K8S_PROMETHEUS_URL: http://prometheus-k8s.monitoring.svc:9090
@@ -592,7 +592,7 @@ binlog:
   pump:
     create: false
     replicas: 1
-    image: pingcap/tidb-binlog:v4.0.6
+    image: pingcap/tidb-binlog:v4.0.7
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -661,7 +661,7 @@ binlog:
 
   drainer:
     create: false
-    image: pingcap/tidb-binlog:v4.0.6
+    image: pingcap/tidb-binlog:v4.0.7
     imagePullPolicy: IfNotPresent
     logLevel: info
     # storageClassName is a StorageClass provides a way for administrators to describe the "classes" of storage they offer.
@@ -826,7 +826,7 @@ scheduledBackup:
 
 importer:
   create: false
-  image: pingcap/tidb-lightning:v4.0.6
+  image: pingcap/tidb-lightning:v4.0.7
   imagePullPolicy: IfNotPresent
   storageClassName: local-storage
   storage: 200Gi

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -12,7 +12,7 @@ timezone: UTC
 
 # clusterName is the TiDB cluster name that should backup from or restore to.
 clusterName: demo
-clusterVersion: v4.0.6
+clusterVersion: v4.0.7
 
 baseImage: pingcap/tidb-binlog
 imagePullPolicy: IfNotPresent

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -5,7 +5,7 @@
 # timezone is the default system timzone
 timezone: UTC
 
-image: pingcap/tidb-lightning:v4.0.6
+image: pingcap/tidb-lightning:v4.0.7
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -12,12 +12,12 @@ rbac:
 timezone: UTC
 
 # operatorImage is TiDB Operator image
-operatorImage: pingcap/tidb-operator:v1.1.5
+operatorImage: pingcap/tidb-operator:v1.1.6
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 
 # tidbBackupManagerImage is tidb backup manager image
-tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.1.5
+tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.1.6
 
 #
 # Enable or disable tidb-operator features:

--- a/charts/tikv-importer/values.yaml
+++ b/charts/tikv-importer/values.yaml
@@ -8,7 +8,7 @@ timezone: UTC
 # clusterName is the TiDB cluster name, if not specified, the chart release name will be used
 clusterName: demo
 
-image: pingcap/tidb-lightning:v4.0.6
+image: pingcap/tidb-lightning:v4.0.7
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 

--- a/deploy/aliyun/manifests/db-monitor.yaml.example
+++ b/deploy/aliyun/manifests/db-monitor.yaml.example
@@ -46,7 +46,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.6
+    version: v4.0.7
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/aliyun/manifests/db.yaml.example
+++ b/deploy/aliyun/manifests/db.yaml.example
@@ -109,4 +109,4 @@ spec:
   timezone: UTC
   tlsCluster:
     enabled: false
-  version: v4.0.6
+  version: v4.0.7

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -10,7 +10,7 @@ variable "bastion_cpu_core_count" {
 
 variable "operator_version" {
   type    = string
-  default = "v1.1.5"
+  default = "v1.1.6"
 }
 
 variable "operator_helm_values" {
@@ -36,7 +36,7 @@ variable "cluster_name" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v4.0.6"
+  default     = "v4.0.7"
 }
 variable "tidb_cluster_chart_version" {
   description = "tidb-cluster chart version"

--- a/deploy/aws/manifests/db-monitor.yaml.example
+++ b/deploy/aws/manifests/db-monitor.yaml.example
@@ -44,7 +44,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.6
+    version: v4.0.7
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/aws/manifests/db.yaml.example
+++ b/deploy/aws/manifests/db.yaml.example
@@ -109,4 +109,4 @@ spec:
   timezone: UTC
   tlsCluster:
     enabled: false
-  version: v4.0.6
+  version: v4.0.7

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -19,7 +19,7 @@ variable "eks_version" {
 
 variable "operator_version" {
   description = "TiDB operator version"
-  default     = "v1.1.5"
+  default     = "v1.1.6"
 }
 
 variable "operator_values" {
@@ -80,7 +80,7 @@ variable "bastion_instance_type" {
 
 # For aws tutorials compatiablity
 variable "default_cluster_version" {
-  default = "v4.0.6"
+  default = "v4.0.7"
 }
 
 variable "default_cluster_pd_count" {

--- a/deploy/gcp/manifests/db-monitor.yaml.example
+++ b/deploy/gcp/manifests/db-monitor.yaml.example
@@ -44,7 +44,7 @@ spec:
     #  requests:
     #    cpu: 50m
     #    memory: 64Mi
-    version: v4.0.6
+    version: v4.0.7
   kubePrometheusURL: ""
   nodeSelector: {}
   persistent: true

--- a/deploy/gcp/manifests/db.yaml.example
+++ b/deploy/gcp/manifests/db.yaml.example
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: CLUSTER_NAME
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   schedulerName: tidb-scheduler

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -24,11 +24,11 @@ variable "node_locations" {
 
 variable "tidb_version" {
   description = "TiDB version"
-  default     = "v4.0.6"
+  default     = "v4.0.7"
 }
 
 variable "tidb_operator_version" {
-  default = "v1.1.5"
+  default = "v1.1.6"
 }
 
 variable "tidb_operator_chart_version" {

--- a/deploy/modules/aliyun/tidb-cluster/variables.tf
+++ b/deploy/modules/aliyun/tidb-cluster/variables.tf
@@ -12,7 +12,7 @@ variable "image_id" {
 
 variable "tidb_version" {
   description = "TiDB cluster version"
-  default     = "v4.0.6"
+  default     = "v4.0.7"
 }
 
 variable "tidb_cluster_chart_version" {

--- a/deploy/modules/aws/tidb-cluster/variables.tf
+++ b/deploy/modules/aws/tidb-cluster/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v4.0.6"
+  default = "v4.0.7"
 }
 
 variable "ssh_key_name" {

--- a/deploy/modules/gcp/tidb-cluster/variables.tf
+++ b/deploy/modules/gcp/tidb-cluster/variables.tf
@@ -9,7 +9,7 @@ variable "tidb_operator_id" {
 variable "cluster_name" {}
 variable "cluster_version" {
   description = "The TiDB cluster version"
-  default     = "v4.0.6"
+  default     = "v4.0.7"
 }
 variable "tidb_cluster_chart_version" {
   description = "The TiDB cluster chart version"

--- a/deploy/modules/share/tidb-cluster-release/variables.tf
+++ b/deploy/modules/share/tidb-cluster-release/variables.tf
@@ -20,7 +20,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type    = string
-  default = "v4.0.6"
+  default = "v4.0.7"
 }
 
 variable "pd_count" {

--- a/examples/advanced-statefulset/tidb-cluster-scaled.yaml
+++ b/examples/advanced-statefulset/tidb-cluster-scaled.yaml
@@ -5,7 +5,7 @@ metadata:
     tikv.tidb.pingcap.com/delete-slots: '[1]'
   name: asts
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/advanced-statefulset/tidb-cluster.yaml
+++ b/examples/advanced-statefulset/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: asts
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   # ** Basic Configuration **
   # TiDB cluster version
-  version: "v4.0.6"
+  version: "v4.0.7"
 
   # Time zone of TiDB cluster Pods
   timezone: UTC

--- a/examples/auto-scale/tidb-cluster.yaml
+++ b/examples/auto-scale/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: auto-scaling-demo
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/auto-scale/tidb-monitor.yaml
+++ b/examples/auto-scale/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/aws/tidb-cluster.yaml
+++ b/examples/aws/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   configUpdateStrategy: RollingUpdate
   pvReclaimPolicy: Retain

--- a/examples/aws/tidb-monitor.yaml
+++ b/examples/aws/tidb-monitor.yaml
@@ -30,7 +30,7 @@ spec:
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     imagePullPolicy: IfNotPresent
-    version: v4.0.6
+    version: v4.0.7
   kubePrometheusURL: ""
   persistent: true
   prometheus:

--- a/examples/basic-cn/tidb-cluster.yaml
+++ b/examples/basic-cn/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/basic/tidb-cluster.yaml
+++ b/examples/basic/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/gcp/tidb-cluster.yaml
+++ b/examples/gcp/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   configUpdateStrategy: RollingUpdate
   pvReclaimPolicy: Retain

--- a/examples/gcp/tidb-monitor.yaml
+++ b/examples/gcp/tidb-monitor.yaml
@@ -30,7 +30,7 @@ spec:
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     imagePullPolicy: IfNotPresent
-    version: v4.0.6
+    version: v4.0.7
   kubePrometheusURL: ""
   persistent: true
   prometheus:

--- a/examples/heterogeneous-tls/heterogeneous-cluster.yaml
+++ b/examples/heterogeneous-tls/heterogeneous-cluster.yaml
@@ -10,7 +10,7 @@ spec:
     enabled: true
   configUpdateStrategy: RollingUpdate
   enableDynamicConfiguration: true
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   discovery: {}
@@ -38,7 +38,7 @@ spec:
       enabled: true
   tiflash:
     baseImage: pingcap/tiflash
-    version: v4.0.6
+    version: v4.0.7
     maxFailoverCount: 1
     replicas: 1
     storageClaims:

--- a/examples/heterogeneous-tls/tidb-cluster.yaml
+++ b/examples/heterogeneous-tls/tidb-cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   tlsCluster:
     enabled: true
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/heterogeneous-tls/tidb-monitor.yaml
+++ b/examples/heterogeneous-tls/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/heterogeneous/heterogeneous-cluster.yaml
+++ b/examples/heterogeneous/heterogeneous-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: heterogeneous
 spec:
   configUpdateStrategy: RollingUpdate
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/heterogeneous/tidb-cluster.yaml
+++ b/examples/heterogeneous/tidb-cluster.yaml
@@ -6,7 +6,7 @@ kind: TidbCluster
 metadata:
   name: basic
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/heterogeneous/tidb-monitor.yaml
+++ b/examples/heterogeneous/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/initialize/tidb-cluster.yaml
+++ b/examples/initialize/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: initialize-demo
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/monitor-multiple-cluster-non-tls/ns1-cluster.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/ns1-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ns1
   namespace: ns1
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/monitor-multiple-cluster-non-tls/ns2-cluster.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/ns2-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ns2
   namespace: ns2
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
@@ -17,7 +17,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/tidb-monitor.yaml
@@ -23,7 +23,7 @@ spec:
     version: 6.1.6
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/examples/selfsigned-tls/tidb-cluster.yaml
+++ b/examples/selfsigned-tls/tidb-cluster.yaml
@@ -3,7 +3,7 @@ kind: TidbCluster
 metadata:
   name: tls
 spec:
-  version: v4.0.6
+  version: v4.0.7
   timezone: UTC
   pvReclaimPolicy: Retain
   enableDynamicConfiguration: true

--- a/examples/tiflash/tidb-cluster.yaml
+++ b/examples/tiflash/tidb-cluster.yaml
@@ -71,4 +71,4 @@ spec:
       storage: 10Gi
     storageClassName: local-storage
   timezone: UTC
-  version: v4.0.6
+  version: v4.0.7

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -15,7 +15,7 @@ spec:
       type: NodePort
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v4.0.6
+    version: v4.0.7
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -2,7 +2,7 @@ FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_V31=v3.1.2
-ARG TOOLKIT_V40=v4.0.6
+ARG TOOLKIT_V40=v4.0.7
 RUN apk update && apk add ca-certificates
 
 RUN wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
bump cluster version to v4.0.7 & chart version to v1.1.6
### What is changed and how does it work?
ref #3284 #3286 

write and run this script
```shell
old="v1\.1\.5"
new="v1\.1\.6"

find ./deploy -name "*\.tf"| xargs gsed -i "s/$old/$new/g"
find ./charts -name "*\.yaml"| xargs gsed -i "s/$old/$new/g"



old="v4\.0\.6"
new="v4\.0\.7"

find ./deploy -name "*\.yaml.example"| xargs gsed -i "s/$old/$new/g"
find ./examples -name "*\.yaml"| xargs gsed -i "s/$old/$new/g"
find ./deploy -name "*\.tf"| xargs gsed -i "s/$old/$new/g"

find ./charts -name "*\.yaml"| xargs gsed -i "s/$old/$new/g"

gsed -i "s/$old/$new/g" images/tidb-backup-manager/Dockerfile
```

### Check List <!--REMOVE the items that are not applicable-->


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
