### PR TITLE
Fix pd scale in to 0

### DIFF
--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -162,28 +162,6 @@ func (s *pdScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet 
 	}
 	klog.Infof("pd scale in: delete member %s successfully", memberName)
 
-	// double check whether member deleted after delete member
-	// The PD member could be remained after deleting API success, see https://github.com/pingcap/pd/issues/2541
-	// The bug still need to be investigated.
-	membersInfo, err := pdClient.GetMembers()
-	if err != nil {
-		klog.Errorf("pd scale in: failed to get members %s, %v", memberName, err)
-		return err
-	}
-
-	existed := false
-	for _, member := range membersInfo.Members {
-		if member.Name == memberName {
-			existed = true
-			break
-		}
-	}
-	if existed {
-		err = fmt.Errorf("pd scale in: member %s still exist after being deleted", memberName)
-		klog.Error(err)
-		return err
-	}
-
 	pvcName := ordinalPVCName(v1alpha1.PDMemberType, setName, ordinal)
 	pvc, err := s.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
 	if err != nil {

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -374,17 +374,6 @@ func TestPDScalerScaleIn(t *testing.T) {
 			changed:          false,
 			isLeader:         false,
 		},
-		{
-			name:             "delete member success, but get member still remain",
-			pdUpgrading:      false,
-			hasPVC:           true,
-			pvcUpdateErr:     false,
-			deleteMemberErr:  false,
-			statusSyncFailed: false,
-			err:              true,
-			changed:          false,
-			isLeader:         false,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -233,16 +233,15 @@ func TestPDScalerScaleOut(t *testing.T) {
 func TestPDScalerScaleIn(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type testcase struct {
-		name                string
-		pdUpgrading         bool
-		hasPVC              bool
-		pvcUpdateErr        bool
-		deleteMemberErr     bool
-		statusSyncFailed    bool
-		err                 bool
-		changed             bool
-		isLeader            bool
-		isMemberStillRemain bool
+		name             string
+		pdUpgrading      bool
+		hasPVC           bool
+		pvcUpdateErr     bool
+		deleteMemberErr  bool
+		statusSyncFailed bool
+		err              bool
+		changed          bool
+		isLeader         bool
 	}
 
 	testFn := func(test testcase, t *testing.T) {
@@ -293,28 +292,6 @@ func TestPDScalerScaleIn(t *testing.T) {
 			})
 		}
 
-		var membersInfo *pdapi.MembersInfo
-		if test.isMemberStillRemain {
-			membersInfo = &pdapi.MembersInfo{
-				Members: []*pdpb.Member{
-					{
-						Name: fmt.Sprintf("%s-pd-%d", tc.GetName(), 4),
-					},
-				},
-			}
-		} else {
-			membersInfo = &pdapi.MembersInfo{
-				Members: []*pdpb.Member{
-					{
-						Name: fmt.Sprintf("%s-pd-%d", tc.GetName(), 1),
-					},
-				},
-			}
-		}
-		pdClient.AddReaction(pdapi.GetMembersActionType, func(action *pdapi.Action) (i interface{}, err error) {
-			return membersInfo, nil
-		})
-
 		tc.Status.PD.Synced = !test.statusSyncFailed
 
 		err := scaler.ScaleIn(tc, oldSet, newSet)
@@ -332,88 +309,81 @@ func TestPDScalerScaleIn(t *testing.T) {
 
 	tests := []testcase{
 		{
-			name:                "normal",
-			pdUpgrading:         false,
-			hasPVC:              true,
-			pvcUpdateErr:        false,
-			deleteMemberErr:     false,
-			statusSyncFailed:    false,
-			err:                 false,
-			changed:             true,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "normal",
+			pdUpgrading:      false,
+			hasPVC:           true,
+			pvcUpdateErr:     false,
+			deleteMemberErr:  false,
+			statusSyncFailed: false,
+			err:              false,
+			changed:          true,
+			isLeader:         false,
 		},
 		{
-			name:                "able to scale in while pd is upgrading",
-			pdUpgrading:         true,
-			hasPVC:              true,
-			pvcUpdateErr:        false,
-			deleteMemberErr:     false,
-			statusSyncFailed:    false,
-			err:                 false,
-			changed:             true,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "able to scale in while pd is upgrading",
+			pdUpgrading:      true,
+			hasPVC:           true,
+			pvcUpdateErr:     false,
+			deleteMemberErr:  false,
+			statusSyncFailed: false,
+			err:              false,
+			changed:          true,
+			isLeader:         false,
 		},
 		{
-			name:                "error when delete member",
-			hasPVC:              true,
-			pvcUpdateErr:        false,
-			pdUpgrading:         false,
-			deleteMemberErr:     true,
-			statusSyncFailed:    false,
-			err:                 true,
-			changed:             false,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "error when delete member",
+			hasPVC:           true,
+			pvcUpdateErr:     false,
+			pdUpgrading:      false,
+			deleteMemberErr:  true,
+			statusSyncFailed: false,
+			err:              true,
+			changed:          false,
+			isLeader:         false,
 		},
 		{
-			name:                "cache don't have pvc",
-			pdUpgrading:         false,
-			hasPVC:              false,
-			pvcUpdateErr:        false,
-			deleteMemberErr:     false,
-			statusSyncFailed:    false,
-			err:                 true,
-			changed:             false,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "cache don't have pvc",
+			pdUpgrading:      false,
+			hasPVC:           false,
+			pvcUpdateErr:     false,
+			deleteMemberErr:  false,
+			statusSyncFailed: false,
+			err:              true,
+			changed:          false,
+			isLeader:         false,
 		},
 		{
-			name:                "error when update pvc",
-			pdUpgrading:         false,
-			hasPVC:              true,
-			pvcUpdateErr:        true,
-			deleteMemberErr:     false,
-			statusSyncFailed:    false,
-			err:                 true,
-			changed:             false,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "error when update pvc",
+			pdUpgrading:      false,
+			hasPVC:           true,
+			pvcUpdateErr:     true,
+			deleteMemberErr:  false,
+			statusSyncFailed: false,
+			err:              true,
+			changed:          false,
+			isLeader:         false,
 		},
 		{
-			name:                "pd status sync failed",
-			pdUpgrading:         false,
-			hasPVC:              true,
-			pvcUpdateErr:        false,
-			deleteMemberErr:     false,
-			statusSyncFailed:    true,
-			err:                 true,
-			changed:             false,
-			isLeader:            false,
-			isMemberStillRemain: false,
+			name:             "pd status sync failed",
+			pdUpgrading:      false,
+			hasPVC:           true,
+			pvcUpdateErr:     false,
+			deleteMemberErr:  false,
+			statusSyncFailed: true,
+			err:              true,
+			changed:          false,
+			isLeader:         false,
 		},
 		{
-			name:                "delete member success, but get member still remain",
-			pdUpgrading:         false,
-			hasPVC:              true,
-			pvcUpdateErr:        false,
-			deleteMemberErr:     false,
-			statusSyncFailed:    false,
-			err:                 true,
-			changed:             false,
-			isLeader:            false,
-			isMemberStillRemain: true,
+			name:             "delete member success, but get member still remain",
+			pdUpgrading:      false,
+			hasPVC:           true,
+			pvcUpdateErr:     false,
+			deleteMemberErr:  false,
+			statusSyncFailed: false,
+			err:              true,
+			changed:          false,
+			isLeader:         false,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #3452 

### What is changed and how does it work?
basically revert pr #2793 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

- Manual test
    1. deploy a `tidbCluster` named `tidb-old`, setup a `tidbMonitor` watching both `tidb-old` and `tidb-new`
    2. start `sysbench` with `oltp_read_only` workload against `tidb-old`
    3. deploy a `tidbCluster` named `tidb-new`, with `spec.pdAddresses` contains all pd peer urls from `tidb-old`
    4. follow [migrate-tidb-to-kubernetes](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/migrate-tidb-to-kubernetes) to migrate `tidb-old` to `tidb-new`, while monitor grafana dashboard to make sure everything is fine.
    5. PD/TiDB/TiKV pods in `tidb-old` are all scaled to 0

 - Has Go code change

Side effects

None

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue that PD cannot scale in to 0 even if there are other PD members
```
