### PR TITLE
Improve unit test for pkg/util

### DIFF
--- a/pkg/util/crypto/certs_test.go
+++ b/pkg/util/crypto/certs_test.go
@@ -15,9 +15,12 @@ package crypto
 
 import (
 	"crypto/x509"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewCSR(t *testing.T) {
@@ -47,4 +50,86 @@ func TestNewCSR(t *testing.T) {
 		}))
 	g.Expect(csrObj.IPAddresses[0].String()).Should(Equal("10.0.0.1"))
 	g.Expect(csrObj.IPAddresses[1].String()).Should(Equal("fe80:2333::dead:beef"))
+}
+
+var certData = []byte(`-----BEGIN CERTIFICATE-----
+MIIEMDCCAxigAwIBAgIQUJRs7Bjq1ZxN1ZfvdY+grTANBgkqhkiG9w0BAQUFADCB
+gjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3dy54cmFtcHNlY3VyaXR5LmNvbTEk
+MCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2VydmljZXMgSW5jMS0wKwYDVQQDEyRY
+UmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDQxMTAxMTcx
+NDA0WhcNMzUwMTAxMDUzNzE5WjCBgjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3
+dy54cmFtcHNlY3VyaXR5LmNvbTEkMCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2Vy
+dmljZXMgSW5jMS0wKwYDVQQDEyRYUmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBB
+dXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYJB69FbS6
+38eMpSe2OAtp87ZOqCwuIR1cRN8hXX4jdP5efrRKt6atH67gBhbim1vZZ3RrXYCP
+KZ2GG9mcDZhtdhAoWORlsH9KmHmf4MMxfoArtYzAQDsRhtDLooY2YKTVMIJt2W7Q
+DxIEM5dfT2Fa8OT5kavnHTu86M/0ay00fOJIYRyO82FEzG+gSqmUsE3a56k0enI4
+qEHMPJQRfevIpoy3hsvKMzvZPTeL+3o+hiznc9cKV6xkmxnr9A8ECIqsAxcZZPRa
+JSKNNCyy9mgdEm3Tih4U2sSPpuIjhdV6Db1q4Ons7Be7QhtnqiXtRYMh/MHJfNVi
+PvryxS3T/dRlAgMBAAGjgZ8wgZwwEwYJKwYBBAGCNxQCBAYeBABDAEEwCwYDVR0P
+BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMZPoj0GY4QJnM5i5ASs
+jVy16bYbMDYGA1UdHwQvMC0wK6ApoCeGJWh0dHA6Ly9jcmwueHJhbXBzZWN1cml0
+eS5jb20vWEdDQS5jcmwwEAYJKwYBBAGCNxUBBAMCAQEwDQYJKoZIhvcNAQEFBQAD
+ggEBAJEVOQMBG2f7Shz5CmBbodpNl2L5JFMn14JkTpAuw0kbK5rc/Kh4ZzXxHfAR
+vbdI4xD2Dd8/0sm2qlWkSLoC295ZLhVbO50WfUfXN+pfTXYSNrsf16GBBEYgoyxt
+qZ4Bfj8pzgCT3/3JknOJiWSe5yvkHJEs0rnOfc5vMZnT5r7SHpDwCRR5XCOrTdLa
+IR9NmXmd4c8nnxCbHIgNsIpkQTG4DmyQJKSbXHGPurt+HBvbaoAPIbzp26a3QPSy
+i6mx5O+aGtA9aZnuqCij4Tyz8LIRnM98QObd50N9otg6tamN8jSZxNQQ4Qb9CYQQ
+O+7ETPTsJ3xCwnR8gooJybQDJbw=
+-----END CERTIFICATE-----`)
+
+func TestReadCACerts(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// write the ca file for test
+	f, err := ioutil.TempFile("", "")
+	defer os.Remove(f.Name())
+	g.Expect(err).Should(BeNil())
+	_, err = f.Write(certData)
+	g.Expect(err).Should(BeNil())
+
+	_, err = readCACerts(f.Name())
+	g.Expect(err).Should(BeNil())
+}
+
+func TestTlsConfigFromSecret(t *testing.T) {
+	certPem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`)
+	keyPem := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`)
+
+	g := NewGomegaWithT(t)
+	secret := &corev1.Secret{
+		Data: make(map[string][]byte),
+	}
+
+	// test all error case and normal case finally.
+	_, err := LoadTlsConfigFromSecret(secret)
+	g.Expect(err).Should(MatchError("failed to append ca certs"))
+
+	secret.Data[corev1.ServiceAccountRootCAKey] = certData
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err.Error()).Should(MatchRegexp("cert or key does not exist.*"))
+
+	secret.Data[corev1.TLSCertKey] = append(certPem, []byte("messy up data")...)
+	secret.Data[corev1.TLSPrivateKeyKey] = keyPem
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err.Error()).Should(MatchRegexp("unable to load certificates from secret.*"))
+
+	secret.Data[corev1.TLSCertKey] = certPem
+	secret.Data[corev1.TLSPrivateKeyKey] = keyPem
+	_, err = LoadTlsConfigFromSecret(secret)
+	g.Expect(err).Should(BeNil())
 }

--- a/pkg/util/dmcluster/dmcluster_test.go
+++ b/pkg/util/dmcluster/dmcluster_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dmcluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var conditions []v1alpha1.DMClusterCondition
+
+	c := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason1")
+	conditions = append(conditions, *c)
+
+	status := v1alpha1.DMClusterStatus{
+		Conditions: conditions,
+	}
+
+	// test GetDMClusterCondition
+	getc := GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c))
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterConditionType("not exist"))
+	g.Expect(getc).Should(BeNil())
+
+	// test SetDMClusterCondition
+
+	//  we are about to add already exists and has the same status and reason then we are not going to update
+	SetDMClusterCondition(&status, *c)
+	g.Expect(len(status.Conditions)).Should(Equal(1))
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c))
+
+	// Do not update lastTransitionTime if the status of the condition doesn't change.
+	c2 := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason2")
+	for c2.LastTransitionTime.Equal(&c.LastTransitionTime) {
+		c2.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+	SetDMClusterCondition(&status, *c2)
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc.LastTransitionTime).Should(Equal(c.LastTransitionTime))
+	g.Expect(getc.LastTransitionTime).ShouldNot(Equal(c2.LastTransitionTime))
+	g.Expect(getc.Reason).Should(Equal(c2.Reason))
+
+	// status change from True -> False
+	c3 := NewDMClusterCondition(v1alpha1.DMClusterReady, v1.ConditionFalse, StatfulSetNotUpToDate, "reason3")
+	SetDMClusterCondition(&status, *c3)
+	getc = GetDMClusterCondition(status, v1alpha1.DMClusterReady)
+	g.Expect(getc).Should(Equal(c3))
+
+	// test GetDMClusterReadyCondition
+	getc = GetDMClusterReadyCondition(status)
+	g.Expect(getc).Should(Equal(c3))
+}

--- a/pkg/util/http/httputil.go
+++ b/pkg/util/http/httputil.go
@@ -42,20 +42,7 @@ func ReadErrorBody(body io.Reader) (err error) {
 
 // GetBodyOK returns the body or an error if the response is not okay
 func GetBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
-	res, err := httpClient.Get(apiURL)
-	if err != nil {
-		return nil, err
-	}
-	defer DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	if res.StatusCode >= 400 {
-		errMsg := fmt.Errorf("Error response %v URL %s,body response: %s", res.StatusCode, apiURL, string(body[:]))
-		return nil, errMsg
-	}
-	return body, err
+	return DoBodyOK(httpClient, apiURL, "GET", nil)
 }
 
 // PutBodyOK will PUT and returns the body or an error if the response is not okay
@@ -73,7 +60,7 @@ func PostBodyOK(httpClient *http.Client, apiURL string, reqBody io.Reader) ([]by
 	return DoBodyOK(httpClient, apiURL, "POST", reqBody)
 }
 
-// DoBodyOK returns the body or an error if the response is not okay
+// DoBodyOK returns the body or an error if the response is not okay(StatusCode >= 400)
 func DoBodyOK(httpClient *http.Client, apiURL, method string, reqBody io.Reader) ([]byte, error) {
 	req, err := http.NewRequest(method, apiURL, reqBody)
 	if err != nil {

--- a/pkg/util/http/httputil_test.go
+++ b/pkg/util/http/httputil_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/iotest"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestReadErrorBody(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var reader io.Reader
+	var err error
+
+	// test read body
+	reader = bytes.NewReader([]byte("ok"))
+	err = ReadErrorBody(reader)
+	g.Expect(err.Error()).Should(Equal("ok"))
+
+	// test failed to read all from reader
+	reader = iotest.TimeoutReader(bytes.NewReader([]byte("ok")))
+	err = ReadErrorBody(reader)
+	g.Expect(err).Should(Equal(iotest.ErrTimeout))
+}
+
+func TestDoBodyOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			// just echo the body
+			data, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(403)
+			}
+			_, err = w.Write(data)
+			if err != nil {
+				w.WriteHeader(403)
+			}
+			w.WriteHeader(200)
+		case "/server_error":
+			w.WriteHeader(500)
+			return
+		}
+	}))
+
+	g := NewGomegaWithT(t)
+	cli := ts.Client()
+
+	// test normal
+	reqBody := bytes.NewReader([]byte("ok"))
+	data, err := DoBodyOK(cli, ts.URL+"/ok", "GET", reqBody)
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("ok")))
+
+	// test error status code
+	_, err = DoBodyOK(cli, ts.URL+"/server_error", "GET", reqBody)
+	g.Expect(err).ShouldNot(BeNil())
+
+	// test GetBodyOK
+	data, err = GetBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test PutBodyOK
+	data, err = PutBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test DeleteBodyOK
+	data, err = DeleteBodyOK(cli, ts.URL+"/ok")
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("")))
+
+	// test PostBodyOK
+	data, err = PostBodyOK(cli, ts.URL+"/ok", bytes.NewReader([]byte("ok")))
+	g.Expect(err).Should(BeNil())
+	g.Expect(data).Should(Equal([]byte("ok")))
+}

--- a/pkg/util/tidbcluster/tidbcluster_test.go
+++ b/pkg/util/tidbcluster/tidbcluster_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbcluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var conditions []v1alpha1.TidbClusterCondition
+
+	c := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason1")
+
+	conditions = append(conditions, *c)
+
+	status := v1alpha1.TidbClusterStatus{
+		Conditions: conditions,
+	}
+
+	// test GetTidbClusterCondition
+	getc := GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c))
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterConditionType("not exist"))
+	g.Expect(getc).Should(BeNil())
+
+	// test SetTidbClusterCondition
+
+	//  we are about to add already exists and has the same status and reason then we are not going to update
+	SetTidbClusterCondition(&status, *c)
+	g.Expect(len(status.Conditions)).Should(Equal(1))
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c))
+
+	// Do not update lastTransitionTime if the status of the condition doesn't change.
+	c2 := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionTrue, StatfulSetNotUpToDate, "reason2")
+	for c2.LastTransitionTime.Equal(&c.LastTransitionTime) {
+		c2.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+	SetTidbClusterCondition(&status, *c2)
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc.LastTransitionTime).Should(Equal(c.LastTransitionTime))
+	g.Expect(getc.LastTransitionTime).ShouldNot(Equal(c2.LastTransitionTime))
+	g.Expect(getc.Reason).Should(Equal(c2.Reason))
+
+	// status change from True -> False
+	c3 := NewTidbClusterCondition(v1alpha1.TidbClusterReady, v1.ConditionFalse, StatfulSetNotUpToDate, "reason3")
+	SetTidbClusterCondition(&status, *c3)
+	getc = GetTidbClusterCondition(status, v1alpha1.TidbClusterReady)
+	g.Expect(getc).Should(Equal(c3))
+
+	// test GetTidbClusterReadyCondition
+	getc = GetTidbClusterReadyCondition(status)
+	g.Expect(getc).Should(Equal(c3))
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -154,9 +154,6 @@ func GetAutoScalingOutSlots(tc *v1alpha1.TidbCluster, memberType v1alpha1.Member
 	default:
 		return s
 	}
-	if tc.Annotations == nil {
-		return s
-	}
 	v, existed := tc.Annotations[l]
 	if !existed {
 		return s

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -14,15 +14,20 @@
 package util
 
 import (
+	"encoding/json"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -134,6 +139,64 @@ func TestGetPodOrdinals(t *testing.T) {
 				t.Errorf("expects %v got %v", tt.deleteSlots.List(), got.List())
 			}
 		})
+	}
+}
+
+func TestGetAutoScalingOutSlots(t *testing.T) {
+	g := NewGomegaWithT(t)
+	slice := []int32{1, 2}
+	sliceData, err := json.Marshal(slice)
+	sliceString := string(sliceData)
+	g.Expect(err).Should(BeNil())
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				label.AnnTiKVAutoScalingOutOrdinals: sliceString,
+				label.AnnTiDBAutoScalingOutOrdinals: sliceString,
+			},
+		},
+	}
+
+	var get sets.Int32
+	get = GetAutoScalingOutSlots(tc, v1alpha1.PDMemberType)
+	g.Expect(get).Should(Equal(sets.Int32{}))
+
+	get = GetAutoScalingOutSlots(tc, v1alpha1.TiKVMemberType)
+	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
+
+	get = GetAutoScalingOutSlots(tc, v1alpha1.TiDBMemberType)
+	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
+}
+
+func TestName(t *testing.T) {
+	tcName := "test_cluster"
+	com := "com_name"
+	var name string
+	g := NewGomegaWithT(t)
+
+	name = ClusterClientTLSSecretName(tcName)
+	g.Expect(name).Should(Equal(tcName + "-cluster-client-secret"))
+
+	name = ClusterTLSSecretName(tcName, com)
+	g.Expect(name).Should(Equal(tcName + "-" + com + "-cluster-secret"))
+
+	name = TiDBClientTLSSecretName(tcName)
+	g.Expect(name).Should(Equal(tcName + "-tidb-client-secret"))
+}
+
+func TestSortEnvByName(t *testing.T) {
+	f := fuzz.New().NilChance(0.0)
+	for i := 0; i < 10; i++ {
+		var envs []corev1.EnvVar
+		f.Fuzz(&envs)
+
+		sort.Sort(SortEnvByName(envs))
+		// check sorted by name
+		for i := 1; i < len(envs); i++ {
+			if envs[i].Name < envs[i-1].Name {
+				t.Fatal(envs, "not sorted by name")
+			}
+		}
 	}
 }
 
@@ -285,5 +348,166 @@ func TestAppendEnvIfPresent(t *testing.T) {
 				t.Errorf("unwant (-want, +got): %s", diff)
 			}
 		})
+	}
+}
+
+func TestAppendOverwriteEnv(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	a := []corev1.EnvVar{
+		{
+			Name:  "ak_1",
+			Value: "ak_1",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_2",
+		},
+	}
+	b := []corev1.EnvVar{
+		{
+			Name:  "bk_1",
+			Value: "bk_1",
+		},
+		{
+			Name:  "ak_1",
+			Value: "ak_10",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_20",
+		},
+		{
+			Name:  "bk_2",
+			Value: "bk_2",
+		},
+	}
+
+	expect := []corev1.EnvVar{
+		{
+			Name:  "ak_1",
+			Value: "ak_10",
+		},
+		{
+			Name:  "ak_2",
+			Value: "ak_20",
+		},
+		{
+			Name:  "bk_1",
+			Value: "bk_1",
+		},
+		{
+			Name:  "bk_2",
+			Value: "bk_2",
+		},
+	}
+
+	get := AppendOverwriteEnv(a, b)
+	g.Expect(get).Should(Equal(expect))
+}
+
+func TestMustNewRequirement(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var r *labels.Requirement
+
+	// test panic
+	g.Expect(func() {
+		_ = MustNewRequirement("key", selection.Operator("un known"), nil)
+	}).Should(Panic())
+
+	// test normal case
+	r = MustNewRequirement("key", selection.Equals, []string{"value"})
+	g.Expect(r).ShouldNot(BeNil())
+}
+
+func TestIsOwnedByTidbCluster(t *testing.T) {
+
+}
+
+func TestRetainManagedFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		desiredSvc *corev1.Service
+		existedSvc *corev1.Service
+		expect     *corev1.Service
+	}{
+		{
+			name:       "test keep HealthCheckNodePort",
+			desiredSvc: &corev1.Service{},
+			existedSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					HealthCheckNodePort: 10,
+				},
+			},
+			expect: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					HealthCheckNodePort: 10,
+				},
+			},
+		},
+		{
+			name: "test keep retain NodePorts",
+			desiredSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 8080,
+						},
+						corev1.ServicePort{
+							NodePort: 0,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+						corev1.ServicePort{
+							NodePort: 30,
+							Port:     20,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			existedSvc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:                corev1.ServiceTypeNodePort,
+					HealthCheckNodePort: 10,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 9090,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expect: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type:                corev1.ServiceTypeNodePort,
+					HealthCheckNodePort: 10,
+					Ports: []corev1.ServicePort{
+						corev1.ServicePort{
+							NodePort: 8080,
+						},
+						corev1.ServicePort{
+							NodePort: 9090,
+							Port:     10,
+							Protocol: corev1.ProtocolTCP,
+						},
+						corev1.ServicePort{
+							NodePort: 30,
+							Port:     20,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		RetainManagedFields(test.desiredSvc, test.existedSvc)
+		if diff := cmp.Diff(test.expect.Spec, test.desiredSvc.Spec); diff != "" {
+			t.Errorf("%v unwant (-want, +got): %s", test.name, diff)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #3396 

after this pr:
➜  util git:(util_test) ✗ go test ./... -cover
ok      github.com/pingcap/tidb-operator/pkg/util       0.041s  coverage: 73.1% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/config        0.013s  coverage: 76.2% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/crypto        0.394s  coverage: 78.6% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/discovery     0.019s  coverage: 85.0% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/dmcluster     0.031s  coverage: 90.0% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/http  0.023s  coverage: 83.3% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/tidbcluster   0.035s  coverage: 90.0% of statements
ok      github.com/pingcap/tidb-operator/pkg/util/toml  0.010s  coverage: 80.0% of statements

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
