### PR TITLE
support toolimage when backup/restore using dumpling/lightning

### DIFF
--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -78,14 +78,14 @@ func (bo *Options) dumpTidbClusterData(backup *v1alpha1.Backup) (string, error) 
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.TiDBClientTLSPath, corev1.TLSPrivateKeyKey)))
 	}
 
-	bin := "/dumpling"
+	binPath := "/dumpling"
 	if backup.Spec.ToolImage != "" {
-		bin = path.Join(util.DumplingBinPath, "dumpling")
+		binPath = path.Join(util.DumplingBinPath, "dumpling")
 	}
 
-	klog.Infof("The dump process is ready, command \"%s %s\"", bin, strings.Join(args, " "))
+	klog.Infof("The dump process is ready, command \"%s %s\"", binPath, strings.Join(args, " "))
 
-	output, err := exec.Command(bin, args...).CombinedOutput()
+	output, err := exec.Command(binPath, args...).CombinedOutput()
 	if err != nil {
 		return bfPath, fmt.Errorf("cluster %s, execute dumpling command %v failed, output: %s, err: %v", bo, args, string(output), err)
 	}

--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -78,9 +78,14 @@ func (bo *Options) dumpTidbClusterData(backup *v1alpha1.Backup) (string, error) 
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.TiDBClientTLSPath, corev1.TLSPrivateKeyKey)))
 	}
 
-	klog.Infof("The dump process is ready, command \"/dumpling %s\"", strings.Join(args, " "))
+	bin := "/dumpling"
+	if backup.Spec.ToolImage != "" {
+		bin = path.Join(util.DumplingBinPath, "dumpling")
+	}
 
-	output, err := exec.Command("/dumpling", args...).CombinedOutput()
+	klog.Infof("The dump process is ready, command \"%s %s\"", bin, strings.Join(args, " "))
+
+	output, err := exec.Command(bin, args...).CombinedOutput()
 	if err != nil {
 		return bfPath, fmt.Errorf("cluster %s, execute dumpling command %v failed, output: %s, err: %v", bo, args, string(output), err)
 	}

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -111,14 +111,14 @@ func (ro *Options) loadTidbClusterData(restorePath string, restore *v1alpha1.Res
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.TiDBClientTLSPath, corev1.TLSPrivateKeyKey)))
 	}
 
-	bin := "/tidb-lightning"
+	binPath := "/tidb-lightning"
 	if restore.Spec.ToolImage != "" {
-		bin = path.Join(util.LightningBinPath, "tidb-lightning")
+		binPath = path.Join(util.LightningBinPath, "tidb-lightning")
 	}
 
-	klog.Infof("The lightning process is ready, command \"%s %s\"", bin, strings.Join(args, " "))
+	klog.Infof("The lightning process is ready, command \"%s %s\"", binPath, strings.Join(args, " "))
 
-	output, err := exec.Command(bin, args...).CombinedOutput()
+	output, err := exec.Command(binPath, args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute loader command %v failed, output: %s, err: %v", ro, args, string(output), err)
 	}

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mholt/archiver"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	backupUtil "github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
@@ -81,7 +82,9 @@ func (ro *Options) downloadBackupData(localPath string, opts []string) error {
 	return nil
 }
 
-func (ro *Options) loadTidbClusterData(restorePath string, tableFilter []string) error {
+func (ro *Options) loadTidbClusterData(restorePath string, restore *v1alpha1.Restore) error {
+	tableFilter := restore.Spec.TableFilter
+
 	if exist := backupUtil.IsDirExist(restorePath); !exist {
 		return fmt.Errorf("dir %s does not exist or is not a dir", restorePath)
 	}
@@ -108,7 +111,14 @@ func (ro *Options) loadTidbClusterData(restorePath string, tableFilter []string)
 		args = append(args, fmt.Sprintf("--key=%s", path.Join(util.TiDBClientTLSPath, corev1.TLSPrivateKeyKey)))
 	}
 
-	output, err := exec.Command("/tidb-lightning", args...).CombinedOutput()
+	bin := "/tidb-lightning"
+	if restore.Spec.ToolImage != "" {
+		bin = path.Join(util.LightningBinPath, "tidb-lightning")
+	}
+
+	klog.Infof("The lightning process is ready, command \"%s %s\"", bin, strings.Join(args, " "))
+
+	output, err := exec.Command(bin, args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute loader command %v failed, output: %s, err: %v", ro, args, string(output), err)
 	}

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -147,7 +147,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 	}
 	klog.Infof("get cluster %s commitTs %s success", rm, commitTs)
 
-	err = rm.loadTidbClusterData(unarchiveDataPath, restore.Spec.TableFilter)
+	err = rm.loadTidbClusterData(unarchiveDataPath, restore)
 	if err != nil {
 		errs = append(errs, err)
 		klog.Errorf("restore cluster %s from backup %s failed, err: %s", rm, rm.BackupPath, err)

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -222,7 +222,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
+<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -1030,7 +1030,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
+<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -2892,7 +2892,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
+<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -10412,7 +10412,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now</p>
+<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -222,7 +222,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -1030,7 +1031,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -2892,7 +2894,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -10412,7 +10415,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -222,7 +222,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -1030,7 +1030,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -2892,7 +2892,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
 </td>
 </tr>
 <tr>
@@ -10412,7 +10412,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -222,7 +222,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images.
+<p>ToolImage specifies the tool image used in <code>Backup</code>, which supports BR and Dumpling images.
 For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
@@ -1031,7 +1031,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images.
+<p>ToolImage specifies the tool image used in <code>Restore</code>, which supports BR and TiDB Lightning images.
 For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>
@@ -2894,7 +2894,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images.
+<p>ToolImage specifies the tool image used in <code>Backup</code>, which supports BR and Dumpling images.
 For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
@@ -10415,7 +10415,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images.
+<p>ToolImage specifies the tool image used in <code>Restore</code>, which supports BR and TiDB Lightning images.
 For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -222,7 +222,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -1030,7 +1030,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -2892,7 +2892,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, and Dumpling images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/dumpling:v4.0.8</code></p>
 </td>
 </tr>
 <tr>
@@ -10412,7 +10412,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR, Lightning and Dumpling images</p>
+<p>ToolImage specifies the tool image used in <code>Backup</code> and <code>Restore</code>, which supports BR and TiDB Lightning images. For examples <code>spec.toolImage: pingcap/br:v4.0.8</code> or <code>spec.toolImage: pingcap/tidb-lightning:v4.0.8</code></p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -936,7 +936,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images",
+							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5203,7 +5203,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images",
+							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -936,7 +936,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images",
+							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5203,7 +5203,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images",
+							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -936,7 +936,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
+							Description: "ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5203,7 +5203,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now",
+							Description: "ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -936,7 +936,7 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`",
+							Description: "ToolImage specifies the tool image used in `Backup`, which supports BR and Dumpling images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5203,7 +5203,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`",
+							Description: "ToolImage specifies the tool image used in `Restore`, which supports BR and TiDB Lightning images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1278,7 +1278,7 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
@@ -1539,7 +1539,7 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	// ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1278,7 +1278,7 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
+	// ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
@@ -1539,7 +1539,7 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	// ToolImage specifies the tool image used in the backup/restore, only BR image is supported for now
+	// ToolImage specifies the tool image used in the backup/restore, supporting BR image and Lightning/Dumpling images
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1278,7 +1278,8 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images.
+	// For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
@@ -1539,7 +1540,8 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images.
+	// For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1278,7 +1278,7 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images.
+	// ToolImage specifies the tool image used in `Backup`, which supports BR and Dumpling images.
 	// For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
@@ -1540,7 +1540,7 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images.
+	// ToolImage specifies the tool image used in `Restore`, which supports BR and TiDB Lightning images.
 	// For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1278,7 +1278,7 @@ type BackupSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, and Dumpling images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/dumpling:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.
@@ -1539,7 +1539,7 @@ type RestoreSpec struct {
 	UseKMS bool `json:"useKMS,omitempty"`
 	// Specify service account of restore
 	ServiceAccount string `json:"serviceAccount,omitempty"`
-	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR, Lightning and Dumpling images
+	// ToolImage specifies the tool image used in `Backup` and `Restore`, which supports BR and TiDB Lightning images. For examples `spec.toolImage: pingcap/br:v4.0.8` or `spec.toolImage: pingcap/tidb-lightning:v4.0.8`
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -45,6 +45,8 @@ var (
 	DMClusterClientTLSPath = "/var/lib/dm-cluster-client-tls"
 	TiDBClientTLSPath      = "/var/lib/tidb-client-tls"
 	BRBinPath              = "/var/lib/br-bin"
+	DumplingBinPath        = "/var/lib/dumpling-bin"
+	LightningBinPath       = "/var/lib/lightning-bin"
 	ClusterClientVolName   = "cluster-client-tls"
 	DMClusterClientVolName = "dm-cluster-client-tls"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Support setting `spec.toolImage` for backup with dumpling and restore with lightning.

Close #3619

### What is changed and how does it work?
If `spec.toolImage` is configured when using dumpling/lightning, add initContainers to copy binary file `dumpling`/`tidb-lightning` from toolImage and run this binary file to backup/restore.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->

- [ ] E2E test <!-- If you added any e2e test cases, check this box -->

- [x] Manual test 

    1. Backup using dumpling when configuring `spec.toolImage`

        Prepare tidb cluster. 

        ```shell
        kind create cluster
        ./hack/local-up-operator.sh
        kubectl apply -f example/basic/tidb-cluster
        ```

        Backup to gcs suing dumpling according to [docs](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/backup-to-gcs), configuration is as follows.

        ```yaml
        ---
        apiVersion: pingcap.com/v1alpha1
        kind: Backup
        metadata:
          name: demo1-backup-gcs
          namespace: default
        spec:
          toolImage: pingcap/dumpling:v4.0.8
          from:
            host: basic-tidb.default
            port: 4000
            user: root
            secretName: backup-demo1-tidb-secret
          gcs:
            secretName: gcs-secret
            projectId: ${project_id}
            bucket: ${bucket}
            prefix: ${prefix}
          storageClassName: standard
          storageSize: 1Gi
        ```

        Backup pod logs show below, we can see that dumpling command is `/var/lib/dumpling-bin/dumpling` backup successfully.

        ```
        I1223 07:27:34.672348       1 export.go:86] The dump process is ready, command "/var/lib/dumpling-bin/dumpling --output=${path} --host=basic-tidb.default --port=4000 --user=root --password= --filter *.* --filter !/^(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.* --threads=16 --rows=10000"
        I1223 07:27:40.657449       1 manager.go:348] backup cluster default/demo1-backup-gcs data to gcs success
        I1223 07:27:40.683256       1 backup_status_updater.go:64] Backup: [default/demo1-backup-gcs] updated successfully
        ```

    2. Restore using tidb-lightning when configuring `spec.toolImage`

        ```yaml
        ---
        apiVersion: pingcap.com/v1alpha1
        kind: Restore
        metadata:
          name: demo2-restore
          namespace: default
        spec:
          toolImage: pingcap/tidb-lightning:v4.0.8
          to:
            host: basic-tidb.default
            port: 4000
            user: root
            secretName: backup-demo1-tidb-secret
          gcs:
            projectId: ${project_id}
            secretName: gcs-secret
            path: gcs://${path}
          storageSize: 1Gi
        ```

        Restore pod logs show below, we can see that command is `/var/lib/lightning-bin/tidb-lightning`, restore successfully.

        ```
        I1223 07:39:21.850310       1 import.go:119] The lightning process is ready, command "/var/lib/lightning-bin/tidb-lightning --status-addr=0.0.0.0:8289 --backend=tidb --server-mode=false --log-file=- --tidb-user=root --tidb-password= --tidb-host=basic-tidb.default --tidb-port=4000"
        I1223 07:39:22.065700       1 manager.go:163] restore cluster default/demo2-restore from backup gcs://${path} success
        I1223 07:39:22.094951       1 restore_status_updater.go:64] Restore: [default/demo2-restore] updated successfully
        ```

    3. Backup/Restore using dumpling/tidb-lightning without configuring `spec.toolImage`

        If we do not set `spec.toolImage` when using dumpling/tidb-lightning, backup-manager will execute binary file `dumpling`/`tidb-lightning` in `tidb-backup-manager` image. Pod logs will show as below, we can see that command is `/dumpling` and `/tidb-lightning` .

        ```
        I1223 07:22:24.858943       1 export.go:86] The dump process is ready, command "/dumpling --output=${path} --host=basic-tidb.default --port=4000 --user=root --password= --filter *.* --filter !/^(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.* --threads=16 --rows=10000"
        I1223 07:22:30.581400       1 manager.go:348] backup cluster default/demo1-backup-gcs data to gcs success
        I1223 07:22:30.610813       1 backup_status_updater.go:64] Backup: [default/demo1-backup-gcs] updated successfully
        ```

        ```
        I1223 07:35:17.027269       1 import.go:119] The lightning process is ready, command "/tidb-lightning --status-addr=0.0.0.0:8289 --backend=tidb --server-mode=false --log-file=- --tidb-user=root --tidb-password= --tidb-host=basic-tidb.default --d=${path} --tidb-port=4000"
        I1223 07:35:17.747189       1 manager.go:163] restore cluster default/demo2-restore from backup gcs://${path} success
        I1223 07:35:17.774306       1 restore_status_updater.go:64] Restore: [default/demo2-restore] updated successfully
        ```

        

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support `spec.toolImage` for `Backup` & `Restore` with Dumpling/TiDB Lightning to define the image used to provide the Dumpling/TiDB Lightning binary executables.
```
