### PR TITLE
Imporve test of pkg/backup

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -391,7 +391,9 @@ int32
 </td>
 <td>
 <p>MaxBackups is to specify how many backups we want to keep
-0 is magic number to indicate un-limited backups.</p>
+0 is magic number to indicate un-limited backups.
+if MaxBackups and MaxReservedTime are set at the same time, MaxReservedTime is preferred
+and MaxBackups is ignored.</p>
 </td>
 </tr>
 <tr>
@@ -2575,7 +2577,9 @@ int32
 </td>
 <td>
 <p>MaxBackups is to specify how many backups we want to keep
-0 is magic number to indicate un-limited backups.</p>
+0 is magic number to indicate un-limited backups.
+if MaxBackups and MaxReservedTime are set at the same time, MaxReservedTime is preferred
+and MaxBackups is ignored.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -793,7 +793,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupScheduleSpec(ref common.ReferenceCal
 					},
 					"maxBackups": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxBackups is to specify how many backups we want to keep 0 is magic number to indicate un-limited backups.",
+							Description: "MaxBackups is to specify how many backups we want to keep 0 is magic number to indicate un-limited backups. if MaxBackups and MaxReservedTime are set at the same time, MaxReservedTime is preferred and MaxBackups is ignored.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1389,6 +1389,8 @@ type BackupScheduleSpec struct {
 	Pause bool `json:"pause,omitempty"`
 	// MaxBackups is to specify how many backups we want to keep
 	// 0 is magic number to indicate un-limited backups.
+	// if MaxBackups and MaxReservedTime are set at the same time, MaxReservedTime is preferred
+	// and MaxBackups is ignored.
 	MaxBackups *int32 `json:"maxBackups,omitempty"`
 	// MaxReservedTime is to specify how long backups we want to keep.
 	MaxReservedTime *string `json:"maxReservedTime,omitempty"`

--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -58,6 +58,7 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 	klog.Infof("start to clean backup %s/%s", ns, name)
 
 	cleanJobName := backup.GetCleanJobName()
+	// FIXME: handle error, should only ignore not found error
 	_, err := bc.deps.JobLister.Jobs(ns).Get(cleanJobName)
 	if err == nil {
 		// already have a clean job running，return directly

--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	"k8s.io/utils/pointer"
@@ -58,12 +59,21 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 	klog.Infof("start to clean backup %s/%s", ns, name)
 
 	cleanJobName := backup.GetCleanJobName()
-	// FIXME: handle error, should only ignore not found error
 	_, err := bc.deps.JobLister.Jobs(ns).Get(cleanJobName)
 	if err == nil {
 		// already have a clean job running，return directly
 		return nil
+	} else if !errors.IsNotFound(err) {
+		bc.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
+			Type:    v1alpha1.BackupRetryFailed,
+			Status:  corev1.ConditionTrue,
+			Reason:  "GetBackupFailed",
+			Message: err.Error(),
+		})
+		return err
 	}
+
+	// no found the clean job, we start to create the clean job.
 
 	if backup.Status.BackupPath == "" {
 		// the backup path is empty, so there is no need to clean up backup data

--- a/pkg/backup/backup/backup_test.go
+++ b/pkg/backup/backup/backup_test.go
@@ -1,0 +1,277 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/backup/constants"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func invalidBackup() *v1alpha1.Backup {
+	b := &v1alpha1.Backup{}
+	b.Namespace = "ns"
+	b.Name = "invalid_name"
+	return b
+}
+
+func validDumplingBackup() *v1alpha1.Backup {
+	b := &v1alpha1.Backup{
+		Spec: v1alpha1.BackupSpec{
+			From: &v1alpha1.TiDBAccessConfig{
+				Host:                "localhost",
+				SecretName:          "secretName",
+				TLSClientSecretName: pointer.StringPtr("secretName"),
+			},
+			StorageSize: "1G",
+			StorageProvider: v1alpha1.StorageProvider{
+				S3: &v1alpha1.S3StorageProvider{
+					Bucket: "s3",
+					Prefix: "prefix-",
+				},
+			},
+		},
+	}
+
+	b.Namespace = "ns"
+	b.Name = "dump_name"
+
+	return b
+}
+
+func validBRBackup() *v1alpha1.Backup {
+	b := &v1alpha1.Backup{
+		Spec: v1alpha1.BackupSpec{
+			From: &v1alpha1.TiDBAccessConfig{
+				Host:       "localhost",
+				SecretName: "secretName",
+			},
+			StorageSize: "1G",
+			StorageProvider: v1alpha1.StorageProvider{
+				S3: &v1alpha1.S3StorageProvider{
+					Bucket:   "s3",
+					Prefix:   "prefix-",
+					Endpoint: "s3://localhost:80",
+				},
+			},
+			Type: v1alpha1.BackupTypeDB,
+			BR: &v1alpha1.BRConfig{
+				ClusterNamespace: "ns",
+				Cluster:          "tidb",
+				DB:               "dbName",
+			},
+		},
+	}
+
+	b.Namespace = "ns"
+	b.Name = "backup_name"
+
+	return b
+}
+
+func TestBackupManagerDumpling(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	var err error
+
+	bm := NewBackupManager(deps).(*backupManager)
+
+	// create backup
+	backup := validDumplingBackup()
+	_, err = deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(backup)
+	g.Expect(err).Should(BeNil())
+
+	// create relate secret
+	helper.createSecret(backup)
+
+	err = bm.syncBackupJob(backup)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupScheduled, "")
+	_, err = deps.KubeClientset.BatchV1().Jobs(backup.Namespace).Get(backup.GetBackupJobName(), metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+}
+
+func TestBackupManagerBR(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	var err error
+
+	bm := NewBackupManager(deps).(*backupManager)
+
+	// test invalid Backup spec
+	backup := invalidBackup()
+	_, err = deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(backup)
+	g.Expect(err).Should(BeNil())
+	err = bm.syncBackupJob(backup)
+	g.Expect(err).ShouldNot(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupInvalid, "")
+
+	// create and use valid backup
+	backup = validBRBackup()
+	_, err = deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(backup)
+	g.Expect(err).Should(BeNil())
+
+	// create relate secret
+	helper.createSecret(backup)
+
+	// failed to get relate tc
+	err = bm.syncBackupJob(backup)
+	g.Expect(err).ShouldNot(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupRetryFailed, "failed to fetch tidbcluster")
+
+	// create relate tc and try again should success and job created.
+	helper.createTC(backup)
+	err = bm.syncBackupJob(backup)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupScheduled, "")
+	_, err = deps.KubeClientset.BatchV1().Jobs(backup.Namespace).Get(backup.GetBackupJobName(), metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+}
+
+func TestClean(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+
+	backup := validBRBackup()
+	_, err := deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(backup)
+	g.Expect(err).Should(BeNil())
+	helper.createSecret(backup)
+	helper.createTC(backup)
+
+	// make the backup need to be clean
+	backup.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+
+	statusUpdater := controller.NewRealBackupConditionUpdater(deps.Clientset, deps.BackupLister, deps.Recorder)
+	bc := NewBackupCleaner(deps, statusUpdater)
+
+	// test empty backup.Status.BackupPath
+	backup.Status.BackupPath = ""
+	err = bc.Clean(backup)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupClean, "")
+
+	// test clean job created
+	backup.Status.BackupPath = "/path"
+	err = bc.Clean(backup)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupClean, "")
+	_, err = deps.KubeClientset.BatchV1().Jobs(backup.Namespace).Get(backup.GetCleanJobName(), metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+	// test already have a clean job running
+	g.Eventually(func() error {
+		_, err := deps.JobLister.Jobs(backup.Namespace).Get(backup.GetCleanJobName())
+		return err
+	}, time.Second*10).Should(BeNil())
+	err = bc.Clean(backup)
+	g.Expect(err).Should(BeNil())
+}
+
+type helper struct {
+	t    *testing.T
+	deps *controller.Dependencies
+	stop chan struct{}
+}
+
+func newHelper(t *testing.T) *helper {
+	deps := controller.NewSimpleClientDependencies()
+	stop := make(chan struct{})
+	deps.InformerFactory.Start(stop)
+	deps.KubeInformerFactory.Start(stop)
+	deps.InformerFactory.WaitForCacheSync(stop)
+	deps.KubeInformerFactory.WaitForCacheSync(stop)
+
+	return &helper{
+		t:    t,
+		deps: deps,
+		stop: stop,
+	}
+}
+
+func (h *helper) close() {
+	close(h.stop)
+}
+
+func (h *helper) hasCondition(ns string, name string, tp v1alpha1.BackupConditionType, reasonSub string) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	get, err := h.deps.Clientset.PingcapV1alpha1().Backups(ns).Get(name, metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+	for _, c := range get.Status.Conditions {
+		if c.Type == tp {
+			if reasonSub == "" || strings.Contains(c.Reason, reasonSub) {
+				return
+			}
+			h.t.Fatalf("%s do not match reason %s", reasonSub, c.Reason)
+		}
+	}
+	h.t.Fatalf("%s/%s do not has condition type: %s, cur conds: %v", ns, name, tp, get.Status.Conditions)
+}
+
+func (h *helper) createSecret(backup *v1alpha1.Backup) {
+	g := NewGomegaWithT(h.t)
+	s := &v1.Secret{}
+	s.Data = map[string][]byte{
+		constants.TidbPasswordKey:   []byte("dummy"),
+		constants.GcsCredentialsKey: []byte("dummy"),
+		constants.S3AccessKey:       []byte("dummy"),
+		constants.S3SecretKey:       []byte("dummy"),
+	}
+	s.Namespace = backup.Namespace
+	s.Name = backup.Spec.From.SecretName
+	_, err := h.deps.KubeClientset.CoreV1().Secrets(s.Namespace).Create(s)
+	g.Expect(err).Should(BeNil())
+}
+
+func (h *helper) createTC(backup *v1alpha1.Backup) {
+	g := NewGomegaWithT(h.t)
+	var err error
+
+	tc := &v1alpha1.TidbCluster{
+		Spec: v1alpha1.TidbClusterSpec{
+			TLSCluster: &v1alpha1.TLSCluster{Enabled: true},
+			TiKV: &v1alpha1.TiKVSpec{
+				BaseImage: "pingcap/tikv",
+			},
+			TiDB: &v1alpha1.TiDBSpec{
+				TLSClient: &v1alpha1.TiDBTLSClient{Enabled: true},
+			},
+		},
+	}
+	tc.Namespace = backup.Spec.BR.ClusterNamespace
+	tc.Name = backup.Spec.BR.Cluster
+	_, err = h.deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+	g.Expect(err).Should(BeNil())
+	// make sure can read tc from lister
+	g.Eventually(func() error {
+		_, err := h.deps.TiDBClusterLister.TidbClusters(tc.Namespace).Get(tc.Name)
+		return err
+	}, time.Second*10).Should(BeNil())
+	g.Expect(err).Should(BeNil())
+}

--- a/pkg/backup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager_test.go
@@ -1,0 +1,313 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupschedule
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/backup/constants"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestManager(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	m := NewBackupScheduleManager(deps).(*backupScheduleManager)
+	var err error
+	bs := &v1alpha1.BackupSchedule{}
+	bs.Namespace = "ns"
+	bs.Name = "bsname"
+
+	// test pause
+	bs.Spec.Pause = true
+	err = m.Sync(bs)
+	g.Expect(err).Should(BeAssignableToTypeOf(&controller.IgnoreError{}))
+	g.Expect(err.Error()).Should(MatchRegexp(".*has been paused.*"))
+
+	// test canPerformNextBackup
+	//
+	// test not found last backup
+	bs.Spec.Pause = false
+	bs.Status.LastBackup = "backupname"
+	err = m.canPerformNextBackup(bs)
+	g.Expect(err).Should(BeNil())
+
+	// test backup complete
+	bk := &v1alpha1.Backup{}
+	bk.Namespace = bs.Namespace
+	bk.Name = bs.Status.LastBackup
+	bk.Status.Conditions = append(bk.Status.Conditions, v1alpha1.BackupCondition{
+		Type:   v1alpha1.BackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk)
+	err = m.canPerformNextBackup(bs)
+	g.Expect(err).Should(BeNil())
+	helper.deleteBackup(bk)
+
+	// test last backup failed state and not scheduled yet
+	bk.Status.Conditions = nil
+	bk.Status.Conditions = append(bk.Status.Conditions, v1alpha1.BackupCondition{
+		Type:   v1alpha1.BackupFailed,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk)
+	err = m.canPerformNextBackup(bs)
+	g.Expect(err).Should(BeAssignableToTypeOf(&controller.RequeueError{}))
+	helper.deleteBackup(bk)
+
+	t.Log("start test normal Sync")
+	bk.Status.Conditions = nil
+	bs.Spec.Schedule = "0 0 * * *" // Run at midnight every day
+
+	now := time.Now()
+	m.now = func() time.Time { return now.AddDate(0, 0, -101) }
+	m.resetLastBackup(bs)
+	// 10 backup, one per day
+	for i := -9; i <= 0; i++ {
+		t.Log("loop id ", i)
+		m.now = func() time.Time { return now.AddDate(0, 0, i) }
+		err = m.Sync(bs)
+		g.Expect(err).Should(BeNil())
+		bks := helper.checkBacklist(bs.Namespace, i+10)
+		// complete the backup created
+		for _, bk := range bks.Items {
+			changed := v1alpha1.UpdateBackupCondition(&bk.Status, &v1alpha1.BackupCondition{
+				Type:   v1alpha1.BackupComplete,
+				Status: v1.ConditionTrue,
+			})
+			if changed {
+				bk.CreationTimestamp = metav1.Time{Time: m.now()}
+				t.Log("complete backup: ", bk.Name)
+				helper.updateBackup(&bk)
+			}
+			g.Expect(err).Should(BeNil())
+		}
+	}
+
+	t.Log("test setting MaxBackups")
+	m.now = time.Now
+	bs.Spec.MaxBackups = pointer.Int32Ptr(3)
+	err = m.Sync(bs)
+	g.Expect(err).Should(BeNil())
+	helper.checkBacklist(bs.Namespace, 3)
+
+	t.Log("test setting setting MaxReservedTime")
+	bs.Spec.MaxBackups = nil
+	bs.Spec.MaxReservedTime = pointer.StringPtr("23h")
+	err = m.Sync(bs)
+	g.Expect(err).Should(BeNil())
+	helper.checkBacklist(bs.Namespace, 1)
+}
+
+func TestGetLastScheduledTime(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	bs := &v1alpha1.BackupSchedule{
+		Spec: v1alpha1.BackupScheduleSpec{},
+		Status: v1alpha1.BackupScheduleStatus{
+			LastBackupTime: &metav1.Time{},
+		},
+	}
+	var getTime *time.Time
+	var err error
+
+	// test invalid format schedule
+	bs.Spec.Schedule = "#$#$#$@"
+	_, err = getLastScheduledTime(bs, time.Now)
+	g.Expect(err).ShouldNot(BeNil())
+
+	bs.Spec.Schedule = "0 0 * * *" // Run once a day at midnight
+	now := time.Now()
+
+	// test last backup time after now
+	bs.Status.LastBackupTime.Time = now.AddDate(0, 0, 1)
+	getTime, err = getLastScheduledTime(bs, time.Now)
+	g.Expect(err).Should(BeNil())
+	g.Expect(getTime).Should(BeNil())
+
+	// test scheduled
+	for i := 0; i < 10; i++ {
+		bs.Status.LastBackupTime.Time = now.AddDate(0, 0, -i-1)
+		getTime, err = getLastScheduledTime(bs, time.Now)
+		g.Expect(err).Should(BeNil())
+		g.Expect(getTime).ShouldNot(BeNil())
+		expectTime := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+		g.Expect(*getTime).Should(Equal(expectTime))
+	}
+
+	// test too many miss
+	bs.Status.LastBackupTime.Time = now.AddDate(-1000, 0, 0)
+	getTime, err = getLastScheduledTime(bs, time.Now)
+	g.Expect(err).Should(BeNil())
+	g.Expect(getTime).Should(BeNil())
+}
+
+func TestBuildBackup(t *testing.T) {
+	now := time.Now()
+	var get *v1alpha1.Backup
+
+	// build BackupSchedule template
+	bs := &v1alpha1.BackupSchedule{
+		Spec: v1alpha1.BackupScheduleSpec{},
+		Status: v1alpha1.BackupScheduleStatus{
+			LastBackupTime: &metav1.Time{},
+		},
+	}
+	bs.Namespace = "ns"
+	bs.Name = "bsname"
+
+	// build Backup template
+	bk := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: bs.Namespace,
+			Name:      bs.GetBackupCRDName(now),
+			Labels:    label.NewBackupSchedule().Instance(bs.Name).BackupSchedule(bs.Name).Labels(),
+			OwnerReferences: []metav1.OwnerReference{
+				controller.GetBackupScheduleOwnerRef(bs),
+			},
+		},
+		Spec: v1alpha1.BackupSpec{
+			StorageSize: constants.DefaultStorageSize,
+		},
+	}
+
+	// test BR == nil
+	get = buildBackup(bs, now)
+	if diff := cmp.Diff(bk, get); diff != "" {
+		t.Errorf("unexpected (-want, +got): %s", diff)
+	}
+	// should keep StorageSize from BackupSchedule
+	bs.Spec.StorageSize = "9527G"
+	bk.Spec.StorageSize = bs.Spec.StorageSize
+	get = buildBackup(bs, now)
+	if diff := cmp.Diff(bk, get); diff != "" {
+		t.Errorf("unexpected (-want, +got): %s", diff)
+	}
+
+	// test BR != nil
+	bs.Spec.BackupTemplate.BR = &v1alpha1.BRConfig{}
+	bk.Spec.BR = bs.Spec.BackupTemplate.BR.DeepCopy()
+	bk.Spec.StorageSize = "" // no use for BR
+	get = buildBackup(bs, now)
+	if diff := cmp.Diff(bk, get); diff != "" {
+		t.Errorf("unexpected (-want, +got): %s", diff)
+	}
+}
+
+type helper struct {
+	t    *testing.T
+	deps *controller.Dependencies
+	stop chan struct{}
+}
+
+func newHelper(t *testing.T) *helper {
+	deps := controller.NewSimpleClientDependencies()
+	stop := make(chan struct{})
+	deps.InformerFactory.Start(stop)
+	deps.KubeInformerFactory.Start(stop)
+	deps.InformerFactory.WaitForCacheSync(stop)
+	deps.KubeInformerFactory.WaitForCacheSync(stop)
+
+	return &helper{
+		t:    t,
+		deps: deps,
+		stop: stop,
+	}
+}
+
+func (h *helper) close() {
+	close(h.stop)
+}
+
+// check for exists num Backup and return the exists backups "BackupList".
+func (h *helper) checkBacklist(ns string, num int) (bks *v1alpha1.BackupList) {
+	t := h.t
+	deps := h.deps
+	g := NewGomegaWithT(t)
+
+	t.Helper()
+	g.Eventually(func() error {
+		var err error
+		bks, err = deps.Clientset.PingcapV1alpha1().Backups(ns).List(metav1.ListOptions{})
+		g.Expect(err).Should(BeNil())
+		if len(bks.Items) != num {
+			var names []string
+			for _, bk := range bks.Items {
+				names = append(names, bk.Name)
+			}
+			return fmt.Errorf("there %d backup, but should be %d, cur backups: %v", len(bks.Items), num, names)
+		}
+		return nil
+	}, time.Second*10).Should(BeNil())
+
+	return
+}
+
+func (h *helper) updateBackup(bk *v1alpha1.Backup) {
+	t := h.t
+	deps := h.deps
+	g := NewGomegaWithT(t)
+	_, err := deps.Clientset.PingcapV1alpha1().Backups(bk.Namespace).Update(bk)
+	g.Expect(err).Should(BeNil())
+
+	g.Eventually(func() error {
+		get, err := deps.BackupLister.Backups(bk.Namespace).Get(bk.Name)
+		if err != nil {
+			return err
+		}
+
+		diff := cmp.Diff(get, bk)
+		if diff == "" {
+			return nil
+		}
+
+		return fmt.Errorf("not synced yet: %s", diff)
+	}, time.Second*10).Should(BeNil())
+}
+
+func (h *helper) createBackup(bk *v1alpha1.Backup) {
+	t := h.t
+	deps := h.deps
+	g := NewGomegaWithT(t)
+	_, err := deps.Clientset.PingcapV1alpha1().Backups(bk.Namespace).Create(bk)
+	g.Expect(err).Should(BeNil())
+	g.Eventually(func() error {
+		_, err := deps.BackupLister.Backups(bk.Namespace).Get(bk.Name)
+		return err
+	}, time.Second*10).Should(BeNil())
+}
+
+func (h *helper) deleteBackup(bk *v1alpha1.Backup) {
+	t := h.t
+	deps := h.deps
+	g := NewGomegaWithT(t)
+	err := deps.Clientset.PingcapV1alpha1().Backups(bk.Namespace).Delete(bk.Name, nil)
+	g.Expect(err).Should(BeNil())
+	g.Eventually(func() error {
+		_, err := deps.BackupLister.Backups(bk.Namespace).Get(bk.Name)
+		return err
+	}, time.Second*10).ShouldNot(BeNil())
+}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -81,15 +80,12 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 	}
 
 	if err != nil {
-		updateErr := rm.statusUpdater.Update(restore, &v1alpha1.RestoreCondition{
+		rm.statusUpdater.Update(restore, &v1alpha1.RestoreCondition{
 			Type:    v1alpha1.RestoreInvalid,
 			Status:  corev1.ConditionTrue,
 			Reason:  "InvalidSpec",
 			Message: err.Error(),
 		})
-		if updateErr != nil {
-			klog.Warning(updateErr)
-		}
 
 		return controller.IgnoreErrorf("invalid restore spec %s/%s", ns, name)
 	}

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -1,0 +1,231 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/backup/constants"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+var validDumpRestore = &v1alpha1.Restore{
+	Spec: v1alpha1.RestoreSpec{
+		To: &v1alpha1.TiDBAccessConfig{
+			Host:                "localhost",
+			SecretName:          "secretName",
+			TLSClientSecretName: pointer.StringPtr("secretName"),
+		},
+		StorageSize: "1G",
+		StorageProvider: v1alpha1.StorageProvider{
+			S3: &v1alpha1.S3StorageProvider{
+				Bucket:   "bname",
+				Endpoint: "s3://pingcap/",
+			},
+		},
+	},
+}
+
+var validBRRestore = &v1alpha1.Restore{
+	Spec: v1alpha1.RestoreSpec{
+		To: &v1alpha1.TiDBAccessConfig{
+			Host:       "localhost",
+			SecretName: "secretName",
+		},
+		BR: &v1alpha1.BRConfig{
+			ClusterNamespace: "ns",
+			Cluster:          "tcName",
+		},
+		Type: v1alpha1.BackupTypeFull,
+		StorageProvider: v1alpha1.StorageProvider{
+			S3: &v1alpha1.S3StorageProvider{
+				Bucket:   "bname",
+				Endpoint: "s3://pingcap/",
+			},
+		},
+	},
+}
+
+func TestInvalid(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	var err error
+
+	restore := &v1alpha1.Restore{}
+	restore.Namespace = "ns"
+	restore.Name = "restore"
+	helper.createRestore(restore)
+
+	m := NewRestoreManager(deps)
+	err = m.Sync(restore)
+	g.Expect(err).ShouldNot(BeNil())
+	helper.hasCondition(restore.Namespace, restore.Name, v1alpha1.RestoreInvalid, "InvalidSpec")
+}
+
+func TestDumplingRestore(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	var err error
+
+	// create restore
+	restore := validDumpRestore.DeepCopy()
+	restore.Namespace = "ns"
+	restore.Name = "name"
+	helper.createRestore(restore)
+	helper.createSecret(restore)
+
+	m := NewRestoreManager(deps)
+	err = m.Sync(restore)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(restore.Namespace, restore.Name, v1alpha1.RestoreScheduled, "")
+	helper.jobCreated(restore)
+}
+
+func TestBRRestore(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	var err error
+
+	// create restore
+	restore := validBRRestore.DeepCopy()
+	restore.Namespace = "ns"
+	restore.Name = "name"
+	helper.createRestore(restore)
+	helper.createSecret(restore)
+	helper.createTC(restore)
+
+	m := NewRestoreManager(deps)
+	err = m.Sync(restore)
+	g.Expect(err).Should(BeNil())
+	helper.hasCondition(restore.Namespace, restore.Name, v1alpha1.RestoreScheduled, "")
+	helper.jobCreated(restore)
+}
+
+type helper struct {
+	t    *testing.T
+	deps *controller.Dependencies
+	stop chan struct{}
+}
+
+func newHelper(t *testing.T) *helper {
+	deps := controller.NewSimpleClientDependencies()
+	stop := make(chan struct{})
+	deps.InformerFactory.Start(stop)
+	deps.KubeInformerFactory.Start(stop)
+	deps.InformerFactory.WaitForCacheSync(stop)
+	deps.KubeInformerFactory.WaitForCacheSync(stop)
+
+	return &helper{
+		stop: stop,
+		t:    t,
+		deps: deps,
+	}
+}
+
+func (h *helper) close() {
+	close(h.stop)
+}
+
+func (h *helper) hasCondition(ns string, name string, tp v1alpha1.RestoreConditionType, reasonSub string) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	get, err := h.deps.Clientset.PingcapV1alpha1().Restores(ns).Get(name, metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+	for _, c := range get.Status.Conditions {
+		if c.Type == tp {
+			if reasonSub == "" || strings.Contains(c.Reason, reasonSub) {
+				return
+			}
+			h.t.Fatalf("%s do not match reason %s", reasonSub, c.Reason)
+		}
+	}
+	h.t.Fatalf("%s/%s do not has condition type: %s, cur conds: %v", ns, name, tp, get.Status.Conditions)
+}
+
+func (h *helper) jobCreated(restore *v1alpha1.Restore) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	_, err := h.deps.KubeClientset.BatchV1().Jobs(restore.Namespace).Get(restore.GetRestoreJobName(), metav1.GetOptions{})
+	g.Expect(err).Should(BeNil())
+}
+
+func (h *helper) createSecret(restore *v1alpha1.Restore) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	s := &v1.Secret{}
+	s.Data = map[string][]byte{
+		constants.TidbPasswordKey:   []byte("dummy"),
+		constants.GcsCredentialsKey: []byte("dummy"),
+		constants.S3AccessKey:       []byte("dummy"),
+		constants.S3SecretKey:       []byte("dummy"),
+	}
+	s.Namespace = restore.Namespace
+	s.Name = restore.Spec.To.SecretName
+	_, err := h.deps.KubeClientset.CoreV1().Secrets(s.Namespace).Create(s)
+	g.Expect(err).Should(BeNil())
+}
+
+func (h *helper) createRestore(restore *v1alpha1.Restore) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	var err error
+
+	_, err = h.deps.Clientset.PingcapV1alpha1().Restores(restore.Namespace).Create(restore)
+	g.Expect(err).Should(BeNil())
+	g.Eventually(func() error {
+		_, err := h.deps.RestoreLister.Restores(restore.Namespace).Get(restore.Name)
+		return err
+	}, time.Second*10).Should(BeNil())
+}
+
+func (h *helper) createTC(restore *v1alpha1.Restore) {
+	h.t.Helper()
+	g := NewGomegaWithT(h.t)
+	var err error
+
+	tc := &v1alpha1.TidbCluster{
+		Spec: v1alpha1.TidbClusterSpec{
+			TLSCluster: &v1alpha1.TLSCluster{Enabled: true},
+			TiKV: &v1alpha1.TiKVSpec{
+				BaseImage: "pingcap/tikv",
+			},
+			TiDB: &v1alpha1.TiDBSpec{
+				TLSClient: &v1alpha1.TiDBTLSClient{Enabled: true},
+			},
+		},
+	}
+	tc.Namespace = restore.Spec.BR.ClusterNamespace
+	tc.Name = restore.Spec.BR.Cluster
+	_, err = h.deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+	g.Expect(err).Should(BeNil())
+	// make sure can read tc from lister
+	g.Eventually(func() error {
+		_, err := h.deps.TiDBClusterLister.TidbClusters(tc.Namespace).Get(tc.Name)
+		return err
+	}, time.Second*10).Should(BeNil())
+	g.Expect(err).Should(BeNil())
+}

--- a/pkg/controller/dependences.go
+++ b/pkg/controller/dependences.go
@@ -304,6 +304,7 @@ func newFakeControl(kubeClientset kubernetes.Interface, informerFactory informer
 	genericCtrl := NewFakeGenericControl()
 	// Shared variables to construct `Dependencies` and some of its fields
 	return Controls{
+		JobControl:         NewFakeJobControl(kubeInformerFactory.Batch().V1().Jobs()),
 		ConfigMapControl:   NewFakeConfigMapControl(kubeInformerFactory.Core().V1().ConfigMaps()),
 		StatefulSetControl: NewFakeStatefulSetControl(kubeInformerFactory.Apps().V1().StatefulSets()),
 		ServiceControl:     NewFakeServiceControl(kubeInformerFactory.Core().V1().Services(), kubeInformerFactory.Core().V1().Endpoints()),
@@ -320,6 +321,17 @@ func newFakeControl(kubeClientset kubernetes.Interface, informerFactory informer
 		TiDBControl:        NewFakeTiDBControl(),
 		BackupControl:      NewFakeBackupControl(informerFactory.Pingcap().V1alpha1().Backups()),
 	}
+}
+
+// NewSimpleClientDependencies returns a dependencies
+// the returning Dependencies use NewSimpleClientset and is useful for test.
+func NewSimpleClientDependencies() *Dependencies {
+	deps := NewFakeDependencies()
+
+	// TODO make all controller use real controller with simple client.
+	deps.BackupControl = NewRealBackupControl(deps.Clientset, deps.Recorder)
+	deps.JobControl = NewRealJobControl(deps.KubeClientset, deps.Recorder)
+	return deps
 }
 
 // NewFakeDependencies returns a fake dependencies for testing

--- a/pkg/controller/dependences_test.go
+++ b/pkg/controller/dependences_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFakeTidbCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	deps := NewFakeDependencies()
+	stop := make(chan struct{})
+	defer close(stop)
+	deps.InformerFactory.Start(stop)
+	deps.InformerFactory.WaitForCacheSync(stop)
+
+	for i := 0; i < 10; i++ {
+		tc := &v1alpha1.TidbCluster{}
+		tc.Namespace = "ns"
+		tc.Name = "tcName" + strconv.Itoa(i)
+
+		_, err := deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
+		g.Expect(err).Should(BeNil())
+
+		_, err = deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(tc.Name, v1.GetOptions{})
+		g.Expect(err).Should(BeNil())
+
+		g.Eventually(func() error {
+			_, err := deps.TiDBClusterLister.TidbClusters(tc.Namespace).Get(tc.Name)
+			return err
+		}, time.Second*10).Should(BeNil())
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
close #2920 

    Imporve test of pkg/backup

    Add test for all pkg under pkg/backup/
    ?       github.com/pingcap/tidb-operator/pkg/backup     [no test files]
    ok      github.com/pingcap/tidb-operator/pkg/backup/backup      6.446s  coverage: 75.3% of statements
    ok      github.com/pingcap/tidb-operator/pkg/backup/backupschedule      2.318s  coverage: 79.3% of statements
    ?       github.com/pingcap/tidb-operator/pkg/backup/constants   [no test files]
    ok      github.com/pingcap/tidb-operator/pkg/backup/restore     6.462s  coverage: 75.0% of statements
    ok      github.com/pingcap/tidb-operator/pkg/backup/util        0.044s  coverage: 94.7% of statements
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has Go code change


Side effects


Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
