### PR TITLE
ci: fix ngihtly build

### DIFF
--- a/ci/release-nightly.groovy
+++ b/ci/release-nightly.groovy
@@ -28,66 +28,16 @@ properties([
 podYAML = '''
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app: tidb-operator-nightly
 spec:
   containers:
   - name: golang-builder
     image: 'golang:latest'
+    command: ["/bin/bash", "-c", "--"]
+    args: ["trap : TERM; sleep infinity & wait"]
 '''
-
-def build(String name, String code, Map resources = e2ePodResources) {
-    podTemplate(yaml: podYAML) {
-        node(POD_LABEL) {
-            container('main') {
-                def WORKSPACE = pwd()
-                def ARTIFACTS = "${WORKSPACE}/go/src/github.com/pingcap/tidb-operator/_artifacts"
-                try {
-                    dir("${WORKSPACE}/go/src/github.com/pingcap/tidb-operator") {
-                        unstash 'tidb-operator'
-                        stage("Debug Info") {
-                            println "debug host: 172.16.5.15"
-                            println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
-                            sh """
-                            echo "====== shell env ======"
-                            echo "pwd: \$(pwd)"
-                            env
-                            echo "====== go env ======"
-                            go env
-                            echo "====== docker version ======"
-                            docker version
-                            """
-                        }
-                        stage('Run') {
-                            sh """#!/bin/bash
-                            export GOPATH=${WORKSPACE}/go
-                            export ARTIFACTS=${ARTIFACTS}
-                            export RUNNER_SUITE_NAME=${name}
-                            ${code}
-                            """
-                        }
-                    }
-                } finally {
-                    dir(ARTIFACTS) {
-                        sh """#!/bin/bash
-                        echo "info: change ownerships for jenkins"
-                        chown -R 1000:1000 .
-                        echo "info: print total size of artifacts"
-                        du -sh .
-                        echo "info: list all files"
-                        find .
-                        echo "info: moving all artifacts into a sub-directory"
-                        shopt -s extglob
-                        mkdir ${name}
-                        mv !(${name}) ${name}/
-                        """
-                        archiveArtifacts artifacts: "${name}/**", allowEmptyArchive: true
-                        junit testResults: "${name}/*.xml", allowEmptyResults: true
-                    }
-                }
-            }
-        }
-    }
-}
-
 
 try {
     def GITHASH
@@ -101,10 +51,10 @@ try {
         GIT_REF = env.ghprbActualCommit
     }
 
-    timeout (time: 1, unit: 'HOURS') {
+    timeout (time: 20, unit: 'MINUTES') {
         // use fixed label, so we can reuse previous workers
         // increase version in pod label when we update pod template
-        def buildPodLabel = "tidb-operator-build-v1"
+        def buildPodLabel = "tidb-operator-build-nightly"
         def resources = [
             requests: [
                 cpu: "4",
@@ -112,7 +62,7 @@ try {
             ],
             limits: [
                 cpu: "8",
-                memory: "32G"
+                memory: "16G"
             ],
         ]
         podTemplate(
@@ -123,7 +73,7 @@ try {
             idleMinutes: 180,
         ) {
         node(buildPodLabel) {
-            container("main") {
+            container("golang-builder") {
                 dir("${PROJECT_DIR}") {
 
                     stage('Checkout') {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
The pipeline for nightly build was not correct and was using cached pod for E2E tests.

### What is changed and how does it work?
Properly create and manage pod for nightly builds themselves.

This does not affect any real codes and testing CI jobs, should be safe to merge.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has CI related scripts change

Related changes

 - Need to cherry-pick to the release branch

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
