### PR TITLE
let force upgrade happen before scale

### DIFF
--- a/pkg/manager/member/dm_master_member_manager.go
+++ b/pkg/manager/member/dm_master_member_manager.go
@@ -203,6 +203,16 @@ func (m *masterMemberManager) syncMasterStatefulSetForDMCluster(dc *v1alpha1.DMC
 		return controller.RequeueErrorf("DMCluster: [%s/%s], waiting for dm-master cluster running", ns, dcName)
 	}
 
+	if !dc.Status.Master.Synced {
+		force := NeedForceUpgrade(dc.Annotations)
+		if force {
+			dc.Status.Master.Phase = v1alpha1.UpgradePhase
+			setUpgradePartition(newMasterSet, 0)
+			errSTS := updateStatefulSet(m.deps.StatefulSetControl, dc, newMasterSet, oldMasterSet)
+			return controller.RequeueErrorf("dmcluster: [%s/%s]'s dm-master needs force upgrade, %v", ns, dcName, errSTS)
+		}
+	}
+
 	// Scaling takes precedence over upgrading because:
 	// - if a dm-master fails in the upgrading, users may want to delete it or add
 	//   new replicas
@@ -222,16 +232,6 @@ func (m *masterMemberManager) syncMasterStatefulSetForDMCluster(dc *v1alpha1.DMC
 			if err := m.failover.Failover(dc); err != nil {
 				return err
 			}
-		}
-	}
-
-	if !dc.Status.Master.Synced {
-		force := NeedForceUpgrade(dc.Annotations)
-		if force {
-			dc.Status.Master.Phase = v1alpha1.UpgradePhase
-			setUpgradePartition(newMasterSet, 0)
-			errSTS := updateStatefulSet(m.deps.StatefulSetControl, dc, newMasterSet, oldMasterSet)
-			return controller.RequeueErrorf("dmcluster: [%s/%s]'s dm-master needs force upgrade, %v", ns, dcName, errSTS)
 		}
 	}
 

--- a/pkg/manager/member/dm_master_member_manager_test.go
+++ b/pkg/manager/member/dm_master_member_manager_test.go
@@ -697,8 +697,7 @@ func TestMasterMemberManagerSyncMasterSts(t *testing.T) {
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(set.Spec.Template.Spec.Containers[0].Image).To(Equal("dm-test-image-2:v2.0.0-rc.2"))
-				// scale in one pd from 3 -> 2
-				g.Expect(*set.Spec.Replicas).To(Equal(int32(2)))
+				g.Expect(*set.Spec.Replicas).To(Equal(int32(1)))
 				g.Expect(*set.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(0)))
 			},
 			expectDMClusterFn: func(g *GomegaWithT, dc *v1alpha1.DMCluster) {

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -208,14 +208,12 @@ func (m *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClust
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], waiting for PD cluster running", ns, tcName)
 	}
 
-	if !tc.Status.PD.Synced {
-		force := NeedForceUpgrade(tc.Annotations)
-		if force {
-			tc.Status.PD.Phase = v1alpha1.UpgradePhase
-			setUpgradePartition(newPDSet, 0)
-			errSTS := updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
-			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
-		}
+	// Force update takes precedence over scaling because force upgrade won't take effect when cluster gets stuck at scaling
+	if !tc.Status.PD.Synced && NeedForceUpgrade(tc.Annotations) {
+		tc.Status.PD.Phase = v1alpha1.UpgradePhase
+		setUpgradePartition(newPDSet, 0)
+		errSTS := updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
+		return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
 	}
 
 	// Scaling takes precedence over upgrading because:

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -208,6 +208,16 @@ func (m *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClust
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], waiting for PD cluster running", ns, tcName)
 	}
 
+	if !tc.Status.PD.Synced {
+		force := NeedForceUpgrade(tc.Annotations)
+		if force {
+			tc.Status.PD.Phase = v1alpha1.UpgradePhase
+			setUpgradePartition(newPDSet, 0)
+			errSTS := updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
+			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
+		}
+	}
+
 	// Scaling takes precedence over upgrading because:
 	// - if a pd fails in the upgrading, users may want to delete it or add
 	//   new replicas
@@ -224,16 +234,6 @@ func (m *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClust
 			if err := m.failover.Failover(tc); err != nil {
 				return err
 			}
-		}
-	}
-
-	if !tc.Status.PD.Synced {
-		force := NeedForceUpgrade(tc.Annotations)
-		if force {
-			tc.Status.PD.Phase = v1alpha1.UpgradePhase
-			setUpgradePartition(newPDSet, 0)
-			errSTS := updateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
-			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s pd needs force upgrade, %v", ns, tcName, errSTS)
 		}
 	}
 

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -699,8 +699,7 @@ func TestPDMemberManagerSyncPDSts(t *testing.T) {
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(set.Spec.Template.Spec.Containers[0].Image).To(Equal("pd-test-image:v2"))
-				// scale in one pd from 3 -> 2
-				g.Expect(*set.Spec.Replicas).To(Equal(int32(2)))
+				g.Expect(*set.Spec.Replicas).To(Equal(int32(1)))
 				g.Expect(*set.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(0)))
 			},
 			expectTidbClusterFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Currently, force upgrade won't take effect if we fail at scaling.

### What is changed and how does it work?
Let force upgrade happen before scaling.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

Code changes

 - Has Go code change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
