### PR TITLE
fix gcs br backup&restore path

### DIFF
--- a/cmd/backup-manager/app/util/remote.go
+++ b/cmd/backup-manager/app/util/remote.go
@@ -95,6 +95,7 @@ func NewStorageBackend(provider v1alpha1.StorageProvider) (*blob.Bucket, error) 
 }
 
 // genStorageArgs returns the arg for --storage option and the remote/local path for br
+// TODO: add unit test
 func genStorageArgs(provider v1alpha1.StorageProvider) ([]string, error) {
 	st := util.GetStorageType(provider)
 	switch st {

--- a/cmd/backup-manager/app/util/remote.go
+++ b/cmd/backup-manager/app/util/remote.go
@@ -212,7 +212,7 @@ func newGcsStorage(conf *gcsConfig) (*blob.Bucket, error) {
 // newGcsStorageOption constructs the arg for --storage option and the remote path for br
 func newGcsStorageOption(conf *gcsConfig) []string {
 	var gcsoptions []string
-	path := fmt.Sprintf("gcs://%s", path.Join(conf.bucket, conf.prefix))
+	path := fmt.Sprintf("gcs://%s/", path.Join(conf.bucket, conf.prefix))
 	gcsoptions = append(gcsoptions, fmt.Sprintf("--storage=%s", path))
 	if conf.storageClass != "" {
 		gcsoptions = append(gcsoptions, fmt.Sprintf("--gcs.storage-class=%s", conf.storageClass))

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -99,7 +99,7 @@ func GetStoragePath(backup *v1alpha1.Backup) (string, error) {
 	case v1alpha1.BackupStorageTypeGcs:
 		prefix = backup.Spec.StorageProvider.Gcs.Prefix
 		bucket = backup.Spec.StorageProvider.Gcs.Bucket
-		url = fmt.Sprintf("gcs://%s", path.Join(bucket, prefix))
+		url = fmt.Sprintf("gcs://%s/", path.Join(bucket, prefix))
 		return url, nil
 	case v1alpha1.BackupStorageTypeLocal:
 		prefix = backup.Spec.StorageProvider.Local.Prefix

--- a/cmd/backup-manager/app/util/util_test.go
+++ b/cmd/backup-manager/app/util/util_test.go
@@ -243,7 +243,7 @@ func TestGetRemotePath(t *testing.T) {
 					},
 				},
 			},
-			expect: "gcs://test1-demo1",
+			expect: "gcs://test1-demo1/",
 		},
 		{
 			name: "unknow storage type",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
in release v1.1.8, after #3517, the gcs path for BR backup&restore is not backward-compatible with tidb 4.0.8

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
add trailing slash `/` back for gcs paths.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
ref https://docs.google.com/document/d/1kqw4moTM7HRnXhncdcWOrr23v7MBQNENm8pA_PsQOWE/edit
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [x] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
  - incompatible with 1.1.8
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->
  - should mention that operator v1.1.8 has this issue, so that users should skip this version

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix compatibility issue for using BR to backup/restore from/to gcs
```
