### PR TITLE
Improve pkg/webhook test

### DIFF
--- a/pkg/webhook/pod/pd_deleter.go
+++ b/pkg/webhook/pod/pd_deleter.go
@@ -190,7 +190,6 @@ func (pc *PodAdmissionControl) admitDeleteExceedReplicasPDPod(payload *admitPayl
 
 // this pod is a pd leader, we should transfer pd leader to other pd pod before it gets deleted before.
 func (pc *PodAdmissionControl) transferPDLeader(payload *admitPayload) *admission.AdmissionResponse {
-
 	name := payload.pod.Name
 	namespace := payload.pod.Namespace
 	ordinal, err := operatorUtils.GetOrdinalFromPodName(name)

--- a/pkg/webhook/pod/pd_deleter_test.go
+++ b/pkg/webhook/pod/pd_deleter_test.go
@@ -57,7 +57,6 @@ func TestPDDeleterDelete(t *testing.T) {
 
 	testFn := func(test *testcase) {
 		t.Log(test.name)
-
 		/**
 		init statefulset with 3 replicas
 		deletePod := tc-pd-2
@@ -139,7 +138,7 @@ func TestPDDeleterDelete(t *testing.T) {
 		if test.isLeader {
 			fakePDClient.AddReaction(pdapi.GetPDLeaderActionType, func(action *pdapi.Action) (interface{}, error) {
 				leader := pdpb.Member{
-					Name: pdUtils.PdPodName(tcName, 3),
+					Name: deletePod.Name,
 				}
 				return &leader, nil
 			})

--- a/pkg/webhook/pod/pods.go
+++ b/pkg/webhook/pod/pods.go
@@ -364,7 +364,7 @@ func (pc *PodAdmissionControl) admintCreatePods(ar *admission.AdmissionRequest) 
 		} else {
 			pdClient = pc.pdControl.GetPDClient(pdapi.Namespace(namespace), ownerTc.Name, ownerTc.IsTLSClusterEnabled())
 		}
-		return pc.admitCreateTiKVPod(pod, pdClient)
+		return admitCreateTiKVPod(pod, pdClient)
 	}
 
 	return util.ARSuccess()

--- a/pkg/webhook/pod/tikv_creater.go
+++ b/pkg/webhook/pod/tikv_creater.go
@@ -29,11 +29,11 @@ const (
 	tikvNotBootstrapped = `TiKV cluster not bootstrapped, please start TiKV first"`
 )
 
-func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.PDClient) *admission.AdmissionResponse {
-
+func admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.PDClient) *admission.AdmissionResponse {
 	name := pod.Name
 	namespace := pod.Namespace
 
+	// always success if tikv is not bootstrapped
 	stores, err := pdClient.GetStores()
 	if err != nil {
 		if strings.HasSuffix(err.Error(), tikvNotBootstrapped+"\n") {
@@ -42,6 +42,7 @@ func (pc *PodAdmissionControl) admitCreateTiKVPod(pod *core.Pod, pdClient pdapi.
 		klog.Infof("Failed to get stores during pod [%s/%s] creation, error: %v", namespace, name, err)
 		return util.ARFail(err)
 	}
+
 	evictLeaderSchedulers, err := pdClient.GetEvictLeaderSchedulers()
 	if err != nil {
 		if strings.HasSuffix(err.Error(), tikvNotBootstrapped+"\n") {

--- a/pkg/webhook/pod/tikv_creater_test.go
+++ b/pkg/webhook/pod/tikv_creater_test.go
@@ -1,0 +1,65 @@
+package pod
+
+import (
+	"strconv"
+	"testing"
+
+	"errors"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb-operator/pkg/pdapi"
+	admission "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAdmitCreateTiKVPod(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	_, err := kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	pdClient := pdapi.NewFakePDClient()
+
+	var resp *admission.AdmissionResponse
+
+	// success if tikv is not bootstrapped
+	pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
+		return nil, errors.New(tikvNotBootstrapped + "\n")
+	})
+	resp = admitCreateTiKVPod(pod, pdClient)
+	g.Expect(resp.Allowed).Should(BeTrue())
+
+	// test should end evict leader and success
+	storeID := 1
+	pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
+		store := &pdapi.StoreInfo{
+			Store: &pdapi.MetaStore{
+				Store: &metapb.Store{
+					Id:      uint64(storeID),
+					Address: pod.Name + ":8080",
+				},
+			},
+			Status: &pdapi.StoreStatus{LeaderCount: 1},
+		}
+		return &pdapi.StoresInfo{
+			Count:  1,
+			Stores: []*pdapi.StoreInfo{store},
+		}, nil
+	})
+	pdClient.AddReaction(pdapi.GetEvictLeaderSchedulersActionType, func(action *pdapi.Action) (interface{}, error) {
+		return []string{"a-b-c-" + strconv.Itoa(storeID)}, nil
+	})
+	endEvictLeader := false
+	pdClient.AddReaction(pdapi.EndEvictLeaderActionType, func(action *pdapi.Action) (interface{}, error) {
+		endEvictLeader = true
+		return nil, nil
+	})
+
+	resp = admitCreateTiKVPod(pod, pdClient)
+	g.Expect(resp.Allowed).Should(BeTrue())
+	g.Expect(endEvictLeader).Should(BeTrue())
+}

--- a/pkg/webhook/pod/tikv_creater_test.go
+++ b/pkg/webhook/pod/tikv_creater_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pod
 
 import (

--- a/pkg/webhook/pod/tikv_deleter.go
+++ b/pkg/webhook/pod/tikv_deleter.go
@@ -183,7 +183,6 @@ func (pc *PodAdmissionControl) admitDeleteUpTiKVPod(payload *admitPayload, store
 }
 
 func (pc *PodAdmissionControl) admitDeleteUpTiKVPodDuringUpgrading(payload *admitPayload, store *pdapi.StoreInfo) *admission.AdmissionResponse {
-
 	name := payload.pod.Name
 	namespace := payload.pod.Namespace
 	tc, ok := payload.controller.(*v1alpha1.TidbCluster)
@@ -221,7 +220,6 @@ func (pc *PodAdmissionControl) admitDeleteUpTiKVPodDuringUpgrading(payload *admi
 // Users should offline the target tikv into tombstone first, then scale-in it.
 // In other cases, we would admit to delete the down tikv pod like upgrading.
 func (pc *PodAdmissionControl) admitDeleteDownTikvPod(payload *admitPayload) *admission.AdmissionResponse {
-
 	isInOrdinal, err := operatorUtils.IsPodOrdinalNotExceedReplicas(payload.pod, payload.ownerStatefulSet)
 	if err != nil {
 		return util.ARFail(err)

--- a/pkg/webhook/pod/tikv_util.go
+++ b/pkg/webhook/pod/tikv_util.go
@@ -80,7 +80,6 @@ func checkFormerTiKVPodStatus(kubeCli kubernetes.Interface, controllerDesc contr
 }
 
 func addEvictLeaderAnnotation(kubeCli kubernetes.Interface, pod *core.Pod) error {
-
 	name := pod.Name
 	namespace := pod.Namespace
 
@@ -100,7 +99,6 @@ func addEvictLeaderAnnotation(kubeCli kubernetes.Interface, pod *core.Pod) error
 }
 
 func isTiKVReadyToUpgrade(upgradePod *core.Pod, store *pdapi.StoreInfo, evictLeaderTimeout time.Duration) bool {
-
 	if store.Status.LeaderCount == 0 {
 		klog.Infof("pod[%s/%s] has no region leader in store[%d]", upgradePod.Namespace, upgradePod.Name, store.Store.Id)
 		return true
@@ -120,7 +118,6 @@ func isTiKVReadyToUpgrade(upgradePod *core.Pod, store *pdapi.StoreInfo, evictLea
 }
 
 func beginEvictLeader(kubeCli kubernetes.Interface, storeID uint64, pod *core.Pod, pdClient pdapi.PDClient) error {
-
 	name := pod.Name
 	namespace := pod.Namespace
 
@@ -151,7 +148,6 @@ func endEvictLeader(storeInfo *pdapi.StoreInfo, pdClient pdapi.PDClient) error {
 }
 
 func getStoreByPod(pod *core.Pod, storesInfo *pdapi.StoresInfo) (*pdapi.StoreInfo, error) {
-
 	name := pod.Name
 	namespace := pod.Namespace
 

--- a/pkg/webhook/pod/util_test.go
+++ b/pkg/webhook/pod/util_test.go
@@ -16,6 +16,7 @@ package pod
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
@@ -26,7 +27,9 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -172,6 +175,118 @@ func TestCheckTiKVFormerPodStatus(t *testing.T) {
 			g.Expect(err).Should(HaveOccurred())
 		}
 	}
+}
+func TestIsTiKVReadyToUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	store0 := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 0},
+	}
+
+	store1 := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 1},
+	}
+
+	tests := []struct {
+		name    string
+		pod     *core.Pod
+		store   *pdapi.StoreInfo
+		timeout time.Duration
+		result  bool
+	}{
+		{
+			name:    "leader count is zero should be ready",
+			pod:     &core.Pod{},
+			store:   store0,
+			timeout: time.Second,
+			result:  true,
+		},
+		{
+			name:    "not EvictLeaderBeginTime should be false",
+			pod:     &core.Pod{},
+			store:   store1,
+			timeout: time.Second,
+			result:  false,
+		},
+		{
+			name: "timeout should be true",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						EvictLeaderBeginTime: time.Now().AddDate(0, 0, -1 /* one day */).Format(time.RFC3339),
+					},
+				},
+			},
+			store:   store1,
+			timeout: time.Hour * 12,
+			result:  true,
+		},
+		{
+			name: "not timeout should be false",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						EvictLeaderBeginTime: time.Now().AddDate(0, 0, -1 /* one day */).Format(time.RFC3339),
+					},
+				},
+			},
+			store:   store1,
+			timeout: time.Hour * 25,
+			result:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Log("test: ", test.name)
+		get := isTiKVReadyToUpgrade(test.pod, test.store, test.timeout)
+		g.Expect(get).Should(Equal(test.result))
+	}
+}
+
+func TestEvictLeader(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	_, err := kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	store := &pdapi.StoreInfo{
+		Store: &pdapi.MetaStore{
+			Store: &metapb.Store{
+				Id: 1,
+			},
+		},
+		Status: &pdapi.StoreStatus{LeaderCount: 1},
+	}
+	pdClient := pdapi.NewFakePDClient()
+
+	err = beginEvictLeader(kubeCli, store.Store.Id, pod, pdClient)
+	g.Expect(err).Should(BeNil())
+	err = endEvictLeader(store, pdClient)
+	g.Expect(err).Should(BeNil())
+}
+
+func TestAddEvictLeaderAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeCli := kubefake.NewSimpleClientset()
+
+	pod := &core.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "name"
+	err := addEvictLeaderAnnotation(kubeCli, pod)
+	g.Expect(err).ShouldNot(BeNil()) // not exist
+
+	// create first and add again should success.
+	_, err = kubeCli.CoreV1().Pods(pod.Namespace).Create(pod)
+	g.Expect(err).Should(BeNil())
+	err = addEvictLeaderAnnotation(kubeCli, pod)
+	g.Expect(err).Should(BeNil())
 }
 
 func buildStoresInfo(tc *v1alpha1.TidbCluster, sts *apps.StatefulSet) *pdapi.StoresInfo {

--- a/pkg/webhook/util/util.go
+++ b/pkg/webhook/util/util.go
@@ -14,7 +14,6 @@
 package util
 
 import (
-	"crypto/tls"
 	"encoding/json"
 
 	"gomodules.xyz/jsonpatch/v2"
@@ -49,17 +48,6 @@ func ARPatch(patch []byte) *admission.AdmissionResponse {
 		Patch:     patch,
 		PatchType: func() *admission.PatchType { p := admission.PatchTypeJSONPatch; return &p }(),
 	}
-}
-
-// config tls cert for server
-func ConfigTLS(certFile string, keyFile string) (*tls.Config, error) {
-	sCert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, err
-	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{sCert},
-	}, nil
 }
 
 func CreateJsonPatch(original, current runtime.Object) ([]byte, error) {

--- a/pkg/webhook/util/util_test.go
+++ b/pkg/webhook/util/util_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	admission "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAR(t *testing.T) {
+	g := NewGomegaWithT(t)
+	var resp *admission.AdmissionResponse
+
+	resp = ARFail(errors.New("err"))
+	g.Expect(resp.Allowed).Should(BeFalse())
+
+	resp = ARSuccess()
+	g.Expect(resp.Allowed).Should(BeTrue())
+
+	resp = ARPatch(nil)
+	g.Expect(resp.Allowed).Should(BeTrue())
+}
+
+func TestCreateJsonPatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	original := &v1.Pod{}
+	original.Name = "old"
+	current := &v1.Pod{}
+	current.Name = "new"
+
+	data, err := CreateJsonPatch(original, current)
+	g.Expect(err).Should(BeNil())
+
+	var ops []jsonpatch.Operation
+	err = json.Unmarshal(data, &ops)
+	g.Expect(err).Should(BeNil())
+	op := ops[0]
+	g.Expect(op).Should(Equal(jsonpatch.Operation{
+		Operation: "replace",
+		Path:      "/metadata/name",
+		Value:     "new",
+	}))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
after this pr:
   github.com/pingcap/tidb-operator/pkg/webhook/pod        2.815s  coverage: 64.0% of statements
ok      github.com/pingcap/tidb-operator/pkg/webhook/statefulset        0.063s  coverage: 80.0% of statements
ok      github.com/pingcap/tidb-operator/pkg/webhook/strategy   0.053s  coverage: 81.7% of statements
ok      github.com/pingcap/tidb-operator/pkg/webhook/util       0.020s  coverage: 85.7% of statements

fix #2938 
### What is changed and how does it work?



### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
