### PR TITLE
remove RUNAsUser when init monitor pod

### DIFF
--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -33,7 +33,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func GetMonitorObjectName(monitor *v1alpha1.TidbMonitor) string {
@@ -327,9 +326,6 @@ chmod 777 /data/prometheus /data/grafana
 			},
 		},
 		Command: command,
-		SecurityContext: &core.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(0),
-		},
 		VolumeMounts: []core.VolumeMount{
 			{
 				MountPath: "/prometheus-rules",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix #3460 
To avoid the situation that, in some Kubernetes platforms, the default user is not 0, setting `RunAsUsr: 0` may cause Grafana container to fail to start. More info see [issue](https://github.com/pingcap/tidb-operator/issues/3460). 


### What is changed and how does it work?
Remove `SecurityContext` for the initializer container of the monitor deployment.
When remove `SecurityContext`，the security policy is `runAsUser: rule: 'RunAsAny' `.
https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test  
 successed
 - E2E test  
 do not run
 - Stability test 
 do not run
 - Manual test (add detailed scripts or steps below)
initializer container start successfully, yaml config as below. We can see that `securityContext` is empty. 
```
    image: pingcap/tidb-monitor-initializer:v4.0.7
    imagePullPolicy: IfNotPresent
    name: monitor-initializer
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    ...
  nodeName: kind-control-plane
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: basic-monitor
  serviceAccountName: basic-monitor
  terminationGracePeriodSeconds: 30
```

 - No code

Code changes

 - Has Go code change


Side effects


Related changes

<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
