### PR TITLE
add options for local and gcs provider in backup

### DIFF
--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -65,13 +65,13 @@ func (bo *Options) cleanBRRemoteBackupData(backup *v1alpha1.Backup) error {
 
 func (bo *Options) cleanRemoteBackupData(bucket string, opts []string) error {
 	destBucket := util.NormalizeBucketURI(bucket)
-	args := util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", destBucket, "")
+	args := util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", destBucket, "", true)
 	output, err := exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone delete command failed, output: %s, err: %v", bo, string(output), err)
 	}
 
-	args = util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", fmt.Sprintf("%s.tmp", destBucket), "")
+	args = util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", fmt.Sprintf("%s.tmp", destBucket), "", true)
 	output, err = exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone delete command failed, output: %s, err: %v", bo, string(output), err)

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -65,13 +65,13 @@ func (bo *Options) cleanBRRemoteBackupData(backup *v1alpha1.Backup) error {
 
 func (bo *Options) cleanRemoteBackupData(bucket string, opts []string) error {
 	destBucket := util.NormalizeBucketURI(bucket)
-	args := util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", destBucket, "", true)
+	args := util.ConstructRcloneArgs(constants.RcloneConfigArg, opts, "delete", destBucket, "", true)
 	output, err := exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone delete command failed, output: %s, err: %v", bo, string(output), err)
 	}
 
-	args = util.ConstructArgs(constants.RcloneConfigArg, opts, "delete", fmt.Sprintf("%s.tmp", destBucket), "", true)
+	args = util.ConstructRcloneArgs(constants.RcloneConfigArg, opts, "delete", fmt.Sprintf("%s.tmp", destBucket), "", true)
 	output, err = exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone delete command failed, output: %s, err: %v", bo, string(output), err)

--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -90,24 +90,24 @@ func (bo *Options) dumpTidbClusterData(backup *v1alpha1.Backup) (string, error) 
 func (bo *Options) backupDataToRemote(source, bucketURI string, opts []string) error {
 	destBucket := backupUtil.NormalizeBucketURI(bucketURI)
 	tmpDestBucket := fmt.Sprintf("%s.tmp", destBucket)
-	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "copyto", source, tmpDestBucket, true)
+	args := backupUtil.ConstructRcloneArgs(constants.RcloneConfigArg, opts, "copyto", source, tmpDestBucket, true)
 	// TODO: We may need to use exec.CommandContext to control timeouts.
 	output, err := exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone copyto command for upload backup data %s failed, output: %s, err: %v", bo, bucketURI, string(output), err)
 	}
 
-	klog.Infof("cluster %s rclone copy data from %s data to %s, log: %s", bo, source, tmpDestBucket, output)
+	klog.Infof("cluster %s, rclone copy data from %s to %s, log: %s", bo, source, tmpDestBucket, output)
 	klog.Infof("upload cluster %s backup data to %s successfully, now move it to permanent URL %s", bo, tmpDestBucket, destBucket)
 
 	// the backup was a success
 	// remove .tmp extension
-	args = backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "moveto", tmpDestBucket, destBucket, true)
+	args = backupUtil.ConstructRcloneArgs(constants.RcloneConfigArg, opts, "moveto", tmpDestBucket, destBucket, true)
 	output, err = exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone moveto command failed, output: %s, err: %v", bo, string(output), err)
 	}
-	klog.Infof("cluster %s rclone move data from %s data to %s, log: %s", bo, tmpDestBucket, destBucket, output)
+	klog.Infof("cluster %s, rclone move data from %s to %s, log: %s", bo, tmpDestBucket, destBucket, output)
 	return nil
 }
 
@@ -117,7 +117,7 @@ func getBackupSize(backupPath string, opts []string) (int64, error) {
 	if exist := backupUtil.IsFileExist(backupPath); !exist {
 		return size, fmt.Errorf("file %s does not exist or is not regular file", backupPath)
 	}
-	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, nil, "ls", backupPath, "", false)
+	args := backupUtil.ConstructRcloneArgs(constants.RcloneConfigArg, nil, "ls", backupPath, "", false)
 	out, err := exec.Command("rclone", args...).CombinedOutput()
 	if err != nil {
 		return size, fmt.Errorf("failed to get backup %s size, err: %v", backupPath, err)

--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -93,21 +93,21 @@ func (bo *Options) backupDataToRemote(source, bucketURI string, opts []string) e
 	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "copyto", source, tmpDestBucket, true)
 	// TODO: We may need to use exec.CommandContext to control timeouts.
 	output, err := exec.Command("rclone", args...).CombinedOutput()
-	klog.Infof("rclone copy data from %s data to %s. rclone log: %s", source, tmpDestBucket, output)
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone copyto command for upload backup data %s failed, output: %s, err: %v", bo, bucketURI, string(output), err)
 	}
 
+	klog.Infof("cluster %s rclone copy data from %s data to %s, log: %s", bo, source, tmpDestBucket, output)
 	klog.Infof("upload cluster %s backup data to %s successfully, now move it to permanent URL %s", bo, tmpDestBucket, destBucket)
 
 	// the backup was a success
 	// remove .tmp extension
 	args = backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "moveto", tmpDestBucket, destBucket, true)
 	output, err = exec.Command("rclone", args...).CombinedOutput()
-	klog.Infof("rclone move data from %s data to %s. rclone log: %s", tmpDestBucket, destBucket, output)
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute rclone moveto command failed, output: %s, err: %v", bo, string(output), err)
 	}
+	klog.Infof("cluster %s rclone move data from %s data to %s, log: %s", bo, tmpDestBucket, destBucket, output)
 	return nil
 }
 

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -47,7 +47,7 @@ func (ro *Options) downloadBackupData(localPath string, opts []string) error {
 	}
 
 	remoteBucket := backupUtil.NormalizeBucketURI(ro.BackupPath)
-	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "copyto", remoteBucket, localPath)
+	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "copyto", remoteBucket, localPath, true)
 	rcCopy := exec.Command("rclone", args...)
 
 	stdOut, err := rcCopy.StdoutPipe()

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -47,7 +47,7 @@ func (ro *Options) downloadBackupData(localPath string, opts []string) error {
 	}
 
 	remoteBucket := backupUtil.NormalizeBucketURI(ro.BackupPath)
-	args := backupUtil.ConstructArgs(constants.RcloneConfigArg, opts, "copyto", remoteBucket, localPath, true)
+	args := backupUtil.ConstructRcloneArgs(constants.RcloneConfigArg, opts, "copyto", remoteBucket, localPath, true)
 	rcCopy := exec.Command("rclone", args...)
 
 	stdOut, err := rcCopy.StdoutPipe()

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -391,16 +391,21 @@ func GetCommitTsFromBRMetaData(provider v1alpha1.StorageProvider) (uint64, error
 // ConstructArgs constructs the rclone args
 func ConstructArgs(conf string, opts []string, command, source, dest string, rcloneLog bool) []string {
 	var args []string
+	defaultLog := true
 	if conf != "" {
 		args = append(args, conf)
 	}
 	if len(opts) > 0 {
 		for _, opt := range opts {
-			if opt == "-q" || strings.HasPrefix(opt, "-v") {
-				rcloneLog = false
+			if rcloneLog == false && strings.HasPrefix(opt, "-v") {
+				defaultLog = false
+				continue
 			}
+			if opt == "-q" || opt == "--quiet" {
+				defaultLog = false
+			}
+			args = append(args, opt)
 		}
-		args = append(args, opts...)
 	}
 	if command != "" {
 		args = append(args, command)
@@ -411,7 +416,7 @@ func ConstructArgs(conf string, opts []string, command, source, dest string, rcl
 	if dest != "" {
 		args = append(args, dest)
 	}
-	if rcloneLog {
+	if defaultLog {
 		args = append(args, "-v")
 	}
 	return args

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -389,12 +389,17 @@ func GetCommitTsFromBRMetaData(provider v1alpha1.StorageProvider) (uint64, error
 }
 
 // ConstructArgs constructs the rclone args
-func ConstructArgs(conf string, opts []string, command, source, dest string) []string {
+func ConstructArgs(conf string, opts []string, command, source, dest string, rcloneLog bool) []string {
 	var args []string
 	if conf != "" {
 		args = append(args, conf)
 	}
 	if len(opts) > 0 {
+		for _, opt := range opts {
+			if opt == "-q" || strings.HasPrefix(opt, "-v") {
+				rcloneLog = false
+			}
+		}
 		args = append(args, opts...)
 	}
 	if command != "" {
@@ -405,6 +410,9 @@ func ConstructArgs(conf string, opts []string, command, source, dest string) []s
 	}
 	if dest != "" {
 		args = append(args, dest)
+	}
+	if rcloneLog {
+		args = append(args, "-v")
 	}
 	return args
 }

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -388,8 +388,8 @@ func GetCommitTsFromBRMetaData(provider v1alpha1.StorageProvider) (uint64, error
 	return backupMeta.EndVersion, nil
 }
 
-// ConstructArgs constructs the rclone args
-func ConstructArgs(conf string, opts []string, command, source, dest string, rcloneLog bool) []string {
+// ConstructRcloneArgs constructs the rclone args
+func ConstructRcloneArgs(conf string, opts []string, command, source, dest string, verboseLog bool) []string {
 	var args []string
 	defaultLog := true
 	if conf != "" {
@@ -397,8 +397,8 @@ func ConstructArgs(conf string, opts []string, command, source, dest string, rcl
 	}
 	if len(opts) > 0 {
 		for _, opt := range opts {
-			if rcloneLog == false && strings.HasPrefix(opt, "-v") {
-				defaultLog = false
+			// If forbid logging with verboseLog==false, user-provided args starting with -v or --verbose should be filtered out.
+			if !verboseLog && (strings.HasPrefix(opt, "-v") || strings.HasPrefix(opt, "--verbose")) {
 				continue
 			}
 			if opt == "-q" || opt == "--quiet" {
@@ -406,6 +406,9 @@ func ConstructArgs(conf string, opts []string, command, source, dest string, rcl
 			}
 			args = append(args, opt)
 		}
+	}
+	if defaultLog && verboseLog {
+		args = append(args, "-v")
 	}
 	if command != "" {
 		args = append(args, command)
@@ -415,9 +418,6 @@ func ConstructArgs(conf string, opts []string, command, source, dest string, rcl
 	}
 	if dest != "" {
 		args = append(args, dest)
-	}
-	if defaultLog {
-		args = append(args, "-v")
 	}
 	return args
 }

--- a/cmd/backup-manager/app/util/util_test.go
+++ b/cmd/backup-manager/app/util/util_test.go
@@ -403,6 +403,92 @@ func TestGetCommitTsFromMetadata(t *testing.T) {
 	g.Expect(commitTs).To(Equal("409054741514944513"))
 }
 
+func TestConstructRcloneArgs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name       string
+		config     string
+		opts       []string
+		command    string
+		source     string
+		dest       string
+		verboseLog bool
+		expect     []string
+	}
+
+	tests := []*testcase{
+		{
+			name:       "rclonels_wo_opts",
+			config:     appconstant.RcloneConfigArg,
+			opts:       nil,
+			command:    "ls",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: false,
+			expect:     []string{"--config=/tmp/rclone.conf", "ls", "src", "dst"},
+		},
+		{
+			name:       "rclonels_w_opts",
+			config:     appconstant.RcloneConfigArg,
+			opts:       []string{"-v", "-vv", "--verbose=4", "-v=4", "--ignore-checksum"},
+			command:    "ls",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: false,
+			expect:     []string{"--config=/tmp/rclone.conf", "--ignore-checksum", "ls", "src", "dst"},
+		},
+		{
+			name:       "rclonels_w_q",
+			config:     appconstant.RcloneConfigArg,
+			opts:       []string{"-q"},
+			command:    "ls",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: false,
+			expect:     []string{"--config=/tmp/rclone.conf", "-q", "ls", "src", "dst"},
+		},
+		{
+			name:       "rclonecp_wo_opts",
+			config:     appconstant.RcloneConfigArg,
+			opts:       nil,
+			command:    "copyto",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: true,
+			expect:     []string{"--config=/tmp/rclone.conf", "-v", "copyto", "src", "dst"},
+		},
+		{
+			name:       "rclonecp_w_opts",
+			config:     appconstant.RcloneConfigArg,
+			opts:       []string{"-v", "-vv", "--verbose=4", "-v=4"},
+			command:    "copyto",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: true,
+			expect:     []string{"--config=/tmp/rclone.conf", "-v", "-vv", "--verbose=4", "-v=4", "-v", "copyto", "src", "dst"},
+		},
+		{
+			name:       "rclonecp_w_q",
+			config:     appconstant.RcloneConfigArg,
+			opts:       []string{"-q"},
+			command:    "copyto",
+			source:     "src",
+			dest:       "dst",
+			verboseLog: true,
+			expect:     []string{"--config=/tmp/rclone.conf", "-q", "copyto", "src", "dst"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ConstructRcloneArgs(tt.config, tt.opts, tt.command, tt.source, tt.dest, tt.verboseLog)
+			g.Expect(opts).To(Equal(tt.expect))
+		})
+	}
+
+}
+
 func newBackup() *v1alpha1.Backup {
 	return &v1alpha1.Backup{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator! Please read TiDB Operator's [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #3561 , user can configure logging options for rclone  in yaml file, example as below.
### What is changed and how does it work?
- Code chages
    Add options in LocalStorageProvider and GcsStorageProvider
    
- How does it work
    User can configure rclone options in yaml file when starting backup/restore jobs like below. We set `-v` flag as default for rclone command to output [logging info](https://rclone.org/docs/#logging). If user set logging flags such as `-q` , `-v=4` , user defined flags will take precedence.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

- E2E test

- Stability test

- Manual test (add detailed scripts or steps below)

  - Backup&Restore using aws s3 AWS-KMS enabled

    1. Create a kind cluster and generate test data with go-tpc

        ```shell
        kind create cluster
        ./hack/local-up-operator.sh
        kubectl apply -f example/basic/tidb-cluster.yaml
        go-tpc -H 127.0.0.1 -P 4000 -D tpcc tpcc --warehouses 8 --parts 4 prepare
        ```

    2. [Backup data to aws s3 with dumpling](https://docs.pingcap.com/tidb-in-kubernetes/dev/backup-to-s3)

        ```
        kubectl apply -f https://github.com/pingcap/tidb-operator/blob/master/manifests/backup/backup-rbac.yaml -n test1
        kubectl create secret generic s3-secret --from-literal=access_key=xxx --from-literal=secret_key=yyy
        kubectl create secret generic backup-demo1-tidb-secret --from-literal=password=${password}
        ```

        backup-s3.yaml

        ```yaml
        ---
        apiVersion: pingcap.com/v1alpha1
        kind: Backup
        metadata:
          name: demo1-backup-s3
        spec:
          from:
            host: basic-tidb.default
            port: 4000
            user: root
            secretName: backup-demo1-tidb-secret
          s3:
            provider: aws
            secretName: s3-secret
            region: ${region}
            bucket: ${bucket}
            prefix: ${prefix}
            options:
            - --ignore-checksum
          storageSize: 10Gi
        ```

        ```shell
        kubectl apply -f backup-s3.yaml
        ```

        If backup success, rclone logging will be as below.

        ```text
        I1209 07:26:38.010409       1 export.go:96] rclone copy data from /backup/chenbinbackup/tidbbackup/backup-2020-12-09T07:22:30Z.tgz data to s3:chenbinbackup/tidbbackup/backup-2020-12-09T07:22:30Z.tgz.tmp. rclone log: 
        Transferred:   	      110M / 319.592 MBytes, 34%, 1.845 MBytes/s, ETA 1m53s
        Transferred:            0 / 1, 0%
        Elapsed time:        59.6s
        Transferring:
        *               backup-2020-12-09T07:22:30Z.tgz: 34% /319.592M, 2.004M/s, 1m44s
        2020/12/09 07:25:35 INFO  :
        Transferred:   	      230M / 319.592 MBytes, 72%, 1.923 MBytes/s, ETA 46s
        Transferred:            0 / 1, 0%
        Elapsed time:      1m59.6s
        Transferring:
        *               backup-2020-12-09T07:22:30Z.tgz: 71% /319.592M, 1.743M/s, 51s
        2020/12/09 07:26:35 INFO  :
        Transferred:   	  319.592M / 319.592 MBytes, 100%, 1.779 MBytes/s, ETA 0s
        Transferred:            0 / 1, 0%
        Elapsed time:      2m59.6s
        Transferring:
        *               backup-2020-12-09T07:22:30Z.tgz:100% /319.592M, 1.121M/s, 0s
        2020/12/09 07:26:37 INFO  : backup-2020-12-09T07:22:30Z.tgz: Copied (new)
        2020/12/09 07:26:37 INFO  :
        Transferred:   	  319.592M / 319.592 MBytes, 100%, 1.755 MBytes/s, ETA 0s
        Transferred:            1 / 1, 100%
        Elapsed time:       3m2.1s
        ```

  - Backup&Restore using aws s3

      Config is like previous subsection, refer to [doc](https://docs.pingcap.com/tidb-in-kubernetes/dev/backup-to-gcs), rclone logging  outputs like previous subsection.

Code changes

- Has Go code change

Side effects
None

Related changes

- Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Append verbose flag '-v' to rclone command as default in lightning and dumpling for troubleshooting.
```