### PR TITLE
Refine basic examples about "max-open-files" for TiKV

### DIFF
--- a/examples/basic-cn/tidb-cluster.yaml
+++ b/examples/basic-cn/tidb-cluster.yaml
@@ -31,6 +31,12 @@ spec:
       storage:
         # In basic examples, we set this to avoid using too much storage.
         reserve-space: "0MB"
+      rocksdb:
+        # In basic examples, we set this to avoid the following error in some Kubernetes clusters:
+        # "the maximum number of open file descriptors is too small, got 1024, expect greater or equal to 82920"
+        max-open-files: 256
+      raftdb:
+        max-open-files: 256
   tidb:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb
     replicas: 1

--- a/examples/basic/tidb-cluster.yaml
+++ b/examples/basic/tidb-cluster.yaml
@@ -31,6 +31,12 @@ spec:
       storage:
         # In basic examples, we set this to avoid using too much storage.
         reserve-space: "0MB"
+      rocksdb:
+        # In basic examples, we set this to avoid the following error in some Kubernetes clusters:
+        # "the maximum number of open file descriptors is too small, got 1024, expect greater or equal to 82920"
+        max-open-files: 256
+      raftdb:
+        max-open-files: 256
   tidb:
     baseImage: pingcap/tidb
     replicas: 1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->

run basic examples in some K8s cluster may got `the maximum number of open file descriptors is too small, got 1024, expect greater or equal to 82920` for TiKV.

### What is changed and how does it work?

add `max-open-files: 256` config item for `rocksdb` and `raftdb`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

- None

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
