### PR TITLE
Support cancel backup and restore jobs via signal and update status with failed pod

### DIFF
--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -84,13 +84,13 @@ spec:
       requests:
         cpu: <%= resources.requests.cpu %>
         memory: <%= resources.requests.memory %>
-        ephemeral-storage: 70Gi
+        ephemeral-storage: 100Gi
     <% } %>
     <% if (resources.limits) { %>
       limits:
         cpu: <%= resources.limits.cpu %>
         memory: <%= resources.limits.memory %>
-        ephemeral-storage: 70Gi
+        ephemeral-storage: 100Gi
     <% } %>
 <% } %>
     # kind needs /lib/modules and cgroups from the host
@@ -164,15 +164,15 @@ String buildPodYAML(Map m = [:]) {
 }
 
 e2ePodResources = [
-        requests: [
-            cpu: "4",
-            memory: "4Gi"
-        ],
-        limits: [
-            cpu: "8",
-            memory: "8Gi"
-        ],
-    ]
+    requests: [
+        cpu: "6",
+        memory: "10Gi"
+    ],
+    limits: [
+        cpu: "8",
+        memory: "16Gi"
+    ],
+]
 
 def build(String name, String code, Map resources = e2ePodResources) {
     podTemplate(yaml: buildPodYAML(resources: resources)) {
@@ -251,12 +251,12 @@ try {
         def buildPodLabel = "tidb-operator-build-v1-pingcap-docker-mirror"
         def resources = [
             requests: [
-                cpu: "4",
-                memory: "4G"
+                cpu: "6",
+                memory: "10Gi"
             ],
             limits: [
                 cpu: "8",
-                memory: "32G"
+                memory: "32Gi"
             ],
         ]
         podTemplate(
@@ -342,7 +342,7 @@ try {
         if (GIT_REF ==~ /^(master|)$/ || GIT_REF ==~ /^(release-.*)$/
             || GIT_REF ==~ /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/) {
             // Upload assets if the git ref is the master branch or version tag
-            podTemplate(yaml: buildPodYAML(resources: [requests: [cpu: "1", memory: "1G"]])) {
+            podTemplate(yaml: buildPodYAML(resources: [requests: [cpu: "1", memory: "2Gi"]])) {
                 node(POD_LABEL) {
                     container("main") {
                         dir("${PROJECT_DIR}") {
@@ -366,9 +366,7 @@ try {
                 }
             }
         }
-
     }
-
     currentBuild.result = "SUCCESS"
 } catch (err) {
     println("fatal: " + err)

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -15,6 +15,7 @@ package backup
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,7 +36,7 @@ type Options struct {
 }
 
 // backupData generates br args and runs br binary to do the real backup work
-func (bo *Options) backupData(backup *v1alpha1.Backup) error {
+func (bo *Options) backupData(ctx context.Context, backup *v1alpha1.Backup) error {
 	clusterNamespace := backup.Spec.BR.ClusterNamespace
 	if backup.Spec.BR.ClusterNamespace == "" {
 		clusterNamespace = backup.Namespace
@@ -67,7 +68,7 @@ func (bo *Options) backupData(backup *v1alpha1.Backup) error {
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
 	bin := path.Join(util.BRBinPath, "br")
-	cmd := exec.Command(bin, fullArgs...)
+	cmd := exec.CommandContext(ctx, bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -73,7 +73,7 @@ func (bm *Manager) setOptions(backup *v1alpha1.Backup) {
 
 // ProcessBackup used to process the backup logic
 func (bm *Manager) ProcessBackup() error {
-	ctx, cancel := util.GetContextForSignal(bm.ResourceName)
+	ctx, cancel := util.GetContextForTerminationSignals(bm.ResourceName)
 	defer cancel()
 
 	var errs []error

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -73,7 +73,8 @@ func (bm *Manager) setOptions(backup *v1alpha1.Backup) {
 
 // ProcessBackup used to process the backup logic
 func (bm *Manager) ProcessBackup() error {
-	ctx := util.GetContextForSignal(bm.ResourceName)
+	ctx, cancel := util.GetContextForSignal(bm.ResourceName)
+	defer cancel()
 
 	var errs []error
 	backup, err := bm.backupLister.Backups(bm.Namespace).Get(bm.ResourceName)

--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -47,7 +47,8 @@ func NewManager(
 
 // ProcessCleanBackup used to clean the specific backup
 func (bm *Manager) ProcessCleanBackup() error {
-	ctx := util.GetContextForSignal(fmt.Sprintf("clean %s", bm.BackupName))
+	ctx, cancel := util.GetContextForSignal(fmt.Sprintf("clean %s", bm.BackupName))
+	defer cancel()
 
 	backup, err := bm.backupLister.Backups(bm.Namespace).Get(bm.BackupName)
 	if err != nil {

--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -47,7 +47,7 @@ func NewManager(
 
 // ProcessCleanBackup used to clean the specific backup
 func (bm *Manager) ProcessCleanBackup() error {
-	ctx, cancel := util.GetContextForSignal(fmt.Sprintf("clean %s", bm.BackupName))
+	ctx, cancel := util.GetContextForTerminationSignals(fmt.Sprintf("clean %s", bm.BackupName))
 	defer cancel()
 
 	backup, err := bm.backupLister.Backups(bm.Namespace).Get(bm.BackupName)

--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -16,6 +16,7 @@ package clean
 import (
 	"context"
 	"fmt"
+
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -80,7 +80,7 @@ func (bm *BackupManager) setOptions(backup *v1alpha1.Backup) (string, error) {
 
 // ProcessBackup used to process the backup logic
 func (bm *BackupManager) ProcessBackup() error {
-	ctx, cancel := util.GetContextForSignal(bm.ResourceName)
+	ctx, cancel := util.GetContextForTerminationSignals(bm.ResourceName)
 	defer cancel()
 
 	var errs []error

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -80,7 +80,8 @@ func (bm *BackupManager) setOptions(backup *v1alpha1.Backup) (string, error) {
 
 // ProcessBackup used to process the backup logic
 func (bm *BackupManager) ProcessBackup() error {
-	ctx := util.GetContextForSignal(bm.ResourceName)
+	ctx, cancel := util.GetContextForSignal(bm.ResourceName)
+	defer cancel()
 
 	var errs []error
 	backup, err := bm.backupLister.Backups(bm.Namespace).Get(bm.ResourceName)

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -69,7 +69,7 @@ func (rm *RestoreManager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *RestoreManager) ProcessRestore() error {
-	ctx, cancel := util.GetContextForSignal(rm.ResourceName)
+	ctx, cancel := util.GetContextForTerminationSignals(rm.ResourceName)
 	defer cancel()
 
 	var errs []error

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -14,8 +14,12 @@
 package _import
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
@@ -68,6 +72,21 @@ func (rm *RestoreManager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *RestoreManager) ProcessRestore() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	go func() {
+		sig := <-sc
+		klog.Errorf("got signal %s to exit, the restore %s will be canceled", sig, rm.ResourceName)
+		cancel() // NOTE: the `Message` in `Status.Conditions` will contain `context canceled`.
+	}()
+
 	var errs []error
 	restore, err := rm.restoreLister.Restores(rm.Namespace).Get(rm.ResourceName)
 	if err != nil {
@@ -85,10 +104,10 @@ func (rm *RestoreManager) ProcessRestore() error {
 
 	rm.setOptions(restore)
 
-	return rm.performRestore(restore.DeepCopy())
+	return rm.performRestore(ctx, restore.DeepCopy())
 }
 
-func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
+func (rm *RestoreManager) performRestore(ctx context.Context, restore *v1alpha1.Restore) error {
 	started := time.Now()
 
 	err := rm.StatusUpdater.Update(restore, &v1alpha1.RestoreCondition{
@@ -102,7 +121,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 	var errs []error
 	restoreDataPath := rm.getRestoreDataPath()
 	opts := util.GetOptions(restore.Spec.StorageProvider)
-	if err := rm.downloadBackupData(restoreDataPath, opts); err != nil {
+	if err := rm.downloadBackupData(ctx, restoreDataPath, opts); err != nil {
 		errs = append(errs, err)
 		klog.Errorf("download cluster %s backup %s data failed, err: %s", rm, rm.BackupPath, err)
 		uerr := rm.StatusUpdater.Update(restore, &v1alpha1.RestoreCondition{
@@ -147,7 +166,7 @@ func (rm *RestoreManager) performRestore(restore *v1alpha1.Restore) error {
 	}
 	klog.Infof("get cluster %s commitTs %s success", rm, commitTs)
 
-	err = rm.loadTidbClusterData(unarchiveDataPath, restore)
+	err = rm.loadTidbClusterData(ctx, unarchiveDataPath, restore)
 	if err != nil {
 		errs = append(errs, err)
 		klog.Errorf("restore cluster %s from backup %s failed, err: %s", rm, rm.BackupPath, err)

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -69,7 +69,8 @@ func (rm *RestoreManager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *RestoreManager) ProcessRestore() error {
-	ctx := util.GetContextForSignal(rm.ResourceName)
+	ctx, cancel := util.GetContextForSignal(rm.ResourceName)
+	defer cancel()
 
 	var errs []error
 	restore, err := rm.restoreLister.Restores(rm.Namespace).Get(rm.ResourceName)

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -71,7 +71,8 @@ func (rm *Manager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *Manager) ProcessRestore() error {
-	ctx := util.GetContextForSignal(rm.ResourceName)
+	ctx, cancel := util.GetContextForSignal(rm.ResourceName)
+	defer cancel()
 
 	var errs []error
 	restore, err := rm.restoreLister.Restores(rm.Namespace).Get(rm.ResourceName)

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -71,7 +71,7 @@ func (rm *Manager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *Manager) ProcessRestore() error {
-	ctx, cancel := util.GetContextForSignal(rm.ResourceName)
+	ctx, cancel := util.GetContextForTerminationSignals(rm.ResourceName)
 	defer cancel()
 
 	var errs []error

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -14,9 +14,13 @@
 package restore
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
@@ -70,6 +74,21 @@ func (rm *Manager) setOptions(restore *v1alpha1.Restore) {
 
 // ProcessRestore used to process the restore logic
 func (rm *Manager) ProcessRestore() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	go func() {
+		sig := <-sc
+		klog.Errorf("got signal %s to exit, the restore %s will be canceled", sig, rm.ResourceName)
+		cancel() // NOTE: the `Message` in `Status.Conditions` will contain `context canceled`.
+	}()
+
 	var errs []error
 	restore, err := rm.restoreLister.Restores(rm.Namespace).Get(rm.ResourceName)
 	if err != nil {
@@ -89,7 +108,7 @@ func (rm *Manager) ProcessRestore() error {
 	}
 
 	if restore.Spec.To == nil {
-		return rm.performRestore(restore.DeepCopy(), nil)
+		return rm.performRestore(ctx, restore.DeepCopy(), nil)
 	}
 
 	rm.setOptions(restore)
@@ -103,9 +122,12 @@ func (rm *Manager) ProcessRestore() error {
 			return false, err
 		}
 
-		db, err = util.OpenDB(dsn)
+		db, err = util.OpenDB(ctx, dsn)
 		if err != nil {
 			klog.Warningf("can't connect to tidb cluster %s, err: %s", rm, err)
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
 			return false, nil
 		}
 		return true, nil
@@ -125,10 +147,10 @@ func (rm *Manager) ProcessRestore() error {
 	}
 
 	defer db.Close()
-	return rm.performRestore(restore.DeepCopy(), db)
+	return rm.performRestore(ctx, restore.DeepCopy(), db)
 }
 
-func (rm *Manager) performRestore(restore *v1alpha1.Restore, db *sql.DB) error {
+func (rm *Manager) performRestore(ctx context.Context, restore *v1alpha1.Restore, db *sql.DB) error {
 	started := time.Now()
 
 	err := rm.StatusUpdater.Update(restore, &v1alpha1.RestoreCondition{
@@ -141,7 +163,7 @@ func (rm *Manager) performRestore(restore *v1alpha1.Restore, db *sql.DB) error {
 
 	var errs []error
 
-	commitTs, err := util.GetCommitTsFromBRMetaData(restore.Spec.StorageProvider)
+	commitTs, err := util.GetCommitTsFromBRMetaData(ctx, restore.Spec.StorageProvider)
 	if err != nil {
 		errs = append(errs, err)
 		klog.Errorf("get cluster %s commitTs failed, err: %s", rm, err)
@@ -162,7 +184,7 @@ func (rm *Manager) performRestore(restore *v1alpha1.Restore, db *sql.DB) error {
 
 	// set tikv gc life time to prevent gc when restoring data
 	if db != nil {
-		oldTikvGCTime, err = rm.GetTikvGCLifeTime(db)
+		oldTikvGCTime, err = rm.GetTikvGCLifeTime(ctx, db)
 		if err != nil {
 			errs = append(errs, err)
 			klog.Errorf("cluster %s get %s failed, err: %s", rm, constants.TikvGCVariable, err)
@@ -224,7 +246,7 @@ func (rm *Manager) performRestore(restore *v1alpha1.Restore, db *sql.DB) error {
 		}
 
 		if oldTikvGCTimeDuration < tikvGCTimeDuration {
-			err = rm.SetTikvGCLifeTime(db, tikvGCLifeTime)
+			err = rm.SetTikvGCLifeTime(ctx, db, tikvGCLifeTime)
 			if err != nil {
 				errs = append(errs, err)
 				klog.Errorf("cluster %s set tikv GC life time to %s failed, err: %s", rm, tikvGCLifeTime, err)
@@ -241,10 +263,14 @@ func (rm *Manager) performRestore(restore *v1alpha1.Restore, db *sql.DB) error {
 		}
 	}
 
-	restoreErr := rm.restoreData(restore)
+	restoreErr := rm.restoreData(ctx, restore)
 
 	if db != nil && oldTikvGCTimeDuration < tikvGCTimeDuration {
-		err = rm.SetTikvGCLifeTime(db, oldTikvGCTime)
+		// use another context to revert `tikv_gc_life_time` back.
+		// `DefaultTerminationGracePeriodSeconds` for a pod is 30, so we use a smaller timeout value here.
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 25*time.Second)
+		defer cancel2()
+		err = rm.SetTikvGCLifeTime(ctx2, db, oldTikvGCTime)
 		if err != nil {
 			if restoreErr != nil {
 				errs = append(errs, restoreErr)

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -15,6 +15,7 @@ package restore
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -33,7 +34,7 @@ type Options struct {
 	backupUtil.GenericOptions
 }
 
-func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
+func (ro *Options) restoreData(ctx context.Context, restore *v1alpha1.Restore) error {
 	clusterNamespace := restore.Spec.BR.ClusterNamespace
 	if restore.Spec.BR.ClusterNamespace == "" {
 		clusterNamespace = restore.Namespace
@@ -65,7 +66,7 @@ func (ro *Options) restoreData(restore *v1alpha1.Restore) error {
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
 	bin := path.Join(util.BRBinPath, "br")
-	cmd := exec.Command(bin, fullArgs...)
+	cmd := exec.CommandContext(ctx, bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -424,7 +424,7 @@ func ConstructRcloneArgs(conf string, opts []string, command, source, dest strin
 }
 
 // GetContextForSignal get a context for some signals, and the context will become done after any of these signals triggered.
-func GetContextForSignal(op string) context.Context {
+func GetContextForSignal(op string) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	sc := make(chan os.Signal, 1)
@@ -438,5 +438,5 @@ func GetContextForSignal(op string) context.Context {
 		klog.Errorf("got signal %s to exit, %s will be canceled", sig, op)
 		cancel() // NOTE: the `Message` in `Status.Conditions` will contain `context canceled`.
 	}()
-	return ctx
+	return ctx, cancel
 }

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -423,8 +423,8 @@ func ConstructRcloneArgs(conf string, opts []string, command, source, dest strin
 	return args
 }
 
-// GetContextForSignal get a context for some signals, and the context will become done after any of these signals triggered.
-func GetContextForSignal(op string) (context.Context, context.CancelFunc) {
+// GetContextForTerminationSignals get a context for some termination signals, and the context will become done after any of these signals triggered.
+func GetContextForTerminationSignals(op string) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	sc := make(chan os.Signal, 1)

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -124,8 +124,8 @@ func IsBackupRunning(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
-// IsBackupPrepare returns true if a Backup is Prepare.
-func IsBackupPrepare(backup *Backup) bool {
+// IsBackupPrepared returns true if a Backup is Prepare.
+func IsBackupPrepared(backup *Backup) bool {
 	_, condition := GetBackupCondition(&backup.Status, BackupPrepare)
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -64,14 +64,6 @@ func GetBackupCondition(status *BackupStatus, conditionType BackupConditionType)
 	return -1, nil
 }
 
-// GetBackupLastCondition gets the last BackupCondition from the given BackupStatus.
-func GetBackupLastCondition(status *BackupStatus) *BackupCondition {
-	if status == nil || len(status.Conditions) == 0 {
-		return nil
-	}
-	return &status.Conditions[len(status.Conditions)-1]
-}
-
 // UpdateBackupCondition updates existing Backup condition or creates a new
 // one. Sets LastTransitionTime to now if the status has changed.
 // Returns true if Backup condition has changed or has been added.
@@ -126,6 +118,18 @@ func IsBackupScheduled(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsBackupRunning returns true if a Backup is Running.
+func IsBackupRunning(backup *Backup) bool {
+	_, condition := GetBackupCondition(&backup.Status, BackupRunning)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// IsBackupPrepare returns true if a Backup is Prepare.
+func IsBackupPrepare(backup *Backup) bool {
+	_, condition := GetBackupCondition(&backup.Status, BackupPrepare)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsBackupClean returns true if a Backup has been successfully cleaned up
 func IsBackupClean(backup *Backup) bool {
 	_, condition := GetBackupCondition(&backup.Status, BackupClean)
@@ -140,18 +144,6 @@ func IsCleanCandidate(backup *Backup) bool {
 	default:
 		return false
 	}
-}
-
-// IsBackupLastRunning returns true if a Backup's last condition is Running.
-func IsBackupLastRunning(backup *Backup) bool {
-	condition := GetBackupLastCondition(&backup.Status)
-	return condition != nil && condition.Type == BackupRunning && condition.Status == corev1.ConditionTrue
-}
-
-// IsBackupLastPrepare returns true if a Backup's last condition is Prepare.
-func IsBackupLastPrepare(backup *Backup) bool {
-	condition := GetBackupLastCondition(&backup.Status)
-	return condition != nil && condition.Type == BackupPrepare && condition.Status == corev1.ConditionTrue
 }
 
 // NeedNotClean returns true if a Backup need not to be cleaned up according to cleanPolicy

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -64,6 +64,14 @@ func GetBackupCondition(status *BackupStatus, conditionType BackupConditionType)
 	return -1, nil
 }
 
+// GetBackupLastCondition gets the last BackupCondition from the given BackupStatus.
+func GetBackupLastCondition(status *BackupStatus) *BackupCondition {
+	if status == nil || len(status.Conditions) == 0 {
+		return nil
+	}
+	return &status.Conditions[len(status.Conditions)-1]
+}
+
 // UpdateBackupCondition updates existing Backup condition or creates a new
 // one. Sets LastTransitionTime to now if the status has changed.
 // Returns true if Backup condition has changed or has been added.
@@ -132,6 +140,18 @@ func IsCleanCandidate(backup *Backup) bool {
 	default:
 		return false
 	}
+}
+
+// IsBackupLastRunning returns true if a Backup's last condition is Running.
+func IsBackupLastRunning(backup *Backup) bool {
+	condition := GetBackupLastCondition(&backup.Status)
+	return condition != nil && condition.Type == BackupRunning && condition.Status == corev1.ConditionTrue
+}
+
+// IsBackupLastPrepare returns true if a Backup's last condition is Prepare.
+func IsBackupLastPrepare(backup *Backup) bool {
+	condition := GetBackupLastCondition(&backup.Status)
+	return condition != nil && condition.Type == BackupPrepare && condition.Status == corev1.ConditionTrue
 }
 
 // NeedNotClean returns true if a Backup need not to be cleaned up according to cleanPolicy

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -59,14 +59,6 @@ func GetRestoreCondition(status *RestoreStatus, conditionType RestoreConditionTy
 	return -1, nil
 }
 
-// GetRestoreLastCondition gets the last RestoreCondition from the given RestoreStatus.
-func GetRestoreLastCondition(status *RestoreStatus) *RestoreCondition {
-	if status == nil || len(status.Conditions) == 0 {
-		return nil
-	}
-	return &status.Conditions[len(status.Conditions)-1]
-}
-
 // UpdateRestoreCondition updates existing Restore condition or creates a new
 // one. Sets LastTransitionTime to now if the status has changed.
 // Returns true if Restore condition has changed or has been added.
@@ -115,8 +107,14 @@ func IsRestoreScheduled(restore *Restore) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
-// IsRestoreLastRunning returns true if a Restore's last condition is Running.
-func IsRestoreLastRunning(restore *Restore) bool {
-	condition := GetRestoreLastCondition(&restore.Status)
-	return condition != nil && condition.Type == RestoreRunning && condition.Status == corev1.ConditionTrue
+// IsRestoreRunning returns true if a Restore is Running
+func IsRestoreRunning(restore *Restore) bool {
+	_, condition := GetRestoreCondition(&restore.Status, RestoreRunning)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// IsRestoreFailed returns true if a Restore is Failed
+func IsRestoreFailed(restore *Restore) bool {
+	_, condition := GetRestoreCondition(&restore.Status, RestoreFailed)
+	return condition != nil && condition.Status == corev1.ConditionTrue
 }

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -19,12 +19,16 @@ import "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 type BackupManager interface {
 	// Sync	implements the logic for syncing Backup.
 	Sync(backup *v1alpha1.Backup) error
+	// UpdateCondition updates the condition for a Backup.
+	UpdateCondition(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error
 }
 
 // RestoreManager implements the logic for manage restore.
 type RestoreManager interface {
 	// Sync	implements the logic for syncing Restore.
 	Sync(backup *v1alpha1.Restore) error
+	// UpdateCondition updates the condition for a Restore.
+	UpdateCondition(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error
 }
 
 // BackupScheduleManager implements the logic for manage backupSchedule.

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -63,6 +63,10 @@ func (bm *backupManager) Sync(backup *v1alpha1.Backup) error {
 	return bm.syncBackupJob(backup)
 }
 
+func (bm *backupManager) UpdateCondition(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error {
+	return bm.statusUpdater.Update(backup, condition, nil)
+}
+
 func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 	ns := backup.GetNamespace()
 	name := backup.GetName()
@@ -562,6 +566,10 @@ func (m *FakeBackupManager) SetSyncError(err error) {
 
 func (m *FakeBackupManager) Sync(_ *v1alpha1.Backup) error {
 	return m.err
+}
+
+func (m *FakeBackupManager) UpdateCondition(_ *v1alpha1.Backup, _ *v1alpha1.BackupCondition) error {
+	return nil
 }
 
 var _ backup.BackupManager = &FakeBackupManager{}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -48,6 +48,10 @@ func (rm *restoreManager) Sync(restore *v1alpha1.Restore) error {
 	return rm.syncRestoreJob(restore)
 }
 
+func (rm *restoreManager) UpdateCondition(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
+	return rm.statusUpdater.Update(restore, condition, nil)
+}
+
 func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 	ns := restore.GetNamespace()
 	name := restore.GetName()
@@ -229,7 +233,7 @@ func (rm *restoreManager) makeImportJob(restore *v1alpha1.Restore) (*batchv1.Job
 		})
 	}
 
-	restoreLabel := label.NewBackup().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
+	restoreLabel := label.NewRestore().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
 	serviceAccount := constants.DefaultServiceAccountName
 	if restore.Spec.ServiceAccount != "" {
 		serviceAccount = restore.Spec.ServiceAccount
@@ -338,7 +342,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		args = append(args, fmt.Sprintf("--tikvVersion=%s", tikvVersion))
 	}
 
-	restoreLabel := label.NewBackup().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
+	restoreLabel := label.NewRestore().Instance(restore.GetInstanceName()).RestoreJob().Restore(name)
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
 	if tc.IsTLSClusterEnabled() {
@@ -528,6 +532,10 @@ func (frm *FakeRestoreManager) SetSyncError(err error) {
 
 func (frm *FakeRestoreManager) Sync(_ *v1alpha1.Restore) error {
 	return frm.err
+}
+
+func (frm *FakeRestoreManager) UpdateCondition(_ *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
+	return nil
 }
 
 var _ backup.RestoreManager = &FakeRestoreManager{}

--- a/pkg/controller/backup/backup_control.go
+++ b/pkg/controller/backup/backup_control.go
@@ -124,6 +124,7 @@ var _ ControlInterface = &defaultBackupControl{}
 type FakeBackupControl struct {
 	backupIndexer       cache.Indexer
 	updateBackupTracker controller.RequestTracker
+	condition           *v1alpha1.BackupCondition
 }
 
 // NewFakeBackupControl returns a FakeBackupControl
@@ -131,6 +132,7 @@ func NewFakeBackupControl(backupInformer informers.BackupInformer) *FakeBackupCo
 	return &FakeBackupControl{
 		backupInformer.Informer().GetIndexer(),
 		controller.RequestTracker{},
+		nil,
 	}
 }
 
@@ -151,7 +153,8 @@ func (c *FakeBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
 }
 
 // UpdateCondition updates the condition for a Backup.
-func (c *FakeBackupControl) UpdateCondition(_ *v1alpha1.Backup, _ *v1alpha1.BackupCondition) error {
+func (c *FakeBackupControl) UpdateCondition(_ *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error {
+	c.condition = condition
 	return nil
 }
 

--- a/pkg/controller/backup/backup_control.go
+++ b/pkg/controller/backup/backup_control.go
@@ -32,6 +32,8 @@ import (
 type ControlInterface interface {
 	// UpdateBackup implements the control logic for backup job and backup clean job's creation, deletion
 	UpdateBackup(backup *v1alpha1.Backup) error
+	// UpdateCondition updates the condition for a Backup.
+	UpdateCondition(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error
 }
 
 // NewDefaultBackupControl returns a new instance of the default implementation BackupControlInterface that
@@ -62,6 +64,11 @@ func (c *defaultBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
 	}
 
 	return c.updateBackup(backup)
+}
+
+// UpdateCondition updates the condition for a Backup.
+func (c *defaultBackupControl) UpdateCondition(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition) error {
+	return c.backupManager.UpdateCondition(backup, condition)
 }
 
 func (c *defaultBackupControl) updateBackup(backup *v1alpha1.Backup) error {
@@ -141,6 +148,11 @@ func (c *FakeBackupControl) UpdateBackup(backup *v1alpha1.Backup) error {
 	}
 
 	return c.backupIndexer.Add(backup)
+}
+
+// UpdateCondition updates the condition for a Backup.
+func (c *FakeBackupControl) UpdateCondition(_ *v1alpha1.Backup, _ *v1alpha1.BackupCondition) error {
+	return nil
 }
 
 var _ ControlInterface = &FakeBackupControl{}

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -159,7 +159,7 @@ func (c *Controller) updateBackup(cur interface{}) {
 	}
 
 	if v1alpha1.IsBackupFailed(newBackup) {
-		klog.Infof("backup %s/%s is Failed, skipping.", ns, name)
+		klog.V(4).Infof("backup %s/%s is Failed, skipping.", ns, name)
 		return
 	}
 
@@ -186,11 +186,6 @@ func (c *Controller) updateBackup(cur interface{}) {
 			}
 		}
 		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing or Failed, skipping.", ns, name)
-		return
-	}
-
-	if v1alpha1.IsBackupScheduled(newBackup) {
-		klog.V(4).Infof("backup %s/%s is already Scheduled, skipping", ns, name)
 		return
 	}
 

--- a/pkg/controller/restore/restore_control.go
+++ b/pkg/controller/restore/restore_control.go
@@ -27,6 +27,8 @@ import (
 type ControlInterface interface {
 	// UpdateRestore implements the control logic for restore job creation, update, and deletion
 	UpdateRestore(restore *v1alpha1.Restore) error
+	// UpdateCondition updates the condition for a Restore.
+	UpdateCondition(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error
 }
 
 // NewDefaultRestoreControl returns a new instance of the default implementation RestoreControlInterface that
@@ -47,6 +49,11 @@ var _ ControlInterface = &defaultRestoreControl{}
 func (c *defaultRestoreControl) UpdateRestore(restore *v1alpha1.Restore) error {
 	restore.SetGroupVersionKind(controller.RestoreControllerKind)
 	return c.restoreManager.Sync(restore)
+}
+
+// UpdateCondition updates the condition for a Restore.
+func (c *defaultRestoreControl) UpdateCondition(restore *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
+	return c.restoreManager.UpdateCondition(restore, condition)
 }
 
 // FakeRestoreControl is a fake RestoreControlInterface
@@ -77,6 +84,11 @@ func (c *FakeRestoreControl) UpdateRestore(backup *v1alpha1.Restore) error {
 	}
 
 	return c.backupIndexer.Add(backup)
+}
+
+// UpdateCondition updates the condition for a Restore.
+func (c *FakeRestoreControl) UpdateCondition(_ *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
+	return nil
 }
 
 var _ ControlInterface = &FakeRestoreControl{}

--- a/pkg/controller/restore/restore_control.go
+++ b/pkg/controller/restore/restore_control.go
@@ -60,6 +60,7 @@ func (c *defaultRestoreControl) UpdateCondition(restore *v1alpha1.Restore, condi
 type FakeRestoreControl struct {
 	backupIndexer        cache.Indexer
 	updateRestoreTracker controller.RequestTracker
+	condition            *v1alpha1.RestoreCondition
 }
 
 // NewFakeRestoreControl returns a FakeRestoreControl
@@ -67,6 +68,7 @@ func NewFakeRestoreControl(restoreInformer informers.RestoreInformer) *FakeResto
 	return &FakeRestoreControl{
 		restoreInformer.Informer().GetIndexer(),
 		controller.RequestTracker{},
+		nil,
 	}
 }
 
@@ -87,7 +89,8 @@ func (c *FakeRestoreControl) UpdateRestore(backup *v1alpha1.Restore) error {
 }
 
 // UpdateCondition updates the condition for a Restore.
-func (c *FakeRestoreControl) UpdateCondition(_ *v1alpha1.Restore, _ *v1alpha1.RestoreCondition) error {
+func (c *FakeRestoreControl) UpdateCondition(_ *v1alpha1.Restore, condition *v1alpha1.RestoreCondition) error {
+	c.condition = condition
 	return nil
 }
 

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -178,6 +178,7 @@ func (c *Controller) updateRestore(cur interface{}) {
 			}
 		}
 		klog.V(4).Infof("restore %s/%s is already Scheduled, Running or Failed, skipping.", ns, name)
+		return
 	}
 
 	klog.V(4).Infof("restore object %s/%s enqueue", ns, name)

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -151,7 +151,7 @@ func (c *Controller) updateRestore(cur interface{}) {
 	}
 
 	if v1alpha1.IsRestoreFailed(newRestore) {
-		klog.Infof("restore %s/%s is Failed, skipping.", ns, name)
+		klog.V(4).Infof("restore %s/%s is Failed, skipping.", ns, name)
 		return
 	}
 
@@ -178,11 +178,6 @@ func (c *Controller) updateRestore(cur interface{}) {
 			}
 		}
 		klog.V(4).Infof("restore %s/%s is already Scheduled, Running or Failed, skipping.", ns, name)
-	}
-
-	if v1alpha1.IsRestoreScheduled(newRestore) {
-		klog.V(4).Infof("restore %s/%s is already Scheduled, skipping", ns, name)
-		return
 	}
 
 	klog.V(4).Infof("restore object %s/%s enqueue", ns, name)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

support cancel backup and restore jobs via signal.

fix #3675 

### What is changed and how does it work?

receive signal via `signal.Notify` and then cancel context for backup/restore processing.

**NOTE**: 

- Archive/Unarchive backuped data can still be blocked and killed, because no context supported yet.
- It seems that the job controller will re-create a new pod when the old one is evicted, ref https://github.com/kubernetes/kubernetes/issues/96363#issuecomment-745433925

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 --> (after introduced https://github.com/pingcap/failpoint, it should be easier to test)
    - test for cancel signal
        1. modify the code to inject waiting operations via `time.Sleep` or `<-ctx.Done()`
        2. `exec` into the backup/restore pod and send a signal via `kill -15 1`
        3. observe the status of the backup/restore job, somethings like bellow should be found.
            ```
            NAME           STATUS   BACKUPPATH   BACKUPSIZE   COMMITTS   AGE
            basic-backup   Failed                                        21s
        
            Status:
            Backup Path:           
            Backup Size:           0
            Backup Size Readable:  
            Commit Ts:             
            Conditions:
                Last Transition Time:  2021-01-12T08:01:26Z
                Message:               
                Reason:                
                Status:                True
                Type:                  Scheduled
                Last Transition Time:  2021-01-12T08:01:27Z
                Message:               
                Reason:                
                Status:                True
                Type:                  Running
                Last Transition Time:  2021-01-12T08:01:33Z
                Message:               cluster operator-dev/basic-backup, execute dumpling command [--output=/backup/operator-dev/backup-2021-01-12T08:01:33Z --host=basic-tidb --port=4000 --user=root --password= --filter *.* --filter !/^(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.* --threads=16 --rows=10000] failed, output: , err: context canceled
                Reason:                DumpTidbClusterFailed
                Status:                True
                Type:                  Failed
            Phase:                   Failed
            Time Completed:          <nil>
            Time Started:            <nil>
            Events:
            Type    Reason            Age   From                     Message
            ----    ------            ----  ----                     -------
            Normal  SuccessfulCreate  12s   tidb-controller-manager  create job operator-dev/backup-basic-backup for cluster basic-backup backup successful
            ```

    - test for failed pod
        1. modify the code to inject waiting operations via `return errors.New("xxxx")`
        2. observe the status of the backup/restore job, somethings like bellow should be found.
            ```
            Status:
            Commit Ts:
            Conditions:
                Last Transition Time:  2021-01-14T09:51:03Z
                Message:
                Reason:
                Status:                True
                Type:                  Scheduled
                Last Transition Time:  2021-01-14T09:51:05Z
                Message:
                Reason:
                Status:                True
                Type:                  Running
                Last Transition Time:  2021-01-14T09:51:31Z
                Message:               have failed pod restore-basic-restore-gqzl5
                Reason:                AlreadyFailed
                Status:                True
                Type:                  Failed
            Phase:                   Failed
            Time Completed:          <nil>
            Time Started:            <nil>
            Events:
            Type    Reason            Age   From                     Message
            ----    ------            ----  ----                     -------
            Normal  SuccessfulCreate  28m   tidb-controller-manager  create job operator-dev/restore-basic-restore for cluster basic-restore restore successful
            ````

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that the status of backup or restore is not `Failed` after the pod has been evicted or killed.
```
