### PR TITLE
add init container for BR backup/restore to supply the BR bin

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -65,7 +65,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) error {
 	}
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
-	bin := "br" + backupUtil.Suffix(bo.TiKVVersion)
+	bin := path.Join(util.BRBinPath, "br")
 	cmd := exec.Command(bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -64,7 +64,7 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	}
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
-	bin := "br" + backupUtil.Suffix(ro.TiKVVersion)
+	bin := path.Join(util.BRBinPath, "br")
 	cmd := exec.Command(bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -215,7 +215,7 @@ DumplingConfig
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>toolImage</code></br>
 <em>
 string
 </em>
@@ -1022,7 +1022,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>toolImage</code></br>
 <em>
 string
 </em>
@@ -2871,7 +2871,7 @@ DumplingConfig
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>toolImage</code></br>
 <em>
 string
 </em>
@@ -10208,7 +10208,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>toolImage</code></br>
 <em>
 string
 </em>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2434,6 +2434,17 @@ bool
 </tr>
 <tr>
 <td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image specifies the BR image used in the backup/restore</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>options</code></br>
 <em>
 []string

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -215,6 +215,18 @@ DumplingConfig
 </tr>
 <tr>
 <td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>imagePullSecrets</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
@@ -1006,6 +1018,18 @@ string
 </td>
 <td>
 <p>Specify service account of restore</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
 </td>
 </tr>
 <tr>
@@ -2434,17 +2458,6 @@ bool
 </tr>
 <tr>
 <td>
-<code>image</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Image specifies the BR image used in the backup/restore</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>options</code></br>
 <em>
 []string
@@ -2854,6 +2867,18 @@ DumplingConfig
 <td>
 <em>(Optional)</em>
 <p>Base tolerations of backup Pods, components may add more tolerations upon this respectively</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
 </td>
 </tr>
 <tr>
@@ -10179,6 +10204,18 @@ string
 </td>
 <td>
 <p>Specify service account of restore</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
 </td>
 </tr>
 <tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13412,6 +13412,8 @@ spec:
                   type: integer
                 db:
                   type: string
+                image:
+                  type: string
                 logLevel:
                   type: string
                 onLine:
@@ -13878,6 +13880,8 @@ spec:
                   type: integer
                 db:
                   type: string
+                image:
+                  type: string
                 logLevel:
                   type: string
                 onLine:
@@ -14332,6 +14336,8 @@ spec:
                       format: int64
                       type: integer
                     db:
+                      type: string
+                    image:
                       type: string
                     logLevel:
                       type: string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13488,8 +13488,6 @@ spec:
               - projectId
               - secretName
               type: object
-            image:
-              type: string
             imagePullSecrets:
               items:
                 properties:
@@ -13561,6 +13559,8 @@ spec:
                     type: string
                 type: object
               type: array
+            toolImage:
+              type: string
             useKMS:
               type: boolean
           type: object
@@ -13926,8 +13926,6 @@ spec:
               - projectId
               - secretName
               type: object
-            image:
-              type: string
             imagePullSecrets:
               items:
                 properties:
@@ -14016,6 +14014,8 @@ spec:
                     type: string
                 type: object
               type: array
+            toolImage:
+              type: string
             useKMS:
               type: boolean
           type: object
@@ -14413,8 +14413,6 @@ spec:
                   - projectId
                   - secretName
                   type: object
-                image:
-                  type: string
                 imagePullSecrets:
                   items:
                     properties:
@@ -14486,6 +14484,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                toolImage:
+                  type: string
                 useKMS:
                   type: boolean
               type: object

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13412,8 +13412,6 @@ spec:
                   type: integer
                 db:
                   type: string
-                image:
-                  type: string
                 logLevel:
                   type: string
                 onLine:
@@ -13490,6 +13488,8 @@ spec:
               - projectId
               - secretName
               type: object
+            image:
+              type: string
             imagePullSecrets:
               items:
                 properties:
@@ -13880,8 +13880,6 @@ spec:
                   type: integer
                 db:
                   type: string
-                image:
-                  type: string
                 logLevel:
                   type: string
                 onLine:
@@ -13928,6 +13926,8 @@ spec:
               - projectId
               - secretName
               type: object
+            image:
+              type: string
             imagePullSecrets:
               items:
                 properties:
@@ -14337,8 +14337,6 @@ spec:
                       type: integer
                     db:
                       type: string
-                    image:
-                      type: string
                     logLevel:
                       type: string
                     onLine:
@@ -14415,6 +14413,8 @@ spec:
                   - projectId
                   - secretName
                   type: object
+                image:
+                  type: string
                 imagePullSecrets:
                   items:
                     properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -928,7 +928,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 							},
 						},
 					},
-					"image": {
+					"toolImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
 							Type:        []string{"string"},
@@ -5103,7 +5103,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
-					"image": {
+					"toolImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
 							Type:        []string{"string"},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -590,6 +590,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image specifies the BR image used in the backup/restore",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"options": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Options means options for backup data to remote storage with BR. These options has highest priority.",

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -590,13 +590,6 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
-					"image": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Image specifies the BR image used in the backup/restore",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"options": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Options means options for backup data to remote storage with BR. These options has highest priority.",
@@ -933,6 +926,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 									},
 								},
 							},
+						},
+					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"imagePullSecrets": {
@@ -5099,6 +5099,13 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					"serviceAccount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specify service account of restore",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1263,7 +1263,7 @@ type BackupSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
 	// +optional
-	ToolImage string `json:"image,omitempty"`
+	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
@@ -1522,7 +1522,7 @@ type RestoreSpec struct {
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
 	// +optional
-	ToolImage string `json:"image,omitempty"`
+	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1261,6 +1261,9 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
+	// +optional
+	ToolImage string `json:"image,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
@@ -1313,8 +1316,6 @@ type BRConfig struct {
 	SendCredToTikv *bool `json:"sendCredToTikv,omitempty"`
 	// OnLine specifies whether online during restore
 	OnLine *bool `json:"onLine,omitempty"`
-	// Image specifies the BR image used in the backup/restore
-	Image string `json:"image,omitempty"`
 	// Options means options for backup data to remote storage with BR. These options has highest priority.
 	Options []string `json:"options,omitempty"`
 }
@@ -1519,6 +1520,9 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
+	// +optional
+	ToolImage string `json:"image,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1313,6 +1313,8 @@ type BRConfig struct {
 	SendCredToTikv *bool `json:"sendCredToTikv,omitempty"`
 	// OnLine specifies whether online during restore
 	OnLine *bool `json:"onLine,omitempty"`
+	// Image specifies the BR image used in the backup/restore
+	Image string `json:"image,omitempty"`
 	// Options means options for backup data to remote storage with BR. These options has highest priority.
 	Options []string `json:"options,omitempty"`
 }

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -371,7 +371,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		ReadOnly:  false,
 		MountPath: util.BRBinPath,
 	}
-	volumeMounts = append(volumeMounts, brVolume)
+	volumeMounts = append(volumeMounts, brVolumeMount)
 
 	volumes = append(volumes, corev1.Volume{
 		Name: "br-bin",
@@ -386,8 +386,8 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 	}
 
 	brImage := "pingcap/br:" + tikvVersion
-	if backup.Spec.BR.Image != "" {
-		brImage = backup.Spec.BR.Image
+	if backup.Spec.ToolImage != "" {
+		brImage = backup.Spec.ToolImage
 	}
 
 	podSpec := &corev1.PodTemplateSpec{
@@ -402,9 +402,9 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 					Name:            "br",
 					Image:           brImage,
 					Command:         []string{"/bin/sh", "-c"},
-					Args:            []string{"cp /br /var/lib/br-bin/br; echo 'BR copy finished'"},
+					Args:            []string{fmt.Sprintf("cp /br %s/br; echo 'BR copy finished'", util.BRBinPath)},
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					VolumeMounts:    []corev1.VolumeMount{brVolume},
+					VolumeMounts:    []corev1.VolumeMount{brVolumeMount},
 					Resources:       backup.Spec.ResourceRequirements,
 				},
 			},

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -366,7 +366,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		})
 	}
 
-	brVolume := corev1.VolumeMount{
+	brVolumeMount := corev1.VolumeMount{
 		Name:      "br-bin",
 		ReadOnly:  false,
 		MountPath: util.BRBinPath,
@@ -402,7 +402,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 					Name:            "br",
 					Image:           brImage,
 					Command:         []string{"/bin/sh", "-c"},
-					Args:            []string{"cp /br /var/lib/br-bin/br; echo 'copy finished'"},
+					Args:            []string{"cp /br /var/lib/br-bin/br; echo 'BR copy finished'"},
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					VolumeMounts:    []corev1.VolumeMount{brVolume},
 					Resources:       backup.Spec.ResourceRequirements,

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -347,12 +347,12 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		})
 	}
 
-	brVolume := corev1.VolumeMount{
+	brVolumeMount := corev1.VolumeMount{
 		Name:      "br-bin",
 		ReadOnly:  false,
 		MountPath: util.BRBinPath,
 	}
-	volumeMounts = append(volumeMounts, brVolume)
+	volumeMounts = append(volumeMounts, brVolumeMount)
 
 	volumes = append(volumes, corev1.Volume{
 		Name: "br-bin",
@@ -367,8 +367,8 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 	}
 
 	brImage := "pingcap/br:" + tikvVersion
-	if restore.Spec.BR.Image != "" {
-		brImage = restore.Spec.BR.Image
+	if restore.Spec.ToolImage != "" {
+		brImage = restore.Spec.ToolImage
 	}
 
 	// TODO: need add ResourceRequirement for restore job
@@ -384,9 +384,9 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 					Name:            "br",
 					Image:           brImage,
 					Command:         []string{"/bin/sh", "-c"},
-					Args:            []string{"cp /br /var/lib/br-bin/br; echo 'copy finished'"},
+					Args:            []string{fmt.Sprintf("cp /br %s/br; echo 'BR copy finished'", util.BRBinPath)},
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					VolumeMounts:    []corev1.VolumeMount{brVolume},
+					VolumeMounts:    []corev1.VolumeMount{brVolumeMount},
 					Resources:       restore.Spec.ResourceRequirements,
 				},
 			},

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -347,10 +347,30 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		})
 	}
 
+	brVolume := corev1.VolumeMount{
+		Name:      "br-bin",
+		ReadOnly:  false,
+		MountPath: util.BRBinPath,
+	}
+	volumeMounts = append(volumeMounts, brVolume)
+
+	volumes = append(volumes, corev1.Volume{
+		Name: "br-bin",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
 	serviceAccount := constants.DefaultServiceAccountName
 	if restore.Spec.ServiceAccount != "" {
 		serviceAccount = restore.Spec.ServiceAccount
 	}
+
+	brImage := "pingcap/br:" + tikvVersion
+	if restore.Spec.BR.Image != "" {
+		brImage = restore.Spec.BR.Image
+	}
+
 	// TODO: need add ResourceRequirement for restore job
 	podSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -359,6 +379,17 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccount,
+			InitContainers: []corev1.Container{
+				{
+					Name:            "br",
+					Image:           brImage,
+					Command:         []string{"/bin/sh", "-c"},
+					Args:            []string{"cp /br /var/lib/br-bin/br; echo 'copy finished'"},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					VolumeMounts:    []corev1.VolumeMount{brVolume},
+					Resources:       restore.Spec.ResourceRequirements,
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:            label.RestoreJobLabelVal,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -39,6 +39,7 @@ import (
 var (
 	ClusterClientTLSPath = "/var/lib/cluster-client-tls"
 	TiDBClientTLSPath    = "/var/lib/tidb-client-tls"
+	BRBinPath            = "/var/lib/br-bin"
 	ClusterClientVolName = "cluster-client-tls"
 )
 


### PR DESCRIPTION
Signed-off-by: gongmengnan <gong.mengnan@ninjavan.co>

<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix https://github.com/pingcap/tidb-operator/issues/3441. 

### What is changed and how does it work?
Added an `image` field in the `spec.br` of Backup and Restore CR as init container. The BR executable file will be provided by the specified image.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

N/A.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
