### PR TITLE
Fix codecs error for non-ASCII char in tidbInitializer job passwordSecret

### DIFF
--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -328,7 +328,7 @@ for file in os.listdir(password_dir):
     if file.startswith('.'):
         continue
     user = file
-    with open(os.path.join(password_dir, file), 'r') as f:
+    with open(os.path.join(password_dir, file), 'r', encoding="utf-8") as f:
         password = f.read()
     if user == 'root':
         conn.cursor().execute("set password for 'root'@'%%' = %s;", (password,))
@@ -336,7 +336,7 @@ for file in os.listdir(password_dir):
         conn.cursor().execute("create user %s@%s identified by %s;", (user, permit_host, password,))
 {{- end }}
 {{- if .InitSQL }}
-with open('/data/init.sql', 'r') as sql:
+with open('/data/init.sql', 'r', encoding="utf-8") as sql:
     for line in sql.readlines():
         conn.cursor().execute(line)
         conn.commit()

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -318,9 +318,9 @@ host = '{{ .ClusterName }}-tidb'
 permit_host = '{{ .PermitHost }}'
 port = 4000
 {{- if .TLS }}
-conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
+conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
 {{- else }}
-conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5)
+conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
 {{- end }}
 {{- if .PasswordSet }}
 password_dir = '/etc/tidb/password'
@@ -328,7 +328,7 @@ for file in os.listdir(password_dir):
     if file.startswith('.'):
         continue
     user = file
-    with open(os.path.join(password_dir, file), 'r', encoding="utf-8") as f:
+    with open(os.path.join(password_dir, file), 'r') as f:
         password = f.read()
     if user == 'root':
         conn.cursor().execute("set password for 'root'@'%%' = %s;", (password,))
@@ -336,7 +336,7 @@ for file in os.listdir(password_dir):
         conn.cursor().execute("create user %s@%s identified by %s;", (user, permit_host, password,))
 {{- end }}
 {{- if .InitSQL }}
-with open('/data/init.sql', 'r', encoding="utf-8") as sql:
+with open('/data/init.sql', 'r') as sql:
     for line in sql.readlines():
         conn.cursor().execute(line)
         conn.commit()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
https://github.com/pingcap/tidb-operator/issues/3568 
The non-ASCII characters in the password will lead the init script broken down.

### What is changed and how does it work?
Add encoding params in tidbInitializer scripts.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Create the root secret
```bash
kubectl create secret generic tidb-secret --from-literal=root=おはよう
```

Modify the examples/initialize/tidb-initializer.yaml and apply, the job is finished
```output
basic-tidb-initializer-gz7tw               0/1     Completed   0          68s
```

Check if the password works

```bash
[root@handlerww-multi-cluster init]# mysql -h 127.0.0.1 -u root -P 4000 
ERROR 1045 (28000): Access denied for user 'root'@'127.0.0.1' (using password: NO)
[root@handlerww-multi-cluster init]# mysql -h 127.0.0.1 -u root -P 4000 -p
Enter password: 
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MySQL connection id is 945
Server version: 5.7.25-TiDB-v4.0.8 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
```

Code changes

- Has Go code change

Side effects

- Breaking backward compatibility

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix codecs error for non-ASCII char password in tidbInitializer job
```
