### PR TITLE
Tidbmonitor add `tidb_cluster `target label .

### DIFF
--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -401,6 +401,14 @@ func scrapeJob(jobName string, componentPattern config.Regexp, cmodel *MonitorCo
 					Action:      config.RelabelReplace,
 					TargetLabel: "component",
 				},
+				{
+					SourceLabels: model.LabelNames{
+						namespaceLabel,
+						instanceLabel,
+					},
+					Separator:   "-",
+					TargetLabel: "tidb_cluster",
+				},
 			},
 		}
 

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -84,6 +84,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tidb
   honor_labels: true
   scrape_interval: 15s
@@ -131,6 +134,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tikv
   honor_labels: true
   scrape_interval: 15s
@@ -178,6 +184,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tiflash
   honor_labels: true
   scrape_interval: 15s
@@ -225,6 +234,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tiflash-proxy
   honor_labels: true
   scrape_interval: 15s
@@ -272,6 +284,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-pump
   honor_labels: true
   scrape_interval: 15s
@@ -319,6 +334,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-drainer
   honor_labels: true
   scrape_interval: 15s
@@ -366,6 +384,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-ticdc
   honor_labels: true
   scrape_interval: 15s
@@ -413,6 +434,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-importer
   honor_labels: true
   scrape_interval: 15s
@@ -460,6 +484,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-lightning
   honor_labels: true
   scrape_interval: 15s
@@ -507,6 +534,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-dm-worker
   honor_labels: true
   scrape_interval: 15s
@@ -554,6 +584,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-dm-master
   honor_labels: true
   scrape_interval: 15s
@@ -601,6 +634,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 remote_write:
 - url: http://localhost:1234
   remote_timeout: 15s
@@ -707,6 +743,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tidb
   honor_labels: true
   scrape_interval: 15s
@@ -757,6 +796,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tikv
   honor_labels: true
   scrape_interval: 15s
@@ -807,6 +849,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tiflash
   honor_labels: true
   scrape_interval: 15s
@@ -857,6 +902,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-tiflash-proxy
   honor_labels: true
   scrape_interval: 15s
@@ -907,6 +955,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-pump
   honor_labels: true
   scrape_interval: 15s
@@ -957,6 +1008,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-drainer
   honor_labels: true
   scrape_interval: 15s
@@ -1007,6 +1061,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-ticdc
   honor_labels: true
   scrape_interval: 15s
@@ -1057,6 +1114,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-importer
   honor_labels: true
   scrape_interval: 15s
@@ -1107,6 +1167,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-lightning
   honor_labels: true
   scrape_interval: 15s
@@ -1154,6 +1217,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-dm-worker
   honor_labels: true
   scrape_interval: 15s
@@ -1204,6 +1270,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 - job_name: ns1-target-dm-master
   honor_labels: true
   scrape_interval: 15s
@@ -1254,6 +1323,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
     target_label: component
     action: replace
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    separator: '-'
+    target_label: tidb_cluster
 `
 	model := &MonitorConfigModel{
 		ClusterInfos: []ClusterRegexInfo{


### PR DESCRIPTION
### What is changed and how does it work?
Tidbmonitor add `tidb_cluster `target label to support multiple cluster monitor.


### Code changes

- [ ] Has Go code change

### Tests
- [ ] Unit test <!-- If you added any unit test cases, check this box -->



### Release Notes

```release-note
Add `tidb_cluster` label for the scrape jobs in TidbMonitor to support multiple clusters monitoring
```
