### PR TITLE
backup: add br checksum concurrency

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -126,6 +126,9 @@ func constructOptions(backup *v1alpha1.Backup) ([]string, error) {
 	if config.Checksum != nil {
 		args = append(args, fmt.Sprintf("--checksum=%t", *config.Checksum))
 	}
+	if config.ChecksumConcurrency != nil {
+		args = append(args, fmt.Sprintf("--checksum-concurrency=%d", *config.ChecksumConcurrency))
+	}
 	args = append(args, config.Options...)
 	return args, nil
 }

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -117,6 +117,9 @@ func constructBROptions(restore *v1alpha1.Restore) ([]string, error) {
 	if config.Checksum != nil {
 		args = append(args, fmt.Sprintf("--checksum=%t", *config.Checksum))
 	}
+	if config.ChecksumConcurrency != nil {
+		args = append(args, fmt.Sprintf("--checksum-concurrency=%d", *config.ChecksumConcurrency))
+	}
 	if config.RateLimit != nil {
 		args = append(args, fmt.Sprintf("--ratelimit=%d", *config.RateLimit))
 	}

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2405,6 +2405,17 @@ uint32
 </tr>
 <tr>
 <td>
+<code>checksum-concurrency</code></br>
+<em>
+uint32
+</em>
+</td>
+<td>
+<p>ChecksumConcurrency is the size of thread pool on each node that execute the checksum task</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>rateLimit</code></br>
 <em>
 uint

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13403,6 +13403,9 @@ spec:
               properties:
                 checksum:
                   type: boolean
+                checksum-concurrency:
+                  format: int64
+                  type: integer
                 cluster:
                   type: string
                 clusterNamespace:
@@ -13871,6 +13874,9 @@ spec:
               properties:
                 checksum:
                   type: boolean
+                checksum-concurrency:
+                  format: int64
+                  type: integer
                 cluster:
                   type: string
                 clusterNamespace:
@@ -14328,6 +14334,9 @@ spec:
                   properties:
                     checksum:
                       type: boolean
+                    checksum-concurrency:
+                      format: int64
+                      type: integer
                     cluster:
                       type: string
                     clusterNamespace:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -555,6 +555,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BRConfig(ref common.ReferenceCallback) com
 							Format:      "int64",
 						},
 					},
+					"checksum-concurrency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ChecksumConcurrency is the size of thread pool on each node that execute the checksum task",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"rateLimit": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RateLimit is the rate limit of the backup task, MB/s per node",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1306,6 +1306,8 @@ type BRConfig struct {
 	StatusAddr string `json:"statusAddr,omitempty"`
 	// Concurrency is the size of thread pool on each node that execute the backup task
 	Concurrency *uint32 `json:"concurrency,omitempty"`
+	// ChecksumConcurrency is the size of thread pool on each node that execute the checksum task
+	ChecksumConcurrency *uint32 `json:"checksum-concurrency,omitempty"`
 	// RateLimit is the rate limit of the backup task, MB/s per node
 	RateLimit *uint `json:"rateLimit,omitempty"`
 	// TimeAgo is the history version of the backup task, e.g. 1m, 1h

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -85,6 +85,11 @@ func (in *BRConfig) DeepCopyInto(out *BRConfig) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.ChecksumConcurrency != nil {
+		in, out := &in.ChecksumConcurrency, &out.ChecksumConcurrency
+		*out = new(uint32)
+		**out = **in
+	}
 	if in.RateLimit != nil {
 		in, out := &in.RateLimit, &out.RateLimit
 		*out = new(uint)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve? <!--add and issue link with summary if exists-->
Add `checksum-concurrency` filed for control the backup and restore concurrency in a node.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

```release-note
Add `spec.br.checksum-concurrency` filed for control the backup and restore concurrency in a node.
```
