### PR TITLE
adjust e2e pod resources

### DIFF
--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -256,7 +256,7 @@ try {
             ],
             limits: [
                 cpu: "8",
-                memory: "16Gi"
+                memory: "32Gi"
             ],
         ]
         podTemplate(
@@ -365,7 +365,7 @@ try {
                     }
                 }
             }
-            }
+        }
     }
     currentBuild.result = "SUCCESS"
 } catch (err) {

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -158,7 +158,7 @@ spec:
 String buildPodYAML(Map m = [:]) {
     m.putIfAbsent("resources", [:])
     m.putIfAbsent("any", false)
-    def engine = new SimpleTemplateEngine()
+    def engine = new groovy.text.SimpleTemplateEngine()
     def template = engine.createTemplate(podYAML).make(m)
     return template.toString()
 }

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -84,13 +84,13 @@ spec:
       requests:
         cpu: <%= resources.requests.cpu %>
         memory: <%= resources.requests.memory %>
-        ephemeral-storage: 70Gi
+        ephemeral-storage: 100Gi
     <% } %>
     <% if (resources.limits) { %>
       limits:
         cpu: <%= resources.limits.cpu %>
         memory: <%= resources.limits.memory %>
-        ephemeral-storage: 70Gi
+        ephemeral-storage: 100Gi
     <% } %>
 <% } %>
     # kind needs /lib/modules and cgroups from the host
@@ -158,21 +158,21 @@ spec:
 String buildPodYAML(Map m = [:]) {
     m.putIfAbsent("resources", [:])
     m.putIfAbsent("any", false)
-    def engine = new groovy.text.SimpleTemplateEngine()
+    def engine = new SimpleTemplateEngine()
     def template = engine.createTemplate(podYAML).make(m)
     return template.toString()
 }
 
 e2ePodResources = [
-        requests: [
-            cpu: "4",
-            memory: "4Gi"
-        ],
-        limits: [
-            cpu: "8",
-            memory: "8Gi"
-        ],
-    ]
+    requests: [
+        cpu: "6",
+        memory: "10Gi"
+    ],
+    limits: [
+        cpu: "8",
+        memory: "16Gi"
+    ],
+]
 
 def build(String name, String code, Map resources = e2ePodResources) {
     podTemplate(yaml: buildPodYAML(resources: resources)) {
@@ -252,11 +252,11 @@ try {
         def resources = [
             requests: [
                 cpu: "4",
-                memory: "4G"
+                memory: "4Gi"
             ],
             limits: [
                 cpu: "8",
-                memory: "32G"
+                memory: "16Gi"
             ],
         ]
         podTemplate(
@@ -342,7 +342,7 @@ try {
         if (GIT_REF ==~ /^(master|)$/ || GIT_REF ==~ /^(release-.*)$/
             || GIT_REF ==~ /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/) {
             // Upload assets if the git ref is the master branch or version tag
-            podTemplate(yaml: buildPodYAML(resources: [requests: [cpu: "1", memory: "1G"]])) {
+            podTemplate(yaml: buildPodYAML(resources: [requests: [cpu: "1", memory: "2Gi"]])) {
                 node(POD_LABEL) {
                     container("main") {
                         dir("${PROJECT_DIR}") {
@@ -365,10 +365,8 @@ try {
                     }
                 }
             }
-        }
-
+            }
     }
-
     currentBuild.result = "SUCCESS"
 } catch (err) {
     println("fatal: " + err)

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -251,8 +251,8 @@ try {
         def buildPodLabel = "tidb-operator-build-v1-pingcap-docker-mirror"
         def resources = [
             requests: [
-                cpu: "4",
-                memory: "4Gi"
+                cpu: "6",
+                memory: "10Gi"
             ],
             limits: [
                 cpu: "8",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
adjust e2e pod resources to avoid eviction during job run.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
adjust ephemeral-storage/cpu/memory of e2e pods

### Code changes

- [ ] Has Go code change
- [x] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
NONE
```
