### PR TITLE
add phase for backup and restore status

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2495,7 +2495,8 @@ string
 <h3 id="backupconditiontype">BackupConditionType</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#backupcondition">BackupCondition</a>)
+<a href="#backupcondition">BackupCondition</a>, 
+<a href="#backupstatus">BackupStatus</a>)
 </p>
 <p>
 <p>BackupConditionType represents a valid condition of a Backup.</p>
@@ -2978,6 +2979,19 @@ string
 </td>
 <td>
 <p>CommitTs is the snapshot time point of tidb cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#backupconditiontype">
+BackupConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Phase is a user readable state inferred from the underlying Backup conditions</p>
 </td>
 </tr>
 <tr>
@@ -9910,7 +9924,8 @@ string
 <h3 id="restoreconditiontype">RestoreConditionType</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#restorecondition">RestoreCondition</a>)
+<a href="#restorecondition">RestoreCondition</a>, 
+<a href="#restorestatus">RestoreStatus</a>)
 </p>
 <p>
 <p>RestoreConditionType represents a valid condition of a Restore.</p>
@@ -10163,6 +10178,19 @@ string
 </td>
 <td>
 <p>CommitTs is the snapshot time point of tidb cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#restoreconditiontype">
+RestoreConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Phase is a user readable state inferred from the underlying Restore conditions</p>
 </td>
 </tr>
 <tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13058,6 +13058,10 @@ metadata:
   name: backups.pingcap.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The current status of the backup
+    name: Status
+    type: string
   - JSONPath: .status.backupPath
     description: The full path of backup data
     name: BackupPath
@@ -13530,6 +13534,10 @@ metadata:
   name: restores.pingcap.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The current status of the restore
+    name: Status
+    type: string
   - JSONPath: .status.timeStarted
     description: The time at which the backup was started
     format: date-time

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -72,6 +72,8 @@ func UpdateBackupCondition(status *BackupStatus, condition *BackupCondition) boo
 	// Try to find this Backup condition.
 	conditionIndex, oldCondition := GetBackupCondition(status, condition.Type)
 
+	status.Phase = condition.Type
+
 	if oldCondition == nil {
 		// We are adding new Backup condition.
 		status.Conditions = append(status.Conditions, *condition)

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -67,6 +67,8 @@ func UpdateRestoreCondition(status *RestoreStatus, condition *RestoreCondition) 
 	// Try to find this Restore condition.
 	conditionIndex, oldCondition := GetRestoreCondition(status, condition.Type)
 
+	status.Phase = condition.Type
+
 	if oldCondition == nil {
 		// We are adding new Restore condition.
 		status.Conditions = append(status.Conditions, *condition)

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1302,8 +1302,10 @@ type BackupStatus struct {
 	// BackupSize is the data size of the backup.
 	BackupSize int64 `json:"backupSize"`
 	// CommitTs is the snapshot time point of tidb cluster.
-	CommitTs   string            `json:"commitTs"`
-	Conditions []BackupCondition `json:"conditions"`
+	CommitTs string `json:"commitTs"`
+	// Phase is a user readable state inferred from the underlying Backup conditions
+	Phase      BackupConditionType `json:"phase"`
+	Conditions []BackupCondition   `json:"conditions"`
 }
 
 // +genclient
@@ -1468,8 +1470,10 @@ type RestoreStatus struct {
 	// TimeCompleted is the time at which the restore was completed.
 	TimeCompleted metav1.Time `json:"timeCompleted"`
 	// CommitTs is the snapshot time point of tidb cluster.
-	CommitTs   string             `json:"commitTs"`
-	Conditions []RestoreCondition `json:"conditions"`
+	CommitTs string `json:"commitTs"`
+	// Phase is a user readable state inferred from the underlying Restore conditions
+	Phase      RestoreConditionType `json:"phase"`
+	Conditions []RestoreCondition   `json:"conditions"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/util/crdutil.go
+++ b/pkg/util/crdutil.go
@@ -162,7 +162,13 @@ var (
 		JSONPath:    ".spec.worker.replicas",
 	}
 	backupAdditionalPrinterColumns []extensionsobj.CustomResourceColumnDefinition
-	backupPathColumn               = extensionsobj.CustomResourceColumnDefinition{
+	backupStatusColumn             = extensionsobj.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "The current status of the backup",
+		JSONPath:    ".status.phase",
+	}
+	backupPathColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "BackupPath",
 		Type:        "string",
 		Description: "The full path of backup data",
@@ -197,7 +203,13 @@ var (
 		JSONPath:    ".status.timeCompleted",
 	}
 	restoreAdditionalPrinterColumns []extensionsobj.CustomResourceColumnDefinition
-	restoreStartedColumn            = extensionsobj.CustomResourceColumnDefinition{
+	restoreStatusColumn             = extensionsobj.CustomResourceColumnDefinition{
+		Name:        "Status",
+		Type:        "string",
+		Description: "The current status of the restore",
+		JSONPath:    ".status.phase",
+	}
+	restoreStartedColumn = extensionsobj.CustomResourceColumnDefinition{
 		Name:        "Started",
 		Type:        "string",
 		Format:      "date-time",
@@ -297,8 +309,8 @@ func init() {
 		dmClusterMasterColumn, dmClusterMasterStorageColumn, dmClusterMasterReadyColumn, dmClusterMasterDesireColumn,
 		dmClusterWorkerColumn, dmClusterWorkerStorageColumn, dmClusterWorkerReadyColumn, dmClusterWorkerDesireColumn,
 		dmClusterStatusMessageColumn, ageColumn)
-	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn, ageColumn)
-	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStartedColumn, restoreCompletedColumn, restoreCommitTSColumn, ageColumn)
+	backupAdditionalPrinterColumns = append(backupAdditionalPrinterColumns, backupStatusColumn, backupPathColumn, backupBackupSizeColumn, backupCommitTSColumn, backupStartedColumn, backupCompletedColumn, ageColumn)
+	restoreAdditionalPrinterColumns = append(restoreAdditionalPrinterColumns, restoreStatusColumn, restoreStartedColumn, restoreCompletedColumn, restoreCommitTSColumn, ageColumn)
 	bksAdditionalPrinterColumns = append(bksAdditionalPrinterColumns, bksScheduleColumn, bksMaxBackups, bksLastBackup, bksLastBackupTime, ageColumn)
 	tidbInitializerPrinterColumns = append(tidbInitializerPrinterColumns, tidbInitializerPhase, ageColumn)
 	autoScalerPrinterColumns = append(autoScalerPrinterColumns, autoScalerTiDBMaxReplicasColumn, autoScalerTiDBMinReplicasColumn,


### PR DESCRIPTION
Signed-off-by: gongmengnan <gong.mengnan@ninjavan.co>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix https://github.com/pingcap/tidb-operator/issues/1658.

### What is changed and how does it work?
`phase` is added in `BackupStatus` and `RestoreStatus`, it will be in sync with the latest condition type and shown when doing `kubectl get`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Code changes

 - Has Go code change

Side effects

N/A

Related changes

N/A

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
