### PR TITLE
fix storageVolumes validate bug 

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/validation/validation.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation.go
@@ -124,6 +124,9 @@ func validatePDSpec(spec *v1alpha1.PDSpec, fldPath *field.Path) field.ErrorList 
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateComponentSpec(&spec.ComponentSpec, fldPath)...)
 	allErrs = append(allErrs, validateRequestsStorage(spec.ResourceRequirements.Requests, fldPath)...)
+	if len(spec.StorageVolumes) > 0 {
+		allErrs = append(allErrs, validateStorageVolumes(spec.StorageVolumes, fldPath.Child("storageVolumes"))...)
+	}
 	return allErrs
 }
 
@@ -229,6 +232,9 @@ func validateTiDBSpec(spec *v1alpha1.TiDBSpec, fldPath *field.Path) field.ErrorL
 	allErrs = append(allErrs, validateComponentSpec(&spec.ComponentSpec, fldPath)...)
 	if spec.Service != nil {
 		allErrs = append(allErrs, validateService(&spec.Service.ServiceSpec, fldPath)...)
+	}
+	if len(spec.StorageVolumes) > 0 {
+		allErrs = append(allErrs, validateStorageVolumes(spec.StorageVolumes, fldPath.Child("storageVolumes"))...)
 	}
 	return allErrs
 }

--- a/pkg/apis/pingcap/v1alpha1/validation/validation.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation.go
@@ -295,8 +295,9 @@ func validateStorageVolumes(storageVolumes []v1alpha1.StorageVolume, fldPath *fi
 	allErrs := field.ErrorList{}
 	for i, storageVolume := range storageVolumes {
 		idxPath := fldPath.Index(i)
-		allErrs = append(allErrs, field.Required(idxPath.Child("name"), "name must not be empty"))
-
+		if len(storageVolume.Name) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "name must not be empty"))
+		}
 		_, err := resource.ParseQuantity(storageVolume.StorageSize)
 		if err != nil {
 			allErrs = append(allErrs, &field.Error{
@@ -304,8 +305,9 @@ func validateStorageVolumes(storageVolumes []v1alpha1.StorageVolume, fldPath *fi
 				Detail: `value of "storageSize" format not supported`,
 			})
 		}
-
-		allErrs = append(allErrs, field.Required(idxPath.Child("mountPath"), "mountPath must not be empty"))
+		if len(storageVolume.MountPath) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("mountPath"), "mountPath must not be empty"))
+		}
 	}
 	return allErrs
 }


### PR DESCRIPTION
### What problem does this PR solve?
Fix the bug that tikv storageVolumes validate bug.

Closes #3583 

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue that TiDB cluster fails to deploy if `spec.tikv.storageVolumes` is configured
```