### PR TITLE
when UpdateStrategy of oldSet is modified to "OnDelete" manually, don't change it.

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2495,7 +2495,8 @@ string
 <h3 id="backupconditiontype">BackupConditionType</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#backupcondition">BackupCondition</a>)
+<a href="#backupcondition">BackupCondition</a>, 
+<a href="#backupstatus">BackupStatus</a>)
 </p>
 <p>
 <p>BackupConditionType represents a valid condition of a Backup.</p>
@@ -2978,6 +2979,19 @@ string
 </td>
 <td>
 <p>CommitTs is the snapshot time point of tidb cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#backupconditiontype">
+BackupConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Phase is a user readable state inferred from the underlying Backup conditions</p>
 </td>
 </tr>
 <tr>
@@ -9910,7 +9924,8 @@ string
 <h3 id="restoreconditiontype">RestoreConditionType</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#restorecondition">RestoreCondition</a>)
+<a href="#restorecondition">RestoreCondition</a>, 
+<a href="#restorestatus">RestoreStatus</a>)
 </p>
 <p>
 <p>RestoreConditionType represents a valid condition of a Restore.</p>
@@ -10163,6 +10178,19 @@ string
 </td>
 <td>
 <p>CommitTs is the snapshot time point of tidb cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#restoreconditiontype">
+RestoreConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Phase is a user readable state inferred from the underlying Restore conditions</p>
 </td>
 </tr>
 <tr>

--- a/hack/split-crd.py
+++ b/hack/split-crd.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to split our CRD YAML file to separate ones,
+# with each CRD's name as its filenam.
+
+
+import argparse
+import logging
+import os
+import yaml
+
+
+def read_file(filename, mode='r'):
+    data = None
+    with open(filename, mode) as f:
+        data = f.read()
+    f.close()
+    return data
+
+
+# write data to file
+def write_file(filename, data, mode='w'):
+    with open(filename, mode) as f:
+        logging.debug("Writing %s of data to %s" % (len(data), filename))
+        try:
+            f.write(str(data, 'utf-8'))
+        except TypeError:
+            f.write(data)
+    f.close()
+
+
+# create target directory, do nothing if it already exists
+def create_dir(path):
+    try:
+        os.makedirs(path)
+        return path
+    except OSError as e:
+        # There is FileExistsError (divided from OSError) in Python 3.3+,
+        # but only OSError in Python 2, so we use errno to check if target
+        # dir already exists.
+        import errno
+        if e.errno == errno.EEXIST and os.path.isdir(path):
+            logging.info("Target path \"%s\" already exist" % path)
+            return path
+        else:
+            logging.fatal("Can not create dir, error is: %s" % str(e))
+            exit(e.errno)
+    return None
+
+
+# Increase indent level for array items to fit OperatorHub's format
+# Modified from: https://web.archive.org/web/20170903201521/https://pyyaml.org/ticket/64#comment:5
+class MyDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(MyDumper, self).increase_indent(flow, False)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Split CRD YAML to separate files.")
+    parser.add_argument("-i", "--input", action="store",
+                        required=True, help="The path to CRD file.")
+    parser.add_argument("-o", "--output", action="store",
+                        required=True, help="The path to output directory.")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        default=False, help="Print verbose output.")
+    args = parser.parse_args()
+
+    # init logger
+    if args.verbose:
+        logging.basicConfig(
+            format='[%(levelname)s] %(message)s (at %(filename)s:%(lineno)d in %(funcName)s).',
+            level=logging.DEBUG)
+        logging.info("Debug logging enabled")
+        logging.debug("Input arguments are: %s" % args)
+    else:
+        logging.basicConfig(
+            format='[%(levelname)s] %(message)s.', level=logging.INFO)
+        logging.info("Using logging level: INFO")
+
+    # prepare output dir
+    create_dir(args.output)
+
+    # read CRD file
+    try:
+        combined_crd = yaml.load_all(
+            read_file(args.input), Loader=yaml.FullLoader)
+    except Exception as e:
+        logging.fatal("error reading CRD file: %s" % str(e))
+        exit(1)
+
+    for crd in combined_crd:
+        try:
+            _name = crd['metadata']['name']
+            logging.info("Read CRD %s" % _name)
+        except KeyError:
+            logging.error("Error parsing CRD, ignore it: %s" % str(e))
+            continue
+
+        # write the CRD to file
+        try:
+            _crd = yaml.dump(crd, indent=2, Dumper=MyDumper, default_flow_style=False)
+        except Exception as e:
+            logging.fatal("error reformating the CRD %s: %s" % (_name, str(e)))
+            exit(1)
+
+        try:
+            _path = os.path.join(args.output, "%s.crd.yaml" % _name)
+            write_file(_path, _crd)
+            logging.info("Write CRD %s to file %s" % (_name, _path))
+        except Exception as e:
+            logging.error("Error writing CRD, ignore it: %s" % str(e))
+            continue
+
+    logging.info("Done")

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13058,6 +13058,10 @@ metadata:
   name: backups.pingcap.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The current status of the backup
+    name: Status
+    type: string
   - JSONPath: .status.backupPath
     description: The full path of backup data
     name: BackupPath
@@ -13530,6 +13534,10 @@ metadata:
   name: restores.pingcap.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The current status of the restore
+    name: Status
+    type: string
   - JSONPath: .status.timeStarted
     description: The time at which the backup was started
     format: date-time

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -72,6 +72,8 @@ func UpdateBackupCondition(status *BackupStatus, condition *BackupCondition) boo
 	// Try to find this Backup condition.
 	conditionIndex, oldCondition := GetBackupCondition(status, condition.Type)
 
+	status.Phase = condition.Type
+
 	if oldCondition == nil {
 		// We are adding new Backup condition.
 		status.Conditions = append(status.Conditions, *condition)

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
@@ -15,6 +15,7 @@ package defaulting
 
 import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
@@ -82,6 +83,15 @@ func setTidbSpecDefault(tc *v1alpha1.TidbCluster) {
 		tc.Spec.TiDB.MaxFailoverCount = pointer.Int32Ptr(3)
 	}
 
+	if tc.Spec.TiDB.StatefulSetUpdateStrategy == nil {
+		tc.Spec.TiDB.StatefulSetUpdateStrategy = &apps.StatefulSetUpdateStrategy{
+			Type: apps.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+				Partition: pointer.Int32Ptr(tc.TiDBStsDesiredReplicas()),
+			},
+		}
+	}
+
 	// Start set config if need.
 	if tc.Spec.TiDB.Config == nil {
 		return
@@ -102,6 +112,15 @@ func setTikvSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiKV.MaxFailoverCount == nil {
 		tc.Spec.TiKV.MaxFailoverCount = pointer.Int32Ptr(3)
 	}
+
+	if tc.Spec.TiKV.StatefulSetUpdateStrategy == nil {
+		tc.Spec.TiKV.StatefulSetUpdateStrategy = &apps.StatefulSetUpdateStrategy{
+			Type: apps.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+				Partition: pointer.Int32Ptr(tc.TiKVStsDesiredReplicas()),
+			},
+		}
+	}
 }
 
 func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
@@ -112,6 +131,15 @@ func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
 	}
 	if tc.Spec.PD.MaxFailoverCount == nil {
 		tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(3)
+	}
+
+	if tc.Spec.PD.StatefulSetUpdateStrategy == nil {
+		tc.Spec.PD.StatefulSetUpdateStrategy = &apps.StatefulSetUpdateStrategy{
+			Type: apps.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+				Partition: pointer.Int32Ptr(tc.PDStsDesiredReplicas()),
+			},
+		}
 	}
 }
 

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -67,6 +67,8 @@ func UpdateRestoreCondition(status *RestoreStatus, condition *RestoreCondition) 
 	// Try to find this Restore condition.
 	conditionIndex, oldCondition := GetRestoreCondition(status, condition.Type)
 
+	status.Phase = condition.Type
+
 	if oldCondition == nil {
 		// We are adding new Restore condition.
 		status.Conditions = append(status.Conditions, *condition)

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -41,6 +42,7 @@ type ComponentAccessor interface {
 	AdditionalContainers() []corev1.Container
 	AdditionalVolumes() []corev1.Volume
 	TerminationGracePeriodSeconds() *int64
+	StatefulSetUpdateStrategy() *apps.StatefulSetUpdateStrategy
 }
 
 type componentAccessorImpl struct {
@@ -57,6 +59,10 @@ type componentAccessorImpl struct {
 
 	// ComponentSpec is the Component Spec
 	ComponentSpec *ComponentSpec
+}
+
+func (a *componentAccessorImpl) StatefulSetUpdateStrategy() *apps.StatefulSetUpdateStrategy {
+	return a.ComponentSpec.StatefulSetUpdateStrategy
 }
 
 func (a *componentAccessorImpl) PodSecurityContext() *corev1.PodSecurityContext {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1302,8 +1302,10 @@ type BackupStatus struct {
 	// BackupSize is the data size of the backup.
 	BackupSize int64 `json:"backupSize"`
 	// CommitTs is the snapshot time point of tidb cluster.
-	CommitTs   string            `json:"commitTs"`
-	Conditions []BackupCondition `json:"conditions"`
+	CommitTs string `json:"commitTs"`
+	// Phase is a user readable state inferred from the underlying Backup conditions
+	Phase      BackupConditionType `json:"phase"`
+	Conditions []BackupCondition   `json:"conditions"`
 }
 
 // +genclient
@@ -1468,8 +1470,10 @@ type RestoreStatus struct {
 	// TimeCompleted is the time at which the restore was completed.
 	TimeCompleted metav1.Time `json:"timeCompleted"`
 	// CommitTs is the snapshot time point of tidb cluster.
-	CommitTs   string             `json:"commitTs"`
-	Conditions []RestoreCondition `json:"conditions"`
+	CommitTs string `json:"commitTs"`
+	// Phase is a user readable state inferred from the underlying Restore conditions
+	Phase      RestoreConditionType `json:"phase"`
+	Conditions []RestoreCondition   `json:"conditions"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -775,6 +775,11 @@ type ComponentSpec struct {
 	// Defaults to 30 seconds.
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// StatefulSetUpdateStrategy indicates the StatefulSetUpdateStrategy that will be
+	// employed to update Pods in the StatefulSet when a revision is made to
+	// Template.
+	StatefulSetUpdateStrategy *apps.StatefulSetUpdateStrategy `json:"updateStrategy,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_control.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_control.go
@@ -33,16 +33,16 @@ type defaultAutoScalerControl struct {
 	autoScalerManager autoscaler.AutoScalerManager
 }
 
-func (tac *defaultAutoScalerControl) ResconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
+func (c *defaultAutoScalerControl) ResconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
 	var errs []error
-	if err := tac.reconcileAutoScaler(ta); err != nil {
+	if err := c.reconcileAutoScaler(ta); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.NewAggregate(errs)
 }
 
-func (tac *defaultAutoScalerControl) reconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
-	return tac.autoScalerManager.Sync(ta)
+func (c *defaultAutoScalerControl) reconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
+	return c.autoScalerManager.Sync(ta)
 }
 
 var _ ControlInterface = &defaultAutoScalerControl{}
@@ -55,13 +55,13 @@ func NewFakeAutoScalerControl() *FakeAutoScalerControl {
 	return &FakeAutoScalerControl{}
 }
 
-func (tac *FakeAutoScalerControl) SetReconcileAutoScalerError(err error) {
-	tac.err = err
+func (c *FakeAutoScalerControl) SetReconcileAutoScalerError(err error) {
+	c.err = err
 }
 
-func (tac *FakeAutoScalerControl) ResconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
-	if tac.err != nil {
-		return tac.err
+func (c *FakeAutoScalerControl) ResconcileAutoScaler(ta *v1alpha1.TidbClusterAutoScaler) error {
+	if c.err != nil {
+		return c.err
 	}
 	return nil
 }

--- a/pkg/controller/backup/backup_control.go
+++ b/pkg/controller/backup/backup_control.go
@@ -51,30 +51,30 @@ type defaultBackupControl struct {
 }
 
 // UpdateBackup executes the core logic loop for a Backup.
-func (bc *defaultBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
+func (c *defaultBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
 	backup.SetGroupVersionKind(controller.BackupControllerKind)
-	if err := bc.addProtectionFinalizer(backup); err != nil {
+	if err := c.addProtectionFinalizer(backup); err != nil {
 		return err
 	}
 
-	if err := bc.removeProtectionFinalizer(backup); err != nil {
+	if err := c.removeProtectionFinalizer(backup); err != nil {
 		return err
 	}
 
-	return bc.updateBackup(backup)
+	return c.updateBackup(backup)
 }
 
-func (bc *defaultBackupControl) updateBackup(backup *v1alpha1.Backup) error {
-	return bc.backupManager.Sync(backup)
+func (c *defaultBackupControl) updateBackup(backup *v1alpha1.Backup) error {
+	return c.backupManager.Sync(backup)
 }
 
-func (bc *defaultBackupControl) addProtectionFinalizer(backup *v1alpha1.Backup) error {
+func (c *defaultBackupControl) addProtectionFinalizer(backup *v1alpha1.Backup) error {
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
 	if needToAddFinalizer(backup) {
 		backup.Finalizers = append(backup.Finalizers, label.BackupProtectionFinalizer)
-		_, err := bc.cli.PingcapV1alpha1().Backups(ns).Update(backup)
+		_, err := c.cli.PingcapV1alpha1().Backups(ns).Update(backup)
 		if err != nil {
 			return fmt.Errorf("add backup %s/%s protection finalizers failed, err: %v", ns, name, err)
 		}
@@ -82,13 +82,13 @@ func (bc *defaultBackupControl) addProtectionFinalizer(backup *v1alpha1.Backup) 
 	return nil
 }
 
-func (bc *defaultBackupControl) removeProtectionFinalizer(backup *v1alpha1.Backup) error {
+func (c *defaultBackupControl) removeProtectionFinalizer(backup *v1alpha1.Backup) error {
 	ns := backup.GetNamespace()
 	name := backup.GetName()
 
 	if needToRemoveFinalizer(backup) {
 		backup.Finalizers = slice.RemoveString(backup.Finalizers, label.BackupProtectionFinalizer, nil)
-		_, err := bc.cli.PingcapV1alpha1().Backups(ns).Update(backup)
+		_, err := c.cli.PingcapV1alpha1().Backups(ns).Update(backup)
 		if err != nil {
 			return fmt.Errorf("remove backup %s/%s protection finalizers failed, err: %v", ns, name, err)
 		}
@@ -127,19 +127,19 @@ func NewFakeBackupControl(backupInformer informers.BackupInformer) *FakeBackupCo
 }
 
 // SetUpdateBackupError sets the error attributes of updateBackupTracker
-func (fbc *FakeBackupControl) SetUpdateBackupError(err error, after int) {
-	fbc.updateBackupTracker.SetError(err).SetAfter(after)
+func (c *FakeBackupControl) SetUpdateBackupError(err error, after int) {
+	c.updateBackupTracker.SetError(err).SetAfter(after)
 }
 
 // UpdateBackup adds the backup to BackupIndexer
-func (fbc *FakeBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
-	defer fbc.updateBackupTracker.Inc()
-	if fbc.updateBackupTracker.ErrorReady() {
-		defer fbc.updateBackupTracker.Reset()
-		return fbc.updateBackupTracker.GetError()
+func (c *FakeBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
+	defer c.updateBackupTracker.Inc()
+	if c.updateBackupTracker.ErrorReady() {
+		defer c.updateBackupTracker.Reset()
+		return c.updateBackupTracker.GetError()
 	}
 
-	return fbc.backupIndexer.Add(backup)
+	return c.backupIndexer.Add(backup)
 }
 
 var _ ControlInterface = &FakeBackupControl{}

--- a/pkg/controller/backup_control.go
+++ b/pkg/controller/backup_control.go
@@ -63,37 +63,37 @@ func NewRealBackupControl(
 	}
 }
 
-func (rbc *realBackupControl) CreateBackup(backup *v1alpha1.Backup) (*v1alpha1.Backup, error) {
+func (c *realBackupControl) CreateBackup(backup *v1alpha1.Backup) (*v1alpha1.Backup, error) {
 	ns := backup.GetNamespace()
 	backupName := backup.GetName()
 
 	bsName := backup.GetLabels()[label.BackupScheduleLabelKey]
-	backup, err := rbc.cli.PingcapV1alpha1().Backups(ns).Create(backup)
+	backup, err := c.cli.PingcapV1alpha1().Backups(ns).Create(backup)
 	if err != nil {
 		klog.Errorf("failed to create Backup: [%s/%s] for backupSchedule/%s, err: %v", ns, backupName, bsName, err)
 	} else {
 		klog.V(4).Infof("create Backup: [%s/%s] for backupSchedule/%s successfully", ns, backupName, bsName)
 	}
-	rbc.recordBackupEvent("create", backup, err)
+	c.recordBackupEvent("create", backup, err)
 	return backup, err
 }
 
-func (rbc *realBackupControl) DeleteBackup(backup *v1alpha1.Backup) error {
+func (c *realBackupControl) DeleteBackup(backup *v1alpha1.Backup) error {
 	ns := backup.GetNamespace()
 	backupName := backup.GetName()
 
 	bsName := backup.GetLabels()[label.BackupScheduleLabelKey]
-	err := rbc.cli.PingcapV1alpha1().Backups(ns).Delete(backupName, nil)
+	err := c.cli.PingcapV1alpha1().Backups(ns).Delete(backupName, nil)
 	if err != nil {
 		klog.Errorf("failed to delete Backup: [%s/%s] for backupSchedule/%s, err: %v", ns, backupName, bsName, err)
 	} else {
 		klog.V(4).Infof("delete backup: [%s/%s] successfully, backupSchedule/%s", ns, backupName, bsName)
 	}
-	rbc.recordBackupEvent("delete", backup, err)
+	c.recordBackupEvent("delete", backup, err)
 	return err
 }
 
-func (rbc *realBackupControl) recordBackupEvent(verb string, backup *v1alpha1.Backup, err error) {
+func (c *realBackupControl) recordBackupEvent(verb string, backup *v1alpha1.Backup, err error) {
 	backupName := backup.GetName()
 	ns := backup.GetNamespace()
 
@@ -102,12 +102,12 @@ func (rbc *realBackupControl) recordBackupEvent(verb string, backup *v1alpha1.Ba
 		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s Backup %s/%s for backupSchedule/%s successful",
 			strings.ToLower(verb), ns, backupName, bsName)
-		rbc.recorder.Event(backup, corev1.EventTypeNormal, reason, msg)
+		c.recorder.Event(backup, corev1.EventTypeNormal, reason, msg)
 	} else {
 		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s Backup %s/%s for backupSchedule/%s failed error: %s",
 			strings.ToLower(verb), ns, backupName, bsName, err)
-		rbc.recorder.Event(backup, corev1.EventTypeWarning, reason, msg)
+		c.recorder.Event(backup, corev1.EventTypeWarning, reason, msg)
 	}
 }
 

--- a/pkg/controller/backup_schedule_status_updater.go
+++ b/pkg/controller/backup_schedule_status_updater.go
@@ -45,7 +45,7 @@ type realBackupScheduleStatusUpdater struct {
 	deps *Dependencies
 }
 
-func (bss *realBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(
+func (u *realBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(
 	bs *v1alpha1.BackupSchedule,
 	newStatus *v1alpha1.BackupScheduleStatus,
 	oldStatus *v1alpha1.BackupScheduleStatus) error {
@@ -54,12 +54,12 @@ func (bss *realBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(
 	bsName := bs.GetName()
 	// don't wait due to limited number of clients, but backoff after the default number of steps
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, updateErr := bss.deps.Clientset.PingcapV1alpha1().BackupSchedules(ns).Update(bs)
+		_, updateErr := u.deps.Clientset.PingcapV1alpha1().BackupSchedules(ns).Update(bs)
 		if updateErr == nil {
 			klog.Infof("BackupSchedule: [%s/%s] updated successfully", ns, bsName)
 			return nil
 		}
-		if updated, err := bss.deps.BackupScheduleLister.BackupSchedules(ns).Get(bsName); err == nil {
+		if updated, err := u.deps.BackupScheduleLister.BackupSchedules(ns).Get(bsName); err == nil {
 			// make a copy so we don't mutate the shared cache
 			bs = updated.DeepCopy()
 			bs.Status = *newStatus
@@ -91,21 +91,21 @@ func NewFakeBackupScheduleStatusUpdater(bsInformer informers.BackupScheduleInfor
 }
 
 // SetUpdateBackupError sets the error attributes of updateBackupScheduleTracker
-func (fbs *FakeBackupScheduleStatusUpdater) SetUpdateBackupScheduleError(err error, after int) {
-	fbs.updateBsTracker.err = err
-	fbs.updateBsTracker.after = after
-	fbs.updateBsTracker.SetError(err).SetAfter(after)
+func (u *FakeBackupScheduleStatusUpdater) SetUpdateBackupScheduleError(err error, after int) {
+	u.updateBsTracker.err = err
+	u.updateBsTracker.after = after
+	u.updateBsTracker.SetError(err).SetAfter(after)
 }
 
 // UpdateBackupSchedule updates the BackupSchedule
-func (fbs *FakeBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(bs *v1alpha1.BackupSchedule, _ *v1alpha1.BackupScheduleStatus, _ *v1alpha1.BackupScheduleStatus) error {
-	defer fbs.updateBsTracker.Inc()
-	if fbs.updateBsTracker.ErrorReady() {
-		defer fbs.updateBsTracker.Reset()
-		return fbs.updateBsTracker.GetError()
+func (u *FakeBackupScheduleStatusUpdater) UpdateBackupScheduleStatus(bs *v1alpha1.BackupSchedule, _ *v1alpha1.BackupScheduleStatus, _ *v1alpha1.BackupScheduleStatus) error {
+	defer u.updateBsTracker.Inc()
+	if u.updateBsTracker.ErrorReady() {
+		defer u.updateBsTracker.Reset()
+		return u.updateBsTracker.GetError()
 	}
 
-	return fbs.BsIndexer.Update(bs)
+	return u.BsIndexer.Update(bs)
 }
 
 var _ BackupScheduleStatusUpdaterInterface = &FakeBackupScheduleStatusUpdater{}

--- a/pkg/controller/backupschedule/backup_schedule_control.go
+++ b/pkg/controller/backupschedule/backup_schedule_control.go
@@ -46,25 +46,25 @@ type defaultBackupScheduleControl struct {
 }
 
 // UpdateBackupSchedule executes the core logic loop for a BackupSchedule.
-func (bsc *defaultBackupScheduleControl) UpdateBackupSchedule(bs *v1alpha1.BackupSchedule) error {
+func (c *defaultBackupScheduleControl) UpdateBackupSchedule(bs *v1alpha1.BackupSchedule) error {
 	var errs []error
 	oldStatus := bs.Status.DeepCopy()
 
-	if err := bsc.updateBackupSchedule(bs); err != nil {
+	if err := c.updateBackupSchedule(bs); err != nil {
 		errs = append(errs, err)
 	}
 	if apiequality.Semantic.DeepEqual(&bs.Status, oldStatus) {
 		return errorutils.NewAggregate(errs)
 	}
-	if err := bsc.statusUpdater.UpdateBackupScheduleStatus(bs.DeepCopy(), &bs.Status, oldStatus); err != nil {
+	if err := c.statusUpdater.UpdateBackupScheduleStatus(bs.DeepCopy(), &bs.Status, oldStatus); err != nil {
 		errs = append(errs, err)
 	}
 
 	return errorutils.NewAggregate(errs)
 }
 
-func (bsc *defaultBackupScheduleControl) updateBackupSchedule(bs *v1alpha1.BackupSchedule) error {
-	return bsc.bsManager.Sync(bs)
+func (c *defaultBackupScheduleControl) updateBackupSchedule(bs *v1alpha1.BackupSchedule) error {
+	return c.bsManager.Sync(bs)
 }
 
 var _ ControlInterface = &defaultBackupScheduleControl{}

--- a/pkg/controller/dmcluster/dm_cluster_control.go
+++ b/pkg/controller/dmcluster/dm_cluster_control.go
@@ -75,56 +75,56 @@ type defaultDMClusterControl struct {
 }
 
 // UpdateStatefulSet executes the core logic loop for a dmcluster.
-func (dcc *defaultDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster) error {
-	dcc.defaulting(dc)
-	if !dcc.validate(dc) {
+func (c *defaultDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster) error {
+	c.defaulting(dc)
+	if !c.validate(dc) {
 		return nil // fatal error, no need to retry on invalid object
 	}
 
 	var errs []error
 	oldStatus := dc.Status.DeepCopy()
 
-	if err := dcc.updateDMCluster(dc); err != nil {
+	if err := c.updateDMCluster(dc); err != nil {
 		errs = append(errs, err)
 	}
 
-	if err := dcc.conditionUpdater.Update(dc); err != nil {
+	if err := c.conditionUpdater.Update(dc); err != nil {
 		errs = append(errs, err)
 	}
 
 	if apiequality.Semantic.DeepEqual(&dc.Status, oldStatus) {
 		return errorutils.NewAggregate(errs)
 	}
-	if _, err := dcc.dcControl.UpdateDMCluster(dc.DeepCopy(), &dc.Status, oldStatus); err != nil {
+	if _, err := c.dcControl.UpdateDMCluster(dc.DeepCopy(), &dc.Status, oldStatus); err != nil {
 		errs = append(errs, err)
 	}
 
 	return errorutils.NewAggregate(errs)
 }
 
-func (dcc *defaultDMClusterControl) defaulting(dc *v1alpha1.DMCluster) {
+func (c *defaultDMClusterControl) defaulting(dc *v1alpha1.DMCluster) {
 	defaulting.SetDMClusterDefault(dc)
 }
 
-func (dcc *defaultDMClusterControl) validate(dc *v1alpha1.DMCluster) bool {
+func (c *defaultDMClusterControl) validate(dc *v1alpha1.DMCluster) bool {
 	errs := v1alpha1validation.ValidateDMCluster(dc)
 	if len(errs) > 0 {
 		aggregatedErr := errs.ToAggregate()
 		klog.Errorf("dm cluster %s/%s is not valid and must be fixed first, aggregated error: %v", dc.GetNamespace(), dc.GetName(), aggregatedErr)
-		dcc.recorder.Event(dc, v1.EventTypeWarning, "FailedValidation", aggregatedErr.Error())
+		c.recorder.Event(dc, v1.EventTypeWarning, "FailedValidation", aggregatedErr.Error())
 		return false
 	}
 	return true
 }
 
-func (dcc *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) error {
+func (c *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) error {
 	var errs []error
-	if err := dcc.reclaimPolicyManager.SyncDM(dc); err != nil {
+	if err := c.reclaimPolicyManager.SyncDM(dc); err != nil {
 		return err
 	}
 
 	// cleaning all orphan pods(dm-master or dm-worker which don't have a related PVC) managed by operator
-	skipReasons, err := dcc.orphanPodsCleaner.Clean(dc)
+	skipReasons, err := c.orphanPodsCleaner.Clean(dc)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (dcc *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) erro
 	//   - upgrade the dm-master cluster
 	//   - scale out/in the dm-master cluster
 	//   - failover the dm-master cluster
-	if err := dcc.masterMemberManager.SyncDM(dc); err != nil {
+	if err := c.masterMemberManager.SyncDM(dc); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -157,7 +157,7 @@ func (dcc *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) erro
 	//   - upgrade the dm-worker cluster
 	//   - scale out/in the dm-worker cluster
 	//   - failover the dm-worker cluster
-	if err := dcc.workerMemberManager.SyncDM(dc); err != nil {
+	if err := c.workerMemberManager.SyncDM(dc); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -165,11 +165,11 @@ func (dcc *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) erro
 	//   - label.StoreIDLabelKey
 	//   - label.MemberIDLabelKey
 	//   - label.NamespaceLabelKey
-	// if err := dcc.metaManager.Sync(dc); err != nil {
+	// if err := c.metaManager.Sync(dc); err != nil {
 	// 	return err
 	// }
 
-	pvcSkipReasons, err := dcc.pvcCleaner.Clean(dc)
+	pvcSkipReasons, err := c.pvcCleaner.Clean(dc)
 	if err != nil {
 		return err
 	}
@@ -182,10 +182,10 @@ func (dcc *defaultDMClusterControl) updateDMCluster(dc *v1alpha1.DMCluster) erro
 	// TODO: sync dm cluster attributes
 	// syncing the some tidbcluster status attributes
 	// 	- sync tidbmonitor reference
-	// return dcc.tidbClusterStatusManager.Sync(dc)
+	// return c.tidbClusterStatusManager.Sync(dc)
 
 	// resize PVC if necessary
-	if err := dcc.pvcResizer.ResizeDM(dc); err != nil {
+	if err := c.pvcResizer.ResizeDM(dc); err != nil {
 		errs = append(errs, err)
 	}
 	return errorutils.NewAggregate(errs)

--- a/pkg/controller/dmcluster_control.go
+++ b/pkg/controller/dmcluster_control.go
@@ -49,7 +49,7 @@ func NewRealDMClusterControl(cli versioned.Interface,
 	}
 }
 
-func (rdc *realDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster, newStatus *v1alpha1.DMClusterStatus, oldStatus *v1alpha1.DMClusterStatus) (*v1alpha1.DMCluster, error) {
+func (c *realDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster, newStatus *v1alpha1.DMClusterStatus, oldStatus *v1alpha1.DMClusterStatus) (*v1alpha1.DMCluster, error) {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
@@ -59,14 +59,14 @@ func (rdc *realDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster, newStat
 	// don't wait due to limited number of clients, but backoff after the default number of steps
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var updateErr error
-		updateDC, updateErr = rdc.cli.PingcapV1alpha1().DMClusters(ns).Update(dc)
+		updateDC, updateErr = c.cli.PingcapV1alpha1().DMClusters(ns).Update(dc)
 		if updateErr == nil {
 			klog.Infof("DMCluster: [%s/%s] updated successfully", ns, dcName)
 			return nil
 		}
 		klog.V(4).Infof("failed to update DMCluster: [%s/%s], error: %v", ns, dcName, updateErr)
 
-		if updated, err := rdc.dcLister.DMClusters(ns).Get(dcName); err == nil {
+		if updated, err := c.dcLister.DMClusters(ns).Get(dcName); err == nil {
 			// make a copy so we don't mutate the shared cache
 			dc = updated.DeepCopy()
 			dc.Status = *status
@@ -99,17 +99,17 @@ func NewFakeDMClusterControl(dcInformer tcinformers.DMClusterInformer) *FakeDMCl
 }
 
 // SetUpdateDMClusterError sets the error attributes of updateDMClusterTracker
-func (ssc *FakeDMClusterControl) SetUpdateDMClusterError(err error, after int) {
-	ssc.updateDMClusterTracker.SetError(err).SetAfter(after)
+func (c *FakeDMClusterControl) SetUpdateDMClusterError(err error, after int) {
+	c.updateDMClusterTracker.SetError(err).SetAfter(after)
 }
 
 // UpdateDMCluster updates the DMCluster
-func (ssc *FakeDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster, _ *v1alpha1.DMClusterStatus, _ *v1alpha1.DMClusterStatus) (*v1alpha1.DMCluster, error) {
-	defer ssc.updateDMClusterTracker.Inc()
-	if ssc.updateDMClusterTracker.ErrorReady() {
-		defer ssc.updateDMClusterTracker.Reset()
-		return dc, ssc.updateDMClusterTracker.GetError()
+func (c *FakeDMClusterControl) UpdateDMCluster(dc *v1alpha1.DMCluster, _ *v1alpha1.DMClusterStatus, _ *v1alpha1.DMClusterStatus) (*v1alpha1.DMCluster, error) {
+	defer c.updateDMClusterTracker.Inc()
+	if c.updateDMClusterTracker.ErrorReady() {
+		defer c.updateDMClusterTracker.Reset()
+		return dc, c.updateDMClusterTracker.GetError()
 	}
 
-	return dc, ssc.DcIndexer.Update(dc)
+	return dc, c.DcIndexer.Update(dc)
 }

--- a/pkg/controller/generic_control.go
+++ b/pkg/controller/generic_control.go
@@ -554,78 +554,78 @@ func NewFakeGenericControl(initObjects ...runtime.Object) *FakeGenericControl {
 		RequestTracker{},
 	}
 }
-func (gc *FakeGenericControl) Create(controller, obj runtime.Object, setOwnerFlag bool) error {
-	defer gc.createTracker.Inc()
-	if gc.createTracker.ErrorReady() {
-		defer gc.createTracker.Reset()
-		return gc.createTracker.GetError()
+func (c *FakeGenericControl) Create(controller, obj runtime.Object, setOwnerFlag bool) error {
+	defer c.createTracker.Inc()
+	if c.createTracker.ErrorReady() {
+		defer c.createTracker.Reset()
+		return c.createTracker.GetError()
 	}
 
-	return gc.control.Create(controller, obj, setOwnerFlag)
+	return c.control.Create(controller, obj, setOwnerFlag)
 }
 
-func (gc *FakeGenericControl) Exist(key client.ObjectKey, obj runtime.Object) (bool, error) {
-	defer gc.existTracker.Inc()
-	if gc.existTracker.ErrorReady() {
-		defer gc.existTracker.Reset()
-		return true, gc.existTracker.GetError()
+func (c *FakeGenericControl) Exist(key client.ObjectKey, obj runtime.Object) (bool, error) {
+	defer c.existTracker.Inc()
+	if c.existTracker.ErrorReady() {
+		defer c.existTracker.Reset()
+		return true, c.existTracker.GetError()
 	}
 
-	return gc.control.Exist(key, obj)
+	return c.control.Exist(key, obj)
 }
 
-func (gc *FakeGenericControl) SetCreateError(err error, after int) {
-	gc.createTracker.SetError(err).SetAfter(after)
+func (c *FakeGenericControl) SetCreateError(err error, after int) {
+	c.createTracker.SetError(err).SetAfter(after)
 }
-func (gc *FakeGenericControl) SetExistError(err error, after int) {
-	gc.existTracker.SetError(err).SetAfter(after)
+func (c *FakeGenericControl) SetExistError(err error, after int) {
+	c.existTracker.SetError(err).SetAfter(after)
 }
-func (gc *FakeGenericControl) SetUpdateStatusError(err error, after int) {
-	gc.updateStatusTracker.SetError(err).SetAfter(after)
-}
-
-func (gc *FakeGenericControl) SetCreateOrUpdateError(err error, after int) {
-	gc.createOrUpdateTracker.SetError(err).SetAfter(after)
+func (c *FakeGenericControl) SetUpdateStatusError(err error, after int) {
+	c.updateStatusTracker.SetError(err).SetAfter(after)
 }
 
-func (gc *FakeGenericControl) SetDeleteError(err error, after int) {
-	gc.deleteTracker.SetError(err).SetAfter(after)
+func (c *FakeGenericControl) SetCreateOrUpdateError(err error, after int) {
+	c.createOrUpdateTracker.SetError(err).SetAfter(after)
+}
+
+func (c *FakeGenericControl) SetDeleteError(err error, after int) {
+	c.deleteTracker.SetError(err).SetAfter(after)
 }
 
 // AddObject is used to prepare the indexer for fakeGenericControl
-func (gc *FakeGenericControl) AddObject(object runtime.Object) error {
-	return gc.FakeCli.Create(context.TODO(), object.DeepCopyObject())
+func (c *FakeGenericControl) AddObject(object runtime.Object) error {
+	return c.FakeCli.Create(context.TODO(), object.DeepCopyObject())
 }
 
 // UpdateStatus update the /status subresource of object
-func (gc *FakeGenericControl) UpdateStatus(obj runtime.Object) error {
-	defer gc.updateStatusTracker.Inc()
-	if gc.updateStatusTracker.ErrorReady() {
-		defer gc.updateStatusTracker.Reset()
-		return gc.updateStatusTracker.GetError()
+func (c *FakeGenericControl) UpdateStatus(obj runtime.Object) error {
+	defer c.updateStatusTracker.Inc()
+	if c.updateStatusTracker.ErrorReady() {
+		defer c.updateStatusTracker.Reset()
+		return c.updateStatusTracker.GetError()
 	}
 
-	return gc.FakeCli.Status().Update(context.TODO(), obj)
+	return c.FakeCli.Status().Update(context.TODO(), obj)
 }
 
-func (gc *FakeGenericControl) CreateOrUpdate(controller, obj runtime.Object, fn MergeFn, setOwnerFlag bool) (runtime.Object, error) {
-	defer gc.createOrUpdateTracker.Inc()
-	if gc.createOrUpdateTracker.ErrorReady() {
-		defer gc.createOrUpdateTracker.Reset()
-		return nil, gc.createOrUpdateTracker.GetError()
+func (c *FakeGenericControl) CreateOrUpdate(controller, obj runtime.Object, fn MergeFn, setOwnerFlag bool) (runtime.Object, error) {
+	defer c.createOrUpdateTracker.Inc()
+	if c.createOrUpdateTracker.ErrorReady() {
+		defer c.createOrUpdateTracker.Reset()
+		return nil, c.createOrUpdateTracker.GetError()
 	}
 
-	return gc.control.CreateOrUpdate(controller, obj, fn, setOwnerFlag)
+	return c.control.CreateOrUpdate(controller, obj, fn, setOwnerFlag)
 }
 
-func (gc *FakeGenericControl) Delete(controller, obj runtime.Object) error {
-	defer gc.deleteTracker.Inc()
-	if gc.deleteTracker.ErrorReady() {
-		defer gc.deleteTracker.Reset()
-		return gc.deleteTracker.GetError()
+func (c *FakeGenericControl) Delete(controller, obj runtime.Object) error {
+	defer c.deleteTracker.Inc()
+	if c.deleteTracker.ErrorReady() {
+		defer c.deleteTracker.Reset()
+		return c.deleteTracker.GetError()
 	}
 
-	return gc.control.Delete(controller, obj)
+	return c.control.Delete(controller, obj)
 }
 
 var _ GenericControlInterface = &FakeGenericControl{}

--- a/pkg/controller/http_client.go
+++ b/pkg/controller/http_client.go
@@ -30,7 +30,7 @@ type httpClient struct {
 	kubeCli kubernetes.Interface
 }
 
-func (hc *httpClient) getHTTPClient(tc *v1alpha1.TidbCluster) (*http.Client, error) {
+func (c *httpClient) getHTTPClient(tc *v1alpha1.TidbCluster) (*http.Client, error) {
 	httpClient := &http.Client{Timeout: timeout}
 	if !tc.IsTLSClusterEnabled() {
 		return httpClient, nil
@@ -39,7 +39,7 @@ func (hc *httpClient) getHTTPClient(tc *v1alpha1.TidbCluster) (*http.Client, err
 	tcName := tc.Name
 	ns := tc.Namespace
 	secretName := util.ClusterClientTLSSecretName(tcName)
-	secret, err := hc.kubeCli.CoreV1().Secrets(ns).Get(secretName, metav1.GetOptions{})
+	secret, err := c.kubeCli.CoreV1().Secrets(ns).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/pvc_control.go
+++ b/pkg/controller/pvc_control.go
@@ -59,11 +59,11 @@ func NewRealPVCControl(
 	}
 }
 
-func (rpc *realPVCControl) GetPVC(name, namespace string) (*corev1.PersistentVolumeClaim, error) {
-	return rpc.pvcLister.PersistentVolumeClaims(namespace).Get(name)
+func (c *realPVCControl) GetPVC(name, namespace string) (*corev1.PersistentVolumeClaim, error) {
+	return c.pvcLister.PersistentVolumeClaims(namespace).Get(name)
 }
 
-func (rpc *realPVCControl) DeletePVC(controller runtime.Object, pvc *corev1.PersistentVolumeClaim) error {
+func (c *realPVCControl) DeletePVC(controller runtime.Object, pvc *corev1.PersistentVolumeClaim) error {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -73,16 +73,16 @@ func (rpc *realPVCControl) DeletePVC(controller runtime.Object, pvc *corev1.Pers
 	namespace := controllerMo.GetNamespace()
 
 	pvcName := pvc.GetName()
-	err := rpc.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Delete(pvcName, nil)
+	err := c.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Delete(pvcName, nil)
 	if err != nil {
 		klog.Errorf("failed to delete PVC: [%s/%s], %s: %s, %v", namespace, pvcName, kind, name, err)
 	}
 	klog.V(4).Infof("delete PVC: [%s/%s] successfully, %s: %s", namespace, pvcName, kind, name)
-	rpc.recordPVCEvent("delete", kind, name, controller, pvcName, err)
+	c.recordPVCEvent("delete", kind, name, controller, pvcName, err)
 	return err
 }
 
-func (rpc *realPVCControl) UpdatePVC(controller runtime.Object, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+func (c *realPVCControl) UpdatePVC(controller runtime.Object, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -98,14 +98,14 @@ func (rpc *realPVCControl) UpdatePVC(controller runtime.Object, pvc *corev1.Pers
 	var updatePVC *corev1.PersistentVolumeClaim
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var updateErr error
-		updatePVC, updateErr = rpc.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
+		updatePVC, updateErr = c.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
 		if updateErr == nil {
 			klog.Infof("update PVC: [%s/%s] successfully, %s: %s", namespace, pvcName, kind, name)
 			return nil
 		}
 		klog.Errorf("failed to update PVC: [%s/%s], %s: %s, error: %v", namespace, pvcName, kind, name, updateErr)
 
-		if updated, err := rpc.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName); err == nil {
+		if updated, err := c.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName); err == nil {
 			// make a copy so we don't mutate the shared cache
 			pvc = updated.DeepCopy()
 			pvc.Labels = labels
@@ -119,7 +119,7 @@ func (rpc *realPVCControl) UpdatePVC(controller runtime.Object, pvc *corev1.Pers
 	return updatePVC, err
 }
 
-func (rpc *realPVCControl) UpdateMetaInfo(controller runtime.Object, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) (*corev1.PersistentVolumeClaim, error) {
+func (c *realPVCControl) UpdateMetaInfo(controller runtime.Object, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) (*corev1.PersistentVolumeClaim, error) {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -163,14 +163,14 @@ func (rpc *realPVCControl) UpdateMetaInfo(controller runtime.Object, pvc *corev1
 	var updatePVC *corev1.PersistentVolumeClaim
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var updateErr error
-		updatePVC, updateErr = rpc.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
+		updatePVC, updateErr = c.kubeCli.CoreV1().PersistentVolumeClaims(namespace).Update(pvc)
 		if updateErr == nil {
 			klog.V(4).Infof("update PVC: [%s/%s] successfully, %s: %s", namespace, pvcName, kind, name)
 			return nil
 		}
 		klog.Errorf("failed to update PVC: [%s/%s], %s: %s, error: %v", namespace, pvcName, kind, name, updateErr)
 
-		if updated, err := rpc.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName); err == nil {
+		if updated, err := c.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName); err == nil {
 			// make a copy so we don't mutate the shared cache
 			pvc = updated.DeepCopy()
 			pvc.Labels = labels
@@ -184,17 +184,17 @@ func (rpc *realPVCControl) UpdateMetaInfo(controller runtime.Object, pvc *corev1
 	return updatePVC, err
 }
 
-func (rpc *realPVCControl) recordPVCEvent(verb, kind, name string, object runtime.Object, pvcName string, err error) {
+func (c *realPVCControl) recordPVCEvent(verb, kind, name string, object runtime.Object, pvcName string, err error) {
 	if err == nil {
 		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s PVC %s in %s %s successful",
 			strings.ToLower(verb), pvcName, kind, name)
-		rpc.recorder.Event(object, corev1.EventTypeNormal, reason, msg)
+		c.recorder.Event(object, corev1.EventTypeNormal, reason, msg)
 	} else {
 		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s PVC %s in %s %s failed error: %s",
 			strings.ToLower(verb), pvcName, kind, name, err)
-		rpc.recorder.Event(object, corev1.EventTypeWarning, reason, msg)
+		c.recorder.Event(object, corev1.EventTypeWarning, reason, msg)
 	}
 }
 
@@ -217,43 +217,43 @@ func NewFakePVCControl(pvcInformer coreinformers.PersistentVolumeClaimInformer) 
 }
 
 // SetUpdatePVCError sets the error attributes of updatePVCTracker
-func (fpc *FakePVCControl) SetUpdatePVCError(err error, after int) {
-	fpc.updatePVCTracker.SetError(err).SetAfter(after)
+func (c *FakePVCControl) SetUpdatePVCError(err error, after int) {
+	c.updatePVCTracker.SetError(err).SetAfter(after)
 }
 
 // SetDeletePVCError sets the error attributes of deletePVCTracker
-func (fpc *FakePVCControl) SetDeletePVCError(err error, after int) {
-	fpc.deletePVCTracker.SetError(err).SetAfter(after)
+func (c *FakePVCControl) SetDeletePVCError(err error, after int) {
+	c.deletePVCTracker.SetError(err).SetAfter(after)
 }
 
 // DeletePVC deletes the pvc
-func (fpc *FakePVCControl) DeletePVC(_ runtime.Object, pvc *corev1.PersistentVolumeClaim) error {
-	defer fpc.deletePVCTracker.Inc()
-	if fpc.deletePVCTracker.ErrorReady() {
-		defer fpc.deletePVCTracker.Reset()
-		return fpc.deletePVCTracker.GetError()
+func (c *FakePVCControl) DeletePVC(_ runtime.Object, pvc *corev1.PersistentVolumeClaim) error {
+	defer c.deletePVCTracker.Inc()
+	if c.deletePVCTracker.ErrorReady() {
+		defer c.deletePVCTracker.Reset()
+		return c.deletePVCTracker.GetError()
 	}
 
-	return fpc.PVCIndexer.Delete(pvc)
+	return c.PVCIndexer.Delete(pvc)
 }
 
 // UpdatePVC updates the annotation, labels and spec of pvc
-func (fpc *FakePVCControl) UpdatePVC(_ runtime.Object, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
-	defer fpc.updatePVCTracker.Inc()
-	if fpc.updatePVCTracker.ErrorReady() {
-		defer fpc.updatePVCTracker.Reset()
-		return nil, fpc.updatePVCTracker.GetError()
+func (c *FakePVCControl) UpdatePVC(_ runtime.Object, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	defer c.updatePVCTracker.Inc()
+	if c.updatePVCTracker.ErrorReady() {
+		defer c.updatePVCTracker.Reset()
+		return nil, c.updatePVCTracker.GetError()
 	}
 
-	return pvc, fpc.PVCIndexer.Update(pvc)
+	return pvc, c.PVCIndexer.Update(pvc)
 }
 
 // UpdateMetaInfo updates the meta info of pvc
-func (fpc *FakePVCControl) UpdateMetaInfo(_ runtime.Object, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) (*corev1.PersistentVolumeClaim, error) {
-	defer fpc.updatePVCTracker.Inc()
-	if fpc.updatePVCTracker.ErrorReady() {
-		defer fpc.updatePVCTracker.Reset()
-		return nil, fpc.updatePVCTracker.GetError()
+func (c *FakePVCControl) UpdateMetaInfo(_ runtime.Object, pvc *corev1.PersistentVolumeClaim, pod *corev1.Pod) (*corev1.PersistentVolumeClaim, error) {
+	defer c.updatePVCTracker.Inc()
+	if c.updatePVCTracker.ErrorReady() {
+		defer c.updatePVCTracker.Reset()
+		return nil, c.updatePVCTracker.GetError()
 	}
 	if pvc.Labels == nil {
 		pvc.Labels = make(map[string]string)
@@ -266,12 +266,12 @@ func (fpc *FakePVCControl) UpdateMetaInfo(_ runtime.Object, pvc *corev1.Persiste
 	setIfNotEmpty(pvc.Labels, label.StoreIDLabelKey, pod.Labels[label.StoreIDLabelKey])
 	setIfNotEmpty(pvc.Labels, label.AnnPodNameKey, pod.GetName())
 	setIfNotEmpty(pvc.Annotations, label.AnnPodNameKey, pod.GetName())
-	return nil, fpc.PVCIndexer.Update(pvc)
+	return nil, c.PVCIndexer.Update(pvc)
 }
 
-func (fpc *FakePVCControl) GetPVC(name, namespace string) (*corev1.PersistentVolumeClaim, error) {
-	defer fpc.updatePVCTracker.Inc()
-	obj, existed, err := fpc.PVCIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+func (c *FakePVCControl) GetPVC(name, namespace string) (*corev1.PersistentVolumeClaim, error) {
+	defer c.updatePVCTracker.Inc()
+	obj, existed, err := c.PVCIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/restore/restore_control.go
+++ b/pkg/controller/restore/restore_control.go
@@ -44,9 +44,9 @@ type defaultRestoreControl struct {
 var _ ControlInterface = &defaultRestoreControl{}
 
 // UpdateRestore executes the core logic loop for a Restore.
-func (rc *defaultRestoreControl) UpdateRestore(restore *v1alpha1.Restore) error {
+func (c *defaultRestoreControl) UpdateRestore(restore *v1alpha1.Restore) error {
 	restore.SetGroupVersionKind(controller.RestoreControllerKind)
-	return rc.restoreManager.Sync(restore)
+	return c.restoreManager.Sync(restore)
 }
 
 // FakeRestoreControl is a fake RestoreControlInterface
@@ -64,19 +64,19 @@ func NewFakeRestoreControl(restoreInformer informers.RestoreInformer) *FakeResto
 }
 
 // SetUpdateRestoreError sets the error attributes of updateRestoreTracker
-func (fbc *FakeRestoreControl) SetUpdateRestoreError(err error, after int) {
-	fbc.updateRestoreTracker.SetError(err).SetAfter(after)
+func (c *FakeRestoreControl) SetUpdateRestoreError(err error, after int) {
+	c.updateRestoreTracker.SetError(err).SetAfter(after)
 }
 
 // UpdateRestore adds the backup to RestoreIndexer
-func (fbc *FakeRestoreControl) UpdateRestore(backup *v1alpha1.Restore) error {
-	defer fbc.updateRestoreTracker.Inc()
-	if fbc.updateRestoreTracker.ErrorReady() {
-		defer fbc.updateRestoreTracker.Reset()
-		return fbc.updateRestoreTracker.GetError()
+func (c *FakeRestoreControl) UpdateRestore(backup *v1alpha1.Restore) error {
+	defer c.updateRestoreTracker.Inc()
+	if c.updateRestoreTracker.ErrorReady() {
+		defer c.updateRestoreTracker.Reset()
+		return c.updateRestoreTracker.GetError()
 	}
 
-	return fbc.backupIndexer.Add(backup)
+	return c.backupIndexer.Add(backup)
 }
 
 var _ ControlInterface = &FakeRestoreControl{}

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -51,7 +51,7 @@ func NewRealRestoreConditionUpdater(
 	}
 }
 
-func (rcu *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
+func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
 	ns := restore.GetNamespace()
 	restoreName := restore.GetName()
 	oldStatus := restore.Status.DeepCopy()
@@ -59,12 +59,12 @@ func (rcu *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condit
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		isUpdate = v1alpha1.UpdateRestoreCondition(&restore.Status, condition)
 		if isUpdate {
-			_, updateErr := rcu.cli.PingcapV1alpha1().Restores(ns).Update(restore)
+			_, updateErr := u.cli.PingcapV1alpha1().Restores(ns).Update(restore)
 			if updateErr == nil {
 				klog.Infof("Restore: [%s/%s] updated successfully", ns, restoreName)
 				return nil
 			}
-			if updated, err := rcu.restoreLister.Restores(ns).Get(restoreName); err == nil {
+			if updated, err := u.restoreLister.Restores(ns).Get(restoreName); err == nil {
 				// make a copy so we don't mutate the shared cache
 				restore = updated.DeepCopy()
 				restore.Status = *oldStatus
@@ -97,19 +97,19 @@ func NewFakeRestoreConditionUpdater(restoreInformer informers.RestoreInformer) *
 }
 
 // SetUpdateRestoreError sets the error attributes of updateRestoreTracker
-func (frc *FakeRestoreConditionUpdater) SetUpdateRestoreError(err error, after int) {
-	frc.updateRestoreTracker.SetError(err).SetAfter(after)
+func (u *FakeRestoreConditionUpdater) SetUpdateRestoreError(err error, after int) {
+	u.updateRestoreTracker.SetError(err).SetAfter(after)
 }
 
 // UpdateRestore updates the Restore
-func (frc *FakeRestoreConditionUpdater) Update(restore *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
-	defer frc.updateRestoreTracker.Inc()
-	if frc.updateRestoreTracker.ErrorReady() {
-		defer frc.updateRestoreTracker.Reset()
-		return frc.updateRestoreTracker.GetError()
+func (u *FakeRestoreConditionUpdater) Update(restore *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
+	defer u.updateRestoreTracker.Inc()
+	if u.updateRestoreTracker.ErrorReady() {
+		defer u.updateRestoreTracker.Reset()
+		return u.updateRestoreTracker.GetError()
 	}
 
-	return frc.RestoreIndexer.Update(restore)
+	return u.RestoreIndexer.Update(restore)
 }
 
 var _ RestoreConditionUpdaterInterface = &FakeRestoreConditionUpdater{}

--- a/pkg/controller/secret_control.go
+++ b/pkg/controller/secret_control.go
@@ -45,8 +45,8 @@ func NewRealSecretControl(
 }
 
 // Load loads cert and key from Secret matching the name
-func (rsc *realSecretControl) Load(ns string, secretName string) ([]byte, []byte, error) {
-	secret, err := rsc.kubeCli.CoreV1().Secrets(ns).Get(secretName, metav1.GetOptions{})
+func (c *realSecretControl) Load(ns string, secretName string) ([]byte, []byte, error) {
+	secret, err := c.kubeCli.CoreV1().Secrets(ns).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,8 +55,8 @@ func (rsc *realSecretControl) Load(ns string, secretName string) ([]byte, []byte
 }
 
 // Check returns true if the secret already exist
-func (rsc *realSecretControl) Check(ns string, secretName string) bool {
-	certBytes, keyBytes, err := rsc.Load(ns, secretName)
+func (c *realSecretControl) Check(ns string, secretName string) bool {
+	certBytes, keyBytes, err := c.Load(ns, secretName)
 	if err != nil {
 		klog.Errorf("certificate validation failed for [%s/%s], error loading cert from secret, %v", ns, secretName, err)
 		return false

--- a/pkg/controller/service_control.go
+++ b/pkg/controller/service_control.go
@@ -55,7 +55,7 @@ func NewRealServiceControl(kubeCli kubernetes.Interface, svcLister corelisters.S
 	}
 }
 
-func (sc *realServiceControl) CreateService(controller runtime.Object, svc *corev1.Service) error {
+func (c *realServiceControl) CreateService(controller runtime.Object, svc *corev1.Service) error {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -63,12 +63,12 @@ func (sc *realServiceControl) CreateService(controller runtime.Object, svc *core
 	kind := controller.GetObjectKind().GroupVersionKind().Kind
 	name := controllerMo.GetName()
 	namespace := controllerMo.GetNamespace()
-	_, err := sc.kubeCli.CoreV1().Services(namespace).Create(svc)
-	sc.recordServiceEvent("create", name, kind, controller, svc, err)
+	_, err := c.kubeCli.CoreV1().Services(namespace).Create(svc)
+	c.recordServiceEvent("create", name, kind, controller, svc, err)
 	return err
 }
 
-func (sc *realServiceControl) UpdateService(controller runtime.Object, svc *corev1.Service) (*corev1.Service, error) {
+func (c *realServiceControl) UpdateService(controller runtime.Object, svc *corev1.Service) (*corev1.Service, error) {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -82,13 +82,13 @@ func (sc *realServiceControl) UpdateService(controller runtime.Object, svc *core
 	var updateSvc *corev1.Service
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var updateErr error
-		updateSvc, updateErr = sc.kubeCli.CoreV1().Services(namespace).Update(svc)
+		updateSvc, updateErr = c.kubeCli.CoreV1().Services(namespace).Update(svc)
 		if updateErr == nil {
 			klog.Infof("update Service: [%s/%s] successfully, kind: %s, name: %s", namespace, svcName, kind, name)
 			return nil
 		}
 
-		if updated, err := sc.svcLister.Services(namespace).Get(svcName); err != nil {
+		if updated, err := c.svcLister.Services(namespace).Get(svcName); err != nil {
 			utilruntime.HandleError(fmt.Errorf("error getting updated Service %s/%s from lister: %v", namespace, svcName, err))
 		} else {
 			svc = updated.DeepCopy()
@@ -100,7 +100,7 @@ func (sc *realServiceControl) UpdateService(controller runtime.Object, svc *core
 	return updateSvc, err
 }
 
-func (sc *realServiceControl) DeleteService(controller runtime.Object, svc *corev1.Service) error {
+func (c *realServiceControl) DeleteService(controller runtime.Object, svc *corev1.Service) error {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -109,23 +109,23 @@ func (sc *realServiceControl) DeleteService(controller runtime.Object, svc *core
 	name := controllerMo.GetName()
 	namespace := controllerMo.GetNamespace()
 
-	err := sc.kubeCli.CoreV1().Services(namespace).Delete(svc.Name, nil)
-	sc.recordServiceEvent("delete", name, kind, controller, svc, err)
+	err := c.kubeCli.CoreV1().Services(namespace).Delete(svc.Name, nil)
+	c.recordServiceEvent("delete", name, kind, controller, svc, err)
 	return err
 }
 
-func (sc *realServiceControl) recordServiceEvent(verb, name, kind string, object runtime.Object, svc *corev1.Service, err error) {
+func (c *realServiceControl) recordServiceEvent(verb, name, kind string, object runtime.Object, svc *corev1.Service, err error) {
 	svcName := svc.GetName()
 	if err == nil {
 		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s Service %s in %s %s successful",
 			strings.ToLower(verb), svcName, kind, name)
-		sc.recorder.Event(object, corev1.EventTypeNormal, reason, msg)
+		c.recorder.Event(object, corev1.EventTypeNormal, reason, msg)
 	} else {
 		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
 		msg := fmt.Sprintf("%s Service %s in %s %s failed error: %s",
 			strings.ToLower(verb), svcName, kind, name, err)
-		sc.recorder.Event(object, corev1.EventTypeWarning, reason, msg)
+		c.recorder.Event(object, corev1.EventTypeWarning, reason, msg)
 	}
 }
 
@@ -154,29 +154,29 @@ func NewFakeServiceControl(svcInformer coreinformers.ServiceInformer, epsInforme
 }
 
 // SetCreateServiceError sets the error attributes of createServiceTracker
-func (ssc *FakeServiceControl) SetCreateServiceError(err error, after int) {
-	ssc.createServiceTracker.SetError(err).SetAfter(after)
+func (c *FakeServiceControl) SetCreateServiceError(err error, after int) {
+	c.createServiceTracker.SetError(err).SetAfter(after)
 }
 
 // SetUpdateServiceError sets the error attributes of updateServiceTracker
-func (ssc *FakeServiceControl) SetUpdateServiceError(err error, after int) {
-	ssc.updateServiceTracker.SetError(err).SetAfter(after)
+func (c *FakeServiceControl) SetUpdateServiceError(err error, after int) {
+	c.updateServiceTracker.SetError(err).SetAfter(after)
 }
 
 // SetDeleteServiceError sets the error attributes of deleteServiceTracker
-func (ssc *FakeServiceControl) SetDeleteServiceError(err error, after int) {
-	ssc.deleteStatefulSetTracker.SetError(err).SetAfter(after)
+func (c *FakeServiceControl) SetDeleteServiceError(err error, after int) {
+	c.deleteStatefulSetTracker.SetError(err).SetAfter(after)
 }
 
 // CreateService adds the service to SvcIndexer
-func (ssc *FakeServiceControl) CreateService(_ runtime.Object, svc *corev1.Service) error {
-	defer ssc.createServiceTracker.Inc()
-	if ssc.createServiceTracker.ErrorReady() {
-		defer ssc.createServiceTracker.Reset()
-		return ssc.createServiceTracker.GetError()
+func (c *FakeServiceControl) CreateService(_ runtime.Object, svc *corev1.Service) error {
+	defer c.createServiceTracker.Inc()
+	if c.createServiceTracker.ErrorReady() {
+		defer c.createServiceTracker.Reset()
+		return c.createServiceTracker.GetError()
 	}
 
-	err := ssc.SvcIndexer.Add(svc)
+	err := c.SvcIndexer.Add(svc)
 	if err != nil {
 		return err
 	}
@@ -188,17 +188,17 @@ func (ssc *FakeServiceControl) CreateService(_ runtime.Object, svc *corev1.Servi
 				Namespace: svc.Namespace,
 			},
 		}
-		return ssc.EpsIndexer.Add(eps)
+		return c.EpsIndexer.Add(eps)
 	}
 	return nil
 }
 
 // UpdateService updates the service of SvcIndexer
-func (ssc *FakeServiceControl) UpdateService(_ runtime.Object, svc *corev1.Service) (*corev1.Service, error) {
-	defer ssc.updateServiceTracker.Inc()
-	if ssc.updateServiceTracker.ErrorReady() {
-		defer ssc.updateServiceTracker.Reset()
-		return nil, ssc.updateServiceTracker.GetError()
+func (c *FakeServiceControl) UpdateService(_ runtime.Object, svc *corev1.Service) (*corev1.Service, error) {
+	defer c.updateServiceTracker.Inc()
+	if c.updateServiceTracker.ErrorReady() {
+		defer c.updateServiceTracker.Reset()
+		return nil, c.updateServiceTracker.GetError()
 	}
 
 	if svc.Spec.Selector != nil {
@@ -208,16 +208,16 @@ func (ssc *FakeServiceControl) UpdateService(_ runtime.Object, svc *corev1.Servi
 				Namespace: svc.Namespace,
 			},
 		}
-		err := ssc.EpsIndexer.Update(eps)
+		err := c.EpsIndexer.Update(eps)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return svc, ssc.SvcIndexer.Update(svc)
+	return svc, c.SvcIndexer.Update(svc)
 }
 
 // DeleteService deletes the service of SvcIndexer
-func (ssc *FakeServiceControl) DeleteService(_ runtime.Object, _ *corev1.Service) error {
+func (c *FakeServiceControl) DeleteService(_ runtime.Object, _ *corev1.Service) error {
 	return nil
 }
 

--- a/pkg/controller/stateful_set_control.go
+++ b/pkg/controller/stateful_set_control.go
@@ -51,7 +51,7 @@ func NewRealStatefuSetControl(kubeCli kubernetes.Interface, setLister appslister
 }
 
 // CreateStatefulSet create a StatefulSet for a controller
-func (sc *realStatefulSetControl) CreateStatefulSet(controller runtime.Object, set *apps.StatefulSet) error {
+func (c *realStatefulSetControl) CreateStatefulSet(controller runtime.Object, set *apps.StatefulSet) error {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -60,17 +60,17 @@ func (sc *realStatefulSetControl) CreateStatefulSet(controller runtime.Object, s
 	name := controllerMo.GetName()
 	namespace := controllerMo.GetNamespace()
 
-	_, err := sc.kubeCli.AppsV1().StatefulSets(namespace).Create(set)
+	_, err := c.kubeCli.AppsV1().StatefulSets(namespace).Create(set)
 	// sink already exists errors
 	if apierrors.IsAlreadyExists(err) {
 		return err
 	}
-	sc.recordStatefulSetEvent("create", kind, name, controller, set, err)
+	c.recordStatefulSetEvent("create", kind, name, controller, set, err)
 	return err
 }
 
 // UpdateStatefulSet update a StatefulSet in a TidbCluster.
-func (sc *realStatefulSetControl) UpdateStatefulSet(controller runtime.Object, set *apps.StatefulSet) (*apps.StatefulSet, error) {
+func (c *realStatefulSetControl) UpdateStatefulSet(controller runtime.Object, set *apps.StatefulSet) (*apps.StatefulSet, error) {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -86,14 +86,14 @@ func (sc *realStatefulSetControl) UpdateStatefulSet(controller runtime.Object, s
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// TODO: verify if StatefulSet identity(name, namespace, labels) matches TidbCluster
 		var updateErr error
-		updatedSS, updateErr = sc.kubeCli.AppsV1().StatefulSets(namespace).Update(set)
+		updatedSS, updateErr = c.kubeCli.AppsV1().StatefulSets(namespace).Update(set)
 		if updateErr == nil {
 			klog.Infof("%s: [%s/%s]'s StatefulSet: [%s/%s] updated successfully", kind, namespace, name, namespace, setName)
 			return nil
 		}
 		klog.Errorf("failed to update %s: [%s/%s]'s StatefulSet: [%s/%s], error: %v", kind, namespace, name, namespace, setName, updateErr)
 
-		if updated, err := sc.setLister.StatefulSets(namespace).Get(setName); err == nil {
+		if updated, err := c.setLister.StatefulSets(namespace).Get(setName); err == nil {
 			// make a copy so we don't mutate the shared cache
 			set = updated.DeepCopy()
 			set.Spec = *setSpec
@@ -107,7 +107,7 @@ func (sc *realStatefulSetControl) UpdateStatefulSet(controller runtime.Object, s
 }
 
 // DeleteStatefulSet delete a StatefulSet in a TidbCluster.
-func (sc *realStatefulSetControl) DeleteStatefulSet(controller runtime.Object, set *apps.StatefulSet) error {
+func (c *realStatefulSetControl) DeleteStatefulSet(controller runtime.Object, set *apps.StatefulSet) error {
 	controllerMo, ok := controller.(metav1.Object)
 	if !ok {
 		return fmt.Errorf("%T is not a metav1.Object, cannot call setControllerReference", controller)
@@ -116,23 +116,23 @@ func (sc *realStatefulSetControl) DeleteStatefulSet(controller runtime.Object, s
 	name := controllerMo.GetName()
 	namespace := controllerMo.GetNamespace()
 
-	err := sc.kubeCli.AppsV1().StatefulSets(namespace).Delete(set.Name, nil)
-	sc.recordStatefulSetEvent("delete", kind, name, controller, set, err)
+	err := c.kubeCli.AppsV1().StatefulSets(namespace).Delete(set.Name, nil)
+	c.recordStatefulSetEvent("delete", kind, name, controller, set, err)
 	return err
 }
 
-func (sc *realStatefulSetControl) recordStatefulSetEvent(verb, kind, name string, object runtime.Object, set *apps.StatefulSet, err error) {
+func (c *realStatefulSetControl) recordStatefulSetEvent(verb, kind, name string, object runtime.Object, set *apps.StatefulSet, err error) {
 	setName := set.Name
 	if err == nil {
 		reason := fmt.Sprintf("Successful%s", strings.Title(verb))
 		message := fmt.Sprintf("%s StatefulSet %s in %s %s successful",
 			strings.ToLower(verb), setName, kind, name)
-		sc.recorder.Event(object, corev1.EventTypeNormal, reason, message)
+		c.recorder.Event(object, corev1.EventTypeNormal, reason, message)
 	} else {
 		reason := fmt.Sprintf("Failed%s", strings.Title(verb))
 		message := fmt.Sprintf("%s StatefulSet %s in %s %s failed error: %s",
 			strings.ToLower(verb), setName, kind, name, err)
-		sc.recorder.Event(object, corev1.EventTypeWarning, reason, message)
+		c.recorder.Event(object, corev1.EventTypeWarning, reason, message)
 	}
 }
 
@@ -161,63 +161,63 @@ func NewFakeStatefulSetControl(setInformer appsinformers.StatefulSetInformer) *F
 }
 
 // SetCreateStatefulSetError sets the error attributes of createStatefulSetTracker
-func (ssc *FakeStatefulSetControl) SetCreateStatefulSetError(err error, after int) {
-	ssc.createStatefulSetTracker.SetError(err).SetAfter(after)
+func (c *FakeStatefulSetControl) SetCreateStatefulSetError(err error, after int) {
+	c.createStatefulSetTracker.SetError(err).SetAfter(after)
 }
 
 // SetUpdateStatefulSetError sets the error attributes of updateStatefulSetTracker
-func (ssc *FakeStatefulSetControl) SetUpdateStatefulSetError(err error, after int) {
-	ssc.updateStatefulSetTracker.SetError(err).SetAfter(after)
+func (c *FakeStatefulSetControl) SetUpdateStatefulSetError(err error, after int) {
+	c.updateStatefulSetTracker.SetError(err).SetAfter(after)
 }
 
 // SetDeleteStatefulSetError sets the error attributes of deleteStatefulSetTracker
-func (ssc *FakeStatefulSetControl) SetDeleteStatefulSetError(err error, after int) {
-	ssc.deleteStatefulSetTracker.SetError(err).SetAfter(after)
+func (c *FakeStatefulSetControl) SetDeleteStatefulSetError(err error, after int) {
+	c.deleteStatefulSetTracker.SetError(err).SetAfter(after)
 }
 
-func (ssc *FakeStatefulSetControl) SetStatusChange(fn func(*apps.StatefulSet)) {
-	ssc.statusChange = fn
+func (c *FakeStatefulSetControl) SetStatusChange(fn func(*apps.StatefulSet)) {
+	c.statusChange = fn
 }
 
 // CreateStatefulSet adds the statefulset to SetIndexer
-func (ssc *FakeStatefulSetControl) CreateStatefulSet(_ runtime.Object, set *apps.StatefulSet) error {
+func (c *FakeStatefulSetControl) CreateStatefulSet(_ runtime.Object, set *apps.StatefulSet) error {
 	defer func() {
-		ssc.createStatefulSetTracker.Inc()
-		ssc.statusChange = nil
+		c.createStatefulSetTracker.Inc()
+		c.statusChange = nil
 	}()
 
-	if ssc.createStatefulSetTracker.ErrorReady() {
-		defer ssc.createStatefulSetTracker.Reset()
-		return ssc.createStatefulSetTracker.GetError()
+	if c.createStatefulSetTracker.ErrorReady() {
+		defer c.createStatefulSetTracker.Reset()
+		return c.createStatefulSetTracker.GetError()
 	}
 
-	if ssc.statusChange != nil {
-		ssc.statusChange(set)
+	if c.statusChange != nil {
+		c.statusChange(set)
 	}
 
-	return ssc.SetIndexer.Add(set)
+	return c.SetIndexer.Add(set)
 }
 
 // UpdateStatefulSet updates the statefulset of SetIndexer
-func (ssc *FakeStatefulSetControl) UpdateStatefulSet(_ runtime.Object, set *apps.StatefulSet) (*apps.StatefulSet, error) {
+func (c *FakeStatefulSetControl) UpdateStatefulSet(_ runtime.Object, set *apps.StatefulSet) (*apps.StatefulSet, error) {
 	defer func() {
-		ssc.updateStatefulSetTracker.Inc()
-		ssc.statusChange = nil
+		c.updateStatefulSetTracker.Inc()
+		c.statusChange = nil
 	}()
 
-	if ssc.updateStatefulSetTracker.ErrorReady() {
-		defer ssc.updateStatefulSetTracker.Reset()
-		return nil, ssc.updateStatefulSetTracker.GetError()
+	if c.updateStatefulSetTracker.ErrorReady() {
+		defer c.updateStatefulSetTracker.Reset()
+		return nil, c.updateStatefulSetTracker.GetError()
 	}
 
-	if ssc.statusChange != nil {
-		ssc.statusChange(set)
+	if c.statusChange != nil {
+		c.statusChange(set)
 	}
-	return set, ssc.SetIndexer.Update(set)
+	return set, c.SetIndexer.Update(set)
 }
 
 // DeleteStatefulSet deletes the statefulset of SetIndexer
-func (ssc *FakeStatefulSetControl) DeleteStatefulSet(_ runtime.Object, _ *apps.StatefulSet) error {
+func (c *FakeStatefulSetControl) DeleteStatefulSet(_ runtime.Object, _ *apps.StatefulSet) error {
 	return nil
 }
 

--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -43,13 +43,13 @@ func NewDefaultTiCDCControl(kubeCli kubernetes.Interface) *defaultTiCDCControl {
 	return &defaultTiCDCControl{httpClient: httpClient{kubeCli: kubeCli}}
 }
 
-func (tcc *defaultTiCDCControl) GetStatus(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error) {
-	httpClient, err := tcc.getHTTPClient(tc)
+func (c *defaultTiCDCControl) GetStatus(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error) {
+	httpClient, err := c.getHTTPClient(tc)
 	if err != nil {
 		return nil, err
 	}
 
-	baseURL := tcc.getBaseURL(tc, ordinal)
+	baseURL := c.getBaseURL(tc, ordinal)
 	url := fmt.Sprintf("%s/status", baseURL)
 	body, err := getBodyOK(httpClient, url)
 	if err != nil {
@@ -61,9 +61,9 @@ func (tcc *defaultTiCDCControl) GetStatus(tc *v1alpha1.TidbCluster, ordinal int3
 	return &status, err
 }
 
-func (tcc *defaultTiCDCControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32) string {
-	if tcc.testURL != "" {
-		return tcc.testURL
+func (c *defaultTiCDCControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32) string {
+	if c.testURL != "" {
+		return c.testURL
 	}
 
 	tcName := tc.GetName()
@@ -85,6 +85,6 @@ func NewFakeTiCDCControl() *FakeTiCDCControl {
 }
 
 // SetHealth set health info for FakeTiCDCControl
-func (ftd *FakeTiCDCControl) SetStatus(status *CaptureStatus) {
-	ftd.status = status
+func (c *FakeTiCDCControl) SetStatus(status *CaptureStatus) {
+	c.status = status
 }

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -59,25 +59,25 @@ func NewDefaultTiDBControl(kubeCli kubernetes.Interface) *defaultTiDBControl {
 	return &defaultTiDBControl{httpClient: httpClient{kubeCli: kubeCli}}
 }
 
-func (tdc *defaultTiDBControl) GetHealth(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
-	httpClient, err := tdc.getHTTPClient(tc)
+func (c *defaultTiDBControl) GetHealth(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
+	httpClient, err := c.getHTTPClient(tc)
 	if err != nil {
 		return false, err
 	}
 
-	baseURL := tdc.getBaseURL(tc, ordinal)
+	baseURL := c.getBaseURL(tc, ordinal)
 	url := fmt.Sprintf("%s/status", baseURL)
 	_, err = getBodyOK(httpClient, url)
 	return err == nil, nil
 }
 
-func (tdc *defaultTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error) {
-	httpClient, err := tdc.getHTTPClient(tc)
+func (c *defaultTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error) {
+	httpClient, err := c.getHTTPClient(tc)
 	if err != nil {
 		return nil, err
 	}
 
-	baseURL := tdc.getBaseURL(tc, ordinal)
+	baseURL := c.getBaseURL(tc, ordinal)
 	url := fmt.Sprintf("%s/info", baseURL)
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -104,13 +104,13 @@ func (tdc *defaultTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) 
 	return &info, nil
 }
 
-func (tdc *defaultTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32) (*config.Config, error) {
-	httpClient, err := tdc.getHTTPClient(tc)
+func (c *defaultTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32) (*config.Config, error) {
+	httpClient, err := c.getHTTPClient(tc)
 	if err != nil {
 		return nil, err
 	}
 
-	baseURL := tdc.getBaseURL(tc, ordinal)
+	baseURL := c.getBaseURL(tc, ordinal)
 	url := fmt.Sprintf("%s/settings", baseURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -155,9 +155,9 @@ func getBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
 	return body, err
 }
 
-func (tdc *defaultTiDBControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32) string {
-	if tdc.testURL != "" {
-		return tdc.testURL
+func (c *defaultTiDBControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32) string {
+	if c.testURL != "" {
+		return c.testURL
 	}
 
 	tcName := tc.GetName()
@@ -182,25 +182,25 @@ func NewFakeTiDBControl() *FakeTiDBControl {
 }
 
 // SetHealth set health info for FakeTiDBControl
-func (ftd *FakeTiDBControl) SetHealth(healthInfo map[string]bool) {
-	ftd.healthInfo = healthInfo
+func (c *FakeTiDBControl) SetHealth(healthInfo map[string]bool) {
+	c.healthInfo = healthInfo
 }
 
-func (ftd *FakeTiDBControl) GetHealth(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
+func (c *FakeTiDBControl) GetHealth(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
 	podName := fmt.Sprintf("%s-%d", TiDBMemberName(tc.GetName()), ordinal)
-	if ftd.healthInfo == nil {
+	if c.healthInfo == nil {
 		return false, nil
 	}
-	if health, ok := ftd.healthInfo[podName]; ok {
+	if health, ok := c.healthInfo[podName]; ok {
 		return health, nil
 	}
 	return false, nil
 }
 
-func (ftd *FakeTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error) {
-	return ftd.tiDBInfo, ftd.getInfoError
+func (c *FakeTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error) {
+	return c.tiDBInfo, c.getInfoError
 }
 
-func (ftd *FakeTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32) (*config.Config, error) {
-	return ftd.tidbConfig, ftd.getInfoError
+func (c *FakeTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32) (*config.Config, error) {
+	return c.tidbConfig, c.getInfoError
 }

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -88,49 +88,49 @@ func NewController(deps *controller.Dependencies) *Controller {
 }
 
 // Run runs the tidbcluster controller.
-func (tcc *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
-	defer tcc.queue.ShutDown()
+	defer c.queue.ShutDown()
 
 	klog.Info("Starting tidbcluster controller")
 	defer klog.Info("Shutting down tidbcluster controller")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(tcc.worker, time.Second, stopCh)
+		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
 	<-stopCh
 }
 
 // worker runs a worker goroutine that invokes processNextWorkItem until the the controller's queue is closed
-func (tcc *Controller) worker() {
-	for tcc.processNextWorkItem() {
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
 	}
 }
 
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
-func (tcc *Controller) processNextWorkItem() bool {
-	key, quit := tcc.queue.Get()
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer tcc.queue.Done(key)
-	if err := tcc.sync(key.(string)); err != nil {
+	defer c.queue.Done(key)
+	if err := c.sync(key.(string)); err != nil {
 		if perrors.Find(err, controller.IsRequeueError) != nil {
 			klog.Infof("TidbCluster: %v, still need sync: %v, requeuing", key.(string), err)
 		} else {
 			utilruntime.HandleError(fmt.Errorf("TidbCluster: %v, sync failed %v, requeuing", key.(string), err))
 		}
-		tcc.queue.AddRateLimited(key)
+		c.queue.AddRateLimited(key)
 	} else {
-		tcc.queue.Forget(key)
+		c.queue.Forget(key)
 	}
 	return true
 }
 
 // sync syncs the given tidbcluster.
-func (tcc *Controller) sync(key string) error {
+func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing TidbCluster %q (%v)", key, time.Since(startTime))
@@ -140,7 +140,7 @@ func (tcc *Controller) sync(key string) error {
 	if err != nil {
 		return err
 	}
-	tc, err := tcc.deps.TiDBClusterLister.TidbClusters(ns).Get(name)
+	tc, err := c.deps.TiDBClusterLister.TidbClusters(ns).Get(name)
 	if errors.IsNotFound(err) {
 		klog.Infof("TidbCluster has been deleted %v", key)
 		return nil
@@ -149,25 +149,25 @@ func (tcc *Controller) sync(key string) error {
 		return err
 	}
 
-	return tcc.syncTidbCluster(tc.DeepCopy())
+	return c.syncTidbCluster(tc.DeepCopy())
 }
 
-func (tcc *Controller) syncTidbCluster(tc *v1alpha1.TidbCluster) error {
-	return tcc.control.UpdateTidbCluster(tc)
+func (c *Controller) syncTidbCluster(tc *v1alpha1.TidbCluster) error {
+	return c.control.UpdateTidbCluster(tc)
 }
 
 // enqueueTidbCluster enqueues the given tidbcluster in the work queue.
-func (tcc *Controller) enqueueTidbCluster(obj interface{}) {
+func (c *Controller) enqueueTidbCluster(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Cound't get key for object %+v: %v", obj, err))
 		return
 	}
-	tcc.queue.Add(key)
+	c.queue.Add(key)
 }
 
 // addStatefulSet adds the tidbcluster for the statefulset to the sync queue
-func (tcc *Controller) addStatefulSet(obj interface{}) {
+func (c *Controller) addStatefulSet(obj interface{}) {
 	set := obj.(*apps.StatefulSet)
 	ns := set.GetNamespace()
 	setName := set.GetName()
@@ -175,21 +175,21 @@ func (tcc *Controller) addStatefulSet(obj interface{}) {
 	if set.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new statefulset shows up in a state that
 		// is already pending deletion. Prevent the statefulset from being a creation observation.
-		tcc.deleteStatefulSet(set)
+		c.deleteStatefulSet(set)
 		return
 	}
 
 	// If it has a ControllerRef, that's all that matters.
-	tc := tcc.resolveTidbClusterFromSet(ns, set)
+	tc := c.resolveTidbClusterFromSet(ns, set)
 	if tc == nil {
 		return
 	}
 	klog.V(4).Infof("StatefulSet %s/%s created, TidbCluster: %s/%s", ns, setName, ns, tc.Name)
-	tcc.enqueueTidbCluster(tc)
+	c.enqueueTidbCluster(tc)
 }
 
 // updateStatefulSet adds the tidbcluster for the current and old statefulsets to the sync queue.
-func (tcc *Controller) updateStatefulSet(old, cur interface{}) {
+func (c *Controller) updateStatefulSet(old, cur interface{}) {
 	curSet := cur.(*apps.StatefulSet)
 	oldSet := old.(*apps.StatefulSet)
 	ns := curSet.GetNamespace()
@@ -201,16 +201,16 @@ func (tcc *Controller) updateStatefulSet(old, cur interface{}) {
 	}
 
 	// If it has a ControllerRef, that's all that matters.
-	tc := tcc.resolveTidbClusterFromSet(ns, curSet)
+	tc := c.resolveTidbClusterFromSet(ns, curSet)
 	if tc == nil {
 		return
 	}
 	klog.V(4).Infof("StatefulSet %s/%s updated, TidbCluster: %s/%s", ns, setName, ns, tc.Name)
-	tcc.enqueueTidbCluster(tc)
+	c.enqueueTidbCluster(tc)
 }
 
 // deleteStatefulSet enqueues the tidbcluster for the statefulset accounting for deletion tombstones.
-func (tcc *Controller) deleteStatefulSet(obj interface{}) {
+func (c *Controller) deleteStatefulSet(obj interface{}) {
 	set, ok := obj.(*apps.StatefulSet)
 	ns := set.GetNamespace()
 	setName := set.GetName()
@@ -232,18 +232,18 @@ func (tcc *Controller) deleteStatefulSet(obj interface{}) {
 	}
 
 	// If it has a TidbCluster, that's all that matters.
-	tc := tcc.resolveTidbClusterFromSet(ns, set)
+	tc := c.resolveTidbClusterFromSet(ns, set)
 	if tc == nil {
 		return
 	}
 	klog.V(4).Infof("StatefulSet %s/%s deleted through %v.", ns, setName, utilruntime.GetCaller())
-	tcc.enqueueTidbCluster(tc)
+	c.enqueueTidbCluster(tc)
 }
 
 // resolveTidbClusterFromSet returns the TidbCluster by a StatefulSet,
 // or nil if the StatefulSet could not be resolved to a matching TidbCluster
 // of the correct Kind.
-func (tcc *Controller) resolveTidbClusterFromSet(namespace string, set *apps.StatefulSet) *v1alpha1.TidbCluster {
+func (c *Controller) resolveTidbClusterFromSet(namespace string, set *apps.StatefulSet) *v1alpha1.TidbCluster {
 	controllerRef := metav1.GetControllerOf(set)
 	if controllerRef == nil {
 		return nil
@@ -254,7 +254,7 @@ func (tcc *Controller) resolveTidbClusterFromSet(namespace string, set *apps.Sta
 	if controllerRef.Kind != controller.ControllerKind.Kind {
 		return nil
 	}
-	tc, err := tcc.deps.TiDBClusterLister.TidbClusters(namespace).Get(controllerRef.Name)
+	tc, err := c.deps.TiDBClusterLister.TidbClusters(namespace).Get(controllerRef.Name)
 	if err != nil {
 		return nil
 	}

--- a/pkg/controller/tidbinitializer/tidb_initializer_control.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_control.go
@@ -33,8 +33,8 @@ type defaultTidbInitializerControl struct {
 	tidbInitManger member.InitManager
 }
 
-func (tic *defaultTidbInitializerControl) ReconcileTidbInitializer(ti *v1alpha1.TidbInitializer) error {
-	return tic.tidbInitManger.Sync(ti)
+func (c *defaultTidbInitializerControl) ReconcileTidbInitializer(ti *v1alpha1.TidbInitializer) error {
+	return c.tidbInitManger.Sync(ti)
 }
 
 var _ ControlInterface = &defaultTidbInitializerControl{}

--- a/pkg/controller/tidbmonitor/tidb_monitor_control.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_control.go
@@ -34,16 +34,16 @@ type defaultTidbMonitorControl struct {
 	monitorManager monitor.MonitorManager
 }
 
-func (tmc *defaultTidbMonitorControl) ReconcileTidbMonitor(tm *v1alpha1.TidbMonitor) error {
+func (c *defaultTidbMonitorControl) ReconcileTidbMonitor(tm *v1alpha1.TidbMonitor) error {
 	var errs []error
-	if err := tmc.reconcileTidbMonitor(tm); err != nil {
+	if err := c.reconcileTidbMonitor(tm); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.NewAggregate(errs)
 }
 
-func (tmc *defaultTidbMonitorControl) reconcileTidbMonitor(tm *v1alpha1.TidbMonitor) error {
-	return tmc.monitorManager.SyncMonitor(tm)
+func (c *defaultTidbMonitorControl) reconcileTidbMonitor(tm *v1alpha1.TidbMonitor) error {
+	return c.monitorManager.SyncMonitor(tm)
 }
 
 var _ ControlInterface = &defaultTidbMonitorControl{}

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -55,47 +55,47 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
-func (tmc *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
-	defer tmc.queue.ShutDown()
+	defer c.queue.ShutDown()
 
 	klog.Info("Starting tidbmonitor controller")
 	defer klog.Info("Shutting down tidbmonitor controller")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(tmc.worker, time.Second, stopCh)
+		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
 	<-stopCh
 }
 
-func (tmc *Controller) worker() {
-	for tmc.processNextWorkItem() {
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
 	}
 }
 
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
-func (tmc *Controller) processNextWorkItem() bool {
-	key, quit := tmc.queue.Get()
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer tmc.queue.Done(key)
-	if err := tmc.sync(key.(string)); err != nil {
+	defer c.queue.Done(key)
+	if err := c.sync(key.(string)); err != nil {
 		if perrors.Find(err, controller.IsRequeueError) != nil {
 			klog.Infof("TidbMonitor: %v, still need sync: %v, requeuing", key.(string), err)
 		} else {
 			utilruntime.HandleError(fmt.Errorf("TidbMonitor: %v, sync failed, err: %v", key.(string), err))
 		}
-		tmc.queue.AddRateLimited(key)
+		c.queue.AddRateLimited(key)
 	} else {
-		tmc.queue.Forget(key)
+		c.queue.Forget(key)
 	}
 	return true
 }
 
-func (tmc *Controller) sync(key string) error {
+func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing TidbMonitor %q (%v)", key, time.Since(startTime))
@@ -105,7 +105,7 @@ func (tmc *Controller) sync(key string) error {
 	if err != nil {
 		return err
 	}
-	tm, err := tmc.deps.TiDBMonitorLister.TidbMonitors(ns).Get(name)
+	tm, err := c.deps.TiDBMonitorLister.TidbMonitors(ns).Get(name)
 	if errors.IsNotFound(err) {
 		klog.Infof("TidbMonitor has been deleted %v", key)
 		return nil
@@ -114,5 +114,5 @@ func (tmc *Controller) sync(key string) error {
 		return err
 	}
 
-	return tmc.control.ReconcileTidbMonitor(tm)
+	return c.control.ReconcileTidbMonitor(tm)
 }

--- a/pkg/dmapi/dmapi.go
+++ b/pkg/dmapi/dmapi.go
@@ -112,10 +112,10 @@ type masterClient struct {
 	httpClient *http.Client
 }
 
-func (mc *masterClient) GetMasters() ([]*MastersInfo, error) {
+func (c *masterClient) GetMasters() ([]*MastersInfo, error) {
 	query := "?master=true"
-	apiURL := fmt.Sprintf("%s/%s%s", mc.url, membersPrefix, query)
-	body, err := httputil.GetBodyOK(mc.httpClient, apiURL)
+	apiURL := fmt.Sprintf("%s/%s%s", c.url, membersPrefix, query)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +134,10 @@ func (mc *masterClient) GetMasters() ([]*MastersInfo, error) {
 	return listMemberResp.ListMemberResp[0].Masters, nil
 }
 
-func (mc *masterClient) GetWorkers() ([]*WorkersInfo, error) {
+func (c *masterClient) GetWorkers() ([]*WorkersInfo, error) {
 	query := "?worker=true"
-	apiURL := fmt.Sprintf("%s/%s%s", mc.url, membersPrefix, query)
-	body, err := httputil.GetBodyOK(mc.httpClient, apiURL)
+	apiURL := fmt.Sprintf("%s/%s%s", c.url, membersPrefix, query)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -156,10 +156,10 @@ func (mc *masterClient) GetWorkers() ([]*WorkersInfo, error) {
 	return listMemberResp.ListMemberResp[0].Workers, nil
 }
 
-func (mc *masterClient) GetLeader() (MembersLeader, error) {
+func (c *masterClient) GetLeader() (MembersLeader, error) {
 	query := "?leader=true"
-	apiURL := fmt.Sprintf("%s/%s%s", mc.url, membersPrefix, query)
-	body, err := httputil.GetBodyOK(mc.httpClient, apiURL)
+	apiURL := fmt.Sprintf("%s/%s%s", c.url, membersPrefix, query)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return MembersLeader{}, err
 	}
@@ -178,10 +178,10 @@ func (mc *masterClient) GetLeader() (MembersLeader, error) {
 	return listMemberResp.ListMemberResp[0].MembersLeader, nil
 }
 
-func (mc *masterClient) EvictLeader() error {
+func (c *masterClient) EvictLeader() error {
 	query := "/1"
-	apiURL := fmt.Sprintf("%s/%s%s", mc.url, leaderPrefix, query)
-	body, err := httputil.PutBodyOK(mc.httpClient, apiURL)
+	apiURL := fmt.Sprintf("%s/%s%s", c.url, leaderPrefix, query)
+	body, err := httputil.PutBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return err
 	}
@@ -197,9 +197,9 @@ func (mc *masterClient) EvictLeader() error {
 	return nil
 }
 
-func (mc *masterClient) deleteMember(query string) error {
-	apiURL := fmt.Sprintf("%s/%s%s", mc.url, membersPrefix, query)
-	body, err := httputil.DeleteBodyOK(mc.httpClient, apiURL)
+func (c *masterClient) deleteMember(query string) error {
+	apiURL := fmt.Sprintf("%s/%s%s", c.url, membersPrefix, query)
+	body, err := httputil.DeleteBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return err
 	}
@@ -215,14 +215,14 @@ func (mc *masterClient) deleteMember(query string) error {
 	return nil
 }
 
-func (mc *masterClient) DeleteMaster(name string) error {
+func (c *masterClient) DeleteMaster(name string) error {
 	query := "/master/" + name
-	return mc.deleteMember(query)
+	return c.deleteMember(query)
 }
 
-func (mc *masterClient) DeleteWorker(name string) error {
+func (c *masterClient) DeleteWorker(name string) error {
 	query := "/worker/" + name
-	return mc.deleteMember(query)
+	return c.deleteMember(query)
 }
 
 // NewMasterClient returns a new MasterClient

--- a/pkg/dmapi/fake_dmapi.go
+++ b/pkg/dmapi/fake_dmapi.go
@@ -53,13 +53,13 @@ func NewFakeMasterClient() *FakeMasterClient {
 	return &FakeMasterClient{reactions: map[ActionType]Reaction{}}
 }
 
-func (pc *FakeMasterClient) AddReaction(actionType ActionType, reaction Reaction) {
-	pc.reactions[actionType] = reaction
+func (c *FakeMasterClient) AddReaction(actionType ActionType, reaction Reaction) {
+	c.reactions[actionType] = reaction
 }
 
 // fakeAPI is a small helper for fake API calls
-func (pc *FakeMasterClient) fakeAPI(actionType ActionType, action *Action) (interface{}, error) {
-	if reaction, ok := pc.reactions[actionType]; ok {
+func (c *FakeMasterClient) fakeAPI(actionType ActionType, action *Action) (interface{}, error) {
+	if reaction, ok := c.reactions[actionType]; ok {
 		result, err := reaction(action)
 		if err != nil {
 			return nil, err
@@ -69,47 +69,47 @@ func (pc *FakeMasterClient) fakeAPI(actionType ActionType, action *Action) (inte
 	return nil, &NotFoundReaction{actionType}
 }
 
-func (pc *FakeMasterClient) GetMasters() ([]*MastersInfo, error) {
+func (c *FakeMasterClient) GetMasters() ([]*MastersInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetMastersActionType, action)
+	result, err := c.fakeAPI(GetMastersActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.([]*MastersInfo), nil
 }
 
-func (pc *FakeMasterClient) GetWorkers() ([]*WorkersInfo, error) {
+func (c *FakeMasterClient) GetWorkers() ([]*WorkersInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetWorkersActionType, action)
+	result, err := c.fakeAPI(GetWorkersActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.([]*WorkersInfo), nil
 }
 
-func (pc *FakeMasterClient) GetLeader() (MembersLeader, error) {
+func (c *FakeMasterClient) GetLeader() (MembersLeader, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetLeaderActionType, action)
+	result, err := c.fakeAPI(GetLeaderActionType, action)
 	if err != nil {
 		return MembersLeader{}, err
 	}
 	return result.(MembersLeader), nil
 }
 
-func (pc *FakeMasterClient) EvictLeader() error {
+func (c *FakeMasterClient) EvictLeader() error {
 	action := &Action{}
-	_, err := pc.fakeAPI(EvictLeaderActionType, action)
+	_, err := c.fakeAPI(EvictLeaderActionType, action)
 	return err
 }
 
-func (pc *FakeMasterClient) DeleteMaster(_ string) error {
+func (c *FakeMasterClient) DeleteMaster(_ string) error {
 	action := &Action{}
-	_, err := pc.fakeAPI(DeleteMasterActionType, action)
+	_, err := c.fakeAPI(DeleteMasterActionType, action)
 	return err
 }
 
-func (pc *FakeMasterClient) DeleteWorker(_ string) error {
+func (c *FakeMasterClient) DeleteWorker(_ string) error {
 	action := &Action{}
-	_, err := pc.fakeAPI(DeleteWorkerActionType, action)
+	_, err := c.fakeAPI(DeleteWorkerActionType, action)
 	return err
 }

--- a/pkg/manager/member/dm_master_failover.go
+++ b/pkg/manager/member/dm_master_failover.go
@@ -44,7 +44,7 @@ func NewMasterFailover(deps *controller.Dependencies) DMFailover {
 // 2. delete the failure member dm-master-0, and mark it deleted (MemberDeleted=true)
 // 3. dm-master member manager will add the count of deleted failure members more replicas
 // If the count of the failure dm-master member with the deleted state (MemberDeleted=true) is equal or greater than MaxFailoverCount, we will skip failover.
-func (mf *masterFailover) Failover(dc *v1alpha1.DMCluster) error {
+func (f *masterFailover) Failover(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
@@ -60,7 +60,7 @@ func (mf *masterFailover) Failover(dc *v1alpha1.DMCluster) error {
 		if masterMember.Health {
 			healthCount++
 		} else {
-			mf.deps.Recorder.Eventf(dc, apiv1.EventTypeWarning, "MasterMemberUnhealthy",
+			f.deps.Recorder.Eventf(dc, apiv1.EventTypeWarning, "MasterMemberUnhealthy",
 				"%s(%s) is unhealthy", podName, masterMember.ID)
 		}
 	}
@@ -85,20 +85,20 @@ func (mf *masterFailover) Failover(dc *v1alpha1.DMCluster) error {
 	}
 	// we can only failover one at a time
 	if notDeletedCount == 0 {
-		return mf.tryToMarkAPeerAsFailure(dc)
+		return f.tryToMarkAPeerAsFailure(dc)
 	}
 
-	return mf.tryToDeleteAFailureMember(dc)
+	return f.tryToDeleteAFailureMember(dc)
 }
 
-func (mf *masterFailover) Recover(dc *v1alpha1.DMCluster) {
+func (f *masterFailover) Recover(dc *v1alpha1.DMCluster) {
 	dc.Status.Master.FailureMembers = nil
 	klog.Infof("dm-master failover: clearing dm-master failoverMembers, %s/%s", dc.GetNamespace(), dc.GetName())
 }
 
-func (mf *masterFailover) RemoveUndesiredFailures(dc *v1alpha1.DMCluster) {}
+func (f *masterFailover) RemoveUndesiredFailures(dc *v1alpha1.DMCluster) {}
 
-func (mf *masterFailover) tryToMarkAPeerAsFailure(dc *v1alpha1.DMCluster) error {
+func (f *masterFailover) tryToMarkAPeerAsFailure(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
@@ -106,14 +106,14 @@ func (mf *masterFailover) tryToMarkAPeerAsFailure(dc *v1alpha1.DMCluster) error 
 		if masterMember.LastTransitionTime.IsZero() {
 			continue
 		}
-		if !mf.isPodDesired(dc, podName) {
+		if !f.isPodDesired(dc, podName) {
 			continue
 		}
 
 		if dc.Status.Master.FailureMembers == nil {
 			dc.Status.Master.FailureMembers = map[string]v1alpha1.MasterFailureMember{}
 		}
-		deadline := masterMember.LastTransitionTime.Add(mf.deps.CLIConfig.MasterFailoverPeriod)
+		deadline := masterMember.LastTransitionTime.Add(f.deps.CLIConfig.MasterFailoverPeriod)
 		_, exist := dc.Status.Master.FailureMembers[podName]
 		if masterMember.Health || time.Now().Before(deadline) || exist {
 			continue
@@ -124,13 +124,13 @@ func (mf *masterFailover) tryToMarkAPeerAsFailure(dc *v1alpha1.DMCluster) error 
 			return err
 		}
 		pvcName := ordinalPVCName(v1alpha1.DMMasterMemberType, controller.DMMasterMemberName(dcName), ordinal)
-		pvc, err := mf.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+		pvc, err := f.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 		if err != nil {
 			return fmt.Errorf("tryToMarkAPeerAsFailure: failed to get pvc %s for dmcluster %s/%s, error: %s", pvcName, ns, dcName, err)
 		}
 
 		msg := fmt.Sprintf("dm-master member[%s] is unhealthy", masterMember.ID)
-		mf.deps.Recorder.Event(dc, apiv1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "dm-master", podName, msg))
+		f.deps.Recorder.Event(dc, apiv1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "dm-master", podName, msg))
 
 		// mark a peer member failed and return an error to skip reconciliation
 		// note that status of dm cluster will be updated always
@@ -151,7 +151,7 @@ func (mf *masterFailover) tryToMarkAPeerAsFailure(dc *v1alpha1.DMCluster) error 
 // pvc. If this succeeds, new pod & pvc will be created by Kubernetes.
 // Note that this will fail if the kubelet on the node which failed pod was
 // running on is not responding.
-func (mf *masterFailover) tryToDeleteAFailureMember(dc *v1alpha1.DMCluster) error {
+func (f *masterFailover) tryToDeleteAFailureMember(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 	var failureMember *v1alpha1.MasterFailureMember
@@ -169,20 +169,20 @@ func (mf *masterFailover) tryToDeleteAFailureMember(dc *v1alpha1.DMCluster) erro
 	}
 
 	// invoke deleteMember api to delete a member from the dm-master cluster
-	err := controller.GetMasterClient(mf.deps.DMMasterControl, dc).DeleteMaster(failurePodName)
+	err := controller.GetMasterClient(f.deps.DMMasterControl, dc).DeleteMaster(failurePodName)
 	if err != nil {
 		klog.Errorf("dm-master failover: failed to delete member: [%s/%s], %v", ns, failurePodName, err)
 		return err
 	}
 	klog.Infof("dm-master failover: delete member: [%s/%s] successfully", ns, failurePodName)
-	mf.deps.Recorder.Eventf(dc, apiv1.EventTypeWarning, "DMMasterMemberDeleted",
+	f.deps.Recorder.Eventf(dc, apiv1.EventTypeWarning, "DMMasterMemberDeleted",
 		"[%s/%s] deleted from dmcluster", ns, failurePodName)
 
 	// The order of old PVC deleting and the new Pod creating is not guaranteed by Kubernetes.
 	// If new Pod is created before old PVC deleted, new Pod will reuse old PVC.
 	// So we must try to delete the PVC and Pod of this dm-master peer over and over,
 	// and let StatefulSet create the new dm-master peer with the same ordinal, but don't use the tombstone PV
-	pod, err := mf.deps.PodLister.Pods(ns).Get(failurePodName)
+	pod, err := f.deps.PodLister.Pods(ns).Get(failurePodName)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("tryToDeleteAFailureMember: failed to get pods %s for dmcluster %s/%s, error: %s", failurePodName, ns, dcName, err)
 	}
@@ -192,19 +192,19 @@ func (mf *masterFailover) tryToDeleteAFailureMember(dc *v1alpha1.DMCluster) erro
 		return err
 	}
 	pvcName := ordinalPVCName(v1alpha1.DMMasterMemberType, controller.DMMasterMemberName(dcName), ordinal)
-	pvc, err := mf.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+	pvc, err := f.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("tryToDeleteAFailureMember: failed to get pvc %s for dmcluster %s/%s, error: %s", pvcName, ns, dcName, err)
 	}
 
 	if pod != nil && pod.DeletionTimestamp == nil {
-		err := mf.deps.PodControl.DeletePod(dc, pod)
+		err := f.deps.PodControl.DeletePod(dc, pod)
 		if err != nil {
 			return err
 		}
 	}
 	if pvc != nil && pvc.DeletionTimestamp == nil && pvc.GetUID() == failureMember.PVCUID {
-		err = mf.deps.PVCControl.DeletePVC(dc, pvc)
+		err = f.deps.PVCControl.DeletePVC(dc, pvc)
 		if err != nil {
 			klog.Errorf("dm-master failover: failed to delete pvc: %s/%s, %v", ns, pvcName, err)
 			return err
@@ -216,7 +216,7 @@ func (mf *masterFailover) tryToDeleteAFailureMember(dc *v1alpha1.DMCluster) erro
 	return nil
 }
 
-func (mf *masterFailover) isPodDesired(dc *v1alpha1.DMCluster, podName string) bool {
+func (f *masterFailover) isPodDesired(dc *v1alpha1.DMCluster, podName string) bool {
 	ordinals := dc.MasterStsDesiredOrdinals(true)
 	ordinal, err := util.GetOrdinalFromPodName(podName)
 	if err != nil {
@@ -240,12 +240,12 @@ func NewFakeMasterFailover() DMFailover {
 	return &fakeMasterFailover{}
 }
 
-func (fmf *fakeMasterFailover) Failover(_ *v1alpha1.DMCluster) error {
+func (f *fakeMasterFailover) Failover(_ *v1alpha1.DMCluster) error {
 	return nil
 }
 
-func (fmf *fakeMasterFailover) Recover(_ *v1alpha1.DMCluster) {
+func (f *fakeMasterFailover) Recover(_ *v1alpha1.DMCluster) {
 }
 
-func (fmf *fakeMasterFailover) RemoveUndesiredFailures(_ *v1alpha1.DMCluster) {
+func (f *fakeMasterFailover) RemoveUndesiredFailures(_ *v1alpha1.DMCluster) {
 }

--- a/pkg/manager/member/dm_master_upgrader.go
+++ b/pkg/manager/member/dm_master_upgrader.go
@@ -34,11 +34,11 @@ func NewMasterUpgrader(deps *controller.Dependencies) DMUpgrader {
 	}
 }
 
-func (mu *masterUpgrader) Upgrade(dc *v1alpha1.DMCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
-	return mu.gracefulUpgrade(dc, oldSet, newSet)
+func (u *masterUpgrader) Upgrade(dc *v1alpha1.DMCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+	return u.gracefulUpgrade(dc, oldSet, newSet)
 }
 
-func (mu *masterUpgrader) gracefulUpgrade(dc *v1alpha1.DMCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (u *masterUpgrader) gracefulUpgrade(dc *v1alpha1.DMCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 	if !dc.Status.Master.Synced {
@@ -78,7 +78,7 @@ func (mu *masterUpgrader) gracefulUpgrade(dc *v1alpha1.DMCluster, oldSet *apps.S
 	for _i := len(podOrdinals) - 1; _i >= 0; _i-- {
 		i := podOrdinals[_i]
 		podName := DMMasterPodName(dcName, i)
-		pod, err := mu.deps.PodLister.Pods(ns).Get(podName)
+		pod, err := u.deps.PodLister.Pods(ns).Get(podName)
 		if err != nil {
 			return fmt.Errorf("gracefulUpgrade: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, dcName, err)
 		}
@@ -100,18 +100,18 @@ func (mu *masterUpgrader) gracefulUpgrade(dc *v1alpha1.DMCluster, oldSet *apps.S
 		//	return nil
 		//}
 
-		return mu.upgradeMasterPod(dc, i, newSet)
+		return u.upgradeMasterPod(dc, i, newSet)
 	}
 
 	return nil
 }
 
-func (mu *masterUpgrader) upgradeMasterPod(dc *v1alpha1.DMCluster, ordinal int32, newSet *apps.StatefulSet) error {
+func (u *masterUpgrader) upgradeMasterPod(dc *v1alpha1.DMCluster, ordinal int32, newSet *apps.StatefulSet) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 	upgradePodName := DMMasterPodName(dcName, ordinal)
 	if dc.Status.Master.Leader.Name == upgradePodName && dc.MasterStsActualReplicas() > 1 {
-		err := mu.evictMasterLeader(dc, upgradePodName)
+		err := u.evictMasterLeader(dc, upgradePodName)
 		if err != nil {
 			klog.Errorf("dm-master upgrader: failed to evict dm-master %s's leader: %v", upgradePodName, err)
 			return err
@@ -124,8 +124,8 @@ func (mu *masterUpgrader) upgradeMasterPod(dc *v1alpha1.DMCluster, ordinal int32
 	return nil
 }
 
-func (mu *masterUpgrader) evictMasterLeader(dc *v1alpha1.DMCluster, podName string) error {
-	return controller.GetMasterPeerClient(mu.deps.DMMasterControl, dc, podName).EvictLeader()
+func (u *masterUpgrader) evictMasterLeader(dc *v1alpha1.DMCluster, podName string) error {
+	return controller.GetMasterPeerClient(u.deps.DMMasterControl, dc, podName).EvictLeader()
 }
 
 type fakeMasterUpgrader struct{}
@@ -135,7 +135,7 @@ func NewFakeMasterUpgrader() DMUpgrader {
 	return &fakeMasterUpgrader{}
 }
 
-func (fmu *fakeMasterUpgrader) Upgrade(dc *v1alpha1.DMCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+func (u *fakeMasterUpgrader) Upgrade(dc *v1alpha1.DMCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	if !dc.Status.Master.Synced {
 		return fmt.Errorf("dmcluster: dm-master status sync failed,can not to be upgraded")
 	}

--- a/pkg/manager/member/dm_worker_failover.go
+++ b/pkg/manager/member/dm_worker_failover.go
@@ -33,7 +33,7 @@ func NewWorkerFailover(deps *controller.Dependencies) DMFailover {
 	return &workerFailover{deps: deps}
 }
 
-func (wf *workerFailover) Failover(dc *v1alpha1.DMCluster) error {
+func (f *workerFailover) Failover(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
@@ -47,7 +47,7 @@ func (wf *workerFailover) Failover(dc *v1alpha1.DMCluster) error {
 			// (before it enters into Offline/Tombstone state)
 			continue
 		}
-		deadline := worker.LastTransitionTime.Add(wf.deps.CLIConfig.WorkerFailoverPeriod)
+		deadline := worker.LastTransitionTime.Add(f.deps.CLIConfig.WorkerFailoverPeriod)
 		exist := false
 		for _, failureWorker := range dc.Status.Worker.FailureMembers {
 			if failureWorker.PodName == podName {
@@ -70,7 +70,7 @@ func (wf *workerFailover) Failover(dc *v1alpha1.DMCluster) error {
 					CreatedAt: metav1.Now(),
 				}
 				msg := fmt.Sprintf("worker[%s/%s] is Offline", ns, worker.Name)
-				wf.deps.Recorder.Event(dc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "worker", podName, msg))
+				f.deps.Recorder.Event(dc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "worker", podName, msg))
 			}
 		}
 	}
@@ -78,12 +78,12 @@ func (wf *workerFailover) Failover(dc *v1alpha1.DMCluster) error {
 	return nil
 }
 
-func (wf *workerFailover) Recover(dc *v1alpha1.DMCluster) {
+func (f *workerFailover) Recover(dc *v1alpha1.DMCluster) {
 	dc.Status.Worker.FailureMembers = nil
 	klog.Infof("dm-worker recover: clear FailureWorkers, %s/%s", dc.GetNamespace(), dc.GetName())
 }
 
-func (wf *workerFailover) RemoveUndesiredFailures(dc *v1alpha1.DMCluster) {
+func (f *workerFailover) RemoveUndesiredFailures(dc *v1alpha1.DMCluster) {
 	for key, failureWorker := range dc.Status.Worker.FailureMembers {
 		if !isWorkerPodDesired(dc, failureWorker.PodName) {
 			// If we delete the pods, e.g. by using advanced statefulset delete
@@ -101,12 +101,12 @@ func NewFakeWorkerFailover() DMFailover {
 	return &fakeWorkerFailover{}
 }
 
-func (fwf *fakeWorkerFailover) Failover(_ *v1alpha1.DMCluster) error {
+func (f *fakeWorkerFailover) Failover(_ *v1alpha1.DMCluster) error {
 	return nil
 }
 
-func (fwf *fakeWorkerFailover) Recover(_ *v1alpha1.DMCluster) {
+func (f *fakeWorkerFailover) Recover(_ *v1alpha1.DMCluster) {
 }
 
-func (fwf *fakeWorkerFailover) RemoveUndesiredFailures(_ *v1alpha1.DMCluster) {
+func (f *fakeWorkerFailover) RemoveUndesiredFailures(_ *v1alpha1.DMCluster) {
 }

--- a/pkg/manager/member/dm_worker_member_manager.go
+++ b/pkg/manager/member/dm_worker_member_manager.go
@@ -56,7 +56,7 @@ func NewWorkerMemberManager(deps *controller.Dependencies, scaler Scaler, failov
 	}
 }
 
-func (wmm *workerMemberManager) SyncDM(dc *v1alpha1.DMCluster) error {
+func (m *workerMemberManager) SyncDM(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
@@ -72,26 +72,26 @@ func (wmm *workerMemberManager) SyncDM(dc *v1alpha1.DMCluster) error {
 	}
 
 	// Sync dm-worker Headless Service
-	if err := wmm.syncWorkerHeadlessServiceForDMCluster(dc); err != nil {
+	if err := m.syncWorkerHeadlessServiceForDMCluster(dc); err != nil {
 		return err
 	}
 
 	// Sync dm-worker StatefulSet
-	return wmm.syncWorkerStatefulSetForDMCluster(dc)
+	return m.syncWorkerStatefulSetForDMCluster(dc)
 }
 
-func (wmm *workerMemberManager) syncWorkerHeadlessServiceForDMCluster(dc *v1alpha1.DMCluster) error {
+func (m *workerMemberManager) syncWorkerHeadlessServiceForDMCluster(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
 	newSvc := getNewWorkerHeadlessServiceForDMCluster(dc)
-	oldSvcTmp, err := wmm.deps.ServiceLister.Services(ns).Get(controller.DMWorkerPeerMemberName(dcName))
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(controller.DMWorkerPeerMemberName(dcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return wmm.deps.ServiceControl.CreateService(dc, newSvc)
+		return m.deps.ServiceControl.CreateService(dc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncWorkerHeadlessServiceForDMCluster: failed to get svc %s for cluster %s/%s, error: %s", controller.DMWorkerPeerMemberName(dcName), ns, dcName, err)
@@ -110,7 +110,7 @@ func (wmm *workerMemberManager) syncWorkerHeadlessServiceForDMCluster(dc *v1alph
 		if err != nil {
 			return err
 		}
-		_, err = wmm.deps.ServiceControl.UpdateService(dc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(dc, &svc)
 		return err
 	}
 
@@ -148,11 +148,11 @@ func getNewWorkerHeadlessServiceForDMCluster(dc *v1alpha1.DMCluster) *corev1.Ser
 	return &svc
 }
 
-func (wmm *workerMemberManager) syncWorkerStatefulSetForDMCluster(dc *v1alpha1.DMCluster) error {
+func (m *workerMemberManager) syncWorkerStatefulSetForDMCluster(dc *v1alpha1.DMCluster) error {
 	ns := dc.GetNamespace()
 	dcName := dc.GetName()
 
-	oldStsTmp, err := wmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.DMWorkerMemberName(dcName))
+	oldStsTmp, err := m.deps.StatefulSetLister.StatefulSets(ns).Get(controller.DMWorkerMemberName(dcName))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncWorkerStatefulSetForDMCluster: failed to get sts %s for cluster %s/%s, error: %s", controller.DMWorkerMemberName(dcName), ns, dcName, err)
 	}
@@ -161,7 +161,7 @@ func (wmm *workerMemberManager) syncWorkerStatefulSetForDMCluster(dc *v1alpha1.D
 	oldSts := oldStsTmp.DeepCopy()
 
 	// failed to sync dm-worker status will not affect subsequent logic, just print the errors.
-	if err := wmm.syncDMClusterStatus(dc, oldSts); err != nil {
+	if err := m.syncDMClusterStatus(dc, oldSts); err != nil {
 		klog.Errorf("failed to sync DMCluster: [%s/%s]'s dm-worker status, error: %v", ns, dcName, err)
 	}
 
@@ -170,19 +170,19 @@ func (wmm *workerMemberManager) syncWorkerStatefulSetForDMCluster(dc *v1alpha1.D
 		return nil
 	}
 
-	cm, err := wmm.syncWorkerConfigMap(dc, oldSts)
+	cm, err := m.syncWorkerConfigMap(dc, oldSts)
 	if err != nil {
 		return err
 	}
 
 	// Recover failed workers if any before generating desired statefulset
 	if len(dc.Status.Worker.FailureMembers) > 0 {
-		wmm.failover.RemoveUndesiredFailures(dc)
+		m.failover.RemoveUndesiredFailures(dc)
 	}
 	if len(dc.Status.Worker.FailureMembers) > 0 &&
 		dc.Spec.Worker.RecoverFailover &&
-		shouldRecoverDM(dc, label.DMWorkerLabelVal, wmm.deps.PodLister) {
-		wmm.failover.Recover(dc)
+		shouldRecoverDM(dc, label.DMWorkerLabelVal, m.deps.PodLister) {
+		m.failover.Recover(dc)
 	}
 
 	newSts, err := getNewWorkerSetForDMCluster(dc, cm)
@@ -195,32 +195,32 @@ func (wmm *workerMemberManager) syncWorkerStatefulSetForDMCluster(dc *v1alpha1.D
 		if err != nil {
 			return err
 		}
-		err = wmm.deps.StatefulSetControl.CreateStatefulSet(dc, newSts)
+		err = m.deps.StatefulSetControl.CreateStatefulSet(dc, newSts)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
 
-	if err := wmm.scaler.Scale(dc, oldSts, newSts); err != nil {
+	if err := m.scaler.Scale(dc, oldSts, newSts); err != nil {
 		return err
 	}
 
 	// Perform failover logic if necessary. Note that this will only update
 	// DMCluster status. The actual scaling performs in next sync loop (if a
 	// new replica needs to be added).
-	if wmm.deps.CLIConfig.AutoFailover && dc.Spec.Worker.MaxFailoverCount != nil {
+	if m.deps.CLIConfig.AutoFailover && dc.Spec.Worker.MaxFailoverCount != nil {
 		if dc.WorkerAllPodsStarted() && !dc.WorkerAllMembersReady() {
-			if err := wmm.failover.Failover(dc); err != nil {
+			if err := m.failover.Failover(dc); err != nil {
 				return err
 			}
 		}
 	}
 
-	return updateStatefulSet(wmm.deps.StatefulSetControl, dc, newSts, oldSts)
+	return updateStatefulSet(m.deps.StatefulSetControl, dc, newSts, oldSts)
 }
 
-func (wmm *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set *apps.StatefulSet) error {
+func (m *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set *apps.StatefulSet) error {
 	if set == nil {
 		// skip if not created yet
 		return nil
@@ -228,7 +228,7 @@ func (wmm *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set 
 
 	dc.Status.Worker.StatefulSet = &set.Status
 
-	upgrading, err := wmm.workerStatefulSetIsUpgrading(set, dc)
+	upgrading, err := m.workerStatefulSetIsUpgrading(set, dc)
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func (wmm *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set 
 		dc.Status.Worker.Phase = v1alpha1.NormalPhase
 	}
 
-	dmClient := controller.GetMasterClient(wmm.deps.DMMasterControl, dc)
+	dmClient := controller.GetMasterClient(m.deps.DMMasterControl, dc)
 
 	workersInfo, err := dmClient.GetWorkers()
 	if err != nil {
@@ -287,7 +287,7 @@ func (wmm *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set 
 	return nil
 }
 
-func (wmm *workerMemberManager) workerStatefulSetIsUpgrading(set *apps.StatefulSet, dc *v1alpha1.DMCluster) (bool, error) {
+func (m *workerMemberManager) workerStatefulSetIsUpgrading(set *apps.StatefulSet, dc *v1alpha1.DMCluster) (bool, error) {
 	if statefulSetIsUpgrading(set) {
 		return true, nil
 	}
@@ -299,7 +299,7 @@ func (wmm *workerMemberManager) workerStatefulSetIsUpgrading(set *apps.StatefulS
 	if err != nil {
 		return false, err
 	}
-	workerPods, err := wmm.deps.PodLister.Pods(dc.GetNamespace()).List(selector)
+	workerPods, err := m.deps.PodLister.Pods(dc.GetNamespace()).List(selector)
 	if err != nil {
 		return false, fmt.Errorf("workerStatefulSetIsUpgrading: failed to list pods for cluster %s/%s, selector %s, error: %v", dc.GetNamespace(), instanceName, selector, err)
 	}
@@ -316,12 +316,12 @@ func (wmm *workerMemberManager) workerStatefulSetIsUpgrading(set *apps.StatefulS
 }
 
 // syncWorkerConfigMap syncs the configmap of dm-worker
-func (wmm *workerMemberManager) syncWorkerConfigMap(dc *v1alpha1.DMCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
+func (m *workerMemberManager) syncWorkerConfigMap(dc *v1alpha1.DMCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
 	newCm, err := getWorkerConfigMap(dc)
 	if err != nil {
 		return nil, err
 	}
-	return wmm.deps.TypedControl.CreateOrUpdateConfigMap(dc, newCm)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(dc, newCm)
 }
 
 func getNewWorkerSetForDMCluster(dc *v1alpha1.DMCluster, cm *corev1.ConfigMap) (*apps.StatefulSet, error) {
@@ -577,13 +577,13 @@ func NewFakeWorkerMemberManager() *FakeWorkerMemberManager {
 	return &FakeWorkerMemberManager{}
 }
 
-func (ftmm *FakeWorkerMemberManager) SetSyncError(err error) {
-	ftmm.err = err
+func (m *FakeWorkerMemberManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (ftmm *FakeWorkerMemberManager) SyncDM(dc *v1alpha1.DMCluster) error {
-	if ftmm.err != nil {
-		return ftmm.err
+func (m *FakeWorkerMemberManager) SyncDM(dc *v1alpha1.DMCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	return nil
 }

--- a/pkg/manager/member/orphan_pods_cleaner.go
+++ b/pkg/manager/member/orphan_pods_cleaner.go
@@ -63,7 +63,7 @@ func NewOrphanPodsCleaner(deps *controller.Dependencies) OrphanPodsCleaner {
 	}
 }
 
-func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, error) {
+func (c *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, error) {
 	ns := meta.GetNamespace()
 	skipReason := map[string]string{}
 
@@ -85,7 +85,7 @@ func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, erro
 	if err != nil {
 		return skipReason, err
 	}
-	pods, err := opc.deps.PodLister.Pods(ns).List(selector)
+	pods, err := c.deps.PodLister.Pods(ns).List(selector)
 	if err != nil {
 		return skipReason, fmt.Errorf("clean: failed to get pods list for cluster %s/%s, selector %s, error: %s", ns, meta.GetName(), selector, err)
 	}
@@ -120,7 +120,7 @@ func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, erro
 		var pvcNotFound bool
 		for _, p := range pvcNames {
 			// check informer cache
-			_, err = opc.deps.PVCLister.PersistentVolumeClaims(ns).Get(p)
+			_, err = c.deps.PVCLister.PersistentVolumeClaims(ns).Get(p)
 			if err == nil {
 				continue
 			}
@@ -128,7 +128,7 @@ func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, erro
 				return skipReason, fmt.Errorf("clean: failed to get pvc %s for cluster %s/%s, error: %s", p, ns, meta.GetName(), err)
 			}
 			// if PVC not found in cache, re-check from apiserver directly to make sure the PVC really not exist
-			_, err = opc.deps.KubeClientset.CoreV1().PersistentVolumeClaims(ns).Get(p, metav1.GetOptions{})
+			_, err = c.deps.KubeClientset.CoreV1().PersistentVolumeClaims(ns).Get(p, metav1.GetOptions{})
 			if err == nil {
 				continue
 			}
@@ -147,7 +147,7 @@ func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, erro
 		// if the PVC is not found in apiserver (also informer cache) and the
 		// pod has not been scheduled, delete it and let the stateful
 		// controller to create the pod and its PVC(s) again
-		apiPod, err := opc.deps.KubeClientset.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
+		apiPod, err := c.deps.KubeClientset.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			skipReason[podName] = skipReasonOrphanPodsCleanerPodIsNotFound
 			continue
@@ -172,7 +172,7 @@ func (opc *orphanPodsCleaner) Clean(meta metav1.Object) (map[string]string, erro
 		// As the pod may be updated by kube-scheduler or other components
 		// frequently, we should use the latest object here to avoid API
 		// conflict.
-		err = opc.deps.PodControl.DeletePod(podMeta, apiPod)
+		err = c.deps.PodControl.DeletePod(podMeta, apiPod)
 		if err != nil {
 			klog.Errorf("orphan pods cleaner: failed to clean orphan pod: %s/%s, %v", ns, podName, err)
 			return skipReason, err
@@ -192,12 +192,12 @@ func NewFakeOrphanPodsCleaner() *FakeOrphanPodsCleaner {
 	return &FakeOrphanPodsCleaner{}
 }
 
-func (fpc *FakeOrphanPodsCleaner) SetnOrphanPodCleanerError(err error) {
-	fpc.err = err
+func (c *FakeOrphanPodsCleaner) SetnOrphanPodCleanerError(err error) {
+	c.err = err
 }
 
-func (fpc *FakeOrphanPodsCleaner) Clean(_ metav1.Object) (map[string]string, error) {
-	return nil, fpc.err
+func (c *FakeOrphanPodsCleaner) Clean(_ metav1.Object) (map[string]string, error) {
+	return nil, c.err
 }
 
 var _ OrphanPodsCleaner = &FakeOrphanPodsCleaner{}

--- a/pkg/manager/member/pd_failover.go
+++ b/pkg/manager/member/pd_failover.go
@@ -44,7 +44,7 @@ func NewPDFailover(deps *controller.Dependencies) Failover {
 // 2. delete the failure member pd-0, and mark it deleted (MemberDeleted=true)
 // 3. PD member manager will add the count of deleted failure members more replicas
 // If the count of the failure PD member with the deleted state (MemberDeleted=true) is equal or greater than MaxFailoverCount, we will skip failover.
-func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
+func (f *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
@@ -60,7 +60,7 @@ func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 		if pdMember.Health {
 			healthCount++
 		} else {
-			pf.deps.Recorder.Eventf(tc, apiv1.EventTypeWarning, "PDMemberUnhealthy",
+			f.deps.Recorder.Eventf(tc, apiv1.EventTypeWarning, "PDMemberUnhealthy",
 				"%s(%s) is unhealthy", podName, pdMember.ID)
 		}
 	}
@@ -85,18 +85,18 @@ func (pf *pdFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	}
 	// we can only failover one at a time
 	if notDeletedCount == 0 {
-		return pf.tryToMarkAPeerAsFailure(tc)
+		return f.tryToMarkAPeerAsFailure(tc)
 	}
 
-	return pf.tryToDeleteAFailureMember(tc)
+	return f.tryToDeleteAFailureMember(tc)
 }
 
-func (pf *pdFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (f *pdFailover) Recover(tc *v1alpha1.TidbCluster) {
 	tc.Status.PD.FailureMembers = nil
 	klog.Infof("pd failover: clearing pd failoverMembers, %s/%s", tc.GetNamespace(), tc.GetName())
 }
 
-func (pf *pdFailover) tryToMarkAPeerAsFailure(tc *v1alpha1.TidbCluster) error {
+func (f *pdFailover) tryToMarkAPeerAsFailure(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
@@ -104,14 +104,14 @@ func (pf *pdFailover) tryToMarkAPeerAsFailure(tc *v1alpha1.TidbCluster) error {
 		if pdMember.LastTransitionTime.IsZero() {
 			continue
 		}
-		if !pf.isPodDesired(tc, podName) {
+		if !f.isPodDesired(tc, podName) {
 			continue
 		}
 
 		if tc.Status.PD.FailureMembers == nil {
 			tc.Status.PD.FailureMembers = map[string]v1alpha1.PDFailureMember{}
 		}
-		deadline := pdMember.LastTransitionTime.Add(pf.deps.CLIConfig.PDFailoverPeriod)
+		deadline := pdMember.LastTransitionTime.Add(f.deps.CLIConfig.PDFailoverPeriod)
 		_, exist := tc.Status.PD.FailureMembers[podName]
 		if pdMember.Health || time.Now().Before(deadline) || exist {
 			continue
@@ -122,13 +122,13 @@ func (pf *pdFailover) tryToMarkAPeerAsFailure(tc *v1alpha1.TidbCluster) error {
 			return err
 		}
 		pvcName := ordinalPVCName(v1alpha1.PDMemberType, controller.PDMemberName(tcName), ordinal)
-		pvc, err := pf.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+		pvc, err := f.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 		if err != nil {
 			return fmt.Errorf("tryToMarkAPeerAsFailure: failed to get pvc %s for cluster %s/%s, error: %s", pvcName, ns, tcName, err)
 		}
 
 		msg := fmt.Sprintf("pd member[%s] is unhealthy", pdMember.ID)
-		pf.deps.Recorder.Event(tc, apiv1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "pd", podName, msg))
+		f.deps.Recorder.Event(tc, apiv1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "pd", podName, msg))
 
 		// mark a peer member failed and return an error to skip reconciliation
 		// note that status of tidb cluster will be updated always
@@ -149,7 +149,7 @@ func (pf *pdFailover) tryToMarkAPeerAsFailure(tc *v1alpha1.TidbCluster) error {
 // pvc. If this succeeds, new pod & pvc will be created by Kubernetes.
 // Note that this will fail if the kubelet on the node which failed pod was
 // running on is not responding.
-func (pf *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error {
+func (f *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 	var failureMember *v1alpha1.PDFailureMember
@@ -171,20 +171,20 @@ func (pf *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error 
 		return err
 	}
 	// invoke deleteMember api to delete a member from the pd cluster
-	err = controller.GetPDClient(pf.deps.PDControl, tc).DeleteMemberByID(memberID)
+	err = controller.GetPDClient(f.deps.PDControl, tc).DeleteMemberByID(memberID)
 	if err != nil {
 		klog.Errorf("pd failover: failed to delete member: %d, %v", memberID, err)
 		return err
 	}
 	klog.Infof("pd failover: delete member: %d successfully", memberID)
-	pf.deps.Recorder.Eventf(tc, apiv1.EventTypeWarning, "PDMemberDeleted",
+	f.deps.Recorder.Eventf(tc, apiv1.EventTypeWarning, "PDMemberDeleted",
 		"%s(%d) deleted from cluster", failurePodName, memberID)
 
 	// The order of old PVC deleting and the new Pod creating is not guaranteed by Kubernetes.
 	// If new Pod is created before old PVC deleted, new Pod will reuse old PVC.
 	// So we must try to delete the PVC and Pod of this PD peer over and over,
 	// and let StatefulSet create the new PD peer with the same ordinal, but don't use the tombstone PV
-	pod, err := pf.deps.PodLister.Pods(ns).Get(failurePodName)
+	pod, err := f.deps.PodLister.Pods(ns).Get(failurePodName)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("tryToDeleteAFailureMember: failed to get pods %s for cluster %s/%s, error: %s", failurePodName, ns, tcName, err)
 	}
@@ -194,19 +194,19 @@ func (pf *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error 
 		return err
 	}
 	pvcName := ordinalPVCName(v1alpha1.PDMemberType, controller.PDMemberName(tcName), ordinal)
-	pvc, err := pf.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+	pvc, err := f.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("tryToDeleteAFailureMember: failed to get pvc %s for cluster %s/%s, error: %s", pvcName, ns, tcName, err)
 	}
 
 	if pod != nil && pod.DeletionTimestamp == nil {
-		err := pf.deps.PodControl.DeletePod(tc, pod)
+		err := f.deps.PodControl.DeletePod(tc, pod)
 		if err != nil {
 			return err
 		}
 	}
 	if pvc != nil && pvc.DeletionTimestamp == nil && pvc.GetUID() == failureMember.PVCUID {
-		err = pf.deps.PVCControl.DeletePVC(tc, pvc)
+		err = f.deps.PVCControl.DeletePVC(tc, pvc)
 		if err != nil {
 			klog.Errorf("pd failover: failed to delete pvc: %s/%s, %v", ns, pvcName, err)
 			return err
@@ -218,7 +218,7 @@ func (pf *pdFailover) tryToDeleteAFailureMember(tc *v1alpha1.TidbCluster) error 
 	return nil
 }
 
-func (pf *pdFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
+func (f *pdFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
 	ordinals := tc.PDStsDesiredOrdinals(true)
 	ordinal, err := util.GetOrdinalFromPodName(podName)
 	if err != nil {
@@ -228,7 +228,7 @@ func (pf *pdFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) boo
 	return ordinals.Has(ordinal)
 }
 
-func (pf *pdFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+func (f *pdFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 }
 
 func setMemberDeleted(tc *v1alpha1.TidbCluster, podName string) {
@@ -245,12 +245,12 @@ func NewFakePDFailover() Failover {
 	return &fakePDFailover{}
 }
 
-func (fpf *fakePDFailover) Failover(_ *v1alpha1.TidbCluster) error {
+func (f *fakePDFailover) Failover(_ *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (fpf *fakePDFailover) Recover(_ *v1alpha1.TidbCluster) {
+func (f *fakePDFailover) Recover(_ *v1alpha1.TidbCluster) {
 }
 
-func (fpf *fakePDFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+func (f *fakePDFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 }

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -763,11 +763,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 			},
 			ServiceName:         controller.PDPeerMemberName(tcName),
 			PodManagementPolicy: apps.ParallelPodManagement,
-			UpdateStrategy: apps.StatefulSetUpdateStrategy{
-				Type: apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: pointer.Int32Ptr(tc.Spec.PD.Replicas + int32(failureReplicas)),
-				}},
+			UpdateStrategy:      *basePDSpec.StatefulSetUpdateStrategy(),
 		},
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -63,27 +63,27 @@ func NewPDMemberManager(dependencies *controller.Dependencies, pdScaler Scaler, 
 	}
 }
 
-func (pmm *pdMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+func (m *pdMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	// If pd is not specified return
 	if tc.Spec.PD == nil {
 		return nil
 	}
 
 	// Sync PD Service
-	if err := pmm.syncPDServiceForTidbCluster(tc); err != nil {
+	if err := m.syncPDServiceForTidbCluster(tc); err != nil {
 		return err
 	}
 
 	// Sync PD Headless Service
-	if err := pmm.syncPDHeadlessServiceForTidbCluster(tc); err != nil {
+	if err := m.syncPDHeadlessServiceForTidbCluster(tc); err != nil {
 		return err
 	}
 
 	// Sync PD StatefulSet
-	return pmm.syncPDStatefulSetForTidbCluster(tc)
+	return m.syncPDStatefulSetForTidbCluster(tc)
 }
 
-func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tidb cluster %s/%s is paused, skip syncing for pd service", tc.GetNamespace(), tc.GetName())
 		return nil
@@ -92,14 +92,14 @@ func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	newSvc := pmm.getNewPDServiceForTidbCluster(tc)
-	oldSvcTmp, err := pmm.deps.ServiceLister.Services(ns).Get(controller.PDMemberName(tcName))
+	newSvc := m.getNewPDServiceForTidbCluster(tc)
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(controller.PDMemberName(tcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return pmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncPDServiceForTidbCluster: failed to get svc %s for cluster %s/%s, error: %s", controller.PDMemberName(tcName), ns, tcName, err)
@@ -120,14 +120,14 @@ func (pmm *pdMemberManager) syncPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 			return err
 		}
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		_, err = pmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
 	return nil
 }
 
-func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tidb cluster %s/%s is paused, skip syncing for pd headless service", tc.GetNamespace(), tc.GetName())
 		return nil
@@ -137,13 +137,13 @@ func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.Tid
 	tcName := tc.GetName()
 
 	newSvc := getNewPDHeadlessServiceForTidbCluster(tc)
-	oldSvc, err := pmm.deps.ServiceLister.Services(ns).Get(controller.PDPeerMemberName(tcName))
+	oldSvc, err := m.deps.ServiceLister.Services(ns).Get(controller.PDPeerMemberName(tcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return pmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncPDHeadlessServiceForTidbCluster: failed to get svc %s for cluster %s/%s, error: %s", controller.PDPeerMemberName(tcName), ns, tcName, err)
@@ -160,18 +160,18 @@ func (pmm *pdMemberManager) syncPDHeadlessServiceForTidbCluster(tc *v1alpha1.Tid
 		if err != nil {
 			return err
 		}
-		_, err = pmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
 	return nil
 }
 
-func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	oldPDSetTmp, err := pmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.PDMemberName(tcName))
+	oldPDSetTmp, err := m.deps.StatefulSetLister.StatefulSets(ns).Get(controller.PDMemberName(tcName))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncPDStatefulSetForTidbCluster: fail to get sts %s for cluster %s/%s, error: %s", controller.PDMemberName(tcName), ns, tcName, err)
 	}
@@ -179,7 +179,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 
 	oldPDSet := oldPDSetTmp.DeepCopy()
 
-	if err := pmm.syncTidbClusterStatus(tc, oldPDSet); err != nil {
+	if err := m.syncTidbClusterStatus(tc, oldPDSet); err != nil {
 		klog.Errorf("failed to sync TidbCluster: [%s/%s]'s status, error: %v", ns, tcName, err)
 	}
 
@@ -188,7 +188,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		return nil
 	}
 
-	cm, err := pmm.syncPDConfigMap(tc, oldPDSet)
+	cm, err := m.syncPDConfigMap(tc, oldPDSet)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		if err != nil {
 			return err
 		}
-		if err := pmm.deps.StatefulSetControl.CreateStatefulSet(tc, newPDSet); err != nil {
+		if err := m.deps.StatefulSetControl.CreateStatefulSet(tc, newPDSet); err != nil {
 			return err
 		}
 		tc.Status.PD.StatefulSet = &apps.StatefulSetStatus{}
@@ -213,15 +213,15 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 	//   new replicas
 	// - it's ok to scale in the middle of upgrading (in statefulset controller
 	//   scaling takes precedence over upgrading too)
-	if err := pmm.scaler.Scale(tc, oldPDSet, newPDSet); err != nil {
+	if err := m.scaler.Scale(tc, oldPDSet, newPDSet); err != nil {
 		return err
 	}
 
-	if pmm.deps.CLIConfig.AutoFailover {
-		if pmm.shouldRecover(tc) {
-			pmm.failover.Recover(tc)
+	if m.deps.CLIConfig.AutoFailover {
+		if m.shouldRecover(tc) {
+			m.failover.Recover(tc)
 		} else if tc.PDAllPodsStarted() && !tc.PDAllMembersReady() || tc.PDAutoFailovering() {
-			if err := pmm.failover.Failover(tc); err != nil {
+			if err := m.failover.Failover(tc); err != nil {
 				return err
 			}
 		}
@@ -232,22 +232,22 @@ func (pmm *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClu
 		if force {
 			tc.Status.PD.Phase = v1alpha1.UpgradePhase
 			setUpgradePartition(newPDSet, 0)
-			errSTS := updateStatefulSet(pmm.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
+			errSTS := updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
 			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
 		}
 	}
 
 	if !templateEqual(newPDSet, oldPDSet) || tc.Status.PD.Phase == v1alpha1.UpgradePhase {
-		if err := pmm.upgrader.Upgrade(tc, oldPDSet, newPDSet); err != nil {
+		if err := m.upgrader.Upgrade(tc, oldPDSet, newPDSet); err != nil {
 			return err
 		}
 	}
 
-	return updateStatefulSet(pmm.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
+	return updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
 }
 
 // shouldRecover checks whether we should perform recovery operation.
-func (pmm *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
+func (m *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	if tc.Status.PD.FailureMembers == nil {
 		return false
 	}
@@ -257,7 +257,7 @@ func (pmm *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	// about them because we're going to delete them.
 	for ordinal := range tc.PDStsDesiredOrdinals(true) {
 		name := fmt.Sprintf("%s-%d", controller.PDMemberName(tc.GetName()), ordinal)
-		pod, err := pmm.deps.PodLister.Pods(tc.Namespace).Get(name)
+		pod, err := m.deps.PodLister.Pods(tc.Namespace).Get(name)
 		if err != nil {
 			klog.Errorf("pod %s/%s does not exist: %v", tc.Namespace, name, err)
 			return false
@@ -273,7 +273,7 @@ func (pmm *pdMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	return true
 }
 
-func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (m *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	if set == nil {
 		// skip if not created yet
 		return nil
@@ -284,7 +284,7 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 
 	tc.Status.PD.StatefulSet = &set.Status
 
-	upgrading, err := pmm.pdStatefulSetIsUpgrading(set, tc)
+	upgrading, err := m.pdStatefulSetIsUpgrading(set, tc)
 	if err != nil {
 		return err
 	}
@@ -298,13 +298,13 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 		tc.Status.PD.Phase = v1alpha1.NormalPhase
 	}
 
-	pdClient := controller.GetPDClient(pmm.deps.PDControl, tc)
+	pdClient := controller.GetPDClient(m.deps.PDControl, tc)
 
 	healthInfo, err := pdClient.GetHealth()
 	if err != nil {
 		tc.Status.PD.Synced = false
 		// get endpoints info
-		eps, epErr := pmm.deps.EndpointLister.Endpoints(ns).Get(controller.PDMemberName(tcName))
+		eps, epErr := m.deps.EndpointLister.Endpoints(ns).Get(controller.PDMemberName(tcName))
 		if epErr != nil {
 			return fmt.Errorf("syncTidbClusterStatus: failed to get endpoints %s for cluster %s/%s, err: %s, epErr %s", controller.PDMemberName(tcName), ns, tcName, err, epErr)
 		}
@@ -368,7 +368,7 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 	}
 
 	// k8s check
-	err = pmm.collectUnjoinedMembers(tc, set, pdStatus)
+	err = m.collectUnjoinedMembers(tc, set, pdStatus)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func (pmm *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 }
 
 // syncPDConfigMap syncs the configmap of PD
-func (pmm *pdMemberManager) syncPDConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
+func (m *pdMemberManager) syncPDConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
 
 	// For backward compatibility, only sync tidb configmap when .pd.config is non-nil
 	if tc.Spec.PD.Config == nil {
@@ -394,14 +394,14 @@ func (pmm *pdMemberManager) syncPDConfigMap(tc *v1alpha1.TidbCluster, set *apps.
 		})
 	}
 
-	err = updateConfigMapIfNeed(pmm.deps.ConfigMapLister, tc.BasePDSpec().ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, tc.BasePDSpec().ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}
-	return pmm.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
 }
 
-func (pmm *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Service {
+func (m *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Service {
 	ns := tc.Namespace
 	tcName := tc.Name
 	svcName := controller.PDMemberName(tcName)
@@ -480,7 +480,7 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 	}
 }
 
-func (pmm *pdMemberManager) pdStatefulSetIsUpgrading(set *apps.StatefulSet, tc *v1alpha1.TidbCluster) (bool, error) {
+func (m *pdMemberManager) pdStatefulSetIsUpgrading(set *apps.StatefulSet, tc *v1alpha1.TidbCluster) (bool, error) {
 	if statefulSetIsUpgrading(set) {
 		return true, nil
 	}
@@ -492,7 +492,7 @@ func (pmm *pdMemberManager) pdStatefulSetIsUpgrading(set *apps.StatefulSet, tc *
 	if err != nil {
 		return false, err
 	}
-	pdPods, err := pmm.deps.PodLister.Pods(tc.GetNamespace()).List(selector)
+	pdPods, err := m.deps.PodLister.Pods(tc.GetNamespace()).List(selector)
 	if err != nil {
 		return false, fmt.Errorf("pdStatefulSetIsUpgrading: failed to list pods for cluster %s/%s, selector %s, error: %v", tc.GetNamespace(), instanceName, selector, err)
 	}
@@ -842,12 +842,12 @@ func clusterVersionGreaterThanOrEqualTo4(version string) (bool, error) {
 	return v.Major() >= 4, nil
 }
 
-func (pmm *pdMemberManager) collectUnjoinedMembers(tc *v1alpha1.TidbCluster, set *apps.StatefulSet, pdStatus map[string]v1alpha1.PDMember) error {
+func (m *pdMemberManager) collectUnjoinedMembers(tc *v1alpha1.TidbCluster, set *apps.StatefulSet, pdStatus map[string]v1alpha1.PDMember) error {
 	podSelector, podSelectErr := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if podSelectErr != nil {
 		return podSelectErr
 	}
-	pods, podErr := pmm.deps.PodLister.Pods(tc.Namespace).List(podSelector)
+	pods, podErr := m.deps.PodLister.Pods(tc.Namespace).List(podSelector)
 	if podErr != nil {
 		return fmt.Errorf("collectUnjoinedMembers: failed to list pods for cluster %s/%s, selector %s, error %v", tc.GetNamespace(), tc.GetName(), set.Spec.Selector, podErr)
 	}
@@ -868,7 +868,7 @@ func (pmm *pdMemberManager) collectUnjoinedMembers(tc *v1alpha1.TidbCluster, set
 				return err
 			}
 			pvcName := ordinalPVCName(v1alpha1.PDMemberType, controller.PDMemberName(tc.Name), ordinal)
-			pvc, err := pmm.deps.PVCLister.PersistentVolumeClaims(tc.Namespace).Get(pvcName)
+			pvc, err := m.deps.PVCLister.PersistentVolumeClaims(tc.Namespace).Get(pvcName)
 			if err != nil {
 				return fmt.Errorf("collectUnjoinedMembers: failed to get pvc %s of cluster %s/%s, error %v", pvcName, tc.GetNamespace(), tc.GetName(), err)
 			}
@@ -894,13 +894,13 @@ func NewFakePDMemberManager() *FakePDMemberManager {
 	return &FakePDMemberManager{}
 }
 
-func (fpmm *FakePDMemberManager) SetSyncError(err error) {
-	fpmm.err = err
+func (m *FakePDMemberManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (fpmm *FakePDMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
-	if fpmm.err != nil {
-		return fpmm.err
+func (m *FakePDMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	if len(tc.Status.PD.Members) != 0 {
 		// simulate status update

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -50,26 +50,26 @@ func NewPumpMemberManager(deps *controller.Dependencies) manager.Manager {
 	}
 }
 
-func (pmm *pumpMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+func (m *pumpMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Pump == nil {
 		return nil
 	}
-	if err := pmm.syncHeadlessService(tc); err != nil {
+	if err := m.syncHeadlessService(tc); err != nil {
 		return err
 	}
-	return pmm.syncPumpStatefulSetForTidbCluster(tc)
+	return m.syncPumpStatefulSetForTidbCluster(tc)
 }
 
 //syncPumpStatefulSetForTidbCluster sync statefulset status of pump to tidbcluster
-func (pmm *pumpMemberManager) syncPumpStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
-	oldPumpSetTemp, err := pmm.deps.StatefulSetLister.StatefulSets(tc.Namespace).Get(controller.PumpMemberName(tc.Name))
+func (m *pumpMemberManager) syncPumpStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
+	oldPumpSetTemp, err := m.deps.StatefulSetLister.StatefulSets(tc.Namespace).Get(controller.PumpMemberName(tc.Name))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncPumpStatefulSetForTidbCluster: failed to get sts %s for cluster %s/%s, error: %s", controller.PumpMemberName(tc.Name), tc.GetNamespace(), tc.GetName(), err)
 	}
 	notFound := errors.IsNotFound(err)
 	oldPumpSet := oldPumpSetTemp.DeepCopy()
 
-	if err := pmm.syncTiDBClusterStatus(tc, oldPumpSet); err != nil {
+	if err := m.syncTiDBClusterStatus(tc, oldPumpSet); err != nil {
 		klog.Errorf("failed to sync TidbCluster: [%s/%s]'s status, error: %v", tc.Namespace, tc.Name, err)
 		return err
 	}
@@ -79,7 +79,7 @@ func (pmm *pumpMemberManager) syncPumpStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		return nil
 	}
 
-	cm, err := pmm.syncConfigMap(tc, oldPumpSet)
+	cm, err := m.syncConfigMap(tc, oldPumpSet)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (pmm *pumpMemberManager) syncPumpStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		if err != nil {
 			return err
 		}
-		return pmm.deps.StatefulSetControl.CreateStatefulSet(tc, newPumpSet)
+		return m.deps.StatefulSetControl.CreateStatefulSet(tc, newPumpSet)
 	}
 
 	// Wait for PD & TiKV upgrading done
@@ -101,10 +101,10 @@ func (pmm *pumpMemberManager) syncPumpStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		return nil
 	}
 
-	return updateStatefulSet(pmm.deps.StatefulSetControl, tc, newPumpSet, oldPumpSet)
+	return updateStatefulSet(m.deps.StatefulSetControl, tc, newPumpSet, oldPumpSet)
 }
 
-func (pmm *pumpMemberManager) syncTiDBClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (m *pumpMemberManager) syncTiDBClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	if set == nil {
 		// skip if not created yet
 		return nil
@@ -112,7 +112,7 @@ func (pmm *pumpMemberManager) syncTiDBClusterStatus(tc *v1alpha1.TidbCluster, se
 
 	tc.Status.Pump.StatefulSet = &set.Status
 
-	upgrading, err := pmm.pumpStatefulSetIsUpgrading(set, tc)
+	upgrading, err := m.pumpStatefulSetIsUpgrading(set, tc)
 	if err != nil {
 		return err
 	}
@@ -129,20 +129,20 @@ func (pmm *pumpMemberManager) syncTiDBClusterStatus(tc *v1alpha1.TidbCluster, se
 	return nil
 }
 
-func (pmm *pumpMemberManager) syncHeadlessService(tc *v1alpha1.TidbCluster) error {
+func (m *pumpMemberManager) syncHeadlessService(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tikv cluster %s/%s is paused, skip syncing for pump headless service", tc.GetNamespace(), tc.GetName())
 		return nil
 	}
 
 	newSvc := getNewPumpHeadlessService(tc)
-	oldSvc, err := pmm.deps.ServiceLister.Services(newSvc.Namespace).Get(newSvc.Name)
+	oldSvc, err := m.deps.ServiceLister.Services(newSvc.Namespace).Get(newSvc.Name)
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return pmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncHeadlessService: failed to get svc %s/%s for cluster %s/%s, error %s", newSvc.Namespace, newSvc.Name, tc.GetNamespace(), tc.GetName(), err)
@@ -166,13 +166,13 @@ func (pmm *pumpMemberManager) syncHeadlessService(tc *v1alpha1.TidbCluster) erro
 			svc.OwnerReferences = newSvc.OwnerReferences
 			svc.Labels = newSvc.Labels
 		}
-		_, err = pmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 	return nil
 }
 
-func (pmm *pumpMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *appsv1.StatefulSet) (*corev1.ConfigMap, error) {
+func (m *pumpMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *appsv1.StatefulSet) (*corev1.ConfigMap, error) {
 
 	basePumpSpec, createPump := tc.BasePumpSpec()
 	if !createPump {
@@ -191,11 +191,11 @@ func (pmm *pumpMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *appsv
 		})
 	}
 
-	err = updateConfigMapIfNeed(pmm.deps.ConfigMapLister, basePumpSpec.ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, basePumpSpec.ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}
-	return pmm.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
 }
 
 func getNewPumpHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
@@ -465,7 +465,7 @@ func getPumpLogLevel(tc *v1alpha1.TidbCluster) string {
 	return logLevel
 }
 
-func (pmm *pumpMemberManager) pumpStatefulSetIsUpgrading(set *apps.StatefulSet, tc *v1alpha1.TidbCluster) (bool, error) {
+func (m *pumpMemberManager) pumpStatefulSetIsUpgrading(set *apps.StatefulSet, tc *v1alpha1.TidbCluster) (bool, error) {
 	if statefulSetIsUpgrading(set) {
 		return true, nil
 	}
@@ -476,7 +476,7 @@ func (pmm *pumpMemberManager) pumpStatefulSetIsUpgrading(set *apps.StatefulSet, 
 	if err != nil {
 		return false, err
 	}
-	pumpPods, err := pmm.deps.PodLister.Pods(tc.GetNamespace()).List(selector)
+	pumpPods, err := m.deps.PodLister.Pods(tc.GetNamespace()).List(selector)
 	if err != nil {
 		return false, fmt.Errorf("pumpStatefulSetIsUpgrading: failed to list pods for cluster %s/%s, selector %s, error: %s", tc.GetNamespace(), tc.GetName(), selector, err)
 	}

--- a/pkg/manager/member/pvc_cleaner.go
+++ b/pkg/manager/member/pvc_cleaner.go
@@ -59,15 +59,15 @@ func NewRealPVCCleaner(deps *controller.Dependencies) PVCCleanerInterface {
 	}
 }
 
-func (rpc *realPVCCleaner) Clean(meta metav1.Object) (map[string]string, error) {
-	if skipReason, err := rpc.cleanScheduleLock(meta); err != nil {
+func (c *realPVCCleaner) Clean(meta metav1.Object) (map[string]string, error) {
+	if skipReason, err := c.cleanScheduleLock(meta); err != nil {
 		return skipReason, err
 	}
-	return rpc.reclaimPV(meta)
+	return c.reclaimPV(meta)
 }
 
 // reclaimPV reclaims PV used by tidb cluster if necessary.
-func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, error) {
+func (c *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, error) {
 	var clusterType string
 	switch meta := meta.(type) {
 	case *v1alpha1.TidbCluster:
@@ -86,7 +86,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 
 	skipReason := map[string]string{}
 
-	pvcs, err := rpc.listAllPVCs(meta)
+	pvcs, err := c.listAllPVCs(meta)
 	if err != nil {
 		return skipReason, err
 	}
@@ -126,7 +126,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 			continue
 		}
 
-		_, err := rpc.deps.PodLister.Pods(ns).Get(podName)
+		_, err := c.deps.PodLister.Pods(ns).Get(podName)
 		if err == nil {
 			// PVC is still referenced by this pod, can't reclaim PV
 			skipReason[pvcName] = skipReasonPVCCleanerPVCeferencedByPod
@@ -137,7 +137,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 		}
 
 		// if pod not found in cache, re-check from apiserver directly to make sure the pod really not exist
-		_, err = rpc.deps.KubeClientset.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
+		_, err = c.deps.KubeClientset.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 		if err == nil {
 			// PVC is still referenced by this pod, can't reclaim PV
 			skipReason[pvcName] = skipReasonPVCCleanerPVCeferencedByPod
@@ -149,7 +149,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 
 		// Without pod reference this defer delete PVC, start to reclaim PV
 		pvName := pvc.Spec.VolumeName
-		pv, err := rpc.deps.PVLister.Get(pvName)
+		pv, err := c.deps.PVLister.Get(pvName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				skipReason[pvcName] = skipReasonPVCCleanerNotFoundPV
@@ -159,14 +159,14 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 		}
 
 		if pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
-			err := rpc.deps.PVControl.PatchPVReclaimPolicy(runtimeMeta, pv, corev1.PersistentVolumeReclaimDelete)
+			err := c.deps.PVControl.PatchPVReclaimPolicy(runtimeMeta, pv, corev1.PersistentVolumeReclaimDelete)
 			if err != nil {
 				return skipReason, fmt.Errorf("%s %s/%s patch pv %s to %s failed, err: %v", clusterType, ns, metaName, pvName, corev1.PersistentVolumeReclaimDelete, err)
 			}
 			klog.Infof("%s %s/%s patch pv %s to policy %s success", clusterType, ns, metaName, pvName, corev1.PersistentVolumeReclaimDelete)
 		}
 
-		apiPVC, err := rpc.deps.KubeClientset.CoreV1().PersistentVolumeClaims(ns).Get(pvcName, metav1.GetOptions{})
+		apiPVC, err := c.deps.KubeClientset.CoreV1().PersistentVolumeClaims(ns).Get(pvcName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				skipReason[pvcName] = skipReasonPVCCleanerPVCNotFound
@@ -180,7 +180,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 			continue
 		}
 
-		if err := rpc.deps.PVCControl.DeletePVC(runtimeMeta, pvc); err != nil {
+		if err := c.deps.PVCControl.DeletePVC(runtimeMeta, pvc); err != nil {
 			return skipReason, fmt.Errorf("%s %s/%s delete pvc %s failed, err: %v", clusterType, ns, metaName, pvcName, err)
 		}
 		klog.Infof("%s %s/%s reclaim pv %s success, pvc %s", clusterType, ns, metaName, pvName, pvcName)
@@ -189,7 +189,7 @@ func (rpc *realPVCCleaner) reclaimPV(meta metav1.Object) (map[string]string, err
 }
 
 // cleanScheduleLock cleans AnnPVCPodScheduling label if necessary.
-func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]string, error) {
+func (c *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]string, error) {
 	ns := meta.GetNamespace()
 	metaName := meta.GetName()
 	skipReason := map[string]string{}
@@ -201,7 +201,7 @@ func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]str
 	case *v1alpha1.DMCluster:
 		clusterType = "dmcluster"
 	}
-	pvcs, err := rpc.listAllPVCs(meta)
+	pvcs, err := c.listAllPVCs(meta)
 	if err != nil {
 		return skipReason, err
 	}
@@ -224,7 +224,7 @@ func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]str
 			}
 			// The defer deleting PVC has pod scheduling annotation, so we need to delete the pod scheduling annotation
 			delete(pvc.Annotations, label.AnnPVCPodScheduling)
-			if _, err := rpc.deps.PVCControl.UpdatePVC(runtimeMeta, pvc); err != nil {
+			if _, err := c.deps.PVCControl.UpdatePVC(runtimeMeta, pvc); err != nil {
 				return skipReason, fmt.Errorf("%s %s/%s remove pvc %s pod scheduling annotation faild, err: %v", clusterType, ns, metaName, pvcName, err)
 			}
 			continue
@@ -237,7 +237,7 @@ func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]str
 			continue
 		}
 
-		pod, err := rpc.deps.PodLister.Pods(ns).Get(podName)
+		pod, err := c.deps.PodLister.Pods(ns).Get(podName)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return skipReason, fmt.Errorf("%s %s/%s get pvc %s pod %s failed, err: %v", clusterType, ns, metaName, pvcName, podName, err)
@@ -261,7 +261,7 @@ func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]str
 		}
 
 		delete(pvc.Annotations, label.AnnPVCPodScheduling)
-		if _, err := rpc.deps.PVCControl.UpdatePVC(runtimeMeta, pvc); err != nil {
+		if _, err := c.deps.PVCControl.UpdatePVC(runtimeMeta, pvc); err != nil {
 			return skipReason, fmt.Errorf("%s %s/%s remove pvc %s pod scheduling annotation faild, err: %v", clusterType, ns, metaName, pvcName, err)
 		}
 		klog.Infof("%s %s/%s, clean pvc %s pod scheduling annotation successfully", clusterType, ns, metaName, pvcName)
@@ -271,7 +271,7 @@ func (rpc *realPVCCleaner) cleanScheduleLock(meta metav1.Object) (map[string]str
 }
 
 // listAllPVCs lists all PVCs used by the given tidb cluster.
-func (rpc *realPVCCleaner) listAllPVCs(meta metav1.Object) ([]*corev1.PersistentVolumeClaim, error) {
+func (c *realPVCCleaner) listAllPVCs(meta metav1.Object) ([]*corev1.PersistentVolumeClaim, error) {
 	ns := meta.GetNamespace()
 	metaName := meta.GetName()
 
@@ -291,7 +291,7 @@ func (rpc *realPVCCleaner) listAllPVCs(meta metav1.Object) ([]*corev1.Persistent
 		return nil, fmt.Errorf("cluster %s/%s assemble label selector failed, err: %v", ns, metaName, err)
 	}
 
-	pvcs, err := rpc.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
+	pvcs, err := c.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
 	if err != nil {
 		return nil, fmt.Errorf("cluster %s/%s list pvc failed, selector: %s, err: %v", ns, metaName, selector, err)
 	}
@@ -309,12 +309,12 @@ func NewFakePVCCleaner() *FakePVCCleaner {
 	return &FakePVCCleaner{}
 }
 
-func (fpc *FakePVCCleaner) SetPVCCleanerError(err error) {
-	fpc.err = err
+func (c *FakePVCCleaner) SetPVCCleanerError(err error) {
+	c.err = err
 }
 
-func (fpc *FakePVCCleaner) Clean(_ metav1.Object) (map[string]string, error) {
-	return nil, fpc.err
+func (c *FakePVCCleaner) Clean(_ metav1.Object) (map[string]string, error) {
+	return nil, c.err
 }
 
 var _ PVCCleanerInterface = &FakePVCCleaner{}

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -56,7 +56,7 @@ func NewTiCDCMemberManager(deps *controller.Dependencies) manager.Manager {
 }
 
 // Sync fulfills the manager.Manager interface
-func (tcmm *ticdcMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+func (m *ticdcMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
@@ -72,18 +72,18 @@ func (tcmm *ticdcMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	}
 
 	// Sync CDC Headless Service
-	if err := tcmm.syncCDCHeadlessService(tc); err != nil {
+	if err := m.syncCDCHeadlessService(tc); err != nil {
 		return err
 	}
 
-	return tcmm.syncStatefulSet(tc)
+	return m.syncStatefulSet(tc)
 }
 
-func (tcmm *ticdcMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
+func (m *ticdcMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	oldStsTmp, err := tcmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiCDCMemberName(tcName))
+	oldStsTmp, err := m.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiCDCMemberName(tcName))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncStatefulSet: failed to get sts %s for cluster %s/%s, error: %s", controller.TiCDCMemberName(tcName), ns, tcName, err)
 	}
@@ -92,7 +92,7 @@ func (tcmm *ticdcMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error 
 	oldSts := oldStsTmp.DeepCopy()
 
 	// failed to sync ticdc status will not affect subsequent logic, just print the errors.
-	if err := tcmm.syncTiCDCStatus(tc, oldSts); err != nil {
+	if err := m.syncTiCDCStatus(tc, oldSts); err != nil {
 		klog.Errorf("failed to sync TidbCluster: [%s/%s]'s ticdc status, error: %v",
 			ns, tcName, err)
 	}
@@ -107,7 +107,7 @@ func (tcmm *ticdcMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error 
 		if err != nil {
 			return err
 		}
-		err = tcmm.deps.StatefulSetControl.CreateStatefulSet(tc, newSts)
+		err = m.deps.StatefulSetControl.CreateStatefulSet(tc, newSts)
 		if err != nil {
 			return err
 		}
@@ -119,17 +119,17 @@ func (tcmm *ticdcMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error 
 		return nil
 	}
 
-	return updateStatefulSet(tcmm.deps.StatefulSetControl, tc, newSts, oldSts)
+	return updateStatefulSet(m.deps.StatefulSetControl, tc, newSts, oldSts)
 }
 
-func (tcmm *ticdcMemberManager) syncTiCDCStatus(tc *v1alpha1.TidbCluster, sts *apps.StatefulSet) error {
+func (m *ticdcMemberManager) syncTiCDCStatus(tc *v1alpha1.TidbCluster, sts *apps.StatefulSet) error {
 	if sts == nil {
 		// skip if not created yet
 		return nil
 	}
 
 	tc.Status.TiCDC.StatefulSet = &sts.Status
-	upgrading, err := tcmm.statefulSetIsUpgradingFn(tcmm.deps.PodLister, tcmm.deps.PDControl, sts, tc)
+	upgrading, err := m.statefulSetIsUpgradingFn(m.deps.PodLister, m.deps.PDControl, sts, tc)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (tcmm *ticdcMemberManager) syncTiCDCStatus(tc *v1alpha1.TidbCluster, sts *a
 	ticdcCaptures := map[string]v1alpha1.TiCDCCapture{}
 	for id := range helper.GetPodOrdinals(tc.Status.TiCDC.StatefulSet.Replicas, sts) {
 		podName := fmt.Sprintf("%s-%d", controller.TiCDCMemberName(tc.GetName()), id)
-		capture, err := tcmm.deps.CDCControl.GetStatus(tc, int32(id))
+		capture, err := m.deps.CDCControl.GetStatus(tc, int32(id))
 		if err != nil {
 			return err
 		}
@@ -157,18 +157,18 @@ func (tcmm *ticdcMemberManager) syncTiCDCStatus(tc *v1alpha1.TidbCluster, sts *a
 	return nil
 }
 
-func (tcmm *ticdcMemberManager) syncCDCHeadlessService(tc *v1alpha1.TidbCluster) error {
+func (m *ticdcMemberManager) syncCDCHeadlessService(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
 	newSvc := getNewCDCHeadlessService(tc)
-	oldSvcTmp, err := tcmm.deps.ServiceLister.Services(ns).Get(controller.TiCDCPeerMemberName(tcName))
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(controller.TiCDCPeerMemberName(tcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return tcmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncCDCHeadlessService: failed to get svc %s for cluster %s/%s, error: %s", controller.TiCDCPeerMemberName(tcName), ns, tcName, err)
@@ -187,7 +187,7 @@ func (tcmm *ticdcMemberManager) syncCDCHeadlessService(tc *v1alpha1.TidbCluster)
 		if err != nil {
 			return err
 		}
-		_, err = tcmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
@@ -403,13 +403,13 @@ func NewFakeTiCDCMemberManager() *FakeTiCDCMemberManager {
 	return &FakeTiCDCMemberManager{}
 }
 
-func (ftmm *FakeTiCDCMemberManager) SetSyncError(err error) {
-	ftmm.err = err
+func (m *FakeTiCDCMemberManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (ftmm *FakeTiCDCMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
-	if ftmm.err != nil {
-		return ftmm.err
+func (m *FakeTiCDCMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	return nil
 }

--- a/pkg/manager/member/tidb_discovery_manager.go
+++ b/pkg/manager/member/tidb_discovery_manager.go
@@ -244,13 +244,13 @@ func NewFakeDiscoveryManger() *FakeDiscoveryManager {
 	return &FakeDiscoveryManager{}
 }
 
-func (fdm *FakeDiscoveryManager) SetReconcileError(err error) {
-	fdm.err = err
+func (m *FakeDiscoveryManager) SetReconcileError(err error) {
+	m.err = err
 }
 
-func (fdm *FakeDiscoveryManager) Reconcile(_ *v1alpha1.TidbCluster) error {
-	if fdm.err != nil {
-		return fdm.err
+func (m *FakeDiscoveryManager) Reconcile(_ *v1alpha1.TidbCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	return nil
 }

--- a/pkg/manager/member/tidb_failover.go
+++ b/pkg/manager/member/tidb_failover.go
@@ -36,7 +36,7 @@ func NewTiDBFailover(deps *controller.Dependencies) Failover {
 	}
 }
 
-func (tf *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
+func (f *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	if tc.Status.TiDB.FailureMembers == nil {
 		tc.Status.TiDB.FailureMembers = map[string]v1alpha1.TiDBFailureMember{}
 	}
@@ -57,13 +57,13 @@ func (tf *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	maxFailoverCount := *tc.Spec.TiDB.MaxFailoverCount
 	for _, tidbMember := range tc.Status.TiDB.Members {
 		_, exist := tc.Status.TiDB.FailureMembers[tidbMember.Name]
-		deadline := tidbMember.LastTransitionTime.Add(tf.deps.CLIConfig.TiDBFailoverPeriod)
+		deadline := tidbMember.LastTransitionTime.Add(f.deps.CLIConfig.TiDBFailoverPeriod)
 		if !tidbMember.Health && time.Now().After(deadline) && !exist {
 			if len(tc.Status.TiDB.FailureMembers) >= int(maxFailoverCount) {
 				klog.Warningf("the failover count reachs the limit (%d), no more failover pods will be created", maxFailoverCount)
 				break
 			}
-			pod, err := tf.deps.PodLister.Pods(tc.Namespace).Get(tidbMember.Name)
+			pod, err := f.deps.PodLister.Pods(tc.Namespace).Get(tidbMember.Name)
 			if err != nil {
 				return fmt.Errorf("tidbFailover.Failover: failed to get pods %s for cluster %s/%s, error: %s", tidbMember.Name, tc.GetNamespace(), tc.GetName(), err)
 			}
@@ -79,7 +79,7 @@ func (tf *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
 				CreatedAt: metav1.Now(),
 			}
 			msg := fmt.Sprintf("tidb[%s] is unhealthy", tidbMember.Name)
-			tf.deps.Recorder.Event(tc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "tidb", tidbMember.Name, msg))
+			f.deps.Recorder.Event(tc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "tidb", tidbMember.Name, msg))
 			break
 		}
 	}
@@ -87,11 +87,11 @@ func (tf *tidbFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (tf *tidbFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (f *tidbFailover) Recover(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiDB.FailureMembers = nil
 }
 
-func (tf *tidbFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+func (f *tidbFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 }
 
 type fakeTiDBFailover struct {

--- a/pkg/manager/member/tidb_init_manager.go
+++ b/pkg/manager/member/tidb_init_manager.go
@@ -62,22 +62,22 @@ func NewTiDBInitManager(deps *controller.Dependencies) InitManager {
 	return &tidbInitManager{deps: deps}
 }
 
-func (tm *tidbInitManager) Sync(ti *v1alpha1.TidbInitializer) error {
-	err := tm.syncTiDBInitConfigMap(ti)
+func (m *tidbInitManager) Sync(ti *v1alpha1.TidbInitializer) error {
+	err := m.syncTiDBInitConfigMap(ti)
 	if err != nil {
 		return err
 	}
-	err = tm.syncTiDBInitJob(ti)
+	err = m.syncTiDBInitJob(ti)
 	if err != nil {
 		return err
 	}
-	return tm.updateStatus(ti.DeepCopy())
+	return m.updateStatus(ti.DeepCopy())
 }
 
-func (tm *tidbInitManager) updateStatus(ti *v1alpha1.TidbInitializer) error {
+func (m *tidbInitManager) updateStatus(ti *v1alpha1.TidbInitializer) error {
 	name := controller.TiDBInitializerMemberName(ti.Spec.Clusters.Name)
 	ns := ti.Namespace
-	job, err := tm.deps.JobLister.Jobs(ns).Get(name)
+	job, err := m.deps.JobLister.Jobs(ns).Get(name)
 	if err != nil {
 		return fmt.Errorf("updateStatus: failed to get job %s for TidbInitializer %s/%s, error: %s", name, ns, ti.Name, err)
 	}
@@ -107,7 +107,7 @@ func (tm *tidbInitManager) updateStatus(ti *v1alpha1.TidbInitializer) error {
 	}
 	if update {
 		status := ti.Status.DeepCopy()
-		return controller.GuaranteedUpdate(tm.deps.GenericClient, ti, func() error {
+		return controller.GuaranteedUpdate(m.deps.GenericClient, ti, func() error {
 			ti.Status = *status
 			return nil
 		})
@@ -115,13 +115,13 @@ func (tm *tidbInitManager) updateStatus(ti *v1alpha1.TidbInitializer) error {
 	return nil
 }
 
-func (tm *tidbInitManager) syncTiDBInitConfigMap(ti *v1alpha1.TidbInitializer) error {
+func (m *tidbInitManager) syncTiDBInitConfigMap(ti *v1alpha1.TidbInitializer) error {
 	name := controller.TiDBInitializerMemberName(ti.Spec.Clusters.Name)
 	ns := ti.Namespace
 	cm := &corev1.ConfigMap{}
 	tcName := ti.Spec.Clusters.Name
 
-	exist, err := tm.deps.TypedControl.Exist(client.ObjectKey{
+	exist, err := m.deps.TypedControl.Exist(client.ObjectKey{
 		Namespace: ns,
 		Name:      name,
 	}, cm)
@@ -132,7 +132,7 @@ func (tm *tidbInitManager) syncTiDBInitConfigMap(ti *v1alpha1.TidbInitializer) e
 		return nil
 	}
 
-	tc, err := tm.deps.TiDBClusterLister.TidbClusters(ns).Get(tcName)
+	tc, err := m.deps.TiDBClusterLister.TidbClusters(ns).Get(tcName)
 	if err != nil {
 		return fmt.Errorf("syncTiDBInitConfigMap: failed to get tidbcluster %s for TidbInitializer %s/%s, error: %s", tcName, ns, ti.Name, err)
 	}
@@ -142,7 +142,7 @@ func (tm *tidbInitManager) syncTiDBInitConfigMap(ti *v1alpha1.TidbInitializer) e
 		return err
 	}
 
-	err = tm.deps.TypedControl.Create(ti, newCm)
+	err = m.deps.TypedControl.Create(ti, newCm)
 	if errors.IsAlreadyExists(err) {
 		klog.Infof("Configmap %s/%s already exists", newCm.Namespace, newCm.Name)
 		return nil
@@ -150,12 +150,12 @@ func (tm *tidbInitManager) syncTiDBInitConfigMap(ti *v1alpha1.TidbInitializer) e
 	return err
 }
 
-func (tm *tidbInitManager) syncTiDBInitJob(ti *v1alpha1.TidbInitializer) error {
+func (m *tidbInitManager) syncTiDBInitJob(ti *v1alpha1.TidbInitializer) error {
 	ns := ti.GetNamespace()
 	name := ti.GetName()
 	jobName := controller.TiDBInitializerMemberName(ti.Spec.Clusters.Name)
 
-	_, err := tm.deps.JobLister.Jobs(ns).Get(jobName)
+	_, err := m.deps.JobLister.Jobs(ns).Get(jobName)
 	if err == nil {
 		return nil
 	}
@@ -164,12 +164,12 @@ func (tm *tidbInitManager) syncTiDBInitJob(ti *v1alpha1.TidbInitializer) error {
 		return fmt.Errorf("TiDBInitializer %s/%s get job %s failed, err: %v", ns, ti.Name, name, err)
 	}
 
-	job, err := tm.makeTiDBInitJob(ti)
+	job, err := m.makeTiDBInitJob(ti)
 	if err != nil {
 		return err
 	}
 
-	err = tm.deps.TypedControl.Create(ti, job)
+	err = m.deps.TypedControl.Create(ti, job)
 	if errors.IsAlreadyExists(err) {
 		klog.Infof("Job %s/%s already exists", job.Namespace, job.Name)
 		return nil
@@ -177,12 +177,12 @@ func (tm *tidbInitManager) syncTiDBInitJob(ti *v1alpha1.TidbInitializer) error {
 	return err
 }
 
-func (tm *tidbInitManager) makeTiDBInitJob(ti *v1alpha1.TidbInitializer) (*batchv1.Job, error) {
+func (m *tidbInitManager) makeTiDBInitJob(ti *v1alpha1.TidbInitializer) (*batchv1.Job, error) {
 	jobName := controller.TiDBInitializerMemberName(ti.Spec.Clusters.Name)
 	ns := ti.Namespace
 	tcName := ti.Spec.Clusters.Name
 
-	tc, err := tm.deps.TiDBClusterLister.TidbClusters(ns).Get(tcName)
+	tc, err := m.deps.TiDBClusterLister.TidbClusters(ns).Get(tcName)
 	if err != nil {
 		return nil, fmt.Errorf("makeTiDBInitJob: failed to get tidbcluster %s for TidbInitializer %s/%s, error: %s", tcName, ns, ti.Name, err)
 	}

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -69,7 +69,7 @@ func NewTiDBMemberManager(deps *controller.Dependencies, tidbUpgrader Upgrader, 
 	}
 }
 
-func (tmm *tidbMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+func (m *tidbMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	// If tikv is not specified return
 	if tc.Spec.TiDB == nil {
 		return nil
@@ -87,29 +87,29 @@ func (tmm *tidbMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		}
 	}
 	// Sync TiDB Headless Service
-	if err := tmm.syncTiDBHeadlessServiceForTidbCluster(tc); err != nil {
+	if err := m.syncTiDBHeadlessServiceForTidbCluster(tc); err != nil {
 		return err
 	}
 
 	// Sync TiDB Service before syncing TiDB StatefulSet
-	if err := tmm.syncTiDBService(tc); err != nil {
+	if err := m.syncTiDBService(tc); err != nil {
 		return err
 	}
 
 	if tc.Spec.TiDB.IsTLSClientEnabled() {
-		if err := tmm.checkTLSClientCert(tc); err != nil {
+		if err := m.checkTLSClientCert(tc); err != nil {
 			return err
 		}
 	}
 
 	// Sync TiDB StatefulSet
-	return tmm.syncTiDBStatefulSetForTidbCluster(tc)
+	return m.syncTiDBStatefulSetForTidbCluster(tc)
 }
 
-func (tmm *tidbMemberManager) checkTLSClientCert(tc *v1alpha1.TidbCluster) error {
+func (m *tidbMemberManager) checkTLSClientCert(tc *v1alpha1.TidbCluster) error {
 	ns := tc.Namespace
 	secretName := tlsClientSecretName(tc)
-	secret, err := tmm.deps.SecretLister.Secrets(ns).Get(secretName)
+	secret, err := m.deps.SecretLister.Secrets(ns).Get(secretName)
 	if err != nil {
 		return fmt.Errorf("unable to load certificates from secret %s/%s: %v", ns, secretName, err)
 	}
@@ -127,7 +127,7 @@ func (tmm *tidbMemberManager) checkTLSClientCert(tc *v1alpha1.TidbCluster) error
 	return nil
 }
 
-func (tmm *tidbMemberManager) syncTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *tidbMemberManager) syncTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tidb cluster %s/%s is paused, skip syncing for tidb headless service", tc.GetNamespace(), tc.GetName())
 		return nil
@@ -137,13 +137,13 @@ func (tmm *tidbMemberManager) syncTiDBHeadlessServiceForTidbCluster(tc *v1alpha1
 	tcName := tc.GetName()
 
 	newSvc := getNewTiDBHeadlessServiceForTidbCluster(tc)
-	oldSvcTmp, err := tmm.deps.ServiceLister.Services(ns).Get(controller.TiDBPeerMemberName(tcName))
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(controller.TiDBPeerMemberName(tcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return tmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncTiDBHeadlessServiceForTidbCluster: failed to get svc %s for cluster %s/%s, error: %s", controller.TiDBPeerMemberName(tcName), ns, tcName, err)
@@ -162,25 +162,25 @@ func (tmm *tidbMemberManager) syncTiDBHeadlessServiceForTidbCluster(tc *v1alpha1
 		if err != nil {
 			return err
 		}
-		_, err = tmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
 	return nil
 }
 
-func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	oldTiDBSetTemp, err := tmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))
+	oldTiDBSetTemp, err := m.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncTiDBStatefulSetForTidbCluster: failed to get sts %s for cluster %s/%s, error: %s", controller.TiDBMemberName(tcName), ns, tcName, err)
 	}
 	setNotExist := errors.IsNotFound(err)
 
 	oldTiDBSet := oldTiDBSetTemp.DeepCopy()
-	if err = tmm.syncTidbClusterStatus(tc, oldTiDBSet); err != nil {
+	if err = m.syncTidbClusterStatus(tc, oldTiDBSet); err != nil {
 		return err
 	}
 
@@ -189,7 +189,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		return nil
 	}
 
-	cm, err := tmm.syncTiDBConfigMap(tc, oldTiDBSet)
+	cm, err := m.syncTiDBConfigMap(tc, oldTiDBSet)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		if err != nil {
 			return err
 		}
-		err = tmm.deps.StatefulSetControl.CreateStatefulSet(tc, newTiDBSet)
+		err = m.deps.StatefulSetControl.CreateStatefulSet(tc, newTiDBSet)
 		if err != nil {
 			return err
 		}
@@ -208,26 +208,26 @@ func (tmm *tidbMemberManager) syncTiDBStatefulSetForTidbCluster(tc *v1alpha1.Tid
 		return nil
 	}
 
-	if tmm.deps.CLIConfig.AutoFailover {
-		if tmm.shouldRecover(tc) {
-			tmm.tidbFailover.Recover(tc)
+	if m.deps.CLIConfig.AutoFailover {
+		if m.shouldRecover(tc) {
+			m.tidbFailover.Recover(tc)
 		} else if tc.TiDBAllPodsStarted() && !tc.TiDBAllMembersReady() {
-			if err := tmm.tidbFailover.Failover(tc); err != nil {
+			if err := m.tidbFailover.Failover(tc); err != nil {
 				return err
 			}
 		}
 	}
 
 	if !templateEqual(newTiDBSet, oldTiDBSet) || tc.Status.TiDB.Phase == v1alpha1.UpgradePhase {
-		if err := tmm.tidbUpgrader.Upgrade(tc, oldTiDBSet, newTiDBSet); err != nil {
+		if err := m.tidbUpgrader.Upgrade(tc, oldTiDBSet, newTiDBSet); err != nil {
 			return err
 		}
 	}
 
-	return updateStatefulSet(tmm.deps.StatefulSetControl, tc, newTiDBSet, oldTiDBSet)
+	return updateStatefulSet(m.deps.StatefulSetControl, tc, newTiDBSet, oldTiDBSet)
 }
 
-func (tmm *tidbMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
+func (m *tidbMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	if tc.Status.TiDB.FailureMembers == nil {
 		return false
 	}
@@ -237,7 +237,7 @@ func (tmm *tidbMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	// about them because we're going to delete them.
 	for ordinal := range tc.TiDBStsDesiredOrdinals(true) {
 		name := fmt.Sprintf("%s-%d", controller.TiDBMemberName(tc.GetName()), ordinal)
-		pod, err := tmm.deps.PodLister.Pods(tc.Namespace).Get(name)
+		pod, err := m.deps.PodLister.Pods(tc.Namespace).Get(name)
 		if err != nil {
 			klog.Errorf("pod %s/%s does not exist: %v", tc.Namespace, name, err)
 			return false
@@ -253,7 +253,7 @@ func (tmm *tidbMemberManager) shouldRecover(tc *v1alpha1.TidbCluster) bool {
 	return true
 }
 
-func (tmm *tidbMemberManager) syncTiDBService(tc *v1alpha1.TidbCluster) error {
+func (m *tidbMemberManager) syncTiDBService(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tidb cluster %s/%s is paused, skip syncing for tidb service", tc.GetNamespace(), tc.GetName())
 		return nil
@@ -267,13 +267,13 @@ func (tmm *tidbMemberManager) syncTiDBService(tc *v1alpha1.TidbCluster) error {
 
 	ns := newSvc.Namespace
 
-	oldSvcTmp, err := tmm.deps.ServiceLister.Services(ns).Get(newSvc.Name)
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(newSvc.Name)
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return tmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncTiDBService: failed to get svc %s for cluster %s/%s, error: %s", newSvc.Name, ns, tc.GetName(), err)
@@ -305,7 +305,7 @@ func (tmm *tidbMemberManager) syncTiDBService(tc *v1alpha1.TidbCluster) error {
 			svc.OwnerReferences = newSvc.OwnerReferences
 			svc.Labels = newSvc.Labels
 		}
-		_, err = tmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
@@ -313,7 +313,7 @@ func (tmm *tidbMemberManager) syncTiDBService(tc *v1alpha1.TidbCluster) error {
 }
 
 // syncTiDBConfigMap syncs the configmap of tidb
-func (tmm *tidbMemberManager) syncTiDBConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
+func (m *tidbMemberManager) syncTiDBConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
 
 	// For backward compatibility, only sync tidb configmap when .tidb.config is non-nil
 	if tc.Spec.TiDB.Config == nil {
@@ -333,11 +333,11 @@ func (tmm *tidbMemberManager) syncTiDBConfigMap(tc *v1alpha1.TidbCluster, set *a
 
 	klog.V(3).Info("get tidb in use config map name: ", inUseName)
 
-	err = updateConfigMapIfNeed(tmm.deps.ConfigMapLister, tc.BaseTiDBSpec().ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, tc.BaseTiDBSpec().ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}
-	return tmm.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
 }
 
 func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
@@ -754,7 +754,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	return tidbSet
 }
 
-func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (m *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	if set == nil {
 		// skip if not created yet
 		return nil
@@ -762,7 +762,7 @@ func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, se
 
 	tc.Status.TiDB.StatefulSet = &set.Status
 
-	upgrading, err := tmm.tidbStatefulSetIsUpgradingFn(tmm.deps.PodLister, set, tc)
+	upgrading, err := m.tidbStatefulSetIsUpgradingFn(m.deps.PodLister, set, tc)
 	if err != nil {
 		return err
 	}
@@ -778,7 +778,7 @@ func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, se
 	tidbStatus := map[string]v1alpha1.TiDBMember{}
 	for id := range helper.GetPodOrdinals(tc.Status.TiDB.StatefulSet.Replicas, set) {
 		name := fmt.Sprintf("%s-%d", controller.TiDBMemberName(tc.GetName()), id)
-		health, err := tmm.deps.TiDBControl.GetHealth(tc, int32(id))
+		health, err := m.deps.TiDBControl.GetHealth(tc, int32(id))
 		if err != nil {
 			return err
 		}
@@ -795,7 +795,7 @@ func (tmm *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, se
 				newTidbMember.LastTransitionTime = oldTidbMember.LastTransitionTime
 			}
 		}
-		pod, err := tmm.deps.PodLister.Pods(tc.GetNamespace()).Get(name)
+		pod, err := m.deps.PodLister.Pods(tc.GetNamespace()).Get(name)
 		if err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("syncTidbClusterStatus: failed to get pods %s for cluster %s/%s, error: %s", name, tc.GetNamespace(), tc.GetName(), err)
 		}
@@ -853,13 +853,13 @@ func NewFakeTiDBMemberManager() *FakeTiDBMemberManager {
 	return &FakeTiDBMemberManager{}
 }
 
-func (ftmm *FakeTiDBMemberManager) SetSyncError(err error) {
-	ftmm.err = err
+func (m *FakeTiDBMemberManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (ftmm *FakeTiDBMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
-	if ftmm.err != nil {
-		return ftmm.err
+func (m *FakeTiDBMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	if len(tc.Status.TiDB.Members) != 0 {
 		// simulate status update

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -745,9 +745,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			},
 			ServiceName:         controller.TiDBPeerMemberName(tcName),
 			PodManagementPolicy: apps.ParallelPodManagement,
-			UpdateStrategy: apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: pointer.Int32Ptr(tc.TiDBStsDesiredReplicas())},
-			},
+			UpdateStrategy:      *baseTiDBSpec.StatefulSetUpdateStrategy(),
 		},
 	}
 

--- a/pkg/manager/member/tidb_upgrader.go
+++ b/pkg/manager/member/tidb_upgrader.go
@@ -34,7 +34,7 @@ func NewTiDBUpgrader(deps *controller.Dependencies) Upgrader {
 	}
 }
 
-func (tu *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (u *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 
 	// when scale replica to 0 , all nodes crash and tidb is in upgrade phase, this method will throw error about pod is upgrade.
 	// so  directly return nil when scale replica to 0.
@@ -82,7 +82,7 @@ func (tu *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 	for _i := len(podOrdinals) - 1; _i >= 0; _i-- {
 		i := podOrdinals[_i]
 		podName := tidbPodName(tcName, i)
-		pod, err := tu.deps.PodLister.Pods(ns).Get(podName)
+		pod, err := u.deps.PodLister.Pods(ns).Get(podName)
 		if err != nil {
 			return fmt.Errorf("tidbUpgrader.Upgrade: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
 		}
@@ -97,13 +97,13 @@ func (tu *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 			}
 			continue
 		}
-		return tu.upgradeTiDBPod(tc, i, newSet)
+		return u.upgradeTiDBPod(tc, i, newSet)
 	}
 
 	return nil
 }
 
-func (tu *tidbUpgrader) upgradeTiDBPod(tc *v1alpha1.TidbCluster, ordinal int32, newSet *apps.StatefulSet) error {
+func (u *tidbUpgrader) upgradeTiDBPod(tc *v1alpha1.TidbCluster, ordinal int32, newSet *apps.StatefulSet) error {
 	setUpgradePartition(newSet, ordinal)
 	return nil
 }
@@ -115,7 +115,7 @@ func NewFakeTiDBUpgrader() Upgrader {
 	return &fakeTiDBUpgrader{}
 }
 
-func (ftdu *fakeTiDBUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+func (u *fakeTiDBUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/tidbcluster_status_manager.go
+++ b/pkg/manager/member/tidbcluster_status_manager.go
@@ -41,28 +41,28 @@ func NewTidbClusterStatusManager(deps *controller.Dependencies) *TidbClusterStat
 	}
 }
 
-func (tcsm *TidbClusterStatusManager) Sync(tc *v1alpha1.TidbCluster) error {
-	return tcsm.syncTidbMonitorRefAndKey(tc)
+func (m *TidbClusterStatusManager) Sync(tc *v1alpha1.TidbCluster) error {
+	return m.syncTidbMonitorRefAndKey(tc)
 }
 
-func (tcsm *TidbClusterStatusManager) syncTidbMonitorRefAndKey(tc *v1alpha1.TidbCluster) error {
-	tm, err := tcsm.syncTidbMonitorRef(tc)
+func (m *TidbClusterStatusManager) syncTidbMonitorRefAndKey(tc *v1alpha1.TidbCluster) error {
+	tm, err := m.syncTidbMonitorRef(tc)
 	if err != nil {
 		return err
 	}
-	err = tcsm.syncDashboardMetricStorage(tc, tm)
+	err = m.syncDashboardMetricStorage(tc, tm)
 	if err != nil {
 		return err
 	}
-	return tcsm.syncAutoScalerRef(tc)
+	return m.syncAutoScalerRef(tc)
 }
 
-func (tcsm *TidbClusterStatusManager) syncTidbMonitorRef(tc *v1alpha1.TidbCluster) (*v1alpha1.TidbMonitor, error) {
+func (m *TidbClusterStatusManager) syncTidbMonitorRef(tc *v1alpha1.TidbCluster) (*v1alpha1.TidbMonitor, error) {
 	if tc.Status.Monitor == nil {
 		return nil, nil
 	}
 	tmRef := tc.Status.Monitor
-	tm, err := tcsm.deps.Clientset.PingcapV1alpha1().TidbMonitors(tmRef.Namespace).Get(tmRef.Name, metav1.GetOptions{})
+	tm, err := m.deps.Clientset.PingcapV1alpha1().TidbMonitors(tmRef.Namespace).Get(tmRef.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			tc.Status.Monitor = nil
@@ -90,11 +90,11 @@ func (tcsm *TidbClusterStatusManager) syncTidbMonitorRef(tc *v1alpha1.TidbCluste
 	return tm, nil
 }
 
-func (tcsm *TidbClusterStatusManager) syncDashboardMetricStorage(tc *v1alpha1.TidbCluster, tm *v1alpha1.TidbMonitor) error {
+func (m *TidbClusterStatusManager) syncDashboardMetricStorage(tc *v1alpha1.TidbCluster, tm *v1alpha1.TidbMonitor) error {
 	if tc.Spec.PD == nil {
 		return nil
 	}
-	pdEtcdClient, err := tcsm.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name, tc.IsTLSClusterEnabled())
+	pdEtcdClient, err := m.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name, tc.IsTLSClusterEnabled())
 
 	if err != nil {
 		return err
@@ -126,14 +126,14 @@ func (tcsm *TidbClusterStatusManager) syncDashboardMetricStorage(tc *v1alpha1.Ti
 	return nil
 }
 
-func (tcsm *TidbClusterStatusManager) syncAutoScalerRef(tc *v1alpha1.TidbCluster) error {
+func (m *TidbClusterStatusManager) syncAutoScalerRef(tc *v1alpha1.TidbCluster) error {
 	if tc.Status.AutoScaler == nil {
 		klog.V(4).Infof("tc[%s/%s] autoscaler is empty", tc.Namespace, tc.Name)
 		return nil
 	}
 	tacNamespace := tc.Status.AutoScaler.Namespace
 	tacName := tc.Status.AutoScaler.Name
-	tac, err := tcsm.deps.TiDBClusterAutoScalerLister.TidbClusterAutoScalers(tacNamespace).Get(tacName)
+	tac, err := m.deps.TiDBClusterAutoScalerLister.TidbClusterAutoScalers(tacNamespace).Get(tacName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Infof("tc[%s/%s] failed to find tac[%s/%s]", tc.Namespace, tc.Name, tacNamespace, tacName)

--- a/pkg/manager/member/tiflash_scaler.go
+++ b/pkg/manager/member/tiflash_scaler.go
@@ -36,18 +36,18 @@ func NewTiFlashScaler(deps *controller.Dependencies) Scaler {
 	return &tiflashScaler{generalScaler: generalScaler{deps: deps}}
 }
 
-func (tfs *tiflashScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tiflashScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	scaling, _, _, _ := scaleOne(oldSet, newSet)
 	if scaling > 0 {
-		return tfs.ScaleOut(meta, oldSet, newSet)
+		return s.ScaleOut(meta, oldSet, newSet)
 	} else if scaling < 0 {
-		return tfs.ScaleIn(meta, oldSet, newSet)
+		return s.ScaleIn(meta, oldSet, newSet)
 	}
 	// we only sync auto scaler annotations when we are finishing syncing scaling
-	return tfs.SyncAutoScalerAnn(meta, oldSet)
+	return s.SyncAutoScalerAnn(meta, oldSet)
 }
 
-func (tfs *tiflashScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tiflashScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	tc, ok := meta.(*v1alpha1.TidbCluster)
 	if !ok {
 		return nil
@@ -57,7 +57,7 @@ func (tfs *tiflashScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet,
 	resetReplicas(newSet, oldSet)
 
 	klog.Infof("scaling out tiflash statefulset %s/%s, ordinal: %d (replicas: %d, delete slots: %v)", oldSet.Namespace, oldSet.Name, ordinal, replicas, deleteSlots.List())
-	_, err := tfs.deleteDeferDeletingPVC(tc, oldSet.GetName(), v1alpha1.TiFlashMemberType, ordinal)
+	_, err := s.deleteDeferDeletingPVC(tc, oldSet.GetName(), v1alpha1.TiFlashMemberType, ordinal)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (tfs *tiflashScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet,
 	return nil
 }
 
-func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	tc, ok := meta.(*v1alpha1.TidbCluster)
 	if !ok {
 		return nil
@@ -81,7 +81,7 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 	klog.Infof("scaling in tiflash statefulset %s/%s, ordinal: %d (replicas: %d, delete slots: %v)", oldSet.Namespace, oldSet.Name, ordinal, replicas, deleteSlots.List())
 	// We need delete store from cluster before decreasing the statefulset replicas
 	podName := ordinalPodName(v1alpha1.TiFlashMemberType, tcName, ordinal)
-	pod, err := tfs.deps.PodLister.Pods(ns).Get(podName)
+	pod, err := s.deps.PodLister.Pods(ns).Get(podName)
 	if err != nil {
 		return fmt.Errorf("tiflashScaler.ScaleIn: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
 	}
@@ -100,7 +100,7 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 				return err
 			}
 			if state != v1alpha1.TiKVStateOffline {
-				if err := controller.GetPDClient(tfs.deps.PDControl, tc).DeleteStore(id); err != nil {
+				if err := controller.GetPDClient(s.deps.PDControl, tc).DeleteStore(id); err != nil {
 					klog.Errorf("tiflash scale in: failed to delete store %d, %v", id, err)
 					return err
 				}
@@ -119,7 +119,7 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 			// TODO: double check if store is really not in Up/Offline/Down state
 			klog.Infof("TiFlash %s/%s store %d becomes tombstone", ns, podName, id)
 
-			err = tfs.updateDeferDeletingPVC(tc, v1alpha1.TiFlashMemberType, ordinal)
+			err = s.updateDeferDeletingPVC(tc, v1alpha1.TiFlashMemberType, ordinal)
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 	// 2. This can happen when TiFlash pod has not been successfully registered in the cluster, such as always pending.
 	//    In this situation we should delete this TiFlash pod immediately to avoid blocking the subsequent operations.
 	if !podutil.IsPodReady(pod) {
-		safeTimeDeadline := pod.CreationTimestamp.Add(5 * tfs.deps.CLIConfig.ResyncDuration)
+		safeTimeDeadline := pod.CreationTimestamp.Add(5 * s.deps.CLIConfig.ResyncDuration)
 		if time.Now().Before(safeTimeDeadline) {
 			// Wait for 5 resync periods to ensure that the following situation does not occur:
 			//
@@ -148,8 +148,8 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 			return fmt.Errorf("TiFlash %s/%s is not ready, wait for some resync periods to synced its status", ns, podName)
 		}
 		klog.Infof("Pod %s/%s not ready for more than %v and no store for it, scale in it",
-			ns, podName, 5*tfs.deps.CLIConfig.ResyncDuration)
-		err = tfs.updateDeferDeletingPVC(tc, v1alpha1.TiFlashMemberType, ordinal)
+			ns, podName, 5*s.deps.CLIConfig.ResyncDuration)
+		err = s.updateDeferDeletingPVC(tc, v1alpha1.TiFlashMemberType, ordinal)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func (tfs *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, 
 }
 
 // SyncAutoScalerAnn reclaims the auto-scaling-out slots if the target pods no longer exist
-func (tfs *tiflashScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
+func (s *tiflashScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }
 

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -51,6 +51,6 @@ func NewFakeTiFlashUpgrader() Upgrader {
 	return &fakeTiFlashUpgrader{}
 }
 
-func (tku *fakeTiFlashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+func (u *fakeTiFlashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/tikv_failover.go
+++ b/pkg/manager/member/tikv_failover.go
@@ -34,7 +34,7 @@ func NewTiKVFailover(deps *controller.Dependencies) Failover {
 	return &tikvFailover{deps: deps}
 }
 
-func (tf *tikvFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
+func (f *tikvFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) bool {
 	ordinals := tc.TiKVStsDesiredOrdinals(true)
 	ordinal, err := util.GetOrdinalFromPodName(podName)
 	if err != nil {
@@ -44,7 +44,7 @@ func (tf *tikvFailover) isPodDesired(tc *v1alpha1.TidbCluster, podName string) b
 	return ordinals.Has(ordinal)
 }
 
-func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
+func (f *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
@@ -53,13 +53,13 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 		if store.LastTransitionTime.IsZero() {
 			continue
 		}
-		if !tf.isPodDesired(tc, podName) {
+		if !f.isPodDesired(tc, podName) {
 			// we should ignore the store record of deleted pod, otherwise the
 			// record of deleted pod may be added back to failure stores
 			// (before it enters into Offline/Tombstone state)
 			continue
 		}
-		deadline := store.LastTransitionTime.Add(tf.deps.CLIConfig.TiKVFailoverPeriod)
+		deadline := store.LastTransitionTime.Add(f.deps.CLIConfig.TiKVFailoverPeriod)
 		exist := false
 		for _, failureStore := range tc.Status.TiKV.FailureStores {
 			if failureStore.PodName == podName {
@@ -83,7 +83,7 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 					CreatedAt: metav1.Now(),
 				}
 				msg := fmt.Sprintf("store[%s] is Down", store.ID)
-				tf.deps.Recorder.Event(tc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "tikv", podName, msg))
+				f.deps.Recorder.Event(tc, corev1.EventTypeWarning, unHealthEventReason, fmt.Sprintf(unHealthEventMsgPattern, "tikv", podName, msg))
 			}
 		}
 	}
@@ -91,9 +91,9 @@ func (tf *tikvFailover) Failover(tc *v1alpha1.TidbCluster) error {
 	return nil
 }
 
-func (tf *tikvFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
+func (f *tikvFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 	for key, failureStore := range tc.Status.TiKV.FailureStores {
-		if !tf.isPodDesired(tc, failureStore.PodName) {
+		if !f.isPodDesired(tc, failureStore.PodName) {
 			// If we delete the pods, e.g. by using advanced statefulset delete
 			// slots feature. We should remove the record of undesired pods,
 			// otherwise an extra replacement pod will be created.
@@ -102,7 +102,7 @@ func (tf *tikvFailover) RemoveUndesiredFailures(tc *v1alpha1.TidbCluster) {
 	}
 }
 
-func (tf *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
+func (f *tikvFailover) Recover(tc *v1alpha1.TidbCluster) {
 	tc.Status.TiKV.FailureStores = nil
 	klog.Infof("TiKV recover: clear FailureStores, %s/%s", tc.GetNamespace(), tc.GetName())
 }

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -512,12 +512,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			},
 			ServiceName:         headlessSvcName,
 			PodManagementPolicy: apps.ParallelPodManagement,
-			UpdateStrategy: apps.StatefulSetUpdateStrategy{
-				Type: apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-					Partition: pointer.Int32Ptr(tc.TiKVStsDesiredReplicas()),
-				},
-			},
+			UpdateStrategy:      *baseTiKVSpec.StatefulSetUpdateStrategy(),
 		},
 	}
 	return tikvset, nil

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -81,7 +81,7 @@ type SvcConfig struct {
 }
 
 // Sync fulfills the manager.Manager interface
-func (tkmm *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+func (m *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	// If tikv is not specified return
 	if tc.Spec.TiKV == nil {
 		return nil
@@ -104,14 +104,14 @@ func (tkmm *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		},
 	}
 	for _, svc := range svcList {
-		if err := tkmm.syncServiceForTidbCluster(tc, svc); err != nil {
+		if err := m.syncServiceForTidbCluster(tc, svc); err != nil {
 			return err
 		}
 	}
-	return tkmm.syncStatefulSetForTidbCluster(tc)
+	return m.syncStatefulSetForTidbCluster(tc)
 }
 
-func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) error {
+func (m *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) error {
 	if tc.Spec.Paused {
 		klog.V(4).Infof("tikv cluster %s/%s is paused, skip syncing for tikv service", tc.GetNamespace(), tc.GetName())
 		return nil
@@ -121,13 +121,13 @@ func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluste
 	tcName := tc.GetName()
 
 	newSvc := getNewServiceForTidbCluster(tc, svcConfig)
-	oldSvcTmp, err := tkmm.deps.ServiceLister.Services(ns).Get(svcConfig.MemberName(tcName))
+	oldSvcTmp, err := m.deps.ServiceLister.Services(ns).Get(svcConfig.MemberName(tcName))
 	if errors.IsNotFound(err) {
 		err = controller.SetServiceLastAppliedConfigAnnotation(newSvc)
 		if err != nil {
 			return err
 		}
-		return tkmm.deps.ServiceControl.CreateService(tc, newSvc)
+		return m.deps.ServiceControl.CreateService(tc, newSvc)
 	}
 	if err != nil {
 		return fmt.Errorf("syncServiceForTidbCluster: failed to get svc %s for cluster %s/%s, error: %s", svcConfig.MemberName(tcName), ns, tcName, err)
@@ -148,18 +148,18 @@ func (tkmm *tikvMemberManager) syncServiceForTidbCluster(tc *v1alpha1.TidbCluste
 			return err
 		}
 		svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		_, err = tkmm.deps.ServiceControl.UpdateService(tc, &svc)
+		_, err = m.deps.ServiceControl.UpdateService(tc, &svc)
 		return err
 	}
 
 	return nil
 }
 
-func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
+func (m *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
-	oldSetTmp, err := tkmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiKVMemberName(tcName))
+	oldSetTmp, err := m.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiKVMemberName(tcName))
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("syncStatefulSetForTidbCluster: failed to get sts %s for cluster %s/%s, error: %s", controller.TiKVMemberName(tcName), ns, tcName, err)
 	}
@@ -167,7 +167,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 
 	oldSet := oldSetTmp.DeepCopy()
 
-	if err := tkmm.syncTidbClusterStatus(tc, oldSet); err != nil {
+	if err := m.syncTidbClusterStatus(tc, oldSet); err != nil {
 		return err
 	}
 
@@ -176,19 +176,19 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		return nil
 	}
 
-	cm, err := tkmm.syncTiKVConfigMap(tc, oldSet)
+	cm, err := m.syncTiKVConfigMap(tc, oldSet)
 	if err != nil {
 		return err
 	}
 
 	// Recover failed stores if any before generating desired statefulset
 	if len(tc.Status.TiKV.FailureStores) > 0 {
-		tkmm.failover.RemoveUndesiredFailures(tc)
+		m.failover.RemoveUndesiredFailures(tc)
 	}
 	if len(tc.Status.TiKV.FailureStores) > 0 &&
 		tc.Spec.TiKV.RecoverFailover &&
-		shouldRecover(tc, label.TiKVLabelVal, tkmm.deps.PodLister) {
-		tkmm.failover.Recover(tc)
+		shouldRecover(tc, label.TiKVLabelVal, m.deps.PodLister) {
+		m.failover.Recover(tc)
 	}
 
 	newSet, err := getNewTiKVSetForTidbCluster(tc, cm)
@@ -200,7 +200,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		if err != nil {
 			return err
 		}
-		err = tkmm.deps.StatefulSetControl.CreateStatefulSet(tc, newSet)
+		err = m.deps.StatefulSetControl.CreateStatefulSet(tc, newSet)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 		return nil
 	}
 
-	if _, err := tkmm.setStoreLabelsForTiKV(tc); err != nil {
+	if _, err := m.setStoreLabelsForTiKV(tc); err != nil {
 		return err
 	}
 
@@ -217,31 +217,31 @@ func (tkmm *tikvMemberManager) syncStatefulSetForTidbCluster(tc *v1alpha1.TidbCl
 	//   new replicas
 	// - it's ok to scale in the middle of upgrading (in statefulset controller
 	//   scaling takes precedence over upgrading too)
-	if err := tkmm.scaler.Scale(tc, oldSet, newSet); err != nil {
+	if err := m.scaler.Scale(tc, oldSet, newSet); err != nil {
 		return err
 	}
 
 	// Perform failover logic if necessary. Note that this will only update
 	// TidbCluster status. The actual scaling performs in next sync loop (if a
 	// new replica needs to be added).
-	if tkmm.deps.CLIConfig.AutoFailover && tc.Spec.TiKV.MaxFailoverCount != nil {
+	if m.deps.CLIConfig.AutoFailover && tc.Spec.TiKV.MaxFailoverCount != nil {
 		if tc.TiKVAllPodsStarted() && !tc.TiKVAllStoresReady() {
-			if err := tkmm.failover.Failover(tc); err != nil {
+			if err := m.failover.Failover(tc); err != nil {
 				return err
 			}
 		}
 	}
 
 	if !templateEqual(newSet, oldSet) || tc.Status.TiKV.Phase == v1alpha1.UpgradePhase {
-		if err := tkmm.upgrader.Upgrade(tc, oldSet, newSet); err != nil {
+		if err := m.upgrader.Upgrade(tc, oldSet, newSet); err != nil {
 			return err
 		}
 	}
 
-	return updateStatefulSet(tkmm.deps.StatefulSetControl, tc, newSet, oldSet)
+	return updateStatefulSet(m.deps.StatefulSetControl, tc, newSet, oldSet)
 }
 
-func (tkmm *tikvMemberManager) syncTiKVConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
+func (m *tikvMemberManager) syncTiKVConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
 	// For backward compatibility, only sync tidb configmap when .tikv.config is non-nil
 	if tc.Spec.TiKV.Config == nil {
 		return nil, nil
@@ -258,11 +258,11 @@ func (tkmm *tikvMemberManager) syncTiKVConfigMap(tc *v1alpha1.TidbCluster, set *
 		})
 	}
 
-	err = updateConfigMapIfNeed(tkmm.deps.ConfigMapLister, tc.BaseTiKVSpec().ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, tc.BaseTiKVSpec().ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}
-	return tkmm.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(tc, newCm)
 }
 
 func getNewServiceForTidbCluster(tc *v1alpha1.TidbCluster, svcConfig SvcConfig) *corev1.Service {
@@ -618,13 +618,13 @@ func labelTiKV(tc *v1alpha1.TidbCluster) label.Label {
 	return label.New().Instance(instanceName).TiKV()
 }
 
-func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
+func (m *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) error {
 	if set == nil {
 		// skip if not created yet
 		return nil
 	}
 	tc.Status.TiKV.StatefulSet = &set.Status
-	upgrading, err := tkmm.statefulSetIsUpgradingFn(tkmm.deps.PodLister, tkmm.deps.PDControl, set, tc)
+	upgrading, err := m.statefulSetIsUpgradingFn(m.deps.PodLister, m.deps.PDControl, set, tc)
 	if err != nil {
 		return err
 	}
@@ -641,7 +641,7 @@ func (tkmm *tikvMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	stores := map[string]v1alpha1.TiKVStore{}
 	tombstoneStores := map[string]v1alpha1.TiKVStore{}
 
-	pdCli := controller.GetPDClient(tkmm.deps.PDControl, tc)
+	pdCli := controller.GetPDClient(m.deps.PDControl, tc)
 	// This only returns Up/Down/Offline stores
 	storesInfo, err := pdCli.GetStores()
 	if err != nil {
@@ -727,12 +727,12 @@ func getTiKVStore(store *pdapi.StoreInfo) *v1alpha1.TiKVStore {
 	}
 }
 
-func (tkmm *tikvMemberManager) setStoreLabelsForTiKV(tc *v1alpha1.TidbCluster) (int, error) {
+func (m *tikvMemberManager) setStoreLabelsForTiKV(tc *v1alpha1.TidbCluster) (int, error) {
 	ns := tc.GetNamespace()
 	// for unit test
 	setCount := 0
 
-	pdCli := controller.GetPDClient(tkmm.deps.PDControl, tc)
+	pdCli := controller.GetPDClient(m.deps.PDControl, tc)
 	storesInfo, err := pdCli.GetStores()
 	if err != nil {
 		return setCount, err
@@ -764,24 +764,24 @@ func (tkmm *tikvMemberManager) setStoreLabelsForTiKV(tc *v1alpha1.TidbCluster) (
 		}
 		podName := status.PodName
 
-		pod, err := tkmm.deps.PodLister.Pods(ns).Get(podName)
+		pod, err := m.deps.PodLister.Pods(ns).Get(podName)
 		if err != nil {
 			return setCount, fmt.Errorf("setStoreLabelsForTiKV: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tc.GetName(), err)
 		}
 
 		nodeName := pod.Spec.NodeName
-		ls, err := tkmm.getNodeLabels(nodeName, locationLabels)
+		ls, err := m.getNodeLabels(nodeName, locationLabels)
 		if err != nil || len(ls) == 0 {
 			klog.Warningf("node: [%s] has no node labels, skipping set store labels for Pod: [%s/%s]", nodeName, ns, podName)
 			continue
 		}
 
-		if !tkmm.storeLabelsEqualNodeLabels(store.Store.Labels, ls) {
+		if !m.storeLabelsEqualNodeLabels(store.Store.Labels, ls) {
 			set, err := pdCli.SetStoreLabels(store.Store.Id, ls)
 			if err != nil {
 				msg := fmt.Sprintf("failed to set labels %v for store (id: %d, pod: %s/%s): %v ",
 					ls, store.Store.Id, ns, podName, err)
-				tkmm.deps.Recorder.Event(tc, corev1.EventTypeWarning, FailedSetStoreLabels, msg)
+				m.deps.Recorder.Event(tc, corev1.EventTypeWarning, FailedSetStoreLabels, msg)
 				continue
 			}
 			if set {
@@ -794,8 +794,8 @@ func (tkmm *tikvMemberManager) setStoreLabelsForTiKV(tc *v1alpha1.TidbCluster) (
 	return setCount, nil
 }
 
-func (tkmm *tikvMemberManager) getNodeLabels(nodeName string, storeLabels []string) (map[string]string, error) {
-	node, err := tkmm.deps.NodeLister.Get(nodeName)
+func (m *tikvMemberManager) getNodeLabels(nodeName string, storeLabels []string) (map[string]string, error) {
+	node, err := m.deps.NodeLister.Get(nodeName)
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +820,7 @@ func (tkmm *tikvMemberManager) getNodeLabels(nodeName string, storeLabels []stri
 
 // storeLabelsEqualNodeLabels compares store labels with node labels
 // for historic reasons, PD stores TiKV labels as []*StoreLabel which is a key-value pair slice
-func (tkmm *tikvMemberManager) storeLabelsEqualNodeLabels(storeLabels []*metapb.StoreLabel, nodeLabels map[string]string) bool {
+func (m *tikvMemberManager) storeLabelsEqualNodeLabels(storeLabels []*metapb.StoreLabel, nodeLabels map[string]string) bool {
 	ls := map[string]string{}
 	for _, label := range storeLabels {
 		key := label.GetKey()
@@ -866,13 +866,13 @@ func NewFakeTiKVMemberManager() *FakeTiKVMemberManager {
 	return &FakeTiKVMemberManager{}
 }
 
-func (ftmm *FakeTiKVMemberManager) SetSyncError(err error) {
-	ftmm.err = err
+func (m *FakeTiKVMemberManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (ftmm *FakeTiKVMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
-	if ftmm.err != nil {
-		return ftmm.err
+func (m *FakeTiKVMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
+	if m.err != nil {
+		return m.err
 	}
 	if len(tc.Status.TiKV.Stores) != 0 {
 		// simulate status update

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -41,18 +41,18 @@ func NewTiKVScaler(deps *controller.Dependencies) *tikvScaler {
 	return &tikvScaler{generalScaler: generalScaler{deps: deps}}
 }
 
-func (tsd *tikvScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tikvScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	scaling, _, _, _ := scaleOne(oldSet, newSet)
 	if scaling > 0 {
-		return tsd.ScaleOut(meta, oldSet, newSet)
+		return s.ScaleOut(meta, oldSet, newSet)
 	} else if scaling < 0 {
-		return tsd.ScaleIn(meta, oldSet, newSet)
+		return s.ScaleIn(meta, oldSet, newSet)
 	}
 	// we only sync auto scaler annotations when we are finishing syncing scaling
-	return tsd.SyncAutoScalerAnn(meta, oldSet)
+	return s.SyncAutoScalerAnn(meta, oldSet)
 }
 
-func (tsd *tikvScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tikvScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	_, ordinal, replicas, deleteSlots := scaleOne(oldSet, newSet)
 	resetReplicas(newSet, oldSet)
 	obj, ok := meta.(runtime.Object)
@@ -67,9 +67,9 @@ func (tsd *tikvScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, ne
 	default:
 		return fmt.Errorf("tikv.ScaleOut, failed to convert cluster %s/%s", meta.GetNamespace(), meta.GetName())
 	}
-	_, err := tsd.deps.PVCLister.PersistentVolumeClaims(meta.GetNamespace()).Get(pvcName)
+	_, err := s.deps.PVCLister.PersistentVolumeClaims(meta.GetNamespace()).Get(pvcName)
 	if err == nil {
-		_, err = tsd.deleteDeferDeletingPVC(obj, oldSet.GetName(), v1alpha1.TiKVMemberType, ordinal)
+		_, err = s.deleteDeferDeletingPVC(obj, oldSet.GetName(), v1alpha1.TiKVMemberType, ordinal)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func (tsd *tikvScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, ne
 	return nil
 }
 
-func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	ns := meta.GetNamespace()
 	tcName := meta.GetName()
 	// we can only remove one member at a time when scaling in
@@ -99,7 +99,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	default:
 		return fmt.Errorf("tikvScaler.ScaleIn: failed to convert cluster %s/%s", meta.GetNamespace(), meta.GetName())
 	}
-	pod, err := tsd.deps.PodLister.Pods(ns).Get(podName)
+	pod, err := s.deps.PodLister.Pods(ns).Get(podName)
 	if err != nil {
 		return fmt.Errorf("tikvScaler.ScaleIn: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
 	}
@@ -115,7 +115,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 			storeState = store.State
 		}
 	}
-	config, err := controller.GetPDClient(tsd.deps.PDControl, tc).GetConfig()
+	config, err := controller.GetPDClient(s.deps.PDControl, tc).GetConfig()
 	if err != nil {
 		return err
 	}
@@ -123,18 +123,18 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	if upNumber < int(maxReplicas) {
 		errMsg := fmt.Sprintf("the number of stores in Up state of TidbCluster [%s/%s] is %d, less than MaxReplicas in PD configuration(%d), can't scale in TiKV, podname %s ", meta.GetNamespace(), meta.GetName(), upNumber, maxReplicas, podName)
 		klog.Error(errMsg)
-		tsd.deps.Recorder.Event(tc, v1.EventTypeWarning, "FailedScaleIn", errMsg)
+		s.deps.Recorder.Event(tc, v1.EventTypeWarning, "FailedScaleIn", errMsg)
 		return nil
 	} else if upNumber == int(maxReplicas) {
 		if storeState == v1alpha1.TiKVStateUp {
 			errMsg := fmt.Sprintf("can't scale in TiKV of TidbCluster [%s/%s], cause the number of up stores is equal to MaxReplicas in PD configuration(%d), and the store in Pod %s which is going to be deleted is up too", meta.GetNamespace(), meta.GetName(), maxReplicas, podName)
 			klog.Error(errMsg)
-			tsd.deps.Recorder.Event(tc, v1.EventTypeWarning, "FailedScaleIn", errMsg)
+			s.deps.Recorder.Event(tc, v1.EventTypeWarning, "FailedScaleIn", errMsg)
 			return nil
 		}
 	}
 
-	if tsd.deps.CLIConfig.PodWebhookEnabled {
+	if s.deps.CLIConfig.PodWebhookEnabled {
 		setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
 		return nil
 	}
@@ -147,7 +147,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 				return err
 			}
 			if state != v1alpha1.TiKVStateOffline {
-				if err := controller.GetPDClient(tsd.deps.PDControl, tc).DeleteStore(id); err != nil {
+				if err := controller.GetPDClient(s.deps.PDControl, tc).DeleteStore(id); err != nil {
 					klog.Errorf("tikv scale in: failed to delete store %d, %v", id, err)
 					return err
 				}
@@ -167,7 +167,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 			klog.Infof("TiKV %s/%s store %d becomes tombstone", ns, podName, id)
 
 			pvcName := ordinalPVCName(v1alpha1.TiKVMemberType, setName, ordinal)
-			pvc, err := tsd.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+			pvc, err := s.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 			if err != nil {
 				return fmt.Errorf("tikvScaler.ScaleIn: failed to get pvc %s for cluster %s/%s, error: %s", pvcName, ns, tcName, err)
 			}
@@ -176,7 +176,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 			}
 			now := time.Now().Format(time.RFC3339)
 			pvc.Annotations[label.AnnPVCDeferDeleting] = now
-			_, err = tsd.deps.PVCControl.UpdatePVC(tc, pvc)
+			_, err = s.deps.PVCControl.UpdatePVC(tc, pvc)
 			if err != nil {
 				klog.Errorf("tikv scale in: failed to set pvc %s/%s annotation: %s to %s",
 					ns, pvcName, label.AnnPVCDeferDeleting, now)
@@ -198,11 +198,11 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	//    In this situation we should delete this TiKV pod immediately to avoid blocking the subsequent operations.
 	if !podutil.IsPodReady(pod) {
 		pvcName := ordinalPVCName(v1alpha1.TiKVMemberType, setName, ordinal)
-		pvc, err := tsd.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+		pvc, err := s.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 		if err != nil {
 			return fmt.Errorf("tikvScaler.ScaleIn: failed to get pvc %s for cluster %s/%s, error: %s", pvcName, ns, tcName, err)
 		}
-		safeTimeDeadline := pod.CreationTimestamp.Add(5 * tsd.deps.CLIConfig.ResyncDuration)
+		safeTimeDeadline := pod.CreationTimestamp.Add(5 * s.deps.CLIConfig.ResyncDuration)
 		if time.Now().Before(safeTimeDeadline) {
 			// Wait for 5 resync periods to ensure that the following situation does not occur:
 			//
@@ -219,7 +219,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 		}
 		now := time.Now().Format(time.RFC3339)
 		pvc.Annotations[label.AnnPVCDeferDeleting] = now
-		_, err = tsd.deps.PVCControl.UpdatePVC(tc, pvc)
+		_, err = s.deps.PVCControl.UpdatePVC(tc, pvc)
 		if err != nil {
 			klog.Errorf("pod %s not ready, tikv scale in: failed to set pvc %s/%s annotation: %s to %s",
 				podName, ns, pvcName, label.AnnPVCDeferDeleting, now)
@@ -234,7 +234,7 @@ func (tsd *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 }
 
 // SyncAutoScalerAnn would reclaim the auto-scaling out slots if the target pod is no longer existed
-func (tsd *tikvScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
+func (s *tikvScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
 	tc, ok := meta.(*v1alpha1.TidbCluster)
 	if !ok {
 		return nil
@@ -270,25 +270,25 @@ func NewFakeTiKVScaler() Scaler {
 	return &fakeTiKVScaler{}
 }
 
-func (fsd *fakeTiKVScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *fakeTiKVScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	if *newSet.Spec.Replicas > *oldSet.Spec.Replicas {
-		return fsd.ScaleOut(meta, oldSet, newSet)
+		return s.ScaleOut(meta, oldSet, newSet)
 	} else if *newSet.Spec.Replicas < *oldSet.Spec.Replicas {
-		return fsd.ScaleIn(meta, oldSet, newSet)
+		return s.ScaleIn(meta, oldSet, newSet)
 	}
 	return nil
 }
 
-func (fsd *fakeTiKVScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *fakeTiKVScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas+1, nil)
 	return nil
 }
 
-func (fsd *fakeTiKVScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (s *fakeTiKVScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
 	return nil
 }
 
-func (fsd *fakeTiKVScaler) SyncAutoScalerAnn(_ metav1.Object, actual *apps.StatefulSet) error {
+func (s *fakeTiKVScaler) SyncAutoScalerAnn(_ metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -206,6 +206,15 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 
 		pdClient := controller.NewFakePDClient(pdControl, tc)
 
+		pdClient.AddReaction(pdapi.GetConfigActionType, func(action *pdapi.Action) (interface{}, error) {
+			var replicas uint64 = 3
+			return &pdapi.PDConfigFromAPI{
+				Replication: &pdapi.PDReplicationConfig{
+					MaxReplicas: &replicas,
+				},
+			}, nil
+		})
+
 		if test.delStoreErr {
 			pdClient.AddReaction(pdapi.DeleteStoreActionType, func(action *pdapi.Action) (interface{}, error) {
 				return nil, fmt.Errorf("delete store error")
@@ -276,15 +285,13 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 			isPodReady:    true,
 			hasSynced:     true,
 			pvcUpdateErr:  false,
-			errExpectFn:   errExpectNotNil,
+			errExpectFn:   errExpectNil,
 			changed:       false,
 		},
 		{
 			name:          "tikv pod is not ready now, not sure if the status has been synced",
 			tikvUpgrading: false,
-			storeFun: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-			},
+			storeFun:      notReadyStoreFun,
 			delStoreErr:   false,
 			hasPVC:        true,
 			storeIDSynced: true,
@@ -297,9 +304,7 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 		{
 			name:          "tikv pod is not ready now, make sure the status has been synced",
 			tikvUpgrading: false,
-			storeFun: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{}
-			},
+			storeFun:      notReadyStoreFun,
 			delStoreErr:   false,
 			hasPVC:        true,
 			storeIDSynced: true,
@@ -420,6 +425,19 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 			errExpectFn:   errExpectNotNil,
 			changed:       false,
 		},
+		{
+			name:          "minimal up stores, scale in TiKV is not allowed",
+			tikvUpgrading: false,
+			storeFun:      minimalUpStoreFun,
+			delStoreErr:   false,
+			hasPVC:        true,
+			storeIDSynced: true,
+			isPodReady:    true,
+			hasSynced:     true,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -448,10 +466,37 @@ func normalStoreFun(tc *v1alpha1.TidbCluster) {
 			PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 4),
 			State:   v1alpha1.TiKVStateUp,
 		},
+		"10": {
+			ID:      "10",
+			PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 0),
+			State:   v1alpha1.TiKVStateUp,
+		},
+		"11": {
+			ID:      "11",
+			PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 1),
+			State:   v1alpha1.TiKVStateUp,
+		},
+		"12": {
+			ID:      "12",
+			PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 2),
+			State:   v1alpha1.TiKVStateUp,
+		},
+		"13": {
+			ID:      "13",
+			PodName: ordinalPodName(v1alpha1.TiKVMemberType, tc.GetName(), 3),
+			State:   v1alpha1.TiKVStateUp,
+		},
 	}
 }
 
+func notReadyStoreFun(tc *v1alpha1.TidbCluster) {
+	normalStoreFun(tc)
+	delete(tc.Status.TiKV.Stores, "1")
+}
+
 func tombstoneStoreFun(tc *v1alpha1.TidbCluster) {
+	notReadyStoreFun(tc)
+
 	tc.Status.TiKV.TombstoneStores = map[string]v1alpha1.TiKVStore{
 		"1": {
 			ID:      "1",
@@ -459,6 +504,13 @@ func tombstoneStoreFun(tc *v1alpha1.TidbCluster) {
 			State:   v1alpha1.TiKVStateTombstone,
 		},
 	}
+}
+
+func minimalUpStoreFun(tc *v1alpha1.TidbCluster) {
+	normalStoreFun(tc)
+
+	tc.Status.TiKV.Stores["12"] = v1alpha1.TiKVStore{State: v1alpha1.TiKVStateDown}
+	tc.Status.TiKV.Stores["13"] = v1alpha1.TiKVStore{State: v1alpha1.TiKVStateDown}
 }
 
 func readyPodFunc(pod *corev1.Pod) {

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -48,7 +48,7 @@ func NewTiKVUpgrader(deps *controller.Dependencies) TiKVUpgrader {
 	}
 }
 
-func (tku *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+func (u *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	ns := meta.GetNamespace()
 	tcName := meta.GetName()
 
@@ -97,12 +97,12 @@ func (tku *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, n
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
 	for _i := len(podOrdinals) - 1; _i >= 0; _i-- {
 		i := podOrdinals[_i]
-		store := tku.getStoreByOrdinal(meta.GetName(), *status, i)
+		store := u.getStoreByOrdinal(meta.GetName(), *status, i)
 		if store == nil {
 			continue
 		}
 		podName := TikvPodName(tcName, i)
-		pod, err := tku.deps.PodLister.Pods(ns).Get(podName)
+		pod, err := u.deps.PodLister.Pods(ns).Get(podName)
 		if err != nil {
 			return fmt.Errorf("tikvUpgrader.Upgrade: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
 		}
@@ -123,7 +123,7 @@ func (tku *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, n
 			continue
 		}
 
-		if tku.deps.CLIConfig.PodWebhookEnabled {
+		if u.deps.CLIConfig.PodWebhookEnabled {
 			setUpgradePartition(newSet, i)
 			return nil
 		}
@@ -131,17 +131,17 @@ func (tku *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, n
 		if !ok {
 			return fmt.Errorf("cluster[%s/%s] failed to upgrading tikv due to not tidbcluster and not enabled pod webhook", meta.GetNamespace(), meta.GetName())
 		}
-		return tku.upgradeTiKVPod(tc, i, newSet)
+		return u.upgradeTiKVPod(tc, i, newSet)
 	}
 
 	return nil
 }
 
-func (tku *tikvUpgrader) upgradeTiKVPod(tc *v1alpha1.TidbCluster, ordinal int32, newSet *apps.StatefulSet) error {
+func (u *tikvUpgrader) upgradeTiKVPod(tc *v1alpha1.TidbCluster, ordinal int32, newSet *apps.StatefulSet) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 	upgradePodName := TikvPodName(tcName, ordinal)
-	upgradePod, err := tku.deps.PodLister.Pods(ns).Get(upgradePodName)
+	upgradePod, err := u.deps.PodLister.Pods(ns).Get(upgradePodName)
 	if err != nil {
 		return fmt.Errorf("upgradeTiKVPod: failed to get pods %s for cluster %s/%s, error: %s", upgradePodName, ns, tcName, err)
 	}
@@ -154,11 +154,11 @@ func (tku *tikvUpgrader) upgradeTiKVPod(tc *v1alpha1.TidbCluster, ordinal int32,
 			}
 			_, evicting := upgradePod.Annotations[EvictLeaderBeginTime]
 			if !evicting {
-				return tku.beginEvictLeader(tc, storeID, upgradePod)
+				return u.beginEvictLeader(tc, storeID, upgradePod)
 			}
 
-			if tku.readyToUpgrade(upgradePod, store, tc.TiKVEvictLeaderTimeout()) {
-				err := tku.endEvictLeader(tc, ordinal)
+			if u.readyToUpgrade(upgradePod, store, tc.TiKVEvictLeaderTimeout()) {
+				err := u.endEvictLeader(tc, ordinal)
 				if err != nil {
 					return err
 				}
@@ -173,7 +173,7 @@ func (tku *tikvUpgrader) upgradeTiKVPod(tc *v1alpha1.TidbCluster, ordinal int32,
 	return controller.RequeueErrorf("tidbcluster: [%s/%s] no store status found for tikv pod: [%s]", ns, tcName, upgradePodName)
 }
 
-func (tku *tikvUpgrader) readyToUpgrade(upgradePod *corev1.Pod, store v1alpha1.TiKVStore, evictLeaderTimeout time.Duration) bool {
+func (u *tikvUpgrader) readyToUpgrade(upgradePod *corev1.Pod, store v1alpha1.TiKVStore, evictLeaderTimeout time.Duration) bool {
 	if store.LeaderCount == 0 {
 		return true
 	}
@@ -190,10 +190,10 @@ func (tku *tikvUpgrader) readyToUpgrade(upgradePod *corev1.Pod, store v1alpha1.T
 	return false
 }
 
-func (tku *tikvUpgrader) beginEvictLeader(tc *v1alpha1.TidbCluster, storeID uint64, pod *corev1.Pod) error {
+func (u *tikvUpgrader) beginEvictLeader(tc *v1alpha1.TidbCluster, storeID uint64, pod *corev1.Pod) error {
 	ns := tc.GetNamespace()
 	podName := pod.GetName()
-	err := controller.GetPDClient(tku.deps.PDControl, tc).BeginEvictLeader(storeID)
+	err := controller.GetPDClient(u.deps.PDControl, tc).BeginEvictLeader(storeID)
 	if err != nil {
 		klog.Errorf("tikv upgrader: failed to begin evict leader: %d, %s/%s, %v",
 			storeID, ns, podName, err)
@@ -205,7 +205,7 @@ func (tku *tikvUpgrader) beginEvictLeader(tc *v1alpha1.TidbCluster, storeID uint
 	}
 	now := time.Now().Format(time.RFC3339)
 	pod.Annotations[EvictLeaderBeginTime] = now
-	_, err = tku.deps.PodControl.UpdatePod(tc, pod)
+	_, err = u.deps.PodControl.UpdatePod(tc, pod)
 	if err != nil {
 		klog.Errorf("tikv upgrader: failed to set pod %s/%s annotation %s to %s, %v",
 			ns, podName, EvictLeaderBeginTime, now, err)
@@ -216,21 +216,21 @@ func (tku *tikvUpgrader) beginEvictLeader(tc *v1alpha1.TidbCluster, storeID uint
 	return nil
 }
 
-func (tku *tikvUpgrader) endEvictLeader(tc *v1alpha1.TidbCluster, ordinal int32) error {
+func (u *tikvUpgrader) endEvictLeader(tc *v1alpha1.TidbCluster, ordinal int32) error {
 	// wait 5 second before delete evict scheduler，it is for auto test can catch these info
-	if tku.deps.CLIConfig.TestMode {
+	if u.deps.CLIConfig.TestMode {
 		time.Sleep(5 * time.Second)
 	}
-	store := tku.getStoreByOrdinal(tc.GetName(), tc.Status.TiKV, ordinal)
+	store := u.getStoreByOrdinal(tc.GetName(), tc.Status.TiKV, ordinal)
 	storeID, err := strconv.ParseUint(store.ID, 10, 64)
 	if err != nil {
 		return err
 	}
 
 	if tc.IsHeterogeneous() {
-		err = tku.deps.PDControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled()).EndEvictLeader(storeID)
+		err = u.deps.PDControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled()).EndEvictLeader(storeID)
 	} else {
-		err = tku.deps.PDControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled()).EndEvictLeader(storeID)
+		err = u.deps.PDControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled()).EndEvictLeader(storeID)
 	}
 
 	if err != nil {
@@ -241,7 +241,7 @@ func (tku *tikvUpgrader) endEvictLeader(tc *v1alpha1.TidbCluster, ordinal int32)
 	return nil
 }
 
-func (tku *tikvUpgrader) getStoreByOrdinal(name string, status v1alpha1.TiKVStatus, ordinal int32) *v1alpha1.TiKVStore {
+func (u *tikvUpgrader) getStoreByOrdinal(name string, status v1alpha1.TiKVStatus, ordinal int32) *v1alpha1.TiKVStore {
 	podName := TikvPodName(name, ordinal)
 	for _, store := range status.Stores {
 		if store.PodName == podName {
@@ -258,7 +258,7 @@ func NewFakeTiKVUpgrader() TiKVUpgrader {
 	return &fakeTiKVUpgrader{}
 }
 
-func (tku *fakeTiKVUpgrader) Upgrade(meta metav1.Object, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+func (u *fakeTiKVUpgrader) Upgrade(meta metav1.Object, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
 	tc := meta.(*v1alpha1.TidbCluster)
 	tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
 	return nil

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -306,6 +306,9 @@ func updateStatefulSet(setCtl controller.StatefulSetControlInterface, object run
 		}
 		*set.Spec.Replicas = *newSet.Spec.Replicas
 		set.Spec.UpdateStrategy = newSet.Spec.UpdateStrategy
+		if oldSet.Spec.UpdateStrategy.Type == apps.OnDeleteStatefulSetStrategyType || oldSet.Spec.UpdateStrategy.RollingUpdate == nil {
+			set.Spec.UpdateStrategy = oldSet.Spec.UpdateStrategy
+		}
 		if isOrphan {
 			set.OwnerReferences = newSet.OwnerReferences
 			set.Labels = newSet.Labels

--- a/pkg/manager/meta/reclaim_policy_manager.go
+++ b/pkg/manager/meta/reclaim_policy_manager.go
@@ -37,19 +37,19 @@ func NewReclaimPolicyManager(deps *controller.Dependencies) *reclaimPolicyManage
 	}
 }
 
-func (rpm *reclaimPolicyManager) Sync(tc *v1alpha1.TidbCluster) error {
-	return rpm.sync(v1alpha1.TiDBClusterKind, tc, tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy)
+func (m *reclaimPolicyManager) Sync(tc *v1alpha1.TidbCluster) error {
+	return m.sync(v1alpha1.TiDBClusterKind, tc, tc.IsPVReclaimEnabled(), *tc.Spec.PVReclaimPolicy)
 }
 
-func (rpm *reclaimPolicyManager) SyncMonitor(tm *v1alpha1.TidbMonitor) error {
-	return rpm.sync(v1alpha1.TiDBMonitorKind, tm, false, *tm.Spec.PVReclaimPolicy)
+func (m *reclaimPolicyManager) SyncMonitor(tm *v1alpha1.TidbMonitor) error {
+	return m.sync(v1alpha1.TiDBMonitorKind, tm, false, *tm.Spec.PVReclaimPolicy)
 }
 
-func (rpm *reclaimPolicyManager) SyncDM(dc *v1alpha1.DMCluster) error {
-	return rpm.sync(v1alpha1.DMClusterKind, dc, dc.IsPVReclaimEnabled(), *dc.Spec.PVReclaimPolicy)
+func (m *reclaimPolicyManager) SyncDM(dc *v1alpha1.DMCluster) error {
+	return m.sync(v1alpha1.DMClusterKind, dc, dc.IsPVReclaimEnabled(), *dc.Spec.PVReclaimPolicy)
 }
 
-func (rpm *reclaimPolicyManager) sync(kind string, obj runtime.Object, isPVReclaimEnabled bool, policy corev1.PersistentVolumeReclaimPolicy) error {
+func (m *reclaimPolicyManager) sync(kind string, obj runtime.Object, isPVReclaimEnabled bool, policy corev1.PersistentVolumeReclaimPolicy) error {
 	var (
 		meta         = obj.(metav1.ObjectMetaAccessor).GetObjectMeta()
 		ns           = meta.GetNamespace()
@@ -72,7 +72,7 @@ func (rpm *reclaimPolicyManager) sync(kind string, obj runtime.Object, isPVRecla
 		return err
 	}
 
-	pvcs, err := rpm.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
+	pvcs, err := m.deps.PVCLister.PersistentVolumeClaims(ns).List(selector)
 	if err != nil {
 		return fmt.Errorf("reclaimPolicyManager.sync: failed to list pvc for %s %s/%s, selector %s, error: %s", kind, ns, instanceName, selector, err)
 	}
@@ -87,7 +87,7 @@ func (rpm *reclaimPolicyManager) sync(kind string, obj runtime.Object, isPVRecla
 		if l := label.Label(pvc.Labels); kind == v1alpha1.TiDBClusterKind && (!l.IsPD() && !l.IsTiDB() && !l.IsTiKV() && !l.IsTiFlash() && !l.IsPump()) {
 			continue
 		}
-		pv, err := rpm.deps.PVLister.Get(pvc.Spec.VolumeName)
+		pv, err := m.deps.PVLister.Get(pvc.Spec.VolumeName)
 		if err != nil {
 			return fmt.Errorf("reclaimPolicyManager.sync: failed to get pvc %s for %s %s/%s, error: %s", pvc.Spec.VolumeName, kind, ns, instanceName, err)
 		}
@@ -95,7 +95,7 @@ func (rpm *reclaimPolicyManager) sync(kind string, obj runtime.Object, isPVRecla
 		if pv.Spec.PersistentVolumeReclaimPolicy == policy {
 			continue
 		}
-		err = rpm.deps.PVControl.PatchPVReclaimPolicy(obj, pv, policy)
+		err = m.deps.PVControl.PatchPVReclaimPolicy(obj, pv, policy)
 		if err != nil {
 			return err
 		}
@@ -114,14 +114,14 @@ func NewFakeReclaimPolicyManager() *FakeReclaimPolicyManager {
 	return &FakeReclaimPolicyManager{}
 }
 
-func (frpm *FakeReclaimPolicyManager) SetSyncError(err error) {
-	frpm.err = err
+func (m *FakeReclaimPolicyManager) SetSyncError(err error) {
+	m.err = err
 }
 
-func (frpm *FakeReclaimPolicyManager) Sync(_ *v1alpha1.TidbCluster) error {
-	return frpm.err
+func (m *FakeReclaimPolicyManager) Sync(_ *v1alpha1.TidbCluster) error {
+	return m.err
 }
 
-func (frpm *FakeReclaimPolicyManager) SyncDM(_ *v1alpha1.DMCluster) error {
-	return frpm.err
+func (m *FakeReclaimPolicyManager) SyncDM(_ *v1alpha1.DMCluster) error {
+	return m.err
 }

--- a/pkg/monitor/monitor/monitor_manager.go
+++ b/pkg/monitor/monitor/monitor_manager.go
@@ -57,7 +57,7 @@ func NewMonitorManager(deps *controller.Dependencies) *MonitorManager {
 	}
 }
 
-func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
+func (m *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	if monitor.DeletionTimestamp != nil {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	if len(tcRef.Namespace) < 1 {
 		tcRef.Namespace = monitor.Namespace
 	}
-	tc, err := mm.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).Get(tcRef.Name, metav1.GetOptions{})
+	tc, err := m.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).Get(tcRef.Name, metav1.GetOptions{})
 	if err != nil {
 		rerr := fmt.Errorf("get tm[%s/%s]'s target tc[%s/%s] failed, err: %v", monitor.Namespace, monitor.Name, tcRef.Namespace, tcRef.Name, err)
 		return rerr
@@ -78,7 +78,7 @@ func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	if tc.Status.Monitor != nil {
 		if tc.Status.Monitor.Name != monitor.Name || tc.Status.Monitor.Namespace != monitor.Namespace {
 			err := fmt.Errorf("tm[%s/%s]'s target tc[%s/%s] already referenced by TidbMonitor [%s/%s]", monitor.Namespace, monitor.Name, tc.Namespace, tc.Name, tc.Status.Monitor.Namespace, tc.Status.Monitor.Name)
-			mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, err.Error())
+			m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, err.Error())
 			return err
 		}
 	}
@@ -86,17 +86,17 @@ func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	// TODO: Support validating webhook that forbids the tidbmonitor to update the monitorRef for the tidbcluster whose monitorRef has already
 	// been set by another TidbMonitor.
 	// Patch tidbcluster status first to avoid multi tidbmonitor monitoring the same tidbcluster
-	if err := mm.patchTidbClusterStatus(&tcRef, monitor); err != nil {
+	if err := m.patchTidbClusterStatus(&tcRef, monitor); err != nil {
 		message := fmt.Sprintf("Sync TidbMonitorRef into targetCluster[%s/%s] status failed, err:%v", tc.Namespace, tc.Name, err)
 		klog.Error(message)
-		mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, err.Error())
+		m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, err.Error())
 		return err
 	}
 
 	// Sync Service
-	if err := mm.syncTidbMonitorService(monitor); err != nil {
+	if err := m.syncTidbMonitorService(monitor); err != nil {
 		message := fmt.Sprintf("Sync TidbMonitor[%s/%s] Service failed, err: %v", monitor.Namespace, monitor.Name, err)
-		mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
+		m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
 		return err
 	}
 	klog.V(4).Infof("tm[%s/%s]'s service synced", monitor.Namespace, monitor.Name)
@@ -104,40 +104,40 @@ func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	var pvc *corev1.PersistentVolumeClaim
 	if monitor.Spec.Persistent {
 		var err error
-		pvc, err = mm.syncTidbMonitorPVC(monitor)
+		pvc, err = m.syncTidbMonitorPVC(monitor)
 		if err != nil {
 			message := fmt.Sprintf("Sync TidbMonitor[%s/%s] PVC failed,err:%v", monitor.Namespace, monitor.Name, err)
-			mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
+			m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
 			return err
 		}
 		klog.V(4).Infof("tm[%s/%s]'s pvc synced", monitor.Namespace, monitor.Name)
 
 		// syncing all PVs managed by this tidbmonitor
-		if err := mm.pvManager.SyncMonitor(monitor); err != nil {
+		if err := m.pvManager.SyncMonitor(monitor); err != nil {
 			return err
 		}
 		klog.V(4).Infof("tm[%s/%s]'s pv synced", monitor.Namespace, monitor.Name)
 	}
 
 	// Sync Deployment
-	if err := mm.syncTidbMonitorDeployment(tc, monitor); err != nil {
+	if err := m.syncTidbMonitorDeployment(tc, monitor); err != nil {
 		message := fmt.Sprintf("Sync TidbMonitor[%s/%s] Deployment failed,err:%v", monitor.Namespace, monitor.Name, err)
-		mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
+		m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
 		return err
 	}
 
 	// After the pvc has consumer, we sync monitor pv's labels
 	if monitor.Spec.Persistent {
-		if err := mm.syncTidbMonitorPV(monitor, pvc); err != nil {
+		if err := m.syncTidbMonitorPV(monitor, pvc); err != nil {
 			return err
 		}
 	}
 	klog.V(4).Infof("tm[%s/%s]'s deployment synced", monitor.Namespace, monitor.Name)
 
 	// Sync Ingress
-	if err := mm.syncIngress(monitor); err != nil {
+	if err := m.syncIngress(monitor); err != nil {
 		message := fmt.Sprintf("Sync TidbMonitor[%s/%s] Ingress failed,err:%v", monitor.Namespace, monitor.Name, err)
-		mm.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
+		m.deps.Recorder.Event(monitor, corev1.EventTypeWarning, FailedSync, message)
 		return err
 	}
 	klog.V(4).Infof("tm[%s/%s]'s ingress synced", monitor.Namespace, monitor.Name)
@@ -145,10 +145,10 @@ func (mm *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	return nil
 }
 
-func (mm *MonitorManager) syncTidbMonitorService(monitor *v1alpha1.TidbMonitor) error {
+func (m *MonitorManager) syncTidbMonitorService(monitor *v1alpha1.TidbMonitor) error {
 	services := getMonitorService(monitor)
 	for _, svc := range services {
-		_, err := mm.deps.TypedControl.CreateOrUpdateService(monitor, svc)
+		_, err := m.deps.TypedControl.CreateOrUpdateService(monitor, svc)
 		if err != nil {
 			klog.Errorf("tm[%s/%s]'s service[%s] failed to sync,err: %v", monitor.Namespace, monitor.Name, svc.Name, err)
 			return controller.RequeueErrorf("tm[%s/%s]'s service[%s] failed to sync,err: %v", monitor.Namespace, monitor.Name, svc.Name, err)
@@ -157,10 +157,10 @@ func (mm *MonitorManager) syncTidbMonitorService(monitor *v1alpha1.TidbMonitor) 
 	return nil
 }
 
-func (mm *MonitorManager) syncTidbMonitorPVC(monitor *v1alpha1.TidbMonitor) (*corev1.PersistentVolumeClaim, error) {
+func (m *MonitorManager) syncTidbMonitorPVC(monitor *v1alpha1.TidbMonitor) (*corev1.PersistentVolumeClaim, error) {
 
 	pvc := getMonitorPVC(monitor)
-	pvc, err := mm.deps.TypedControl.CreateOrUpdatePVC(monitor, pvc, false)
+	pvc, err := m.deps.TypedControl.CreateOrUpdatePVC(monitor, pvc, false)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s pvc failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return nil, err
@@ -168,33 +168,33 @@ func (mm *MonitorManager) syncTidbMonitorPVC(monitor *v1alpha1.TidbMonitor) (*co
 	return pvc, nil
 }
 
-func (mm *MonitorManager) syncTidbMonitorPV(monitor *v1alpha1.TidbMonitor, pvc *corev1.PersistentVolumeClaim) error {
+func (m *MonitorManager) syncTidbMonitorPV(monitor *v1alpha1.TidbMonitor, pvc *corev1.PersistentVolumeClaim) error {
 	// update meta info for pv
-	pv, err := mm.deps.PVLister.Get(pvc.Spec.VolumeName)
+	pv, err := m.deps.PVLister.Get(pvc.Spec.VolumeName)
 	if err != nil {
 		return err
 	}
-	_, err = mm.deps.PVControl.UpdateMetaInfo(monitor, pv)
+	_, err = m.deps.PVControl.UpdateMetaInfo(monitor, pv)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) error {
+func (m *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) error {
 
-	cm, err := mm.syncTidbMonitorConfig(tc, monitor)
+	cm, err := m.syncTidbMonitorConfig(tc, monitor)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s configmap failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
 	}
-	secret, err := mm.syncTidbMonitorSecret(monitor)
+	secret, err := m.syncTidbMonitorSecret(monitor)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s secret failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
 	}
 
-	sa, err := mm.syncTidbMonitorRbac(monitor)
+	sa, err := m.syncTidbMonitorRbac(monitor)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s rbac failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
@@ -205,7 +205,7 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, mo
 		klog.Errorf("tm[%s/%s]'s deployment failed to generate,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
 	}
-	_, err = mm.deps.TypedControl.CreateOrUpdateDeployment(monitor, deployment)
+	_, err = m.deps.TypedControl.CreateOrUpdateDeployment(monitor, deployment)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s deployment failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return err
@@ -214,15 +214,15 @@ func (mm *MonitorManager) syncTidbMonitorDeployment(tc *v1alpha1.TidbCluster, mo
 	return nil
 }
 
-func (mm *MonitorManager) syncTidbMonitorSecret(monitor *v1alpha1.TidbMonitor) (*corev1.Secret, error) {
+func (m *MonitorManager) syncTidbMonitorSecret(monitor *v1alpha1.TidbMonitor) (*corev1.Secret, error) {
 	if monitor.Spec.Grafana == nil {
 		return nil, nil
 	}
 	newSt := getMonitorSecret(monitor)
-	return mm.deps.TypedControl.CreateOrUpdateSecret(monitor, newSt)
+	return m.deps.TypedControl.CreateOrUpdateSecret(monitor, newSt)
 }
 
-func (mm *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) (*corev1.ConfigMap, error) {
+func (m *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monitor *v1alpha1.TidbMonitor) (*corev1.ConfigMap, error) {
 	if features.DefaultFeatureGate.Enabled(features.AutoScaling) {
 		// TODO: We need to update the status to tell users we are monitoring extra clusters
 		// Get all autoscaling clusters for TC, and add them to .Spec.Clusters to
@@ -241,7 +241,7 @@ func (mm *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monito
 				continue
 			}
 			selector := labels.NewSelector().Add(*r1).Add(*r2)
-			tcList, err := mm.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
+			tcList, err := m.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
 			if err != nil {
 				klog.Errorf("tm[%s/%s] gets tc[%s/%s]'s autoscaling clusters failed, err: %v", monitor.Namespace, monitor.Name, tcRef.Namespace, tcRef.Name, err)
 				continue
@@ -276,7 +276,7 @@ func (mm *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monito
 		if config.ConfigMapRef.Namespace != nil {
 			namespace = *config.ConfigMapRef.Namespace
 		}
-		externalCM, err := mm.deps.ConfigMapControl.GetConfigMap(monitor, &corev1.ConfigMap{
+		externalCM, err := m.deps.ConfigMapControl.GetConfigMap(monitor, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.ConfigMapRef.Name,
 				Namespace: namespace,
@@ -290,12 +290,12 @@ func (mm *MonitorManager) syncTidbMonitorConfig(tc *v1alpha1.TidbCluster, monito
 			newCM.Data["prometheus-config"] = externalContent
 		}
 	}
-	return mm.deps.TypedControl.CreateOrUpdateConfigMap(monitor, newCM)
+	return m.deps.TypedControl.CreateOrUpdateConfigMap(monitor, newCM)
 }
 
-func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*corev1.ServiceAccount, error) {
+func (m *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*corev1.ServiceAccount, error) {
 	sa := getMonitorServiceAccount(monitor)
-	sa, err := mm.deps.TypedControl.CreateOrUpdateServiceAccount(monitor, sa)
+	sa, err := m.deps.TypedControl.CreateOrUpdateServiceAccount(monitor, sa)
 	if err != nil {
 		klog.Errorf("tm[%s/%s]'s serviceaccount failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 		return nil, err
@@ -307,7 +307,7 @@ func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*c
 			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
-	if supported, err := utildiscovery.IsAPIGroupVersionSupported(mm.discoveryInterface, "security.openshift.io/v1"); err != nil {
+	if supported, err := utildiscovery.IsAPIGroupVersionSupported(m.discoveryInterface, "security.openshift.io/v1"); err != nil {
 		return nil, err
 	} else if supported {
 		// We must use 'anyuid' SecurityContextConstraint to run our container as root.
@@ -322,7 +322,7 @@ func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*c
 
 	if monitor.Spec.ClusterScoped {
 		role := getMonitorClusterRole(monitor, policyRules)
-		role, err = mm.deps.TypedControl.CreateOrUpdateClusterRole(monitor, role)
+		role, err = m.deps.TypedControl.CreateOrUpdateClusterRole(monitor, role)
 		if err != nil {
 			klog.Errorf("tm[%s/%s]'s clusterrole failed to sync, err: %v", monitor.Namespace, monitor.Name, err)
 			return nil, err
@@ -330,14 +330,14 @@ func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*c
 
 		rb := getMonitorClusterRoleBinding(sa, role, monitor)
 
-		_, err = mm.deps.TypedControl.CreateOrUpdateClusterRoleBinding(monitor, rb)
+		_, err = m.deps.TypedControl.CreateOrUpdateClusterRoleBinding(monitor, rb)
 		if err != nil {
 			klog.Errorf("tm[%s/%s]'s clusterrolebinding failed to sync, err: %v", monitor.Namespace, monitor.Name, err)
 			return nil, err
 		}
 	} else {
 		role := getMonitorRole(monitor, policyRules)
-		role, err = mm.deps.TypedControl.CreateOrUpdateRole(monitor, role)
+		role, err = m.deps.TypedControl.CreateOrUpdateRole(monitor, role)
 		if err != nil {
 			klog.Errorf("tm[%s/%s]'s role failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 			return nil, err
@@ -345,7 +345,7 @@ func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*c
 
 		rb := getMonitorRoleBinding(sa, role, monitor)
 
-		_, err = mm.deps.TypedControl.CreateOrUpdateRoleBinding(monitor, rb)
+		_, err = m.deps.TypedControl.CreateOrUpdateRoleBinding(monitor, rb)
 		if err != nil {
 			klog.Errorf("tm[%s/%s]'s rolebinding failed to sync,err: %v", monitor.Namespace, monitor.Name, err)
 			return nil, err
@@ -355,47 +355,47 @@ func (mm *MonitorManager) syncTidbMonitorRbac(monitor *v1alpha1.TidbMonitor) (*c
 	return sa, nil
 }
 
-func (mm *MonitorManager) syncIngress(monitor *v1alpha1.TidbMonitor) error {
-	if err := mm.syncPrometheusIngress(monitor); err != nil {
+func (m *MonitorManager) syncIngress(monitor *v1alpha1.TidbMonitor) error {
+	if err := m.syncPrometheusIngress(monitor); err != nil {
 		return err
 	}
 
-	return mm.syncGrafanaIngress(monitor)
+	return m.syncGrafanaIngress(monitor)
 }
 
-func (mm *MonitorManager) syncPrometheusIngress(monitor *v1alpha1.TidbMonitor) error {
+func (m *MonitorManager) syncPrometheusIngress(monitor *v1alpha1.TidbMonitor) error {
 	if monitor.Spec.Prometheus.Ingress == nil {
-		return mm.removeIngressIfExist(monitor, prometheusName(monitor))
+		return m.removeIngressIfExist(monitor, prometheusName(monitor))
 	}
 
 	ingress := getPrometheusIngress(monitor)
-	_, err := mm.deps.TypedControl.CreateOrUpdateIngress(monitor, ingress)
+	_, err := m.deps.TypedControl.CreateOrUpdateIngress(monitor, ingress)
 	return err
 }
 
-func (mm *MonitorManager) syncGrafanaIngress(monitor *v1alpha1.TidbMonitor) error {
+func (m *MonitorManager) syncGrafanaIngress(monitor *v1alpha1.TidbMonitor) error {
 	if monitor.Spec.Grafana == nil || monitor.Spec.Grafana.Ingress == nil {
-		return mm.removeIngressIfExist(monitor, grafanaName(monitor))
+		return m.removeIngressIfExist(monitor, grafanaName(monitor))
 	}
 	ingress := getGrafanaIngress(monitor)
-	_, err := mm.deps.TypedControl.CreateOrUpdateIngress(monitor, ingress)
+	_, err := m.deps.TypedControl.CreateOrUpdateIngress(monitor, ingress)
 	return err
 }
 
 // removeIngressIfExist removes Ingress if it exists
-func (mm *MonitorManager) removeIngressIfExist(monitor *v1alpha1.TidbMonitor, name string) error {
-	ingress, err := mm.deps.IngressLister.Ingresses(monitor.Namespace).Get(name)
+func (m *MonitorManager) removeIngressIfExist(monitor *v1alpha1.TidbMonitor, name string) error {
+	ingress, err := m.deps.IngressLister.Ingresses(monitor.Namespace).Get(name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	return mm.deps.TypedControl.Delete(monitor, ingress)
+	return m.deps.TypedControl.Delete(monitor, ingress)
 }
 
-func (mm *MonitorManager) patchTidbClusterStatus(tcRef *v1alpha1.TidbClusterRef, monitor *v1alpha1.TidbMonitor) error {
-	tc, err := mm.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).Get(tcRef.Name, metav1.GetOptions{})
+func (m *MonitorManager) patchTidbClusterStatus(tcRef *v1alpha1.TidbClusterRef, monitor *v1alpha1.TidbMonitor) error {
+	tc, err := m.deps.Clientset.PingcapV1alpha1().TidbClusters(tcRef.Namespace).Get(tcRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -424,6 +424,6 @@ func (mm *MonitorManager) patchTidbClusterStatus(tcRef *v1alpha1.TidbClusterRef,
 	if err != nil {
 		return err
 	}
-	_, err = mm.deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Patch(tc.Name, types.MergePatchType, mergePatch)
+	_, err = m.deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Patch(tc.Name, types.MergePatchType, mergePatch)
 	return err
 }

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -812,6 +812,11 @@ func TestGetMonitorPrometheusContainer(t *testing.T) {
 							BaseImage: "hub.pingcap.net",
 							Version:   "latest",
 						},
+						Config: &v1alpha1.PrometheusConfiguration{
+							CommandOptions: []string{
+								"--web.external-url=https://www.example.com/prometheus/",
+							},
+						},
 					},
 				},
 			},
@@ -825,6 +830,7 @@ func TestGetMonitorPrometheusContainer(t *testing.T) {
 					"--config.file=/etc/prometheus/prometheus.yml",
 					"--storage.tsdb.path=/data/prometheus",
 					"--storage.tsdb.retention=0d",
+					"--web.external-url=https://www.example.com/prometheus/",
 				},
 				Ports: []corev1.ContainerPort{
 					corev1.ContainerPort{

--- a/pkg/pdapi/fake_pdapi.go
+++ b/pkg/pdapi/fake_pdapi.go
@@ -70,13 +70,13 @@ func NewFakePDClient() *FakePDClient {
 	return &FakePDClient{reactions: map[ActionType]Reaction{}}
 }
 
-func (pc *FakePDClient) AddReaction(actionType ActionType, reaction Reaction) {
-	pc.reactions[actionType] = reaction
+func (c *FakePDClient) AddReaction(actionType ActionType, reaction Reaction) {
+	c.reactions[actionType] = reaction
 }
 
 // fakeAPI is a small helper for fake API calls
-func (pc *FakePDClient) fakeAPI(actionType ActionType, action *Action) (interface{}, error) {
-	if reaction, ok := pc.reactions[actionType]; ok {
+func (c *FakePDClient) fakeAPI(actionType ActionType, action *Action) (interface{}, error) {
+	if reaction, ok := c.reactions[actionType]; ok {
 		result, err := reaction(action)
 		if err != nil {
 			return nil, err
@@ -86,73 +86,73 @@ func (pc *FakePDClient) fakeAPI(actionType ActionType, action *Action) (interfac
 	return nil, &NotFoundReaction{actionType}
 }
 
-func (pc *FakePDClient) GetHealth() (*HealthInfo, error) {
+func (c *FakePDClient) GetHealth() (*HealthInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetHealthActionType, action)
+	result, err := c.fakeAPI(GetHealthActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*HealthInfo), nil
 }
 
-func (pc *FakePDClient) GetConfig() (*PDConfigFromAPI, error) {
+func (c *FakePDClient) GetConfig() (*PDConfigFromAPI, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetConfigActionType, action)
+	result, err := c.fakeAPI(GetConfigActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*PDConfigFromAPI), nil
 }
 
-func (pc *FakePDClient) GetCluster() (*metapb.Cluster, error) {
+func (c *FakePDClient) GetCluster() (*metapb.Cluster, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetClusterActionType, action)
+	result, err := c.fakeAPI(GetClusterActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*metapb.Cluster), nil
 }
 
-func (pc *FakePDClient) GetMembers() (*MembersInfo, error) {
+func (c *FakePDClient) GetMembers() (*MembersInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetMembersActionType, action)
+	result, err := c.fakeAPI(GetMembersActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*MembersInfo), nil
 }
 
-func (pc *FakePDClient) GetStores() (*StoresInfo, error) {
+func (c *FakePDClient) GetStores() (*StoresInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetStoresActionType, action)
+	result, err := c.fakeAPI(GetStoresActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*StoresInfo), nil
 }
 
-func (pc *FakePDClient) GetTombStoneStores() (*StoresInfo, error) {
+func (c *FakePDClient) GetTombStoneStores() (*StoresInfo, error) {
 	action := &Action{}
-	result, err := pc.fakeAPI(GetTombStoneStoresActionType, action)
+	result, err := c.fakeAPI(GetTombStoneStoresActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*StoresInfo), nil
 }
 
-func (pc *FakePDClient) GetStore(id uint64) (*StoreInfo, error) {
+func (c *FakePDClient) GetStore(id uint64) (*StoreInfo, error) {
 	action := &Action{
 		ID: id,
 	}
-	result, err := pc.fakeAPI(GetStoreActionType, action)
+	result, err := c.fakeAPI(GetStoreActionType, action)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*StoreInfo), nil
 }
 
-func (pc *FakePDClient) DeleteStore(id uint64) error {
-	if reaction, ok := pc.reactions[DeleteStoreActionType]; ok {
+func (c *FakePDClient) DeleteStore(id uint64) error {
+	if reaction, ok := c.reactions[DeleteStoreActionType]; ok {
 		action := &Action{ID: id}
 		_, err := reaction(action)
 		return err
@@ -160,8 +160,8 @@ func (pc *FakePDClient) DeleteStore(id uint64) error {
 	return nil
 }
 
-func (pc *FakePDClient) SetStoreState(id uint64, state string) error {
-	if reaction, ok := pc.reactions[SetStoreStateActionType]; ok {
+func (c *FakePDClient) SetStoreState(id uint64, state string) error {
+	if reaction, ok := c.reactions[SetStoreStateActionType]; ok {
 		action := &Action{ID: id}
 		_, err := reaction(action)
 		return err
@@ -169,8 +169,8 @@ func (pc *FakePDClient) SetStoreState(id uint64, state string) error {
 	return nil
 }
 
-func (pc *FakePDClient) DeleteMemberByID(id uint64) error {
-	if reaction, ok := pc.reactions[DeleteMemberByIDActionType]; ok {
+func (c *FakePDClient) DeleteMemberByID(id uint64) error {
+	if reaction, ok := c.reactions[DeleteMemberByIDActionType]; ok {
 		action := &Action{ID: id}
 		_, err := reaction(action)
 		return err
@@ -178,8 +178,8 @@ func (pc *FakePDClient) DeleteMemberByID(id uint64) error {
 	return nil
 }
 
-func (pc *FakePDClient) DeleteMember(name string) error {
-	if reaction, ok := pc.reactions[DeleteMemberActionType]; ok {
+func (c *FakePDClient) DeleteMember(name string) error {
+	if reaction, ok := c.reactions[DeleteMemberActionType]; ok {
 		action := &Action{Name: name}
 		_, err := reaction(action)
 		return err
@@ -188,8 +188,8 @@ func (pc *FakePDClient) DeleteMember(name string) error {
 }
 
 // SetStoreLabels sets TiKV labels
-func (pc *FakePDClient) SetStoreLabels(storeID uint64, labels map[string]string) (bool, error) {
-	if reaction, ok := pc.reactions[SetStoreLabelsActionType]; ok {
+func (c *FakePDClient) SetStoreLabels(storeID uint64, labels map[string]string) (bool, error) {
+	if reaction, ok := c.reactions[SetStoreLabelsActionType]; ok {
 		action := &Action{ID: storeID, Labels: labels}
 		result, err := reaction(action)
 		return result.(bool), err
@@ -198,8 +198,8 @@ func (pc *FakePDClient) SetStoreLabels(storeID uint64, labels map[string]string)
 }
 
 // UpdateReplicationConfig updates the replication config
-func (pc *FakePDClient) UpdateReplicationConfig(config PDReplicationConfig) error {
-	if reaction, ok := pc.reactions[UpdateReplicationActionType]; ok {
+func (c *FakePDClient) UpdateReplicationConfig(config PDReplicationConfig) error {
+	if reaction, ok := c.reactions[UpdateReplicationActionType]; ok {
 		action := &Action{Replication: config}
 		_, err := reaction(action)
 		return err
@@ -207,8 +207,8 @@ func (pc *FakePDClient) UpdateReplicationConfig(config PDReplicationConfig) erro
 	return nil
 }
 
-func (pc *FakePDClient) BeginEvictLeader(storeID uint64) error {
-	if reaction, ok := pc.reactions[BeginEvictLeaderActionType]; ok {
+func (c *FakePDClient) BeginEvictLeader(storeID uint64) error {
+	if reaction, ok := c.reactions[BeginEvictLeaderActionType]; ok {
 		action := &Action{ID: storeID}
 		_, err := reaction(action)
 		return err
@@ -216,8 +216,8 @@ func (pc *FakePDClient) BeginEvictLeader(storeID uint64) error {
 	return nil
 }
 
-func (pc *FakePDClient) EndEvictLeader(storeID uint64) error {
-	if reaction, ok := pc.reactions[EndEvictLeaderActionType]; ok {
+func (c *FakePDClient) EndEvictLeader(storeID uint64) error {
+	if reaction, ok := c.reactions[EndEvictLeaderActionType]; ok {
 		action := &Action{ID: storeID}
 		_, err := reaction(action)
 		return err
@@ -225,8 +225,8 @@ func (pc *FakePDClient) EndEvictLeader(storeID uint64) error {
 	return nil
 }
 
-func (pc *FakePDClient) GetEvictLeaderSchedulers() ([]string, error) {
-	if reaction, ok := pc.reactions[GetEvictLeaderSchedulersActionType]; ok {
+func (c *FakePDClient) GetEvictLeaderSchedulers() ([]string, error) {
+	if reaction, ok := c.reactions[GetEvictLeaderSchedulersActionType]; ok {
 		action := &Action{}
 		result, err := reaction(action)
 		return result.([]string), err
@@ -234,8 +234,8 @@ func (pc *FakePDClient) GetEvictLeaderSchedulers() ([]string, error) {
 	return nil, nil
 }
 
-func (pc *FakePDClient) GetPDLeader() (*pdpb.Member, error) {
-	if reaction, ok := pc.reactions[GetPDLeaderActionType]; ok {
+func (c *FakePDClient) GetPDLeader() (*pdpb.Member, error) {
+	if reaction, ok := c.reactions[GetPDLeaderActionType]; ok {
 		action := &Action{}
 		result, err := reaction(action)
 		return result.(*pdpb.Member), err
@@ -243,8 +243,8 @@ func (pc *FakePDClient) GetPDLeader() (*pdpb.Member, error) {
 	return nil, nil
 }
 
-func (pc *FakePDClient) TransferPDLeader(memberName string) error {
-	if reaction, ok := pc.reactions[TransferPDLeaderActionType]; ok {
+func (c *FakePDClient) TransferPDLeader(memberName string) error {
+	if reaction, ok := c.reactions[TransferPDLeaderActionType]; ok {
 		action := &Action{Name: memberName}
 		_, err := reaction(action)
 		return err
@@ -252,8 +252,8 @@ func (pc *FakePDClient) TransferPDLeader(memberName string) error {
 	return nil
 }
 
-func (pc *FakePDClient) GetAutoscalingPlans(strategy Strategy) ([]Plan, error) {
-	if reaction, ok := pc.reactions[GetAutoscalingPlansActionType]; ok {
+func (c *FakePDClient) GetAutoscalingPlans(strategy Strategy) ([]Plan, error) {
+	if reaction, ok := c.reactions[GetAutoscalingPlansActionType]; ok {
 		action := &Action{}
 		result, err := reaction(action)
 		return result.([]Plan), err

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -49,15 +49,15 @@ func NewDefaultPDControl(kubeCli kubernetes.Interface) PDControlInterface {
 	return &defaultPDControl{kubeCli: kubeCli, pdClients: map[string]PDClient{}, pdEtcdClients: map[string]PDEtcdClient{}}
 }
 
-func (pdc *defaultPDControl) GetPDEtcdClient(namespace Namespace, tcName string, tlsEnabled bool) (PDEtcdClient, error) {
-	pdc.etcdmutex.Lock()
-	defer pdc.etcdmutex.Unlock()
+func (c *defaultPDControl) GetPDEtcdClient(namespace Namespace, tcName string, tlsEnabled bool) (PDEtcdClient, error) {
+	c.etcdmutex.Lock()
+	defer c.etcdmutex.Unlock()
 
 	var tlsConfig *tls.Config
 	var err error
 
 	if tlsEnabled {
-		tlsConfig, err = GetTLSConfig(pdc.kubeCli, namespace, tcName, util.ClusterClientTLSSecretName(tcName))
+		tlsConfig, err = GetTLSConfig(c.kubeCli, namespace, tcName, util.ClusterClientTLSSecretName(tcName))
 		if err != nil {
 			klog.Errorf("Unable to get tls config for tidb cluster %q, pd etcd client may not work: %v", tcName, err)
 			return nil, err
@@ -65,20 +65,20 @@ func (pdc *defaultPDControl) GetPDEtcdClient(namespace Namespace, tcName string,
 		return NewPdEtcdClient(PDEtcdClientURL(namespace, tcName), DefaultTimeout, tlsConfig)
 	}
 	key := pdEtcdClientKey(namespace, tcName)
-	if _, ok := pdc.pdEtcdClients[key]; !ok {
+	if _, ok := c.pdEtcdClients[key]; !ok {
 		pdetcdClient, err := NewPdEtcdClient(PDEtcdClientURL(namespace, tcName), DefaultTimeout, nil)
 		if err != nil {
 			return nil, err
 		}
-		pdc.pdEtcdClients[key] = pdetcdClient
+		c.pdEtcdClients[key] = pdetcdClient
 	}
-	return pdc.pdEtcdClients[key], nil
+	return c.pdEtcdClients[key], nil
 }
 
 // GetPDClient provides a PDClient of real pd cluster,if the PDClient not existing, it will create new one.
-func (pdc *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tlsEnabled bool) PDClient {
-	pdc.mutex.Lock()
-	defer pdc.mutex.Unlock()
+func (c *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tlsEnabled bool) PDClient {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	var tlsConfig *tls.Config
 	var err error
@@ -86,7 +86,7 @@ func (pdc *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tls
 
 	if tlsEnabled {
 		scheme = "https"
-		tlsConfig, err = GetTLSConfig(pdc.kubeCli, namespace, tcName, util.ClusterClientTLSSecretName(tcName))
+		tlsConfig, err = GetTLSConfig(c.kubeCli, namespace, tcName, util.ClusterClientTLSSecretName(tcName))
 		if err != nil {
 			klog.Errorf("Unable to get tls config for tidb cluster %q, pd client may not work: %v", tcName, err)
 			return &pdClient{url: PdClientURL(namespace, tcName, scheme), httpClient: &http.Client{Timeout: DefaultTimeout}}
@@ -96,10 +96,10 @@ func (pdc *defaultPDControl) GetPDClient(namespace Namespace, tcName string, tls
 	}
 
 	key := pdClientKey(scheme, namespace, tcName)
-	if _, ok := pdc.pdClients[key]; !ok {
-		pdc.pdClients[key] = NewPDClient(PdClientURL(namespace, tcName, scheme), DefaultTimeout, nil)
+	if _, ok := c.pdClients[key]; !ok {
+		c.pdClients[key] = NewPDClient(PdClientURL(namespace, tcName, scheme), DefaultTimeout, nil)
 	}
-	return pdc.pdClients[key]
+	return c.pdClients[key]
 }
 
 // pdClientKey returns the pd client key

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -243,9 +243,9 @@ type schedulerInfo struct {
 	StoreID uint64 `json:"store_id"`
 }
 
-func (pc *pdClient) GetHealth() (*HealthInfo, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, healthPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetHealth() (*HealthInfo, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, healthPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -259,9 +259,9 @@ func (pc *pdClient) GetHealth() (*HealthInfo, error) {
 	}, nil
 }
 
-func (pc *pdClient) GetConfig() (*PDConfigFromAPI, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, configPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetConfig() (*PDConfigFromAPI, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, configPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +273,9 @@ func (pc *pdClient) GetConfig() (*PDConfigFromAPI, error) {
 	return config, nil
 }
 
-func (pc *pdClient) GetCluster() (*metapb.Cluster, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, clusterIDPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetCluster() (*metapb.Cluster, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, clusterIDPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -287,9 +287,9 @@ func (pc *pdClient) GetCluster() (*metapb.Cluster, error) {
 	return cluster, nil
 }
 
-func (pc *pdClient) GetMembers() (*MembersInfo, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, membersPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetMembers() (*MembersInfo, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, membersPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +301,8 @@ func (pc *pdClient) GetMembers() (*MembersInfo, error) {
 	return members, nil
 }
 
-func (pc *pdClient) getStores(apiURL string) (*StoresInfo, error) {
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) getStores(apiURL string) (*StoresInfo, error) {
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -314,17 +314,17 @@ func (pc *pdClient) getStores(apiURL string) (*StoresInfo, error) {
 	return storesInfo, nil
 }
 
-func (pc *pdClient) GetStores() (*StoresInfo, error) {
-	return pc.getStores(fmt.Sprintf("%s/%s", pc.url, storesPrefix))
+func (c *pdClient) GetStores() (*StoresInfo, error) {
+	return c.getStores(fmt.Sprintf("%s/%s", c.url, storesPrefix))
 }
 
-func (pc *pdClient) GetTombStoneStores() (*StoresInfo, error) {
-	return pc.getStores(fmt.Sprintf("%s/%s?state=%d", pc.url, storesPrefix, metapb.StoreState_Tombstone))
+func (c *pdClient) GetTombStoneStores() (*StoresInfo, error) {
+	return c.getStores(fmt.Sprintf("%s/%s?state=%d", c.url, storesPrefix, metapb.StoreState_Tombstone))
 }
 
-func (pc *pdClient) GetStore(storeID uint64) (*StoreInfo, error) {
-	apiURL := fmt.Sprintf("%s/%s/%d", pc.url, storePrefix, storeID)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetStore(storeID uint64) (*StoreInfo, error) {
+	apiURL := fmt.Sprintf("%s/%s/%d", c.url, storePrefix, storeID)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -336,9 +336,9 @@ func (pc *pdClient) GetStore(storeID uint64) (*StoreInfo, error) {
 	return storeInfo, nil
 }
 
-func (pc *pdClient) DeleteStore(storeID uint64) error {
+func (c *pdClient) DeleteStore(storeID uint64) error {
 	var exist bool
-	stores, err := pc.GetStores()
+	stores, err := c.GetStores()
 	if err != nil {
 		return err
 	}
@@ -351,12 +351,12 @@ func (pc *pdClient) DeleteStore(storeID uint64) error {
 	if !exist {
 		return nil
 	}
-	apiURL := fmt.Sprintf("%s/%s/%d", pc.url, storePrefix, storeID)
+	apiURL := fmt.Sprintf("%s/%s/%d", c.url, storePrefix, storeID)
 	req, err := http.NewRequest("DELETE", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -375,13 +375,13 @@ func (pc *pdClient) DeleteStore(storeID uint64) error {
 }
 
 // SetStoreState sets store to specified state.
-func (pc *pdClient) SetStoreState(storeID uint64, state string) error {
-	apiURL := fmt.Sprintf("%s/%s/%d/state?state=%s", pc.url, storePrefix, storeID, state)
+func (c *pdClient) SetStoreState(storeID uint64, state string) error {
+	apiURL := fmt.Sprintf("%s/%s/%d/state?state=%s", c.url, storePrefix, storeID, state)
 	req, err := http.NewRequest("POST", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -398,9 +398,9 @@ func (pc *pdClient) SetStoreState(storeID uint64, state string) error {
 	return fmt.Errorf("failed to delete store %d: %v", storeID, string(body))
 }
 
-func (pc *pdClient) DeleteMemberByID(memberID uint64) error {
+func (c *pdClient) DeleteMemberByID(memberID uint64) error {
 	var exist bool
-	members, err := pc.GetMembers()
+	members, err := c.GetMembers()
 	if err != nil {
 		return err
 	}
@@ -413,12 +413,12 @@ func (pc *pdClient) DeleteMemberByID(memberID uint64) error {
 	if !exist {
 		return nil
 	}
-	apiURL := fmt.Sprintf("%s/%s/id/%d", pc.url, membersPrefix, memberID)
+	apiURL := fmt.Sprintf("%s/%s/id/%d", c.url, membersPrefix, memberID)
 	req, err := http.NewRequest("DELETE", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -430,9 +430,9 @@ func (pc *pdClient) DeleteMemberByID(memberID uint64) error {
 	return fmt.Errorf("failed %v to delete member %d: %v", res.StatusCode, memberID, err2)
 }
 
-func (pc *pdClient) DeleteMember(name string) error {
+func (c *pdClient) DeleteMember(name string) error {
 	var exist bool
-	members, err := pc.GetMembers()
+	members, err := c.GetMembers()
 	if err != nil {
 		return err
 	}
@@ -445,12 +445,12 @@ func (pc *pdClient) DeleteMember(name string) error {
 	if !exist {
 		return nil
 	}
-	apiURL := fmt.Sprintf("%s/%s/name/%s", pc.url, membersPrefix, name)
+	apiURL := fmt.Sprintf("%s/%s/name/%s", c.url, membersPrefix, name)
 	req, err := http.NewRequest("DELETE", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -462,13 +462,13 @@ func (pc *pdClient) DeleteMember(name string) error {
 	return fmt.Errorf("failed %v to delete member %s: %v", res.StatusCode, name, err2)
 }
 
-func (pc *pdClient) SetStoreLabels(storeID uint64, labels map[string]string) (bool, error) {
-	apiURL := fmt.Sprintf("%s/%s/%d/label", pc.url, storePrefix, storeID)
+func (c *pdClient) SetStoreLabels(storeID uint64, labels map[string]string) (bool, error) {
+	apiURL := fmt.Sprintf("%s/%s/%d/label", c.url, storePrefix, storeID)
 	data, err := json.Marshal(labels)
 	if err != nil {
 		return false, err
 	}
-	res, err := pc.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
+	res, err := c.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return false, err
 	}
@@ -480,13 +480,13 @@ func (pc *pdClient) SetStoreLabels(storeID uint64, labels map[string]string) (bo
 	return false, fmt.Errorf("failed %v to set store labels: %v", res.StatusCode, err2)
 }
 
-func (pc *pdClient) UpdateReplicationConfig(config PDReplicationConfig) error {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, pdReplicationPrefix)
+func (c *pdClient) UpdateReplicationConfig(config PDReplicationConfig) error {
+	apiURL := fmt.Sprintf("%s/%s", c.url, pdReplicationPrefix)
 	data, err := json.Marshal(config)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
+	res, err := c.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
@@ -498,14 +498,14 @@ func (pc *pdClient) UpdateReplicationConfig(config PDReplicationConfig) error {
 	return fmt.Errorf("failed %v to update replication: %v", res.StatusCode, err)
 }
 
-func (pc *pdClient) BeginEvictLeader(storeID uint64) error {
+func (c *pdClient) BeginEvictLeader(storeID uint64) error {
 	leaderEvictInfo := getLeaderEvictSchedulerInfo(storeID)
-	apiURL := fmt.Sprintf("%s/%s", pc.url, schedulersPrefix)
+	apiURL := fmt.Sprintf("%s/%s", c.url, schedulersPrefix)
 	data, err := json.Marshal(leaderEvictInfo)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
+	res, err := c.httpClient.Post(apiURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
@@ -521,7 +521,7 @@ func (pc *pdClient) BeginEvictLeader(storeID uint64) error {
 	//   - return nil if the scheduler already exists
 	//
 	// when PD returns standard json response, we should get rid of this verbose code.
-	evictLeaderSchedulers, err := pc.GetEvictLeaderSchedulers()
+	evictLeaderSchedulers, err := c.GetEvictLeaderSchedulers()
 	if err != nil {
 		return err
 	}
@@ -535,14 +535,14 @@ func (pc *pdClient) BeginEvictLeader(storeID uint64) error {
 	return fmt.Errorf("failed %v to begin evict leader of store:[%d],error: %v", res.StatusCode, storeID, err2)
 }
 
-func (pc *pdClient) EndEvictLeader(storeID uint64) error {
+func (c *pdClient) EndEvictLeader(storeID uint64) error {
 	sName := getLeaderEvictSchedulerStr(storeID)
-	apiURL := fmt.Sprintf("%s/%s/%s", pc.url, schedulersPrefix, sName)
+	apiURL := fmt.Sprintf("%s/%s/%s", c.url, schedulersPrefix, sName)
 	req, err := http.NewRequest("DELETE", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func (pc *pdClient) EndEvictLeader(storeID uint64) error {
 	//   - return nil if the scheduler is not found
 	//
 	// when PD returns standard json response, we should get rid of this verbose code.
-	evictLeaderSchedulers, err := pc.GetEvictLeaderSchedulers()
+	evictLeaderSchedulers, err := c.GetEvictLeaderSchedulers()
 	if err != nil {
 		return err
 	}
@@ -577,9 +577,9 @@ func (pc *pdClient) EndEvictLeader(storeID uint64) error {
 	return nil
 }
 
-func (pc *pdClient) GetEvictLeaderSchedulers() ([]string, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, schedulersPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetEvictLeaderSchedulers() ([]string, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, schedulersPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (pc *pdClient) GetEvictLeaderSchedulers() ([]string, error) {
 			evicts = append(evicts, scheduler)
 		}
 	}
-	evictSchedulers, err := pc.filterLeaderEvictScheduler(evicts)
+	evictSchedulers, err := c.filterLeaderEvictScheduler(evicts)
 	if err != nil {
 		return nil, err
 	}
@@ -604,9 +604,9 @@ func (pc *pdClient) GetEvictLeaderSchedulers() ([]string, error) {
 // getEvictLeaderSchedulerConfig gets the config of PD scheduler "evict-leader-scheduler"
 // It's available since PD 3.1.0.
 // In the previous versions, PD API returns 404 and this function will return an error.
-func (pc *pdClient) getEvictLeaderSchedulerConfig() (*evictLeaderSchedulerConfig, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, evictLeaderSchedulerConfigPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) getEvictLeaderSchedulerConfig() (*evictLeaderSchedulerConfig, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, evictLeaderSchedulerConfigPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -622,13 +622,13 @@ func (pc *pdClient) getEvictLeaderSchedulerConfig() (*evictLeaderSchedulerConfig
 // To get more detail, see:
 // - https://github.com/pingcap/tidb-operator/pull/1831
 // - https://github.com/pingcap/pd/issues/2550
-func (pc *pdClient) filterLeaderEvictScheduler(evictLeaderSchedulers []string) ([]string, error) {
+func (c *pdClient) filterLeaderEvictScheduler(evictLeaderSchedulers []string) ([]string, error) {
 	var schedulerIds []string
 	if len(evictLeaderSchedulers) == 1 && evictLeaderSchedulers[0] == evictSchedulerLeader {
 		// If there is only one evcit scehduler entry without store ID postfix.
 		// We should get the store IDs via scheduler config API and append them
 		// to provide consistent results.
-		c, err := pc.getEvictLeaderSchedulerConfig()
+		c, err := c.getEvictLeaderSchedulerConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -641,9 +641,9 @@ func (pc *pdClient) filterLeaderEvictScheduler(evictLeaderSchedulers []string) (
 	return schedulerIds, nil
 }
 
-func (pc *pdClient) GetPDLeader() (*pdpb.Member, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, pdLeaderPrefix)
-	body, err := httputil.GetBodyOK(pc.httpClient, apiURL)
+func (c *pdClient) GetPDLeader() (*pdpb.Member, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, pdLeaderPrefix)
+	body, err := httputil.GetBodyOK(c.httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -655,13 +655,13 @@ func (pc *pdClient) GetPDLeader() (*pdpb.Member, error) {
 	return leader, nil
 }
 
-func (pc *pdClient) TransferPDLeader(memberName string) error {
-	apiURL := fmt.Sprintf("%s/%s/%s", pc.url, pdLeaderTransferPrefix, memberName)
+func (c *pdClient) TransferPDLeader(memberName string) error {
+	apiURL := fmt.Sprintf("%s/%s/%s", c.url, pdLeaderTransferPrefix, memberName)
 	req, err := http.NewRequest("POST", apiURL, nil)
 	if err != nil {
 		return err
 	}
-	res, err := pc.httpClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -673,13 +673,13 @@ func (pc *pdClient) TransferPDLeader(memberName string) error {
 	return fmt.Errorf("failed %v to transfer pd leader to %s,error: %v", res.StatusCode, memberName, err2)
 }
 
-func (pc *pdClient) GetAutoscalingPlans(strategy Strategy) ([]Plan, error) {
-	apiURL := fmt.Sprintf("%s/%s", pc.url, autoscalingPrefix)
+func (c *pdClient) GetAutoscalingPlans(strategy Strategy) ([]Plan, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, autoscalingPrefix)
 	data, err := json.Marshal(strategy)
 	if err != nil {
 		return nil, err
 	}
-	body, err := httputil.PostBodyOK(pc.httpClient, apiURL, bytes.NewBuffer(data))
+	body, err := httputil.PostBodyOK(c.httpClient, apiURL, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pdapi/pdetcd.go
+++ b/pkg/pdapi/pdetcd.go
@@ -51,21 +51,21 @@ func NewPdEtcdClient(url string, timeout time.Duration, tlsConfig *tls.Config) (
 	}, nil
 }
 
-func (pec *pdEtcdClient) Close() error {
-	return pec.etcdClient.Close()
+func (c *pdEtcdClient) Close() error {
+	return c.etcdClient.Close()
 }
 
-func (pec *pdEtcdClient) PutKey(key, value string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), pec.timeout)
+func (c *pdEtcdClient) PutKey(key, value string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
-	_, err := pec.etcdClient.Put(ctx, key, value)
+	_, err := c.etcdClient.Put(ctx, key, value)
 	return err
 }
 
-func (pec *pdEtcdClient) DeleteKey(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), pec.timeout)
+func (c *pdEtcdClient) DeleteKey(key string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
-	kvc := etcdclientv3.NewKV(pec.etcdClient)
+	kvc := etcdclientv3.NewKV(c.etcdClient)
 
 	// perform a delete only if key already exists
 	_, err := kvc.Txn(ctx).

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -162,7 +162,13 @@ var (
 		JSONPath:    ".spec.worker.replicas",
 	}
 	backupAdditionalPrinterColumns []extensionsobj.CustomResourceColumnDefinition
-	backupPathColumn               = extensionsobj.CustomResourceColumnDefinition{
+	backupStatusColumn             = extensionsobj.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "The current status of the backup",
+		JSONPath:    ".status.phase",
+	}
+	backupPathColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "BackupPath",
 		Type:        "string",
 		Description: "The full path of backup data",
@@ -197,7 +203,13 @@ var (
 		JSONPath:    ".status.timeCompleted",
 	}
 	restoreAdditionalPrinterColumns []extensionsobj.CustomResourceColumnDefinition
-	restoreStartedColumn            = extensionsobj.CustomResourceColumnDefinition{
+	restoreStatusColumn             = extensionsobj.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "The current status of the restore",
+		JSONPath:    ".status.phase",
+	}
+	restoreStartedColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Started",
 		Type:        "string",
 		Format:      "date-time",
@@ -297,8 +309,8 @@ func init() {
 		dmClusterMasterColumn, dmClusterMasterStorageColumn, dmClusterMasterReadyColumn, dmClusterMasterDesireColumn,
 		dmClusterWorkerColumn, dmClusterWorkerStorageColumn, dmClusterWorkerReadyColumn, dmClusterWorkerDesireColumn,
 		dmClusterStatusMessageColumn, ageColumn)
-	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn, ageColumn)
-	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStartedColumn, restoreCompletedColumn, restoreCommitTSColumn, ageColumn)
+	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupStatusColumn, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn, ageColumn)
+	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStatusColumn, restoreStartedColumn, restoreCompletedColumn, restoreCommitTSColumn, ageColumn)
 	bksAdditionalPrinterColumns = append(bksAdditionalPrinterColumns, bksScheduleColumn, bksMaxBackups, bksLastBackup, bksLastBackupTime, ageColumn)
 	tidbInitializerPrinterColumns = append(tidbInitializerPrinterColumns, tidbInitializerPhase, ageColumn)
 	autoScalerPrinterColumns = append(autoScalerPrinterColumns, autoScalerTiDBMaxReplicasColumn, autoScalerTiDBMinReplicasColumn,

--- a/pkg/util/crypto/certs_test.go
+++ b/pkg/util/crypto/certs_test.go
@@ -15,9 +15,12 @@ package crypto
 
 import (
 	"crypto/x509"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewCSR(t *testing.T) {
@@ -47,4 +50,86 @@ func TestNewCSR(t *testing.T) {
 		}))
 	g.Expect(csrObj.IPAddresses[0].String()).Should(Equal("10.0.0.1"))
 	g.Expect(csrObj.IPAddresses[1].String()).Should(Equal("fe80:2333::dead:beef"))
+}
+
+var certData = []byte(`-----BEGIN CERTIFICATE-----
+MIIEMDCCAxigAwIBAgIQUJRs7Bjq1ZxN1ZfvdY+grTANBgkqhkiG9w0BAQUFADCB
+gjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3dy54cmFtcHNlY3VyaXR5LmNvbTEk
+MCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2VydmljZXMgSW5jMS0wKwYDVQQDEyRY
+UmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDQxMTAxMTcx
+NDA0WhcNMzUwMTAxMDUzNzE5WjCBgjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3
+dy54cmFtcHNlY3VyaXR5LmNvbTEkMCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2Vy
+dmljZXMgSW5jMS0wKwYDVQQDEyRYUmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBB
+dXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYJB69FbS6
+38eMpSe2OAtp87ZOqCwuIR1cRN8hXX4jdP5efrRKt6atH67gBhbim1vZZ3RrXYCP
+KZ2GG9mcDZhtdhAoWORlsH9KmHmf4MMxfoArtYzAQDsRhtDLooY2YKTVMIJt2W7Q
+DxIEM5dfT2Fa8OT5kavnHTu86M/0ay00fOJIYRyO82FEzG+gSqmUsE3a56k0enI4
+qEHMPJQRfevIpoy3hsvKMzvZPTeL+3o+hiznc9cKV6xkmxnr9A8ECIqsAxcZZPRa
+JSKNNCyy9mgdEm3Tih4U2sSPpuIjhdV6Db1q4Ons7Be7QhtnqiXtRYMh/MHJfNVi
+PvryxS3T/dRlAgMBAAGjgZ8wgZwwEwYJKwYBBAGCNxQCBAYeBABDAEEwCwYDVR0P
+BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMZPoj0GY4QJnM5i5ASs
+jVy16bYbMDYGA1UdHwQvMC0wK6ApoCeGJWh0dHA6Ly9jcmwueHJhbXBzZWN1cml0
+eS5jb20vWEdDQS5jcmwwEAYJKwYBBAGCNxUBBAMCAQEwDQYJKoZIhvcNAQEFBQAD
+ggEBAJEVOQMBG2f7Shz5CmBbodpNl2L5JFMn14JkTpAuw0kbK5rc/Kh4ZzXxHfAR
+vbdI4xD2Dd8/0sm2qlWkSLoC295ZLhVbO50WfUfXN+pfTXYSNrsf16GBBEYgoyxt
+qZ4Bfj8pzgCT3/3JknOJiWSe5yvkHJEs0rnOfc5vMZnT5r7SHpDwCRR5XCOrTdLa
+IR9NmXmd4c8nnxCbHIgNsIpkQTG4DmyQJKSbXHGPurt+HBvbaoAPIbzp26a3QPSy
+i6mx5O+aGtA9aZnuqCij4Tyz8LIRnM98QObd50N9otg6tamN8jSZxNQQ4Qb9CYQQ
+O+7ETPTsJ3xCwnR8gooJybQDJbw=
+-----END CERTIFICATE-----`)
+
+func TestReadCACerts(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// write the ca file for test
+	f, err := ioutil.TempFile("", "")
+	defer os.Remove(f.Name())
+	g.Expect(err).Should(BeNil())
+	_, err = f.Write(certData)
+	g.Expect(err).Should(BeNil())
+
+	_, err = readCACerts(f.Name())
+	g.Expect(err).Should(BeNil())
+}
+
+func TestTlsConfigFromSecret(t *testing.T) {
+	certPem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`)
+	keyPem := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`)
+
+	g := NewGomegaWithT(t)
+	secret := &corev1.Secret{
+		Data: make(map[string][]byte),
+	}
+
+	// test all error case and normal case finally.
+	_, err := LoadTlsConfigFromSecret(secret)
+	g.Expect(err).Should(MatchError("failed to append ca certs"))
+
+	secret.Data[corev1.ServiceAccountRootCAKey] = certData
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err.Error()).Should(MatchRegexp("cert or key does not exist.*"))
+
+	secret.Data[corev1.TLSCertKey] = append(certPem, []byte("messy up data")...)
+	secret.Data[corev1.TLSPrivateKeyKey] = keyPem
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err.Error()).Should(MatchRegexp("unable to load certificates from secret.*"))
+
+	secret.Data[corev1.TLSCertKey] = certPem
+	secret.Data[corev1.TLSPrivateKeyKey] = keyPem
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err).Should(BeNil())
 }

--- a/pkg/util/dmcluster/dmcluster_test.go
+++ b/pkg/util/dmcluster/dmcluster_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dmcluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var conditions []v1alpha1.DMClusterCondition
+
+	c := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason1")
+	conditions = append(conditions, *c)
+
+	status := v1alpha1.DMClusterStatus{
+		Conditions: conditions,
+	}
+
+	// test GetDMClusterCondition
+	getc := GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c))
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterConditionType("not exist"))
+	g.Expect(getc).Should(BeNil())
+
+	// test SetDMClusterCondition
+
+	//  we are about to add already exists and has the same status and reason then we are not going to update
+	SetDMClusterCondition(&status, *c)
+	g.Expect(len(status.Conditions)).Should(Equal(1))
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c))
+
+	// Do not update lastTransitionTime if the status of the condition doesn't change.
+	c2 := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason2")
+	for c2.LastTransitionTime.Equal(&c.LastTransitionTime) {
+		c2.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+	SetDMClusterCondition(&status, *c2)
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc.LastTransitionTime).Should(Equal(c.LastTransitionTime))
+	g.Expect(getc.LastTransitionTime).ShouldNot(Equal(c2.LastTransitionTime))
+	g.Expect(getc.Reason).Should(Equal(c2.Reason))
+
+	// status change from True -> False
+	c3 := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionFalse, StatfulSetNotUpToDate, "reason3")
+	SetDMClusterCondition(&status, *c3)
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c3))
+
+	// test GetDMClusterReadyCondition
+	getc = GetDMClusterReadyCondition(status)
+	g.Expect(getc).Should(Equal(c3))
+}

--- a/pkg/util/http/httputil.go
+++ b/pkg/util/http/httputil.go
@@ -42,20 +42,7 @@ func ReadErrorBody(body io.Reader) (err error) {
 
 // GetBodyOK returns the body or an error if the response is not okay
 func GetBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
-	res, err := httpClient.Get(apiURL)
-	if err != nil {
-		return nil, err
-	}
-	defer DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	if res.StatusCode >= 400 {
-		errMsg := fmt.Errorf("Error response %v URL %s,body response: %s", res.StatusCode, apiURL, string(body[:]))
-		return nil, errMsg
-	}
-	return body, err
+	return DoBodyOK(httpClient, apiURL, "GET", nil)
 }
 
 // PutBodyOK will PUT and returns the body or an error if the response is not okay
@@ -73,7 +60,7 @@ func PostBodyOK(httpClient *http.Client, apiURL string, reqBody io.Reader) ([]by
 	return DoBodyOK(httpClient, apiURL, "POST", reqBody)
 }
 
-// DoBodyOK returns the body or an error if the response is not okay
+// DoBodyOK returns the body or an error if the response is not okay(StatusCode >= 400)
 func DoBodyOK(httpClient *http.Client, apiURL, method string, reqBody io.Reader) ([]byte, error) {
 	req, err := http.NewRequest(method, apiURL, reqBody)
 	if err != nil {

--- a/pkg/util/http/httputil_test.go
+++ b/pkg/util/http/httputil_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/iotest"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestReadErrorBody(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var reader io.Reader
+	var err error
+
+	// test read body
+	reader = bytes.NewReader([]byte("ok"))
+	err = ReadErrorBody(reader)
+	g.Expect(err.Error()).Should(Equal("ok"))
+
+	// test failed to read all from reader
+	reader = iotest.TimeoutReader(bytes.NewReader([]byte("ok")))
+	err = ReadErrorBody(reader)
+	g.Expect(err).Should(Equal(iotest.ErrTimeout))
+}
+
+func TestDoBodyOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			// just echo the body
+			data, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(403)
+			}
+			_, err = w.Write(data)
+			if err != nil {
+				w.WriteHeader(403)
+			}
+			w.WriteHeader(200)
+		case "/server_error":
+			w.WriteHeader(500)
+			return
+		}
+	}))
+
+	g := NewGomegaWithT(t)
+	cli := ts.Client()
+
+	// test normal
+	reqBody := bytes.NewReader([]byte("ok"))
+	data, err := DoBodyOK(cli, ts.URL+"/ok", "GET", reqBody)
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("ok")))
+
+	// test error status code
+	_, err = DoBodyOK(cli, ts.URL+"/server_error", "GET", reqBody)
+	g.Expect(err).ShouldNot(BeNil())
+
+	// test GetBodyOK
+	data, err = GetBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test PutBodyOK
+	data, err = PutBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test DeleteBodyOK
+	data, err = DeleteBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test PostBodyOK
+	data, err = PostBodyOK(cli, ts.URL+"/ok", bytes.NewReader([]byte("ok")))
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("ok")))
+}

--- a/pkg/util/tidbcluster/tidbcluster_test.go
+++ b/pkg/util/tidbcluster/tidbcluster_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbcluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var conditions []v1alpha1.TidbClusterCondition
+
+	c := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason1")
+
+	conditions = append(conditions, *c)
+
+	status := v1alpha1.TidbClusterStatus{
+		Conditions: conditions,
+	}
+
+	// test GetTidbClusterCondition
+	getc := GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c))
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterConditionType("not exist"))
+	g.Expect(getc).Should(BeNil())
+
+	// test SetTidbClusterCondition
+
+	//  we are about to add already exists and has the same status and reason then we are not going to update
+	SetTidbClusterCondition(&status, *c)
+	g.Expect(len(status.Conditions)).Should(Equal(1))
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c))
+
+	// Do not update lastTransitionTime if the status of the condition doesn't change.
+	c2 := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason2")
+	for c2.LastTransitionTime.Equal(&c.LastTransitionTime) {
+		c2.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+	SetTidbClusterCondition(&status, *c2)
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc.LastTransitionTime).Should(Equal(c.LastTransitionTime))
+	g.Expect(getc.LastTransitionTime).ShouldNot(Equal(c2.LastTransitionTime))
+	g.Expect(getc.Reason).Should(Equal(c2.Reason))
+
+	// status change from True -> False
+	c3 := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionFalse, StatfulSetNotUpToDate, "reason3")
+	SetTidbClusterCondition(&status, *c3)
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c3))
+
+	// test GetTidbClusterReadyCondition
+	getc = GetTidbClusterReadyCondition(status)
+	g.Expect(getc).Should(Equal(c3))
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -154,9 +154,6 @@ func GetAutoScalingOutSlots(tc *v1alpha1.TidbCluster, memberType v1alpha1.Member
 	default:
 		return s
 	}
-	if tc.Annotations == nil {
-		return s
-	}
 	v, existed := tc.Annotations[l]
 	if !existed {
 		return s

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -14,15 +14,20 @@
 package util
 
 import (
+	"encoding/json"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -134,6 +139,64 @@ func TestGetPodOrdinals(t *testing.T) {
 				t.Errorf("expects %v got %v", tt.deleteSlots.List(), got.List())
 			}
 		})
+	}
+}
+
+func TestGetAutoScalingOutSlots(t *testing.T) {
+	g := NewGomegaWithT(t)
+	slice := []int32{1, 2}
+	sliceData, err := json.Marshal(slice)
+	sliceString := string(sliceData)
+	g.Expect(err).Should(BeNil())
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				label.AnnTiKVAutoScalingOutOrdinals: sliceString,
+				label.AnnTiDBAutoScalingOutOrdinals: sliceString,
+			},
+		},
+	}
+
+	var get sets.Int32
+	get = GetAutoScalingOutSlots(tc, v1alpha1.PDMemberType)
+	g.Expect(get).Should(Equal(sets.Int32{}))
+
+	get = GetAutoScalingOutSlots(tc, v1alpha1.TiKVMemberType)
+	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
+
+	get = GetAutoScalingOutSlots(tc, v1alpha1.TiDBMemberType)
+	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
+}
+
+func TestName(t *testing.T) {
+	tcName := "test_cluster"
+	com := "com_name"
+	var name string
+	g := NewGomegaWithT(t)
+
+	name = ClusterClientTLSSecretName(tcName)
+	g.Expect(name).Should(Equal(tcName + "-cluster-client-secret"))
+
+	name = ClusterTLSSecretName(tcName, com)
+	g.Expect(name).Should(Equal(tcName + "-" + com + "-cluster-secret"))
+
+	name = TiDBClientTLSSecretName(tcName)
+	g.Expect(name).Should(Equal(tcName + "-tidb-client-secret"))
+}
+
+func TestSortEnvByName(t *testing.T) {
+	f := fuzz.New().NilChance(0.0)
+	for i := 0; i < 10; i++ {
+		var envs []corev1.EnvVar
+		f.Fuzz(&envs)
+
+		sort.Sort(SortEnvByName(envs))
+		// check sorted by name
+		for i := 1; i < len(envs); i++ {
+			if envs[i].Name < envs[i-1].Name {
+				t.Fatal(envs, "not sorted by name")
+			}
+		}
 	}
 }
 
@@ -285,5 +348,166 @@ func TestAppendEnvIfPresent(t *testing.T) {
 				t.Errorf("unwant (-want, +got): %s", diff)
 			}
 		})
+	}
+}
+
+func TestAppendOverwriteEnv(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	a := []corev1.EnvVar{
+		{
+			Name:  "ak_1",
+			Value: "ak_1",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_2",
+		},
+	}
+	b := []corev1.EnvVar{
+		{
+			Name:  "bk_1",
+			Value: "bk_1",
+		},
+		{
+			Name:  "ak_1",
+			Value: "ak_10",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_20",
+		},
+		{
+			Name:  "bk_2",
+			Value: "bk_2",
+		},
+	}
+
+	expect := []corev1.EnvVar{
+		{
+			Name:  "ak_1",
+			Value: "ak_10",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_20",
+		},
+		{
+			Name:  "bk_1",
+			Value: "bk_1",
+		},
+		{
+			Name:  "bk_2",
+			Value: "bk_2",
+		},
+	}
+
+	get := AppendOverwriteEnv(a, b)
+	g.Expect(get).Should(Equal(expect))
+}
+
+func TestMustNewRequirement(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var r *labels.Requirement
+
+	// test panic
+	g.Expect(func() {
+		_ = MustNewRequirement("key", selection.Operator("un known"), nil)
+	}).Should(Panic())
+
+	// test normal case
+	r = MustNewRequirement("key", selection.Equals, []string{"value"})
+	g.Expect(r).ShouldNot(BeNil())
+}
+
+func TestIsOwnedByTidbCluster(t *testing.T) {
+
+}
+
+func TestRetainManagedFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		desiredSvc *corev1.Service
+		existedSvc *corev1.Service
+		expect     *corev1.Service
+	}{
+		{
+			name:       "test keep HealthCheckNodePort",
+			desiredSvc: &corev1.Service{},
+			existedSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					HealthCheckNodePort: 10,
+				},
+			},
+			expect: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					HealthCheckNodePort: 10,
+				},
+			},
+		},
+		{
+			name: "test keep retain NodePorts",
+			desiredSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 8080,
+						},
+						corev1.ServicePort{
+							NodePort: 0,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+						corev1.ServicePort{
+							NodePort: 30,
+							Port:     20,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			existedSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:                corev1.ServiceTypeNodePort,
+					HealthCheckNodePort: 10,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 9090,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expect: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:                corev1.ServiceTypeNodePort,
+					HealthCheckNodePort: 10,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 8080,
+						},
+						corev1.ServicePort{
+							NodePort: 9090,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+						corev1.ServicePort{
+							NodePort: 30,
+							Port:     20,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		RetainManagedFields(test.desiredSvc, test.existedSvc)
+		if diff := cmp.Diff(test.expect.Spec, test.desiredSvc.Spec); diff != "" {
+			t.Errorf("%v unwant (-want, +got): %s", test.name, diff)
+		}
 	}
 }

--- a/pkg/webhook/pod/pd_deleter.go
+++ b/pkg/webhook/pod/pd_deleter.go
@@ -190,7 +190,6 @@ func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(payload *admitPayl
 
 // this pod is a pd leader, we should transfer pd leader to other pd pod before it gets deleted before.
 func (pc *PodAdmissionControl) transferPDLeader(payload *admitPayload) *admission.AdmissionResponse {
-
 	name := payload.pod.Name
 	namespace := payload.pod.Namespace
 	ordinal, err := operatorUtils.GetOrdinalFromPodName(name)

--- a/pkg/webhook/pod/pd_deleter_test.go
+++ b/pkg/webhook/pod/pd_deleter_test.go
@@ -57,7 +57,6 @@ func TestPDDeleterDelete(t *testing.T) {
 
 	testFn := func(test *testcase) {
 		t.Log(test.name)
-
 		/**
 		init statefulset with 3 replicas
 		deletePod := tc-pd-2
@@ -139,7 +138,7 @@ func TestPDDeleterDelete(t *testing.T) {
 		if test.isLeader {
 			fakePDClient.AddReaction(pdapi.GetPDLeaderActionType, func(action *pdapi.Action) (interface{}, error) {
 				leader := pdpb.Member{
-					Name: pdUtils.PdPodName(tcName, 3),
+					Name: deletePod.Name,
 				}
 				return &leader, nil
 			})

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -364,7 +364,7 @@ func (pc *PodAdmissionControl) admintCreatePods(ar *admission.AdmissionRequest) 
 		} else {
 			pdClient = pc.pdControl.GetPDClient(pdapi.Namespace(namespace), ownerTc.Name, ownerTc.IsTLSClusterEnabled())
 		}
-		return pc.admitCreateTiKVPod(pod, pdClient)
+		return admitCreateTiKVPod(pod, pdClient)
 	}
 
 	return util.ARSuccess()

--- a/pkg/webhook/pod/tikv_creater.go
+++ b/pkg/webhook/pod/tikv_creater.go
@@ -29,11 +29,11 @@ const (
 	tikvNotBootstrapped = `TiKV cluster not bootstrapped, please start TiKV first"`
 )
 
-func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.PDClient) *admission.AdmissionResponse {
-
+func admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.PDClient) *admission.AdmissionResponse {
 	name := pod.Name
 	namespace := pod.Namespace
 
+	// always success if tikv is not bootstrapped
 	stores, err := pdClient.GetStores()
 	if err != nil {
 		if strings.HasSuffix(err.Error(), tikvNotBootstrapped+"\n") {
@@ -42,6 +42,7 @@ func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.
 		klog.Infof("Failed to get stores during pod [%s/%s] creation, error: %v", namespace, name, err)
 		return util.ARFail(err)
 	}
+
 	evictLeaderSchedulers, err := pdClient.GetEvictLeaderSchedulers()
 	if err != nil {
 		if strings.HasSuffix(err.Error(), tikvNotBootstrapped+"\n") {

--- a/pkg/webhook/pod/tikv_creater_test.go
+++ b/pkg/webhook/pod/tikv_creater_test.go
@@ -1,0 +1,78 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"strconv"
+	"testing"
+
+	"errors"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb-operator/pkg/pdapi"
+	admission "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAdmitCreateTiKVPod(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	_, err := kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	pdClient := pdapi.NewFakePDClient()
+
+	var resp *admission.AdmissionResponse
+
+	// success if tikv is not bootstrapped
+	pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
+		return nil, errors.New(tikvNotBootstrapped + "\n")
+	})
+	resp = admitCreateTiKVPod(pod, pdClient)
+	g.Expect(resp.Allowed).Should(BeTrue())
+
+	// test should end evict leader and success
+	storeID := 1
+	pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
+		store := &pdapi.StoreInfo{
+			Store: &pdapi.MetaStore{
+				Store: &metapb.Store{
+					Id:      uint64(storeID),
+					Address: pod.Name + ":8080",
+				},
+			},
+			Status: &pdapi.StoreStatus{LeaderCount: 1},
+		}
+		return &pdapi.StoresInfo{
+			Count:  1,
+			Stores: []*pdapi.StoreInfo{store},
+		}, nil
+	})
+	pdClient.AddReaction(pdapi.GetEvictLeaderSchedulersActionType, func(action *pdapi.Action) (interface{}, error) {
+		return []string{"a-b-c-" + strconv.Itoa(storeID)}, nil
+	})
+	endEvictLeader := false
+	pdClient.AddReaction(pdapi.EndEvictLeaderActionType, func(action *pdapi.Action) (interface{}, error) {
+		endEvictLeader = true
+		return nil, nil
+	})
+
+	resp = admitCreateTiKVPod(pod, pdClient)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(endEvictLeader).Should(BeTrue())
+}

--- a/pkg/webhook/pod/tikv_deleter.go
+++ b/pkg/webhook/pod/tikv_deleter.go
@@ -183,7 +183,6 @@ func (pc *PodAdmissionControl) admitDeleteUpTiKVPod(payload *admitPayload, store
 }
 
 func (pc *PodAdmissionControl) admitDeleteUpTiKVPodDuringUpgrading(payload *admitPayload, store *pdapi.StoreInfo) *admission.AdmissionResponse {
-
 	name := payload.pod.Name
 	namespace := payload.pod.Namespace
 	tc, ok := payload.controller.(*v1alpha1.TidbCluster)
@@ -221,7 +220,6 @@ func (pc *PodAdmissionControl) admitDeleteUpTiKVPodDuringUpgrading(payload *admi
 // Users should offline the target tikv into tombstone first, then scale-in it.
 // In other cases, we would admit to delete the down tikv pod like upgrading.
 func (pc *PodAdmissionControl) admitDeleteDownTikvPod(payload *admitPayload) *admission.AdmissionResponse {
-
 	isInOrdinal, err := operatorUtils.IsPodOrdinalNotExceedReplicas(payload.pod, payload.ownerStatefulSet)
 	if err != nil {
 		return util.ARFail(err)

--- a/pkg/webhook/pod/tikv_util.go
+++ b/pkg/webhook/pod/tikv_util.go
@@ -80,7 +80,6 @@ func checkFormerTiKVPodStatus(kubeCli kubernetes.Interface, controllerDesc contr
 }
 
 func addEvictLeaderAnnotation(kubeCli kubernetes.Interface, pod *core.Pod) error {
-
 	name := pod.Name
 	namespace := pod.Namespace
 
@@ -100,7 +99,6 @@ func addEvictLeaderAnnotation(kubeCli kubernetes.Interface, pod *core.Pod) error
 }
 
 func isTiKVReadyToUpgrade(upgradePod *core.Pod, store *pdapi.StoreInfo, evictLeaderTimeout time.Duration) bool {
-
 	if store.Status.LeaderCount == 0 {
 		klog.Infof("pod[%s/%s] has no region leader in store[%d]", upgradePod.Namespace, upgradePod.Name, store.Store.Id)
 		return true
@@ -120,7 +118,6 @@ func isTiKVReadyToUpgrade(upgradePod *core.Pod, store *pdapi.StoreInfo, evictLea
 }
 
 func beginEvictLeader(kubeCli kubernetes.Interface, storeID uint64, pod *core.Pod, pdClient pdapi.PDClient) error {
-
 	name := pod.Name
 	namespace := pod.Namespace
 
@@ -151,7 +148,6 @@ func endEvictLeader(storeInfo *pdapi.StoreInfo, pdClient pdapi.PDClient) error {
 }
 
 func getStoreByPod(pod *core.Pod, storesInfo *pdapi.StoresInfo) (*pdapi.StoreInfo, error) {
-
 	name := pod.Name
 	namespace := pod.Namespace
 

--- a/pkg/webhook/pod/util_test.go
+++ b/pkg/webhook/pod/util_test.go
@@ -16,6 +16,7 @@ package pod
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
@@ -26,7 +27,9 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -172,6 +175,118 @@ func TestCheckTiKVFormerPodStatus(t *testing.T) {
 			g.Expect(err).Should(HaveOccurred())
 		}
 	}
+}
+func TestIsTiKVReadyToUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	store0 := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 0},
+	}
+
+	store1 := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 1},
+	}
+
+	tests := []struct {
+		name    string
+		pod     *core.Pod
+		store   *pdapi.StoreInfo
+		timeout time.Duration
+		result  bool
+	}{
+		{
+			name:    "leader count is zero should be ready",
+			pod:     &core.Pod{},
+			store:   store0,
+			timeout: time.Second,
+			result:  true,
+		},
+		{
+			name:    "not EvictLeaderBeginTime should be false",
+			pod:     &core.Pod{},
+			store:   store1,
+			timeout: time.Second,
+			result:  false,
+		},
+		{
+			name: "timeout should be true",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						EvictLeaderBeginTime: time.Now().AddDate(0, 0, -1 /* one day */).Format(time.RFC3339),
+					},
+				},
+			},
+			store:   store1,
+			timeout: time.Hour * 12,
+			result:  true,
+		},
+		{
+			name: "not timeout should be false",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						EvictLeaderBeginTime: time.Now().AddDate(0, 0, -1 /* one day */).Format(time.RFC3339),
+					},
+				},
+			},
+			store:   store1,
+			timeout: time.Hour * 25,
+			result:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Log("test: ", test.name)
+		get := isTiKVReadyToUpgrade(test.pod, test.store, test.timeout)
+		g.Expect(get).Should(Equal(test.result))
+	}
+}
+
+func TestEvictLeader(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	_, err := kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	store := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{
+				Id: 1,
+			},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 1},
+	}
+	pdClient := pdapi.NewFakePDClient()
+
+	err = beginEvictLeader(kubeCli, store.Store.Id, pod, pdClient)
+	g.Expect(err).Should(BeNil())
+	err = endEvictLeader(store, pdClient)
+	g.Expect(err).Should(BeNil())
+}
+
+func TestAddEvictLeaderAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	err := addEvictLeaderAnnotation(kubeCli, pod)
+	g.Expect(err).ShouldNot(BeNil()) // not exist
+
+	// create first and add again should success.
+	_, err = kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	err = addEvictLeaderAnnotation(kubeCli, pod)
+	g.Expect(err).Should(BeNil())
 }
 
 func buildStoresInfo(tc *v1alpha1.TidbCluster, sts *apps.StatefulSet) *pdapi.StoresInfo {

--- a/pkg/webhook/util/util.go
+++ b/pkg/webhook/util/util.go
@@ -14,7 +14,6 @@
 package util
 
 import (
-	"crypto/tls"
 	"encoding/json"
 
 	"gomodules.xyz/jsonpatch/v2"
@@ -49,17 +48,6 @@ func ARPatch(patch []byte) *admission.AdmissionResponse {
 		Patch:     patch,
 		PatchType: func() *admission.PatchType { p := admission.PatchTypeJSONPatch; return &p }(),
 	}
-}
-
-// config tls cert for server
-func ConfigTLS(certFile string, keyFile string) (*tls.Config, error) {
-	sCert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, err
-	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{sCert},
-	}, nil
 }
 
 func CreateJsonPatch(original, current runtime.Object) ([]byte, error) {

--- a/pkg/webhook/util/util_test.go
+++ b/pkg/webhook/util/util_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	admission "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAR(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var resp *admission.AdmissionResponse
+
+	resp = ARFail(errors.New("err"))
+	g.Expect(resp.Allowed).Should(BeFalse())
+
+	resp = ARSuccess()
+	g.Expect(resp.Allowed).Should(BeTrue())
+
+	resp = ARPatch(nil)
+	g.Expect(resp.Allowed).Should(BeTrue())
+}
+
+func TestCreateJsonPatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := &v1.Pod{}
+	original.Name = "old"
+	current := &v1.Pod{}
+	current.Name = "new"
+
+	data, err := CreateJsonPatch(original, current)
+	g.Expect(err).Should(BeNil())
+
+	var ops []jsonpatch.Operation
+	err = json.Unmarshal(data, &ops)
+	g.Expect(err).Should(BeNil())
+	op := ops[0]
+	g.Expect(op).Should(Equal(jsonpatch.Operation{
+		Operation: "replace",
+		Path:      "/metadata/name",
+		Value:     "new",
+	}))
+}

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -1429,6 +1429,36 @@ var _ = ginkgo.Describe("[tidb-operator] TiDBCluster", func() {
 		framework.Logf("CDC works as expected")
 	})
 
+	ginkgo.Context("when stores number is equal to 3", func() {
+		ginkgo.It("forbid to scale in TiKV and the state of all stores are up", func() {
+			tc := fixture.GetTidbCluster(ns, "scale-in-tikv-test", utilimage.TiDBV4Version)
+			tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+			framework.ExpectNoError(err, "Expected create tidbcluster")
+			err = oa.WaitForTidbClusterReady(tc, 10*time.Minute, 5*time.Second)
+			framework.ExpectNoError(err, "Expected get tidbcluster")
+
+			// scale in tikv
+			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+				tc.Spec.TiKV.Replicas = 2
+				return nil
+			})
+			framework.ExpectNoError(err)
+
+			pdClient, cancel, err := proxiedpdclient.NewProxiedPDClient(c, fw, ns, tc.Name, false)
+			framework.ExpectNoError(err, "create pdClient error")
+			defer cancel()
+			storesInfo, err := pdClient.GetStores()
+			framework.ExpectNoError(err, "get stores info error")
+
+			_ = wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+				framework.ExpectEqual(storesInfo.Count, 3, "Expect number of stores is 3")
+				for _, store := range storesInfo.Stores {
+					framework.ExpectEqual(store.Store.StateName, "Up", "Expect state of stores are Up")
+				}
+				return false, nil
+			})
+		})
+	})
 })
 
 func newTidbClusterConfig(cfg *tests.Config, ns, clusterName, password, tidbVersion string) tests.TidbClusterConfig {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/3387
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change
 

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
