### PR TITLE
allow empty secret in gcs BR

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -13646,7 +13646,6 @@ spec:
                   type: string
               required:
               - projectId
-              - secretName
               type: object
             imagePullSecrets:
               items:
@@ -14085,7 +14084,6 @@ spec:
                   type: string
               required:
               - projectId
-              - secretName
               type: object
             imagePullSecrets:
               items:
@@ -14573,7 +14571,6 @@ spec:
                       type: string
                   required:
                   - projectId
-                  - secretName
                   type: object
                 imagePullSecrets:
                   items:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -2461,7 +2461,7 @@ func schema_pkg_apis_pingcap_v1alpha1_GcsStorageProvider(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"projectId", "secretName"},
+				Required: []string{"projectId"},
 			},
 		},
 	}

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1197,7 +1197,7 @@ type GcsStorageProvider struct {
 	BucketAcl string `json:"bucketAcl,omitempty"`
 	// SecretName is the name of secret which stores the
 	// gcs service account credentials JSON.
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 	// Prefix of the data path.
 	Prefix string `json:"prefix,omitempty"`
 }

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -158,7 +158,9 @@ func generateGcsCertEnvVar(gcs *v1alpha1.GcsStorageProvider) ([]corev1.EnvVar, s
 			Name:  "GCS_STORAGE_CLASS",
 			Value: gcs.StorageClass,
 		},
-		{
+	}
+	if gcs.SecretName != "" {
+		envVars = append(envVars, corev1.EnvVar{
 			Name: "GCS_SERVICE_ACCOUNT_JSON_KEY",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
@@ -166,7 +168,7 @@ func generateGcsCertEnvVar(gcs *v1alpha1.GcsStorageProvider) ([]corev1.EnvVar, s
 					Key:                  constants.GcsCredentialsKey,
 				},
 			},
-		},
+		})
 	}
 	return envVars, "", nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
#3557. 

Allow empty secret when backup/restore to/from gcs in BR.

### What is changed and how does it work?
Change `GcsStorageProvider.SecretName` to`omitempty`, add UT.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->

- [x] E2E test <!-- If you added any e2e test cases, check this box -->

- [x] Manual test 

    - Backup to gcs with BR configuring SecretName

        1. Create a kind cluster and deployment tidb cluster

            ```shell
            kind create cluster
            ./hack/local-up-operator.sh
            kubectl apply -f example/basic/tidb-cluster.yaml
            ```

        2. [Backup to gcs with BR](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-gcs-using-br)

            ```yaml
            curl https://raw.githubusercontent.com/pingcap/tidb-operator/master/manifests/backup/backup-rbac.yaml
            kubectl apply -f backup-rbac.yaml -n test1
            kubectl create secret generic gcs-secret --from-file=credentials=gcs-credentials.json
            kubectl create secret generic backup-demo1-tidb-secret --from-literal=password=${password}
            ```

            backup-gcs.yaml

            ```yaml
            ---
            apiVersion: pingcap.com/v1alpha1
            kind: Backup
            metadata:
              name: demo1-backup-gcs
              namespace: default
            spec:
              from:
                host: basic-tidb.default
                port: 4000
                user: root
                secretName: backup-demo1-tidb-secret
              br:
                cluster: basic
                clusterNamespace: default
              gcs:
                projectId: ${project-id}
                secretName: gcs-secret
                bucket: ${bucket}
                prefix: ${backup}
            ```

            ```shell
            kubectl apply -f backup-gcs.yaml
            ```

            Backup success

            ```
            I1211 09:47:38.339247       1 backup.go:107] Backup data for cluster default/demo1-backup-gcs successfully
            I1211 09:47:38.349994       1 manager.go:274] reset cluster default/demo1-backup-gcs tikv_gc_life_time to 10m0s success
            I1211 09:47:38.350022       1 manager.go:289] backup cluster default/demo1-backup-gcs data to gcs://chenbin_test/backup success
            ```

    - [TODO]Backup to gcs with BR configuring empty SecretName

        Waiting for TiKV [support](https://github.com/pingcap/br/issues/633) GCP application default credentials.

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
NONE
```
