### PR TITLE
Fix PD member name error for multi cluster

### DIFF
--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -21,7 +21,13 @@ import (
 // GetPDClient gets the pd client from the TidbCluster
 func GetPDClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) pdapi.PDClient {
 	if tc.IsHeterogeneous() {
+		if len(tc.Spec.ClusterDomain) > 0 {
+			return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
+		}
 		return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled())
+	}
+	if len(tc.Spec.ClusterDomain) > 0 {
+		return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
 	}
 	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled())
 }

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -22,12 +22,12 @@ import (
 func GetPDClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) pdapi.PDClient {
 	if tc.IsHeterogeneous() {
 		if len(tc.Spec.ClusterDomain) > 0 {
-			return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
+			return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.Spec.ClusterDomain, tc.IsTLSClusterEnabled())
 		}
 		return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled())
 	}
 	if len(tc.Spec.ClusterDomain) > 0 {
-		return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
+		return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.Spec.ClusterDomain, tc.IsTLSClusterEnabled())
 	}
 	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled())
 }

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -27,7 +27,7 @@ func GetPDClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) p
 		return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled())
 	}
 	if len(tc.Spec.ClusterDomain) > 0 {
-		return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.Spec.Cluster.Name, tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
+		return pdControl.GetClusterRefPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.Spec.ClusterDomain,tc.IsTLSClusterEnabled())
 	}
 	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled())
 }

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -77,8 +77,8 @@ func (s *pdScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet
 	totalCount := *oldSet.Spec.Replicas
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
 	for _, i := range podOrdinals {
-		podName := ordinalPodName(v1alpha1.PDMemberType, tcName, i)
-		if member, ok := tc.Status.PD.Members[podName]; ok && member.Health {
+		targetPdName := PdName(tcName, i,tc.Namespace,tc.Spec.ClusterDomain)
+		if member, ok := tc.Status.PD.Members[targetPdName]; ok && member.Health {
 			healthCount++
 		}
 	}

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -77,7 +77,7 @@ func (s *pdScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet
 	totalCount := *oldSet.Spec.Replicas
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
 	for _, i := range podOrdinals {
-		targetPdName := PdName(tcName, i,tc.Namespace,tc.Spec.ClusterDomain)
+		targetPdName := PdName(tcName, i, tc.Namespace, tc.Spec.ClusterDomain)
 		if member, ok := tc.Status.PD.Members[targetPdName]; ok && member.Health {
 			healthCount++
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
- Fix PD member name error when the multi-cluster feature is enabled and the cluster is scaling out.
- Provide the right PD client when the multi-cluster feature is enabled.

### What is changed and how does it work?
Add logic to ScaleOut and GetPDClient.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
The cluster goes normally when deploying new controller-manager. The cluster can scale out normally without admission webhook enabled.

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
