### PR TITLE
support HA scheduling when failover happen

### DIFF
--- a/pkg/scheduler/predicates/ha_test.go
+++ b/pkg/scheduler/predicates/ha_test.go
@@ -1077,7 +1077,10 @@ func TestHAFilter(t *testing.T) {
 				tc, _ := tcGetFn(ns, tcName)
 				pd1 := fmt.Sprintf("%s-%d", controller.PDMemberName(instanceName), 1)
 				tc.Status.PD.FailureMembers = map[string]v1alpha1.PDFailureMember{
-					pd1: {PodName: pd1},
+					pd1: {
+						PodName:       pd1,
+						MemberDeleted: true,
+					},
 				}
 				return tc, nil
 			},

--- a/pkg/scheduler/predicates/ha_test.go
+++ b/pkg/scheduler/predicates/ha_test.go
@@ -439,10 +439,10 @@ func TestHAFilter(t *testing.T) {
 	}
 
 	topologyKey := "zone"
+	instanceName := "demo"
+	clusterName := "cluster-1"
 	testFn := func(test *testcase, t *testing.T) {
 		t.Log(test.name)
-		instanceName := "demo"
-		clusterName := "cluster-1"
 
 		pod := test.podFn(instanceName, clusterName, 0)
 		nodes := test.nodesFn()
@@ -1065,6 +1065,27 @@ func TestHAFilter(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(nodes)).To(Equal(2))
 				g.Expect(getSortedNodeNames(nodes)).To(Equal([]string{"kube-node-2", "kube-node-4"}))
+			},
+		},
+		{
+			name:          "pd-1 is in failureMembers",
+			podFn:         newHAPDPod,
+			nodesFn:       fakeFourNodes,
+			podListFn:     podListFn(map[string][]int32{"kube-node-1": {1}, "kube-node-2": {2}, "kube-node-3": {3}, "kube-node-4": {}}),
+			acquireLockFn: acquireSuccess,
+			tcGetFn: func(ns string, tcName string) (*v1alpha1.TidbCluster, error) {
+				tc, _ := tcGetFn(ns, tcName)
+				pd1 := fmt.Sprintf("%s-%d", controller.PDMemberName(instanceName), 1)
+				tc.Status.PD.FailureMembers = map[string]v1alpha1.PDFailureMember{
+					pd1: {PodName: pd1},
+				}
+				return tc, nil
+			},
+			scheduledNodeGetFn: fakeZeroScheduledNode,
+			expectFn: func(nodes []apiv1.Node, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(nodes)).To(Equal(2))
+				g.Expect(getSortedNodeNames(nodes)).To(Equal([]string{"kube-node-1", "kube-node-4"}))
 			},
 		},
 	}

--- a/pkg/scheduler/predicates/ha_test.go
+++ b/pkg/scheduler/predicates/ha_test.go
@@ -1049,6 +1049,24 @@ func TestHAFilter(t *testing.T) {
 				g.Expect(getSortedNodeNames(nodes)).To(Equal([]string{"kube-node-3"}))
 			},
 		},
+		{
+			name:          "[support-asts] set pd.tidb.pingcap.com/delete-slots: '[2]' ",
+			podFn:         newHAPDPod,
+			nodesFn:       fakeFourNodes,
+			podListFn:     podListFn(map[string][]int32{"kube-node-1": {1}, "kube-node-2": {2}, "kube-node-3": {3}, "kube-node-4": {4}}),
+			acquireLockFn: acquireSuccess,
+			tcGetFn: func(ns string, tcName string) (*v1alpha1.TidbCluster, error) {
+				tc, _ := tcGetFn(ns, tcName)
+				tc.Annotations["pd.tidb.pingcap.com/delete-slots"] = "[2]"
+				return tc, nil
+			},
+			scheduledNodeGetFn: fakeZeroScheduledNode,
+			expectFn: func(nodes []apiv1.Node, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(nodes)).To(Equal(2))
+				g.Expect(getSortedNodeNames(nodes)).To(Equal([]string{"kube-node-2", "kube-node-4"}))
+			},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/3407
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Stability test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
