### PR TITLE
Add additional port support to extend TiDB service

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -12385,6 +12385,21 @@ int
 Optional: Defaults to 0</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>additionalPorts</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#serviceport-v1-core">
+[]Kubernetes core/v1.ServicePort
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Expose the tidb node port for additional usage
+Optional: Defaults to omitted</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tidbslowlogtailerspec">TiDBSlowLogTailerSpec</h3>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -12396,7 +12396,7 @@ Optional: Defaults to 0</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Expose the tidb node port for additional usage
+<p>Expose additional ports for TiDB
 Optional: Defaults to omitted</p>
 </td>
 </tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6609,6 +6609,27 @@ spec:
                   type: boolean
                 service:
                   properties:
+                    additionalPorts:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          nodePort:
+                            format: int32
+                            type: integer
+                          port:
+                            format: int32
+                            type: integer
+                          protocol:
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      type: array
                     exposeStatus:
                       type: boolean
                     externalTrafficPolicy:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -6311,9 +6311,24 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBServiceSpec(ref common.ReferenceCallba
 							Format:      "int32",
 						},
 					},
+					"additionalPorts": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Expose the tidb node port for additional usage Optional: Defaults to omitted",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.ServicePort"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/api/core/v1.ServicePort"},
 	}
 }
 

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -6313,7 +6313,7 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBServiceSpec(ref common.ReferenceCallba
 					},
 					"additionalPorts": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Expose the tidb node port for additional usage Optional: Defaults to omitted",
+							Description: "Expose additional ports for TiDB Optional: Defaults to omitted",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -897,7 +897,7 @@ type TiDBServiceSpec struct {
 	// +optional
 	StatusNodePort *int `json:"statusNodePort,omitempty"`
 
-	// Expose the tidb node port for additional usage
+	// Expose additional ports for TiDB
 	// Optional: Defaults to omitted
 	// +optional
 	AdditionalPorts []corev1.ServicePort `json:"additionalPorts,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -896,6 +896,11 @@ type TiDBServiceSpec struct {
 	// Optional: Defaults to 0
 	// +optional
 	StatusNodePort *int `json:"statusNodePort,omitempty"`
+
+	// Expose the tidb node port for additional usage
+	// Optional: Defaults to omitted
+	// +optional
+	AdditionalPorts []corev1.ServicePort `json:"additionalPorts,omitempty"`
 }
 
 // +k8s:openapi-gen=false

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -4795,6 +4795,11 @@ func (in *TiDBServiceSpec) DeepCopyInto(out *TiDBServiceSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.AdditionalPorts != nil {
+		in, out := &in.AdditionalPorts, &out.AdditionalPorts
+		*out = make([]v1.ServicePort, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -427,6 +427,11 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 			NodePort:   svcSpec.GetMySQLNodePort(),
 		},
 	}
+	if len(tc.Spec.TiDB.Service.AdditionalPorts) > 0 {
+		for _, port := range tc.Spec.TiDB.Service.AdditionalPorts {
+			ports = append(ports, port)
+		}
+	}
 	if svcSpec.ShouldExposeStatus() {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "status",

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -428,9 +428,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 		},
 	}
 	if len(tc.Spec.TiDB.Service.AdditionalPorts) > 0 {
-		for _, port := range tc.Spec.TiDB.Service.AdditionalPorts {
-			ports = append(ports, port)
-		}
+		ports = append(ports, tc.Spec.TiDB.Service.AdditionalPorts...)
 	}
 	if svcSpec.ShouldExposeStatus() {
 		ports = append(ports, corev1.ServicePort{

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -427,9 +427,7 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 			NodePort:   svcSpec.GetMySQLNodePort(),
 		},
 	}
-	if len(tc.Spec.TiDB.Service.AdditionalPorts) > 0 {
-		ports = append(ports, tc.Spec.TiDB.Service.AdditionalPorts...)
-	}
+	ports = append(ports, tc.Spec.TiDB.Service.AdditionalPorts...)
 	if svcSpec.ShouldExposeStatus() {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "status",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #3596 
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Add spec for additional ports
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

```yaml
apiVersion: pingcap.com/v1alpha1
kind: TidbCluster
metadata:
  name: basic
spec:
  version: v4.0.8
  timezone: UTC
  pvReclaimPolicy: Retain
  enableDynamicConfiguration: true
  configUpdateStrategy: RollingUpdate
  discovery: {}
  pd:
    baseImage: registry.cn-beijing.aliyuncs.com/tidb/pd
    replicas: 1
    requests:
      storage: "1Gi"
    config: {}
  tikv:
    baseImage: registry.cn-beijing.aliyuncs.com/tidb/tikv
    replicas: 1
    requests:
      storage: "1Gi"
    config: {}
  tidb:
    baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb
    replicas: 1
    service:
      type: NodePort
      externalTrafficPolicy: Local
      additionalPorts: 
        - name: "health-checker"
          nodePort: 32402
          port: 8080
          protocol: "TCP"
          targetPort: 8080
    config: {}
```

The new TiDB service shows as the feature request:

```yaml
spec:
  clusterIP: 10.105.104.162
  externalTrafficPolicy: Local
  ports:
  - name: mysql-client
    nodePort: 30938
    port: 4000
    protocol: TCP
    targetPort: 4000
  - name: health-checker
    nodePort: 32402
    port: 8080
    protocol: TCP
    targetPort: 8080
  - name: status
    nodePort: 32206
    port: 10080
    protocol: TCP
    targetPort: 10080
```
### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support setting additional ports for the TiDB service
```
