### PR TITLE
Fix logic in UpdateMetainfo for update info to pvc when multi-clustesr enabled

### DIFF
--- a/pkg/controller/pod_control_test.go
+++ b/pkg/controller/pod_control_test.go
@@ -138,7 +138,7 @@ func TestPodControlUpdateMetaInfo(t *testing.T) {
 				pod.Labels[label.ComponentLabelKey] = label.PDLabelVal
 				pod.Labels[label.MemberIDLabelKey] = ""
 				tc.Status.PD.Members = map[string]v1alpha1.PDMember{
-					"333": {Name:"333.cluster.local",ID: "333"},
+					"333": {Name: "333.cluster.local", ID: "333"},
 				}
 			},
 			expectFn: func(g *GomegaWithT, b bool) {
@@ -153,7 +153,6 @@ func TestPodControlUpdateMetaInfo(t *testing.T) {
 		testFn(&tests[i], t)
 	}
 }
-
 
 func TestPodControlUpdateMetaInfoSuccess(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/pkg/controller/pod_control_test.go
+++ b/pkg/controller/pod_control_test.go
@@ -38,6 +38,123 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+func TestPodControlUpdateMetaInfo(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tc := newTidbCluster()
+	pod := newPod(tc)
+	oldPod := newPod(tc)
+	oldPod.Labels = nil
+	fakeClient, pdControl, podLister, podIndexer, recorder := newFakeClientRecorderAndPDControl()
+	podIndexer.Add(oldPod)
+	control := NewRealPodControl(fakeClient, pdControl, podLister, recorder)
+	pdClient := NewFakePDClient(pdControl, tc)
+
+	type testcase struct {
+		name     string
+		update   func(*v1alpha1.TidbCluster)
+		expectFn func(*GomegaWithT, bool)
+	}
+	testFn := func(test *testcase, t *testing.T) {
+		t.Log(test.name)
+
+		test.update(tc)
+		test.expectFn(g, tc.PDIsAvailable())
+	}
+	tests := []testcase{
+		{
+			name: "Test PodControl UpdateMetaInfo ConflictSuccess",
+			update: func(tc *v1alpha1.TidbCluster) {
+				pdClient.AddReaction(pdapi.GetClusterActionType, func(action *pdapi.Action) (interface{}, error) {
+					cluster := &metapb.Cluster{
+						Id: 222,
+					}
+					return cluster, nil
+				})
+				pdClient.AddReaction(pdapi.GetMembersActionType, func(action *pdapi.Action) (interface{}, error) {
+					membersInfo := &pdapi.MembersInfo{
+						Members: []*pdpb.Member{
+							{
+								MemberId: 111,
+							},
+						},
+					}
+					return membersInfo, nil
+				})
+				pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
+					storesInfo := &pdapi.StoresInfo{
+						Stores: []*pdapi.StoreInfo{
+							{
+								Store: &pdapi.MetaStore{
+									Store: &metapb.Store{
+										Id:      333,
+										Address: fmt.Sprintf("%s.web", TestPodName),
+									},
+								},
+							},
+						},
+					}
+					return storesInfo, nil
+				})
+				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{
+					"333": {PodName: TestPodName, ID: "333"},
+				}
+				conflict := false
+				fakeClient.AddReactor("update", "pods", func(action core.Action) (bool, runtime.Object, error) {
+					update := action.(core.UpdateAction)
+					if !conflict {
+						conflict = true
+						return true, oldPod, apierrors.NewConflict(action.GetResource().GroupResource(), pod.Name, errors.New("conflict"))
+					}
+					return true, update.GetObject(), nil
+				})
+			},
+			expectFn: func(g *GomegaWithT, b bool) {
+				updatePod, err := control.UpdateMetaInfo(tc, pod)
+				g.Expect(err).To(Succeed())
+				g.Expect(updatePod.Labels[label.StoreIDLabelKey]).To(Equal("333"))
+				g.Expect(updatePod.Labels[label.ClusterIDLabelKey]).To(Equal("222"))
+			},
+		},
+		{
+			name: "Test PodControl UpdateMetaInfo TiFlash label success",
+			update: func(tc *v1alpha1.TidbCluster) {
+				pod.Labels[label.ComponentLabelKey] = label.TiFlashLabelVal
+				pod.Labels[label.StoreIDLabelKey] = ""
+				tc.Status.TiFlash.Stores = map[string]v1alpha1.TiKVStore{
+					"333": {PodName: TestPodName, ID: "333"},
+				}
+			},
+			expectFn: func(g *GomegaWithT, b bool) {
+				updatePod, err := control.UpdateMetaInfo(tc, pod)
+				g.Expect(err).To(Succeed())
+				g.Expect(updatePod.Labels[label.StoreIDLabelKey]).To(Equal("333"))
+			},
+		},
+		{
+			name: "Test PodControl UpdateMetaInfo PD pod label success",
+			update: func(tc *v1alpha1.TidbCluster) {
+				pod.Name = "333"
+				pod.Labels[label.ComponentLabelKey] = label.PDLabelVal
+				pod.Labels[label.MemberIDLabelKey] = ""
+				tc.Status.PD.Members = map[string]v1alpha1.PDMember{
+					"333": {Name:"333.cluster.local",ID: "333"},
+				}
+			},
+			expectFn: func(g *GomegaWithT, b bool) {
+				updatePod, err := control.UpdateMetaInfo(tc, pod)
+				g.Expect(err).To(Succeed())
+				g.Expect(updatePod.Labels[label.MemberIDLabelKey]).To(Equal("333"))
+			},
+		},
+	}
+
+	for i := range tests {
+		testFn(&tests[i], t)
+	}
+}
+
+
 func TestPodControlUpdateMetaInfoSuccess(t *testing.T) {
 	g := NewGomegaWithT(t)
 	tc := newTidbCluster()
@@ -171,92 +288,6 @@ func TestPodControlUpdateMetaInfoUpdatePodFailed(t *testing.T) {
 	})
 	_, err := control.UpdateMetaInfo(tc, pod)
 	g.Expect(err).To(HaveOccurred())
-}
-
-func TestPodControlUpdateMetaInfoConflictSuccess(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	tc := newTidbCluster()
-	pod := newPod(tc)
-	oldPod := newPod(tc)
-	oldPod.Labels = nil
-	fakeClient, pdControl, podLister, podIndexer, recorder := newFakeClientRecorderAndPDControl()
-	podIndexer.Add(oldPod)
-	control := NewRealPodControl(fakeClient, pdControl, podLister, recorder)
-	pdClient := NewFakePDClient(pdControl, tc)
-
-	type testcase struct {
-		name     string
-		update   func(*v1alpha1.TidbCluster)
-		expectFn func(*GomegaWithT, bool)
-	}
-	testFn := func(test *testcase, t *testing.T) {
-		t.Log(test.name)
-
-		test.update(tc)
-		test.expectFn(g, tc.PDIsAvailable())
-	}
-	tests := []testcase{
-		{
-			name: "Test PodControl UpdateMetaInfo ConflictSuccess",
-			update: func(tc *v1alpha1.TidbCluster) {
-				pdClient.AddReaction(pdapi.GetClusterActionType, func(action *pdapi.Action) (interface{}, error) {
-					cluster := &metapb.Cluster{
-						Id: 222,
-					}
-					return cluster, nil
-				})
-				pdClient.AddReaction(pdapi.GetMembersActionType, func(action *pdapi.Action) (interface{}, error) {
-					membersInfo := &pdapi.MembersInfo{
-						Members: []*pdpb.Member{
-							{
-								MemberId: 111,
-							},
-						},
-					}
-					return membersInfo, nil
-				})
-				pdClient.AddReaction(pdapi.GetStoresActionType, func(action *pdapi.Action) (interface{}, error) {
-					storesInfo := &pdapi.StoresInfo{
-						Stores: []*pdapi.StoreInfo{
-							{
-								Store: &pdapi.MetaStore{
-									Store: &metapb.Store{
-										Id:      333,
-										Address: fmt.Sprintf("%s.web", TestPodName),
-									},
-								},
-							},
-						},
-					}
-					return storesInfo, nil
-				})
-				tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{
-					"333": {PodName: TestPodName, ID: "333"},
-				}
-				conflict := false
-				fakeClient.AddReactor("update", "pods", func(action core.Action) (bool, runtime.Object, error) {
-					update := action.(core.UpdateAction)
-					if !conflict {
-						conflict = true
-						return true, oldPod, apierrors.NewConflict(action.GetResource().GroupResource(), pod.Name, errors.New("conflict"))
-					}
-					return true, update.GetObject(), nil
-				})
-			},
-			expectFn: func(g *GomegaWithT, b bool) {
-				updatePod, err := control.UpdateMetaInfo(tc, pod)
-				g.Expect(err).To(Succeed())
-				g.Expect(updatePod.Labels[label.StoreIDLabelKey]).To(Equal("333"))
-				g.Expect(updatePod.Labels[label.ClusterIDLabelKey]).To(Equal("222"))
-			},
-		},
-	}
-
-	for i := range tests {
-		testFn(&tests[i], t)
-	}
-
 }
 
 func TestPodControlUpdatePod(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix some codes related to PD,TiKV,TiFlash in UpdateMetainfo. When the multi-cluster feature enabled, it may select the wrong members and stores from PD when tidbcluster names conflicts.

### What is changed and how does it work?
Get info from tc.Status.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
