### PR TITLE
add customizable controller rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/yisaer/crd-validation v0.0.3
 	gocloud.dev v0.18.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/yaml.v2 v2.2.4

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
@@ -38,7 +38,10 @@ func NewController(deps *controller.Dependencies) *Controller {
 	t := &Controller{
 		deps:    deps,
 		control: NewDefaultAutoScalerControl(autoscaler.NewAutoScalerManager(deps)),
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tidbclusterautoscaler"),
+		queue: workqueue.NewNamedRateLimitingQueue(
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
+			"tidbclusterautoscaler",
+		),
 	}
 	tidbAutoScalerInformer := deps.InformerFactory.Pingcap().V1alpha1().TidbClusterAutoScalers()
 	controller.WatchForObject(tidbAutoScalerInformer.Informer(), t.queue)

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -45,7 +45,7 @@ func NewController(deps *controller.Dependencies) *Controller {
 		deps:    deps,
 		control: NewDefaultBackupControl(deps.Clientset, backup.NewBackupManager(deps)),
 		queue: workqueue.NewNamedRateLimitingQueue(
-			workqueue.DefaultControllerRateLimiter(),
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
 			"backup",
 		),
 	}

--- a/pkg/controller/backupschedule/backup_schedule_controller.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller.go
@@ -45,7 +45,7 @@ func NewController(deps *controller.Dependencies) *Controller {
 		deps:    deps,
 		control: NewDefaultBackupScheduleControl(controller.NewRealBackupScheduleStatusUpdater(deps), backupschedule.NewBackupScheduleManager(deps)),
 		queue: workqueue.NewNamedRateLimitingQueue(
-			workqueue.DefaultControllerRateLimiter(),
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
 			"backupSchedule",
 		),
 	}

--- a/pkg/controller/dmcluster/dm_cluster_controller.go
+++ b/pkg/controller/dmcluster/dm_cluster_controller.go
@@ -58,7 +58,7 @@ func NewController(deps *controller.Dependencies) *Controller {
 			deps.Recorder,
 		),
 		queue: workqueue.NewNamedRateLimitingQueue(
-			workqueue.DefaultControllerRateLimiter(),
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
 			"dmcluster",
 		),
 	}

--- a/pkg/controller/rate_limiter.go
+++ b/pkg/controller/rate_limiter.go
@@ -1,3 +1,16 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controller
 
 import (

--- a/pkg/controller/rate_limiter.go
+++ b/pkg/controller/rate_limiter.go
@@ -1,0 +1,18 @@
+package controller
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	wq "k8s.io/client-go/util/workqueue"
+)
+
+// NewControllerRateLimiter returns a RateLimiter, which limit the request rate by the stricter one's desicion of two
+// RateLimiters: ItemExponentialFailureRateLimiter and BucketRateLimiter
+func NewControllerRateLimiter(baseDelay, maxDelay time.Duration) wq.RateLimiter {
+	return wq.NewMaxOfRateLimiter(
+		wq.NewItemExponentialFailureRateLimiter(baseDelay, maxDelay),
+		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
+		&wq.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+}

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -45,7 +45,7 @@ func NewController(deps *controller.Dependencies) *Controller {
 		deps:    deps,
 		control: NewDefaultRestoreControl(restore.NewRestoreManager(deps)),
 		queue: workqueue.NewNamedRateLimitingQueue(
-			workqueue.DefaultControllerRateLimiter(),
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
 			"restore",
 		),
 	}

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -64,7 +64,10 @@ func NewController(deps *controller.Dependencies) *Controller {
 			&tidbClusterConditionUpdater{},
 			deps.Recorder,
 		),
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tidbcluster"),
+		queue: workqueue.NewNamedRateLimitingQueue(
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
+			"tidbcluster",
+		),
 	}
 
 	tidbClusterInformer := deps.InformerFactory.Pingcap().V1alpha1().TidbClusters()

--- a/pkg/controller/tidbinitializer/tidb_initializer_controller.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_controller.go
@@ -43,7 +43,10 @@ func NewController(deps *controller.Dependencies) *Controller {
 	c := &Controller{
 		deps:    deps,
 		control: NewDefaultTidbInitializerControl(member.NewTiDBInitManager(deps)),
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tidbinitializer"),
+		queue: workqueue.NewNamedRateLimitingQueue(
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
+			"tidbinitializer",
+		),
 	}
 
 	tidbInitializerInformer := deps.InformerFactory.Pingcap().V1alpha1().TidbInitializers()

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -42,7 +42,10 @@ func NewController(deps *controller.Dependencies) *Controller {
 	c := &Controller{
 		deps:    deps,
 		control: NewDefaultTidbMonitorControl(deps, monitor.NewMonitorManager(deps)),
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tidbmonitor"),
+		queue: workqueue.NewNamedRateLimitingQueue(
+			controller.NewControllerRateLimiter(1*time.Second, 100*time.Second),
+			"tidbmonitor",
+		),
 	}
 
 	tidbMonitorInformer := deps.InformerFactory.Pingcap().V1alpha1().TidbMonitors()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
The current workqueue ratelimiter for controllers are using the default combination of `ItemExponentialFailureRateLimiter` and `BucketRateLimiter`. However the `ItemExponentialFailureRateLimiter` has a `baseDelay` of 5ms and `maxDelay` of 1000s, which is unrealistic.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
add a new controller rate limiter function, and default to `baseDelay=1s` and `maxDelay=100s`

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Optimize CR syncing intervals
```
