### PR TITLE
fix UCLOUD_UFILE_PROXY_HOST

### DIFF
--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -340,7 +340,7 @@ try {
                                     string(credentialsId: 'UCLOUD_PRIVATE_KEY', variable: 'UCLOUD_PRIVATE_KEY'),
                                 ]) {
                                     sh """
-                                    export UCLOUD_UFILE_PROXY_HOST=mainland-hk.ufileos.com
+                                    export UCLOUD_UFILE_PROXY_HOST=pingcap-dev.hk.ufileos.com
                                     export UCLOUD_UFILE_BUCKET=pingcap-dev
                                     export BUILD_BRANCH=${GIT_REF}
                                     export GITHASH=${GITHASH}

--- a/ci/release-nightly.groovy
+++ b/ci/release-nightly.groovy
@@ -166,7 +166,7 @@ try {
                             string(credentialsId: 'UCLOUD_PRIVATE_KEY', variable: 'UCLOUD_PRIVATE_KEY'),
                         ]) {
                             sh """
-                            export UCLOUD_UFILE_PROXY_HOST=mainland-hk.ufileos.com
+                            export UCLOUD_UFILE_PROXY_HOST=pingcap-dev.hk.ufileos.com
                             export UCLOUD_UFILE_BUCKET=pingcap-dev
                             export BUILD_BRANCH=${GIT_REF}
                             export GITHASH=${GITHASH}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
change UCLOUD_UFILE_PROXY_HOST=pingcap-dev.hk.ufileos.com

### What is changed and how does it work?
ucloud proxy url has changed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has CI related scripts change

Side effects

None

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
