### PR TITLE
support multiple cluster

### DIFF
--- a/pkg/monitor/monitor/monitor_manager.go
+++ b/pkg/monitor/monitor/monitor_manager.go
@@ -65,8 +65,8 @@ func (m *MonitorManager) SyncMonitor(monitor *v1alpha1.TidbMonitor) error {
 	if monitor.DeletionTimestamp != nil {
 		return nil
 	}
-	if monitor.Spec.Clusters == nil || len(monitor.Spec.Clusters) != 1 {
-		klog.Errorf("tm[%s/%s] does not configure the target tidbcluster or contain multiple target tidbclusters, ingore sync", monitor.Namespace, monitor.Name)
+	if monitor.Spec.Clusters == nil || len(monitor.Spec.Clusters) < 1 {
+		klog.Errorf("tm[%s/%s] does not configure the target tidbcluster", monitor.Namespace, monitor.Name)
 		return nil
 	}
 

--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -284,7 +284,7 @@ func scrapeJob(jobName string, componentPattern config.Regexp, cmodel *MonitorCo
 		}
 
 		scrapeconfig := &config.ScrapeConfig{
-			JobName:        jobName,
+			JobName:        fmt.Sprintf("%s-%s-%s", cluster.Namespace, cluster.Name, jobName),
 			ScrapeInterval: model.Duration(15 * time.Second),
 			Scheme:         "http",
 			HonorLabels:    true,

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -33,7 +33,7 @@ alerting:
 rule_files:
 - /prometheus-rules/rules/*.rules.yml
 scrape_configs:
-- job_name: pd
+- job_name: ns1-target-pd
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -80,7 +80,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tidb
+- job_name: ns1-target-tidb
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -127,7 +127,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tikv
+- job_name: ns1-target-tikv
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -174,7 +174,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tiflash
+- job_name: ns1-target-tiflash
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -221,7 +221,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tiflash-proxy
+- job_name: ns1-target-tiflash-proxy
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -268,7 +268,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: pump
+- job_name: ns1-target-pump
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -315,7 +315,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: drainer
+- job_name: ns1-target-drainer
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -362,7 +362,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: ticdc
+- job_name: ns1-target-ticdc
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -409,7 +409,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: importer
+- job_name: ns1-target-importer
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -456,7 +456,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: lightning
+- job_name: ns1-target-lightning
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -524,7 +524,7 @@ func TestRenderPrometheusConfigTLSEnabled(t *testing.T) {
 rule_files:
 - /prometheus-rules/rules/*.rules.yml
 scrape_configs:
-- job_name: pd
+- job_name: ns1-target-pd
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -574,7 +574,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tidb
+- job_name: ns1-target-tidb
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -624,7 +624,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tikv
+- job_name: ns1-target-tikv
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -674,7 +674,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tiflash
+- job_name: ns1-target-tiflash
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -724,7 +724,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: tiflash-proxy
+- job_name: ns1-target-tiflash-proxy
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -774,7 +774,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: pump
+- job_name: ns1-target-pump
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -824,7 +824,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: drainer
+- job_name: ns1-target-drainer
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -874,7 +874,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: ticdc
+- job_name: ns1-target-ticdc
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -924,7 +924,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: importer
+- job_name: ns1-target-importer
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -974,7 +974,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
-- job_name: lightning
+- job_name: ns1-target-lightning
   honor_labels: true
   scrape_interval: 15s
   scheme: https


### PR DESCRIPTION
### What problem does this PR solve?

Fix multiple cluster monitor.

 Closes #xxx (issue number)




### Code changes

- [ ] Has Go code change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->



### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
ACTION REQUIRED:
If TidbMonitor CRs are deployed, after upgrading TiDB Operator to this version, please update the `spec.initializer.version` to `v4.0.9`, otherwise, some metrics will not be shown correctly in the Grafana dashboards.
Scrape job names are changed from `${component}` to `${namespace}-${TidbCluster Name}-${component}`
```
