### PR TITLE
support print rocksdb log and raft log to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test:
 	@go test ./cmd/backup-manager/app/... ./pkg/... && echo -e "\nUnit tests run successfully!"
 endif
 
-ALL_CHECKS = EOF codegen terraform boilerplate openapi-spec crd-groups spelling
+ALL_CHECKS = EOF codegen boilerplate openapi-spec crd-groups spelling
 
 check: $(addprefix check-,$(ALL_CHECKS)) lint tidy 
 

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -17922,7 +17922,7 @@ Optional: Defaults to 3</p>
 </tr>
 <tr>
 <td>
-<code>separateRockDBLog</code></br>
+<code>separateRocksDBLog</code></br>
 <em>
 bool
 </em>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -13520,6 +13520,32 @@ TiDBSlowLogTailerSpec
 </tr>
 <tr>
 <td>
+<code>separateRockDBLog</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether output the RocksDB log in an separate sidecar container
+Optional: Defaults to true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>separateRaftLog</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether output the Raft log in an separate sidecar container
+Optional: Defaults to true</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tlsClient</code></br>
 <em>
 <a href="#tidbtlsclient">

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -17929,8 +17929,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Whether output the RocksDB log in an separate sidecar container
-Optional: Defaults to true</p>
+<p>Whether output the RocksDB log in a separate sidecar container
+Optional: Defaults to false</p>
 </td>
 </tr>
 <tr>
@@ -17942,8 +17942,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Whether output the Raft log in an separate sidecar container
-Optional: Defaults to true</p>
+<p>Whether output the Raft log in a separate sidecar container
+Optional: Defaults to false</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -6335,7 +6335,8 @@ uint32
 <h3 id="logtailerspec">LogTailerSpec</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#tiflashspec">TiFlashSpec</a>)
+<a href="#tiflashspec">TiFlashSpec</a>, 
+<a href="#tikvspec">TiKVSpec</a>)
 </p>
 <p>
 <p>LogTailerSpec represents an optional log tailer sidecar container</p>
@@ -13520,32 +13521,6 @@ TiDBSlowLogTailerSpec
 </tr>
 <tr>
 <td>
-<code>separateRockDBLog</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether output the RocksDB log in an separate sidecar container
-Optional: Defaults to true</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>separateRaftLog</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether output the Raft log in an separate sidecar container
-Optional: Defaults to true</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>tlsClient</code></br>
 <em>
 <a href="#tidbtlsclient">
@@ -17943,6 +17918,46 @@ int32
 <em>(Optional)</em>
 <p>MaxFailoverCount limit the max replicas could be added in failover, 0 means no failover
 Optional: Defaults to 3</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>separateRockDBLog</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether output the RocksDB log in an separate sidecar container
+Optional: Defaults to true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>separateRaftLog</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether output the Raft log in an separate sidecar container
+Optional: Defaults to true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logTailer</code></br>
+<em>
+<a href="#logtailerspec">
+LogTailerSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LogTailer is the configurations of the log tailers for TiKV</p>
 </td>
 </tr>
 <tr>

--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -462,8 +462,8 @@ spec:
     ## if enabled, the slow log will be shown in a separate sidecar container
     # separateSlowLog: true
     # slowLogVolumeName: ""
-    # # configures separate sidecar container, where `image` & `imagePullPolicy` will be overwritten by
-    # # the same field in `TidbCluster.helper`
+    ## configures separate sidecar container, where `image` & `imagePullPolicy` will be overwritten by
+    ## the same field in `TidbCluster.helper`
     # slowLogTailer:
     #   requests:
     #     cpu: 1000m
@@ -644,6 +644,21 @@ spec:
     ## Defaults to false
     ## Ref: https://docs.pingcap.com/tidb-in-kubernetes/stable/configure-a-tidb-cluster#mountclusterclientsecret
     mountClusterClientSecret: true
+
+    ## if enabled, the RocksDB log will be shown in a separate sidecar container
+    separateRocksDBLog: true
+
+    ## if enabled, the Raft log will be shown in a separate sidecar container
+    separateRaftLog: true
+
+    ## configures RocksDB/Raft log sidecar container resource requirements
+    # logTailer:
+    #   requests:
+    #     cpu: 1000m
+    #     memory: 1Gi
+    #   limits:
+    #     cpu: 2000m
+    #     memory: 2Gi
 
     ## The storageClassName of the persistent volume for TiKV data storage.
     # storageClassName: ""

--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -461,6 +461,7 @@ spec:
 
     ## if enabled, the slow log will be shown in a separate sidecar container
     # separateSlowLog: true
+    # slowLogVolumeName: ""
     # # configures separate sidecar container, where `image` & `imagePullPolicy` will be overwritten by
     # # the same field in `TidbCluster.helper`
     # slowLogTailer:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -8625,6 +8625,10 @@ spec:
                   type: object
                 schedulerName:
                   type: string
+                separateRaftLog:
+                  type: boolean
+                separateRockDBLog:
+                  type: boolean
                 separateSlowLog:
                   type: boolean
                 service:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -12777,7 +12777,7 @@ spec:
                   type: string
                 separateRaftLog:
                   type: boolean
-                separateRockDBLog:
+                separateRocksDBLog:
                   type: boolean
                 serviceAccount:
                   type: string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -8625,10 +8625,6 @@ spec:
                   type: object
                 schedulerName:
                   type: string
-                separateRaftLog:
-                  type: boolean
-                separateRockDBLog:
-                  type: boolean
                 separateSlowLog:
                   type: boolean
                 service:
@@ -12701,6 +12697,13 @@ spec:
                   type: array
                 limits:
                   type: object
+                logTailer:
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  type: object
                 maxFailoverCount:
                   format: int32
                   type: integer
@@ -12772,6 +12775,10 @@ spec:
                   type: object
                 schedulerName:
                   type: string
+                separateRaftLog:
+                  type: boolean
+                separateRockDBLog:
+                  type: boolean
                 serviceAccount:
                   type: string
                 statefulSetUpdateStrategy:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -7120,6 +7120,20 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiDBSlowLogTailerSpec"),
 						},
 					},
+					"separateRockDBLog": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether output the RocksDB log in an separate sidecar container Optional: Defaults to true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"separateRaftLog": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether output the Raft log in an separate sidecar container Optional: Defaults to true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"tlsClient": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether enable the TLS connection between the SQL client and TiDB server Optional: Defaults to nil",

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -9729,7 +9729,7 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 							Format:      "int32",
 						},
 					},
-					"separateRockDBLog": {
+					"separateRocksDBLog": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether output the RocksDB log in a separate sidecar container Optional: Defaults to false",
 							Type:        []string{"boolean"},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -9731,14 +9731,14 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 					},
 					"separateRockDBLog": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether output the RocksDB log in an separate sidecar container Optional: Defaults to true",
+							Description: "Whether output the RocksDB log in a separate sidecar container Optional: Defaults to false",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"separateRaftLog": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether output the Raft log in an separate sidecar container Optional: Defaults to true",
+							Description: "Whether output the Raft log in a separate sidecar container Optional: Defaults to false",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -7120,20 +7120,6 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiDBSlowLogTailerSpec"),
 						},
 					},
-					"separateRockDBLog": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Whether output the RocksDB log in an separate sidecar container Optional: Defaults to true",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
-					"separateRaftLog": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Whether output the Raft log in an separate sidecar container Optional: Defaults to true",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"tlsClient": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether enable the TLS connection between the SQL client and TiDB server Optional: Defaults to nil",
@@ -9743,6 +9729,26 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 							Format:      "int32",
 						},
 					},
+					"separateRockDBLog": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether output the RocksDB log in an separate sidecar container Optional: Defaults to true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"separateRaftLog": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether output the Raft log in an separate sidecar container Optional: Defaults to true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"logTailer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LogTailer is the configurations of the log tailers for TiKV",
+							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.LogTailerSpec"),
+						},
+					},
 					"storageClassName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The storageClassName of the persistent volume for TiKV data storage. Defaults to Kubernetes default storage class.",
@@ -9802,7 +9808,7 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.StorageVolume", "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVConfigWraper", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
+			"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.LogTailerSpec", "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.StorageVolume", "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.TiKVConfigWraper", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -31,15 +31,18 @@ const (
 	defaultTimeZone           = "UTC"
 	defaultExposeStatus       = true
 	defaultSeparateSlowLog    = true
-	defaultSeparateRocksDBLog = true
-	defaultSeparateRaftLog    = true
+	defaultSeparateRocksDBLog = false
+	defaultSeparateRaftLog    = false
 	defaultEnablePVReclaim    = false
 	// defaultEvictLeaderTimeout is the timeout limit of evict leader
 	defaultEvictLeaderTimeout = 3 * time.Minute
 )
 
 var (
-	defaultTailerSpec = TiDBSlowLogTailerSpec{
+	defaultSlowLogTailerSpec = TiDBSlowLogTailerSpec{
+		ResourceRequirements: corev1.ResourceRequirements{},
+	}
+	defaultLogTailerSpec = LogTailerSpec{
 		ResourceRequirements: corev1.ResourceRequirements{},
 	}
 	defaultHelperSpec = HelperSpec{}
@@ -620,25 +623,32 @@ func (tidb *TiDBSpec) ShouldSeparateSlowLog() bool {
 
 func (tidb *TiDBSpec) GetSlowLogTailerSpec() TiDBSlowLogTailerSpec {
 	if tidb.SlowLogTailer == nil {
-		return defaultTailerSpec
+		return defaultSlowLogTailerSpec
 	}
 	return *tidb.SlowLogTailer
 }
 
-func (tidb *TiDBSpec) ShouldSeparateRocksDBLog() bool {
-	separateRocksDBLog := tidb.SeparateSlowLog
+func (tikv *TiKVSpec) ShouldSeparateRocksDBLog() bool {
+	separateRocksDBLog := tikv.SeparateRocksDBLog
 	if separateRocksDBLog == nil {
 		return defaultSeparateRocksDBLog
 	}
 	return *separateRocksDBLog
 }
 
-func (tidb *TiDBSpec) ShouldSeparateRaftLog() bool {
-	separateRaftLog := tidb.SeparateRaftLog
+func (tikv *TiKVSpec) ShouldSeparateRaftLog() bool {
+	separateRaftLog := tikv.SeparateRaftLog
 	if separateRaftLog == nil {
 		return defaultSeparateRaftLog
 	}
 	return *separateRaftLog
+}
+
+func (tikv *TiKVSpec) GetLogTailerSpec() LogTailerSpec {
+	if tikv.LogTailer == nil {
+		return defaultLogTailerSpec
+	}
+	return *tikv.LogTailer
 }
 
 func (tidbSvc *TiDBServiceSpec) ShouldExposeStatus() bool {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -27,11 +27,13 @@ import (
 
 const (
 	// defaultHelperImage is default image of helper
-	defaultHelperImage     = "busybox:1.26.2"
-	defaultTimeZone        = "UTC"
-	defaultExposeStatus    = true
-	defaultSeparateSlowLog = true
-	defaultEnablePVReclaim = false
+	defaultHelperImage        = "busybox:1.26.2"
+	defaultTimeZone           = "UTC"
+	defaultExposeStatus       = true
+	defaultSeparateSlowLog    = true
+	defaultSeparateRocksDBLog = true
+	defaultSeparateRaftLog    = true
+	defaultEnablePVReclaim    = false
 	// defaultEvictLeaderTimeout is the timeout limit of evict leader
 	defaultEvictLeaderTimeout = 3 * time.Minute
 )
@@ -621,6 +623,22 @@ func (tidb *TiDBSpec) GetSlowLogTailerSpec() TiDBSlowLogTailerSpec {
 		return defaultTailerSpec
 	}
 	return *tidb.SlowLogTailer
+}
+
+func (tidb *TiDBSpec) ShouldSeparateRocksDBLog() bool {
+	separateRocksDBLog := tidb.SeparateSlowLog
+	if separateRocksDBLog == nil {
+		return defaultSeparateRocksDBLog
+	}
+	return *separateRocksDBLog
+}
+
+func (tidb *TiDBSpec) ShouldSeparateRaftLog() bool {
+	separateRaftLog := tidb.SeparateRaftLog
+	if separateRaftLog == nil {
+		return defaultSeparateRaftLog
+	}
+	return *separateRaftLog
 }
 
 func (tidbSvc *TiDBServiceSpec) ShouldExposeStatus() bool {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -421,7 +421,7 @@ type TiKVSpec struct {
 	// Whether output the RocksDB log in a separate sidecar container
 	// Optional: Defaults to false
 	// +optional
-	SeparateRocksDBLog *bool `json:"separateRockDBLog,omitempty"`
+	SeparateRocksDBLog *bool `json:"separateRocksDBLog,omitempty"`
 
 	// Whether output the Raft log in a separate sidecar container
 	// Optional: Defaults to false

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -418,6 +418,20 @@ type TiKVSpec struct {
 	// +optional
 	MaxFailoverCount *int32 `json:"maxFailoverCount,omitempty"`
 
+	// Whether output the RocksDB log in an separate sidecar container
+	// Optional: Defaults to true
+	// +optional
+	SeparateRocksDBLog *bool `json:"separateRockDBLog,omitempty"`
+
+	// Whether output the Raft log in an separate sidecar container
+	// Optional: Defaults to true
+	// +optional
+	SeparateRaftLog *bool `json:"separateRaftLog,omitempty"`
+
+	// LogTailer is the configurations of the log tailers for TiKV
+	// +optional
+	LogTailer *LogTailerSpec `json:"logTailer,omitempty"`
+
 	// The storageClassName of the persistent volume for TiKV data storage.
 	// Defaults to Kubernetes default storage class.
 	// +optional
@@ -615,16 +629,6 @@ type TiDBSpec struct {
 	// The specification of the slow log tailer sidecar
 	// +optional
 	SlowLogTailer *TiDBSlowLogTailerSpec `json:"slowLogTailer,omitempty"`
-
-	// Whether output the RocksDB log in an separate sidecar container
-	// Optional: Defaults to true
-	// +optional
-	SeparateRocksDBLog *bool `json:"separateRockDBLog,omitempty"`
-
-	// Whether output the Raft log in an separate sidecar container
-	// Optional: Defaults to true
-	// +optional
-	SeparateRaftLog *bool `json:"separateRaftLog,omitempty"`
 
 	// Whether enable the TLS connection between the SQL client and TiDB server
 	// Optional: Defaults to nil

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -62,7 +62,7 @@ const (
 	SlowLogTailerMemberType MemberType = "slowlog"
 	// RocksDBLogTailerMemberType is tikv rocksdb log tailer container type
 	RocksDBLogTailerMemberType MemberType = "rocksdblog"
-	// RaftLogTailerMemeberType is tikv raft log tailer container type
+	// RaftLogTailerMemberType is tikv raft log tailer container type
 	RaftLogTailerMemberType MemberType = "raftlog"
 	// TidbMonitorMemberType is tidbmonitor type
 	TidbMonitorMemberType MemberType = "tidbmonitor"

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -418,13 +418,13 @@ type TiKVSpec struct {
 	// +optional
 	MaxFailoverCount *int32 `json:"maxFailoverCount,omitempty"`
 
-	// Whether output the RocksDB log in an separate sidecar container
-	// Optional: Defaults to true
+	// Whether output the RocksDB log in a separate sidecar container
+	// Optional: Defaults to false
 	// +optional
 	SeparateRocksDBLog *bool `json:"separateRockDBLog,omitempty"`
 
-	// Whether output the Raft log in an separate sidecar container
-	// Optional: Defaults to true
+	// Whether output the Raft log in a separate sidecar container
+	// Optional: Defaults to false
 	// +optional
 	SeparateRaftLog *bool `json:"separateRaftLog,omitempty"`
 

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -58,8 +58,12 @@ const (
 	DMMasterMemberType MemberType = "dm-master"
 	// DMWorkerMemberType is dm-worker container type
 	DMWorkerMemberType MemberType = "dm-worker"
-	// SlowLogTailerMemberType is tidb log tailer container type
+	// SlowLogTailerMemberType is tidb slow log tailer container type
 	SlowLogTailerMemberType MemberType = "slowlog"
+	// RocksDBLogTailerMemberType is tikv rocksdb log tailer container type
+	RocksDBLogTailerMemberType MemberType = "rocksdblog"
+	// RaftLogTailerMemeberType is tikv raft log tailer container type
+	RaftLogTailerMemberType MemberType = "raftlog"
 	// TidbMonitorMemberType is tidbmonitor type
 	TidbMonitorMemberType MemberType = "tidbmonitor"
 	// UnknownMemberType is unknown container type
@@ -611,6 +615,16 @@ type TiDBSpec struct {
 	// The specification of the slow log tailer sidecar
 	// +optional
 	SlowLogTailer *TiDBSlowLogTailerSpec `json:"slowLogTailer,omitempty"`
+
+	// Whether output the RocksDB log in an separate sidecar container
+	// Optional: Defaults to true
+	// +optional
+	SeparateRocksDBLog *bool `json:"separateRockDBLog,omitempty"`
+
+	// Whether output the Raft log in an separate sidecar container
+	// Optional: Defaults to true
+	// +optional
+	SeparateRaftLog *bool `json:"separateRaftLog,omitempty"`
 
 	// Whether enable the TLS connection between the SQL client and TiDB server
 	// Optional: Defaults to nil

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -5133,6 +5133,16 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = new(TiDBSlowLogTailerSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SeparateRocksDBLog != nil {
+		in, out := &in.SeparateRocksDBLog, &out.SeparateRocksDBLog
+		*out = new(bool)
+		**out = **in
+	}
+	if in.SeparateRaftLog != nil {
+		in, out := &in.SeparateRaftLog, &out.SeparateRaftLog
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TLSClient != nil {
 		in, out := &in.TLSClient, &out.TLSClient
 		*out = new(TiDBTLSClient)

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -5133,16 +5133,6 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = new(TiDBSlowLogTailerSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SeparateRocksDBLog != nil {
-		in, out := &in.SeparateRocksDBLog, &out.SeparateRocksDBLog
-		*out = new(bool)
-		**out = **in
-	}
-	if in.SeparateRaftLog != nil {
-		in, out := &in.SeparateRaftLog, &out.SeparateRaftLog
-		*out = new(bool)
-		**out = **in
-	}
 	if in.TLSClient != nil {
 		in, out := &in.TLSClient, &out.TLSClient
 		*out = new(TiDBTLSClient)
@@ -7171,6 +7161,21 @@ func (in *TiKVSpec) DeepCopyInto(out *TiKVSpec) {
 		in, out := &in.MaxFailoverCount, &out.MaxFailoverCount
 		*out = new(int32)
 		**out = **in
+	}
+	if in.SeparateRocksDBLog != nil {
+		in, out := &in.SeparateRocksDBLog, &out.SeparateRocksDBLog
+		*out = new(bool)
+		**out = **in
+	}
+	if in.SeparateRaftLog != nil {
+		in, out := &in.SeparateRaftLog, &out.SeparateRaftLog
+		*out = new(bool)
+		**out = **in
+	}
+	if in.LogTailer != nil {
+		in, out := &in.LogTailer, &out.LogTailer
+		*out = new(LogTailerSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StorageClassName != nil {
 		in, out := &in.StorageClassName, &out.StorageClassName

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -438,17 +438,15 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	}
 
 	var containers []corev1.Container
-	if tc.Spec.TiDB.ShouldSeparateRocksDBLog() {
+	if tc.Spec.TiKV.ShouldSeparateRocksDBLog() {
 		// mount a shared volume and tail the RocksDB log to STDOUT using a sidecar.
 		rocksDBLogFilePath := path.Join(tikvDataVol.MountPath, "db/LOG")
 		containers = append(containers, corev1.Container{
 			Name:            v1alpha1.RocksDBLogTailerMemberType.String(),
 			Image:           tc.HelperImage(),
 			ImagePullPolicy: tc.HelperImagePullPolicy(),
-			// we can reuse the SlowLogTailerSpec here
-			// or maybe we should rename SlowLogTailerSpec to LogTailerSpec
-			Resources:    controller.ContainerResource(tc.Spec.TiDB.GetSlowLogTailerSpec().ResourceRequirements),
-			VolumeMounts: []corev1.VolumeMount{tikvDataVol},
+			Resources:       controller.ContainerResource(tc.Spec.TiKV.GetLogTailerSpec().ResourceRequirements),
+			VolumeMounts:    []corev1.VolumeMount{tikvDataVol},
 			Command: []string{
 				"sh",
 				"-c",
@@ -456,17 +454,15 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			},
 		})
 	}
-	if tc.Spec.TiDB.ShouldSeparateRaftLog() {
+	if tc.Spec.TiKV.ShouldSeparateRaftLog() {
 		// mount a shared volume and tail the Raft log to STDOUT using a sidecar.
 		raftLogFilePath := path.Join(tikvDataVol.MountPath, "raft/LOG")
 		containers = append(containers, corev1.Container{
 			Name:            v1alpha1.RaftLogTailerMemberType.String(),
 			Image:           tc.HelperImage(),
 			ImagePullPolicy: tc.HelperImagePullPolicy(),
-			// we can reuse the SlowLogTailerSpec here
-			// or maybe we should rename SlowLogTailerSpec to LogTailerSpec
-			Resources:    controller.ContainerResource(tc.Spec.TiDB.GetSlowLogTailerSpec().ResourceRequirements),
-			VolumeMounts: []corev1.VolumeMount{tikvDataVol},
+			Resources:       controller.ContainerResource(tc.Spec.TiKV.GetLogTailerSpec().ResourceRequirements),
+			VolumeMounts:    []corev1.VolumeMount{tikvDataVol},
 			Command: []string{
 				"sh",
 				"-c",

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -370,26 +370,9 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "enable separate RocksDB log on the fly",
+			name: "enable separate RocksDB and Raft log on the fly",
 			modify: func(tc *v1alpha1.TidbCluster) {
 				tc.Spec.TiKV.SeparateRocksDBLog = pointer.BoolPtr(true)
-			},
-			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
-			errWhenUpdateStatefulSet:     false,
-			errWhenUpdateTiKVPeerService: false,
-			errWhenGetStores:             false,
-			err:                          false,
-			expectTiKVPeerServiceFn:      nil,
-			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(set.Spec.Template.Spec.Containers).To(HaveLen(2))
-			},
-			expectTidbClusterFn: nil,
-		},
-		{
-			name: "enable separate Raft log on the fly",
-			modify: func(tc *v1alpha1.TidbCluster) {
 				tc.Spec.TiKV.SeparateRaftLog = pointer.BoolPtr(true)
 			},
 			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
@@ -401,7 +384,7 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			expectTiKVPeerServiceFn:      nil,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(set.Spec.Template.Spec.Containers).To(HaveLen(2))
+				g.Expect(set.Spec.Template.Spec.Containers).To(HaveLen(3))
 			},
 			expectTidbClusterFn: nil,
 		},

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -369,6 +369,42 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 				g.Expect(len(tc.Status.TiKV.Stores)).To(Equal(0))
 			},
 		},
+		{
+			name: "enable separate RocksDB log on the fly",
+			modify: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.TiKV.SeparateRocksDBLog = pointer.BoolPtr(true)
+			},
+			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
+			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
+			errWhenUpdateStatefulSet:     false,
+			errWhenUpdateTiKVPeerService: false,
+			errWhenGetStores:             false,
+			err:                          false,
+			expectTiKVPeerServiceFn:      nil,
+			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(set.Spec.Template.Spec.Containers).To(HaveLen(2))
+			},
+			expectTidbClusterFn: nil,
+		},
+		{
+			name: "enable separate Raft log on the fly",
+			modify: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.TiKV.SeparateRaftLog = pointer.BoolPtr(true)
+			},
+			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
+			tombstoneStores:              &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
+			errWhenUpdateStatefulSet:     false,
+			errWhenUpdateTiKVPeerService: false,
+			errWhenGetStores:             false,
+			err:                          false,
+			expectTiKVPeerServiceFn:      nil,
+			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(set.Spec.Template.Spec.Containers).To(HaveLen(2))
+			},
+			expectTidbClusterFn: nil,
+		},
 	}
 
 	for i := range tests {

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -142,6 +142,9 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					tc.Spec.TiDB.Replicas = 1
 					tc.Spec.TiKV.SeparateRocksDBLog = pointer.BoolPtr(true)
 					tc.Spec.TiKV.SeparateRaftLog = pointer.BoolPtr(true)
+					tc.Spec.TiKV.LogTailer = &v1alpha1.LogTailerSpec{
+						ResourceRequirements: corev1.ResourceRequirements{},
+					}
 					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)
 					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 30*time.Second)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -143,7 +143,16 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					tc.Spec.TiKV.SeparateRocksDBLog = pointer.BoolPtr(true)
 					tc.Spec.TiKV.SeparateRaftLog = pointer.BoolPtr(true)
 					tc.Spec.TiKV.LogTailer = &v1alpha1.LogTailerSpec{
-						ResourceRequirements: corev1.ResourceRequirements{},
+						ResourceRequirements: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
 					}
 					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -140,6 +140,8 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					ginkgo.By("Deploy a basic tc")
 					tc := fixture.GetTidbCluster(ns, fmt.Sprintf("basic-%s", versionDashed), version)
 					tc.Spec.TiDB.Replicas = 1
+					tc.Spec.TiKV.SeparateRocksDBLog = pointer.BoolPtr(true)
+					tc.Spec.TiKV.SeparateRaftLog = pointer.BoolPtr(true)
 					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)
 					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 30*time.Second)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Currently, we can't query RocksDB log and Raft log in the grafana, because they are not collected by loki.

This PR is designed to support collect them by loki and can be queried in the grafana.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Similar to how we collect TiDB slow log, we use sidecar containers to mount RocksDB and Raft log files and print them in the stdout of the individual container.

Related doc which added in this PR: https://github.com/tidbcloud/infra/pull/621

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
- Print RocksDB and Raft log to stdout to support them be collected and queried in the grafana
```

---

Manual Test Steps:

1. Deploy a default basic cluster

   ```
   > kubectl apply -f examples/basic/tidb-cluster.yaml
   ```

2. Describe pod/basic-tikv-0, only one container tikv

   ```
   > kubectl describe pod/basic-tikv-0
    Containers:
      tikv:
        Container ID:  containerd://3dc2fb0983570374b44081b6d43444ba3dae00b72c15a4c16a6eac14e1f8afcb
        Image:         pingcap/tikv:v4.0.10
        ...
   ```

3. Edit `examples/basic/tidb-cluster.yaml`

   ```
    tikv:
      ...
      separateRocksDBLog: true
      separateRaftLog: true
      logTailer:
        requests:
          cpu: 100m
          memory: 100Mi
        limits:
          cpu: 100m
          memory: 100Mi
   ```

4. Apply

   ```
   > kubectl apply -f examples/basic/tidb-cluster.yaml
   ```

5. Describe pod/basic-tikv-0, now have three containers: rocksdblog, raftlog, tikv

   ```
   > kubectl describe pod/basic-tikv-0
   ...
    Events:
      Type    Reason     Age        From                         Message
      ----    ------     ----       ----                         -------
      Normal  Scheduled  <unknown>                               Successfully assigned pingcap/basic-tikv-0 to kind-control-plane
      Normal  Pulled     9m21s      kubelet, kind-control-plane  Container image "busybox:1.26.2" already present on machine
      Normal  Created    9m21s      kubelet, kind-control-plane  Created container rocksdblog
      Normal  Started    9m21s      kubelet, kind-control-plane  Started container rocksdblog
      Normal  Pulled     9m21s      kubelet, kind-control-plane  Container image "busybox:1.26.2" already present on machine
      Normal  Created    9m21s      kubelet, kind-control-plane  Created container raftlog
      Normal  Started    9m21s      kubelet, kind-control-plane  Started container raftlog
      Normal  Pulled     9m21s      kubelet, kind-control-plane  Container image "pingcap/tikv:v4.0.10" already present on machine
      Normal  Created    9m21s      kubelet, kind-control-plane  Created container tikv
      Normal  Started    9m21s      kubelet, kind-control-plane  Started container tikv   
     ```
6. View log

   ```
    > kubectl logs pod/basic-tikv-0 -c rocksdblog | less
    touch: /var/lib/tikv/db/LOG: No such file or directory
    tail: can't open '/var/lib/tikv/db/LOG': No such file or directory
    tail: /var/lib/tikv/db/LOG has appeared; following end of new file
    2021/02/03-09:25:02.845699 7fd9c11be580 RocksDB version: 6.4.6
    2021/02/03-09:25:02.845830 7fd9c11be580 Git sha rocksdb_build_git_sha:@448a2c9be88ee1348d2194bd5bcd5c563a83d7d6@
    2021/02/03-09:25:02.845851 7fd9c11be580 Compile date Jan 15 2021
    2021/02/03-09:25:02.845867 7fd9c11be580 DB SUMMARY
    ...
   ```

7. pod/basic-tikv-0 spec:

   ```yaml
    spec:
      containers:
      - command:
        - sh
        - -c
        - touch /var/lib/tikv/db/LOG; tail -n0 -F /var/lib/tikv/db/LOG;
        image: busybox:1.26.2
        imagePullPolicy: IfNotPresent
        name: rocksdblog
        resources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
            cpu: 100m
            memory: 100Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /var/lib/tikv
          name: tikv
        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          name: default-token-c4t2c
          readOnly: true
      - command:
        - sh
        - -c
        - touch /var/lib/tikv/raft/LOG; tail -n0 -F /var/lib/tikv/raft/LOG;
        image: busybox:1.26.2
        imagePullPolicy: IfNotPresent
        name: raftlog
        resources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
            cpu: 100m
            memory: 100Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /var/lib/tikv
          name: tikv
        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          name: default-token-c4t2c
          readOnly: true
      - command:
        - /bin/sh
        - /usr/local/bin/tikv_start_script.sh
        env:
        - name: NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: CLUSTER_NAME
          value: basic
        - name: HEADLESS_SERVICE_NAME
          value: basic-tikv-peer
        - name: CAPACITY
          value: "0"
        - name: TZ
          value: UTC
        image: pingcap/tikv:v4.0.10
        imagePullPolicy: IfNotPresent
        name: tikv
        ports:
        - containerPort: 20160
          name: server
          protocol: TCP
        resources: {}
        securityContext:
          privileged: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /etc/podinfo
          name: annotations
          readOnly: true
        - mountPath: /var/lib/tikv
          name: tikv
        - mountPath: /etc/tikv
          name: config
          readOnly: true
        - mountPath: /usr/local/bin
          name: startup-script
          readOnly: true
        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          name: default-token-c4t2c
          readOnly: true
   ```
