### PR TITLE
status missed even if backup job succeeds

### DIFF
--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -62,7 +62,7 @@ func (bm *Manager) performCleanBackup(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "BackupPathIsEmpty",
 			Message: fmt.Sprintf("the cluster %s backup path is empty", bm),
-		})
+		}, nil)
 	}
 
 	var errs []error
@@ -82,7 +82,7 @@ func (bm *Manager) performCleanBackup(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "CleanBackupDataFailed",
 			Message: err.Error(),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -91,5 +91,5 @@ func (bm *Manager) performCleanBackup(backup *v1alpha1.Backup) error {
 	return bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{
 		Type:   v1alpha1.BackupClean,
 		Status: corev1.ConditionTrue,
-	})
+	}, nil)
 }

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -78,7 +78,7 @@ func (rm *RestoreManager) ProcessRestore() error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "GetRestoreCRFailed",
 			Message: err.Error(),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -94,7 +94,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 	err := rm.StatusUpdater.Update(restore, &v1alpha1.RestoreCondition{
 		Type:   v1alpha1.RestoreRunning,
 		Status: corev1.ConditionTrue,
-	})
+	}, nil)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "DownloadBackupDataFailed",
 			Message: fmt.Sprintf("download backup %s data failed, err: %v", rm.BackupPath, err),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -126,7 +126,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "UnarchiveBackupDataFailed",
 			Message: fmt.Sprintf("unarchive backup %s data failed, err: %v", restoreDataPath, err),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -141,7 +141,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "GetCommitTsFailed",
 			Message: err.Error(),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -156,7 +156,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "LoaderBackupDataFailed",
 			Message: fmt.Sprintf("loader backup %s data failed, err: %v", restoreDataPath, err),
-		})
+		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
 	}
@@ -164,12 +164,13 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 
 	finish := time.Now()
 
-	restore.Status.TimeStarted = metav1.Time{Time: started}
-	restore.Status.TimeCompleted = metav1.Time{Time: finish}
-	restore.Status.CommitTs = commitTs
-
+	updateStatus := &controller.RestoreUpdateStatus{
+		TimeStarted:   &metav1.Time{Time: started},
+		TimeCompleted: &metav1.Time{Time: finish},
+		CommitTs:      &commitTs,
+	}
 	return rm.StatusUpdater.Update(restore, &v1alpha1.RestoreCondition{
 		Type:   v1alpha1.RestoreComplete,
 		Status: corev1.ConditionTrue,
-	})
+	}, updateStatus)
 }

--- a/pkg/backup/backup/backup_cleaner.go
+++ b/pkg/backup/backup/backup_cleaner.go
@@ -69,7 +69,7 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "GetBackupFailed",
 			Message: err.Error(),
-		})
+		}, nil)
 		return err
 	}
 
@@ -80,7 +80,7 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 		return bc.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 			Type:   v1alpha1.BackupClean,
 			Status: corev1.ConditionTrue,
-		})
+		}, nil)
 	}
 
 	// not found clean job, create it
@@ -91,7 +91,7 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  reason,
 			Message: err.Error(),
-		})
+		}, nil)
 		return err
 	}
 
@@ -102,14 +102,14 @@ func (bc *backupCleaner) Clean(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "CreateCleanJobFailed",
 			Message: errMsg.Error(),
-		})
+		}, nil)
 		return errMsg
 	}
 
 	return bc.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 		Type:   v1alpha1.BackupClean,
 		Status: corev1.ConditionFalse,
-	})
+	}, nil)
 }
 
 func (bc *backupCleaner) makeCleanJob(backup *v1alpha1.Backup) (*batchv1.Job, string, error) {

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -86,7 +86,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 
@@ -100,7 +100,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "InvalidSpec",
 			Message: err.Error(),
-		})
+		}, nil)
 
 		return controller.IgnoreErrorf("invalid backup spec %s/%s cause %s", ns, name, err.Error())
 	}
@@ -126,7 +126,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 
@@ -137,7 +137,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 
@@ -150,7 +150,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 	}
@@ -162,14 +162,14 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "CreateBackupJobFailed",
 			Message: errMsg.Error(),
-		})
+		}, nil)
 		return errMsg
 	}
 
 	return bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 		Type:   v1alpha1.BackupScheduled,
 		Status: corev1.ConditionTrue,
-	})
+	}, nil)
 }
 
 func (bm *backupManager) makeExportJob(backup *v1alpha1.Backup) (*batchv1.Job, string, error) {

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -71,7 +71,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 
@@ -85,7 +85,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "InvalidSpec",
 			Message: err.Error(),
-		})
+		}, nil)
 
 		return controller.IgnoreErrorf("invalid restore spec %s/%s", ns, name)
 	}
@@ -112,7 +112,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 
@@ -123,7 +123,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 	} else {
@@ -134,7 +134,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 				Status:  corev1.ConditionTrue,
 				Reason:  reason,
 				Message: err.Error(),
-			})
+			}, nil)
 			return err
 		}
 	}
@@ -146,14 +146,14 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 			Status:  corev1.ConditionTrue,
 			Reason:  "CreateRestoreJobFailed",
 			Message: errMsg.Error(),
-		})
+		}, nil)
 		return errMsg
 	}
 
 	return rm.statusUpdater.Update(restore, &v1alpha1.RestoreCondition{
 		Type:   v1alpha1.RestoreScheduled,
 		Status: corev1.ConditionTrue,
-	})
+	}, nil)
 }
 
 func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job, string, error) {

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -84,6 +84,7 @@ func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *
 				klog.Infof("Backup: [%s/%s] updated successfully", ns, backupName)
 				return nil
 			}
+			klog.Errorf("Failed to update backup [%s/%s], error: %v", ns, backupName, updateErr)
 			if updated, err := u.backupLister.Backups(ns).Get(backupName); err == nil {
 				// make a copy so we don't mutate the shared cache
 				backup = updated.DeepCopy()

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -22,15 +22,35 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 )
 
+// BackupUpdateStatus represents the status of a backup to be updated.
+// This structure should keep synced with the fields in `BackupStatus`
+// except for `Phase` and `Conditions`.
+type BackupUpdateStatus struct {
+	// BackupPath is the location of the backup.
+	BackupPath *string
+	// TimeStarted is the time at which the backup was started.
+	TimeStarted *metav1.Time
+	// TimeCompleted is the time at which the backup was completed.
+	TimeCompleted *metav1.Time
+	// BackupSizeReadable is the data size of the backup.
+	// the difference with BackupSize is that its format is human readable
+	BackupSizeReadable *string
+	// BackupSize is the data size of the backup.
+	BackupSize *int64
+	// CommitTs is the snapshot time point of tidb cluster.
+	CommitTs *string
+}
+
 // BackupConditionUpdaterInterface enables updating Backup conditions.
 type BackupConditionUpdaterInterface interface {
-	Update(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error
+	Update(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, newStatus *BackupUpdateStatus) error
 }
 
 type realBackupConditionUpdater struct {
@@ -51,11 +71,12 @@ func NewRealBackupConditionUpdater(
 	}
 }
 
-func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error {
+func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, newStatus *BackupUpdateStatus) error {
 	ns := backup.GetNamespace()
 	backupName := backup.GetName()
 	var isUpdate bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		updateBackupStatus(&backup.Status, newStatus)
 		isUpdate = v1alpha1.UpdateBackupCondition(&backup.Status, condition)
 		if isUpdate {
 			_, updateErr := u.cli.PingcapV1alpha1().Backups(ns).Update(backup)
@@ -74,6 +95,32 @@ func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *
 		return nil
 	})
 	return err
+}
+
+// updateBackupStatus updates existing Backup status
+// from the fields in BackupUpdateStatus.
+func updateBackupStatus(status *v1alpha1.BackupStatus, newStatus *BackupUpdateStatus) {
+	if newStatus == nil {
+		return
+	}
+	if newStatus.BackupPath != nil {
+		status.BackupPath = *newStatus.BackupPath
+	}
+	if newStatus.TimeStarted != nil {
+		status.TimeStarted = *newStatus.TimeStarted
+	}
+	if newStatus.TimeCompleted != nil {
+		status.TimeCompleted = *newStatus.TimeCompleted
+	}
+	if newStatus.BackupSizeReadable != nil {
+		status.BackupSizeReadable = *newStatus.BackupSizeReadable
+	}
+	if newStatus.BackupSize != nil {
+		status.BackupSize = *newStatus.BackupSize
+	}
+	if newStatus.CommitTs != nil {
+		status.CommitTs = *newStatus.CommitTs
+	}
 }
 
 var _ BackupConditionUpdaterInterface = &realBackupConditionUpdater{}
@@ -100,7 +147,7 @@ func (c *FakeBackupConditionUpdater) SetUpdateBackupError(err error, after int) 
 }
 
 // UpdateBackup updates the Backup
-func (c *FakeBackupConditionUpdater) Update(backup *v1alpha1.Backup, _ *v1alpha1.BackupCondition) error {
+func (c *FakeBackupConditionUpdater) Update(backup *v1alpha1.Backup, _ *v1alpha1.BackupCondition, _ *BackupUpdateStatus) error {
 	defer c.updateBackupTracker.Inc()
 	if c.updateBackupTracker.ErrorReady() {
 		defer c.updateBackupTracker.Reset()

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -54,7 +54,6 @@ func NewRealBackupConditionUpdater(
 func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error {
 	ns := backup.GetNamespace()
 	backupName := backup.GetName()
-	oldStatus := backup.Status.DeepCopy()
 	var isUpdate bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		isUpdate = v1alpha1.UpdateBackupCondition(&backup.Status, condition)
@@ -67,7 +66,6 @@ func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *
 			if updated, err := u.backupLister.Backups(ns).Get(backupName); err == nil {
 				// make a copy so we don't mutate the shared cache
 				backup = updated.DeepCopy()
-				backup.Status = *oldStatus
 			} else {
 				utilruntime.HandleError(fmt.Errorf("error getting updated backup %s/%s from lister: %v", ns, backupName, err))
 			}

--- a/pkg/controller/backup_status_updater_test.go
+++ b/pkg/controller/backup_status_updater_test.go
@@ -1,0 +1,123 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpdateBackupStatus(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []struct {
+		name         string
+		status       *v1alpha1.BackupStatus
+		updateStatus *BackupUpdateStatus
+		expectStatus *v1alpha1.BackupStatus
+	}{
+		{
+			name:         "updateStatus is nil",
+			status:       newBackupStatus(),
+			updateStatus: nil,
+			expectStatus: newBackupStatus(),
+		},
+		{
+			name:         "fields are nil",
+			status:       newBackupStatus(),
+			updateStatus: &BackupUpdateStatus{},
+			expectStatus: newBackupStatus(),
+		},
+		{
+			name:         "fields are not nil",
+			status:       newBackupStatus(),
+			updateStatus: newUpdateBackupStatus(),
+			expectStatus: newExpectBackupStatus(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("test: %+v", test.name)
+		updateBackupStatus(test.status, test.updateStatus)
+		g.Expect(*test.status).Should(Equal(*test.expectStatus))
+	}
+}
+
+func newUpdateBackupStatus() *BackupUpdateStatus {
+	ts := "421762809912885269"
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T21:46:59Z")
+	end, _ := time.Parse(time.RFC3339, "2020-12-25T21:50:59Z")
+	path := "abcd"
+	sizeReadable := "5M"
+	size := int64(5024)
+	return &BackupUpdateStatus{
+		CommitTs:           &ts,
+		TimeCompleted:      &metav1.Time{Time: end},
+		TimeStarted:        &metav1.Time{Time: start},
+		BackupPath:         &path,
+		BackupSizeReadable: &sizeReadable,
+		BackupSize:         &size,
+	}
+}
+
+func newBackupStatus() *v1alpha1.BackupStatus {
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T12:46:59Z")
+	path := "xyz"
+	sizeReadable := "1M"
+	size := int64(1024)
+	return &v1alpha1.BackupStatus{
+		CommitTs: "421762809912885249",
+		Conditions: []v1alpha1.BackupCondition{
+			{
+				LastTransitionTime: metav1.Time{Time: start},
+				Message:            "",
+				Reason:             "",
+				Status:             "True",
+				Type:               v1alpha1.BackupInvalid,
+			},
+			{
+				LastTransitionTime: metav1.Time{Time: start},
+				Message:            "",
+				Reason:             "",
+				Status:             "True",
+				Type:               v1alpha1.BackupComplete,
+			},
+		},
+		Phase:              v1alpha1.BackupComplete,
+		TimeCompleted:      metav1.Time{Time: start},
+		TimeStarted:        metav1.Time{Time: start},
+		BackupPath:         path,
+		BackupSizeReadable: sizeReadable,
+		BackupSize:         size,
+	}
+}
+func newExpectBackupStatus() *v1alpha1.BackupStatus {
+	ts := "421762809912885269"
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T21:46:59Z")
+	end, _ := time.Parse(time.RFC3339, "2020-12-25T21:50:59Z")
+	path := "abcd"
+	sizeReadable := "5M"
+	size := int64(5024)
+	s := newBackupStatus()
+	s.CommitTs = ts
+	s.TimeStarted = metav1.Time{Time: start}
+	s.TimeCompleted = metav1.Time{Time: end}
+	s.BackupPath = path
+	s.BackupSizeReadable = sizeReadable
+	s.BackupSize = size
+	return s
+}

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -54,7 +54,6 @@ func NewRealRestoreConditionUpdater(
 func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
 	ns := restore.GetNamespace()
 	restoreName := restore.GetName()
-	oldStatus := restore.Status.DeepCopy()
 	var isUpdate bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		isUpdate = v1alpha1.UpdateRestoreCondition(&restore.Status, condition)
@@ -67,7 +66,6 @@ func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, conditio
 			if updated, err := u.restoreLister.Restores(ns).Get(restoreName); err == nil {
 				// make a copy so we don't mutate the shared cache
 				restore = updated.DeepCopy()
-				restore.Status = *oldStatus
 			} else {
 				utilruntime.HandleError(fmt.Errorf("error getting updated restore %s/%s from lister: %v", ns, restoreName, err))
 			}

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -76,6 +76,7 @@ func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, conditio
 				klog.Infof("Restore: [%s/%s] updated successfully", ns, restoreName)
 				return nil
 			}
+			klog.Errorf("Failed to update resotre [%s/%s], error: %v", ns, restoreName, updateErr)
 			if updated, err := u.restoreLister.Restores(ns).Get(restoreName); err == nil {
 				// make a copy so we don't mutate the shared cache
 				restore = updated.DeepCopy()

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -16,21 +16,33 @@ package controller
 import (
 	"fmt"
 
-	"k8s.io/klog"
-
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/informers/externalversions/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
 )
+
+// RestoreUpdateStatus represents the status of a restore to be updated.
+// This structure should keep synced with the fields in `RestoreStatus`
+// except for `Phase` and `Conditions`.
+type RestoreUpdateStatus struct {
+	// TimeStarted is the time at which the restore was started.
+	TimeStarted *metav1.Time
+	// TimeCompleted is the time at which the restore was completed.
+	TimeCompleted *metav1.Time
+	// CommitTs is the snapshot time point of tidb cluster.
+	CommitTs *string
+}
 
 // RestoreConditionUpdaterInterface enables updating Restore conditions.
 type RestoreConditionUpdaterInterface interface {
-	Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error
+	Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition, newStatus *RestoreUpdateStatus) error
 }
 
 type realRestoreConditionUpdater struct {
@@ -51,11 +63,12 @@ func NewRealRestoreConditionUpdater(
 	}
 }
 
-func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
+func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition, newStatus *RestoreUpdateStatus) error {
 	ns := restore.GetNamespace()
 	restoreName := restore.GetName()
 	var isUpdate bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		updateRestoreStatus(&restore.Status, newStatus)
 		isUpdate = v1alpha1.UpdateRestoreCondition(&restore.Status, condition)
 		if isUpdate {
 			_, updateErr := u.cli.PingcapV1alpha1().Restores(ns).Update(restore)
@@ -74,6 +87,23 @@ func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, conditio
 		return nil
 	})
 	return err
+}
+
+// updateRestoreStatus updates existing Restore status
+// from the fields in RestoreUpdateStatus.
+func updateRestoreStatus(status *v1alpha1.RestoreStatus, newStatus *RestoreUpdateStatus) {
+	if newStatus == nil {
+		return
+	}
+	if newStatus.TimeStarted != nil {
+		status.TimeStarted = *newStatus.TimeStarted
+	}
+	if newStatus.TimeCompleted != nil {
+		status.TimeCompleted = *newStatus.TimeCompleted
+	}
+	if newStatus.CommitTs != nil {
+		status.CommitTs = *newStatus.CommitTs
+	}
 }
 
 var _ RestoreConditionUpdaterInterface = &realRestoreConditionUpdater{}
@@ -100,7 +130,7 @@ func (u *FakeRestoreConditionUpdater) SetUpdateRestoreError(err error, after int
 }
 
 // UpdateRestore updates the Restore
-func (u *FakeRestoreConditionUpdater) Update(restore *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
+func (u *FakeRestoreConditionUpdater) Update(restore *v1alpha1.Restore, _ *v1alpha1.RestoreCondition, _ *RestoreUpdateStatus) error {
 	defer u.updateRestoreTracker.Inc()
 	if u.updateRestoreTracker.ErrorReady() {
 		defer u.updateRestoreTracker.Reset()

--- a/pkg/controller/restore_status_updater_test.go
+++ b/pkg/controller/restore_status_updater_test.go
@@ -1,0 +1,105 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpdateRestoreStatus(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []struct {
+		name         string
+		status       *v1alpha1.RestoreStatus
+		updateStatus *RestoreUpdateStatus
+		expectStatus *v1alpha1.RestoreStatus
+	}{
+		{
+			name:         "updateStatus is nil",
+			status:       newRestoreStatus(),
+			updateStatus: nil,
+			expectStatus: newRestoreStatus(),
+		},
+		{
+			name:         "fields are nil",
+			status:       newRestoreStatus(),
+			updateStatus: &RestoreUpdateStatus{},
+			expectStatus: newRestoreStatus(),
+		},
+		{
+			name:         "fields are not nil",
+			status:       newRestoreStatus(),
+			updateStatus: newUpdateRestoreStatus(),
+			expectStatus: newExpectRestoreStatus(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("test: %+v", test.name)
+		updateRestoreStatus(test.status, test.updateStatus)
+		g.Expect(*test.status).Should(Equal(*test.expectStatus))
+	}
+}
+
+func newUpdateRestoreStatus() *RestoreUpdateStatus {
+	ts := "421762809912885269"
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T21:46:59Z")
+	end, _ := time.Parse(time.RFC3339, "2020-12-25T21:50:59Z")
+	return &RestoreUpdateStatus{
+		CommitTs:      &ts,
+		TimeCompleted: &metav1.Time{Time: end},
+		TimeStarted:   &metav1.Time{Time: start},
+	}
+}
+
+func newRestoreStatus() *v1alpha1.RestoreStatus {
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T12:46:59Z")
+	return &v1alpha1.RestoreStatus{
+		CommitTs: "421762809912885249",
+		Conditions: []v1alpha1.RestoreCondition{
+			{
+				LastTransitionTime: metav1.Time{Time: start},
+				Message:            "",
+				Reason:             "",
+				Status:             "True",
+				Type:               v1alpha1.RestoreInvalid,
+			},
+			{
+				LastTransitionTime: metav1.Time{Time: start},
+				Message:            "",
+				Reason:             "",
+				Status:             "True",
+				Type:               v1alpha1.RestoreComplete,
+			},
+		},
+		Phase:         v1alpha1.RestoreComplete,
+		TimeCompleted: metav1.Time{Time: start},
+		TimeStarted:   metav1.Time{Time: start},
+	}
+}
+func newExpectRestoreStatus() *v1alpha1.RestoreStatus {
+	ts := "421762809912885269"
+	start, _ := time.Parse(time.RFC3339, "2020-12-25T21:46:59Z")
+	end, _ := time.Parse(time.RFC3339, "2020-12-25T21:50:59Z")
+	s := newRestoreStatus()
+	s.CommitTs = ts
+	s.TimeStarted = metav1.Time{Time: start}
+	s.TimeCompleted = metav1.Time{Time: end}
+	return s
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fix the issue that in some cases some fields, e.g. BACKUPPATH, BACKUPSIZE, COMMITTS, etc. in the status of Backup CR or Restore CR are missed even if the backup or restore job succeed.
Fix #3635
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Root cause:
Take the Backup CR for example, and the Restore CR has a similar logic.
Currently, two controllers will update the status of Backup CR, one is the backup controller in the tidb-controller-manager Pod, which only updates the conditions slice in the status. The other is the controller in the backup-manager Pod which is the real backup job and will update all the fields in the status.
With the current status update logic, if something wrong with the update API call, the status updater will retrieve the latest Backup resource from the lister and replace the `status` field totally with the old status, so if the backup-manager Pod updates all the fields in the status and then the tidb-controller-manager Pod updates the conditions slice in the status, all the other fields updated by the backup-manager will be lost.
So we should update the status based on the latest status instead of the old status.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - Run `BackupSchedule` with BR
      -  The clean of the `Backup` CRs works as expected
      -  The status of the `Backup` is updated correctly even if an error occurs during the update:

```
E1230 07:06:10.482472       1 backup_status_updater.go:87] Failed to update backup [ns0/minio-br-2020-12-30t07-06-00], error: Operation cannot be fulfilled on backups.pingcap.com "minio-br-2020-12-30t07-06-00": the object has been modified; please apply your changes to the latest version and try again
I1230 07:06:10.498200       1 backup_status_updater.go:84] Backup: [ns0/minio-br-2020-12-30t07-06-00] updated successfully
```

```
# k get bk -n ns0
NAME                                  STATUS     BACKUPPATH                                                     BACKUPSIZE   COMMITTS             AGE
minio-br-2020-12-30t06-26-00          Complete   s3://backup/ns0/br/ns0-pd.ns0-2379-2020-12-30t06-26-00         278 kB       421870849284636673   38m
minio-br-2020-12-30t06-28-00          Complete   s3://backup/ns0/br/ns0-pd.ns0-2379-2020-12-30t06-28-00         278 kB       421870881108918275   36m
minio-br-2020-12-30t06-30-00          Complete   s3://backup/ns0/br/ns0-pd.ns0-2379-2020-12-30t06-30-00         278 kB       421870912146767873   34m
minio-br-2020-12-30t06-32-00          Complete   s3://backup/ns0/br/ns0-pd.ns0-2379-2020-12-30t06-32-00         278 kB       421870943866191875   32m
```

  - Run `BackupSchedule` with Dumpling
      -  The clean of the `Backup` CRs works as expected
      -  The status of the `Backup` is updated correctly even if an error occurs during the update:

```
E1230 07:08:09.489023       1 backup_status_updater.go:87] Failed to update backup [ns0/minio-dump-2020-12-30t07-08-00], error: Operation cannot be fulfilled on backups.pingcap.com "minio-dump-2020-12-30t07-08-00": the object has been modified; please apply your changes to the latest version and try again
I1230 07:08:09.890044       1 backup_status_updater.go:84] Backup: [ns0/minio-dump-2020-12-30t07-08-00] updated successfully
```

```
# k get bk -n ns0
NAME                                  STATUS     BACKUPPATH                                                     BACKUPSIZE   COMMITTS             AGE
minio-dump-2020-12-30t06-26-00        Complete   s3://backup/ns0/dumpling/backup-2020-12-30T06:26:16Z.tgz       721 B        421870849520566278   38m
minio-dump-2020-12-30t06-28-00        Complete   s3://backup/ns0/dumpling/backup-2020-12-30T06:28:15Z.tgz       721 B        421870880728809476   36m
minio-dump-2020-12-30t06-30-00        Complete   s3://backup/ns0/dumpling/backup-2020-12-30T06:30:15Z.tgz       721 B        421870912382697476   34m
```
    
  - Run `Restore` with BR and the status of the `Restore` is updated correctly even if an error occurs during the update:

```
E1230 06:45:05.777648       1 restore_status_updater.go:79] Failed to update resotre [ns1/br-minio0], error: Operation cannot be fulfilled on restores.pingcap.com "br-minio0": the object has been modified; please apply your changes to the latest version and try again
I1230 06:45:05.794604       1 restore_status_updater.go:76] Restore: [ns1/br-minio0] updated successfully
```

```
# k get rt -n ns1
NAME                 STATUS     STARTED                COMPLETED              COMMITTS             AGE
br-minio0            Complete   2020-12-30T06:44:53Z   2020-12-30T06:45:05Z   421870503280771073   28m
```

  - Run `Restore` with Lightning and the status of the `Restore` is updated correctly even if an error occurs during the update:

```
E1230 06:41:13.551646       1 restore_status_updater.go:79] Failed to update resotre [ns1/light-minio0], error: Operation cannot be fulfilled on restores.pingcap.com "light-minio0": the object has been modified; please apply your changes to the latest version and try again
I1230 06:41:13.568063       1 restore_status_updater.go:76] Restore: [ns1/light-minio0] updated successfully
```

```
# k get rt -n ns1
NAME                 STATUS     STARTED                COMPLETED              COMMITTS             AGE
light-minio0         Complete   2020-12-30T06:41:12Z   2020-12-30T06:41:13Z   421870441493430276   34m
```
### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that `commitTS` or other fields in status may be lost even if the backup job succeeds
```
