### PR TITLE
monitor: fix surprising prometheus commandOptions behavior

### DIFF
--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -812,6 +812,11 @@ func TestGetMonitorPrometheusContainer(t *testing.T) {
 							BaseImage: "hub.pingcap.net",
 							Version:   "latest",
 						},
+						Config: &v1alpha1.PrometheusConfiguration{
+							CommandOptions: []string{
+								"--web.external-url=https://www.example.com/prometheus/",
+							},
+						},
 					},
 				},
 			},
@@ -825,6 +830,7 @@ func TestGetMonitorPrometheusContainer(t *testing.T) {
 					"--config.file=/etc/prometheus/prometheus.yml",
 					"--storage.tsdb.path=/data/prometheus",
 					"--storage.tsdb.retention=0d",
+					"--web.external-url=https://www.example.com/prometheus/",
 				},
 				Ports: []corev1.ContainerPort{
 					corev1.ContainerPort{


### PR DESCRIPTION
# What problem does this PR solve? <!--add and issue link with summary if exists-->

`prometheus.spec.config.commandOptions` has surprising behavior. Setting it overrides flags essential to correct operation, and other config options on the `spec`.

```
        - --web.enable-admin-api	
        - --web.enable-lifecycle	
        - --config.file=/etc/prometheus/prometheus.yml	
        - --storage.tsdb.path=/data/prometheus	
        - --storage.tsdb.retention=12d
```

while merging with with `--log-level`.

### What is changed and how does it work?

Now, `commandOptions` will only append to the existing set of flags. Prometheus will error on startup if a flag is duplicated.

Note that this is a breaking change. I'm assuming that `commandOptions` is a rarely used advanced option and anyone who uses it will be able to apply a fix pretty easily.

A non-breaking alternative is to add an `extraCommandOptions` flag, but that seems a bit overboard.

### Check List <!--REMOVE the items that are not applicable-->

Tests

 - Unit test

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility.

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
The behavior of `prometheus.spec.config.commandOptions` has changed. Any duplicated flags must be removed or Prometheus will fail to start.
```
