### PR TITLE
e2e: refactor tidb version

### DIFF
--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -146,11 +146,11 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			oa.CleanCRDOrDie()
 		})
 
-		ginkgo.It(fmt.Sprintf("should be able to upgrade TiDB Cluster from %s to %s", utilimage.TiDBV3Version, utilimage.TiDBV3UpgradeVersion), func() {
+		ginkgo.It(fmt.Sprintf("should be able to upgrade TiDB Cluster from %s to %s", utilimage.TiDBV4Version, utilimage.TiDBV4UpgradeVersion), func() {
 			log.Logf("start to upgrade tidbcluster with pod admission webhook")
 			// deploy new cluster and test upgrade and scale-in/out with pod admission webhook
-			ginkgo.By(fmt.Sprintf("start initial TidbCluster %q", utilimage.TiDBV3Version))
-			tc := fixture.GetTidbCluster(ns, "admission", utilimage.TiDBV3Version)
+			ginkgo.By(fmt.Sprintf("start initial TidbCluster %q", utilimage.TiDBV4Version))
+			tc := fixture.GetTidbCluster(ns, "admission", utilimage.TiDBV4Version)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 3
 			tc.Spec.TiDB.Replicas = 2
@@ -163,25 +163,25 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			err = setPartitionAnnotation(ns, tc.Name, label.TiKVLabelVal, 1)
 			framework.ExpectNoError(err, "set tikv Partition annotation failed")
 
-			ginkgo.By(fmt.Sprintf("Upgrade TidbCluster version to %q", utilimage.TiDBV3UpgradeVersion))
+			ginkgo.By(fmt.Sprintf("Upgrade TidbCluster version to %q", utilimage.TiDBV4UpgradeVersion))
 			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-				tc.Spec.Version = utilimage.TiDBV3UpgradeVersion
+				tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
 				return nil
 			})
-			framework.ExpectNoError(err, "failed to update TidbCluster to upgrade tidb version to %v", utilimage.TiDBV3UpgradeVersion)
+			framework.ExpectNoError(err, "failed to update TidbCluster to upgrade tidb version to %v", utilimage.TiDBV4UpgradeVersion)
 
-			ginkgo.By(fmt.Sprintf("wait for tikv-1 pod upgrading to %q", utilimage.TiDBV3UpgradeVersion))
+			ginkgo.By(fmt.Sprintf("wait for tikv-1 pod upgrading to %q", utilimage.TiDBV4UpgradeVersion))
 			err = wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
 				tikvPod, err := c.CoreV1().Pods(ns).Get(fmt.Sprintf("%s-tikv-1", tc.Name), metav1.GetOptions{})
 				if err != nil {
 					return false, nil
 				}
-				if tikvPod.Spec.Containers[0].Image != fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV3UpgradeVersion) {
+				if tikvPod.Spec.Containers[0].Image != fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion) {
 					return false, nil
 				}
 				return true, nil
 			})
-			framework.ExpectNoError(err, "failed to upgrade tikv-1 to %q", utilimage.TiDBV3UpgradeVersion)
+			framework.ExpectNoError(err, "failed to upgrade tikv-1 to %q", utilimage.TiDBV4UpgradeVersion)
 
 			ginkgo.By("Wait to see if tikv sts partition annotation remains 1 for 3 min")
 			// TODO: explain the purpose of this testing
@@ -259,13 +259,13 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					TiDB: &v1alpha1.TiDBSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 					},
 					TiKV: &v1alpha1.TiKVSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					PD: &v1alpha1.PDSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			oa.UpgradeOperatorOrDie(ocfg)
 			// now the webhook enabled
 			err = controller.GuaranteedUpdate(genericCli, legacyTc, func() error {
-				legacyTc.Spec.TiDB.Image = fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3UpgradeVersion)
+				legacyTc.Spec.TiDB.Image = fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion)
 				return nil
 			})
 			framework.ExpectNoError(err, "Update legacy TidbCluster should not be influenced by validating")
@@ -307,7 +307,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 				legacyTc.Spec.TiDB.BaseImage = "pingcap/tidb"
 				legacyTc.Spec.TiKV.BaseImage = "pingcap/tikv"
 				legacyTc.Spec.PD.BaseImage = "pingcap/pd"
-				legacyTc.Spec.PD.Version = pointer.StringPtr(utilimage.TiDBV3Version)
+				legacyTc.Spec.PD.Version = pointer.StringPtr(utilimage.TiDBV4UpgradeVersion)
 				return nil
 			})
 			framework.ExpectNoError(err, "failed to update TidbCluster")
@@ -330,12 +330,12 @@ var _ = ginkgo.Describe("[Serial]", func() {
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: &v1alpha1.TiDBSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 					},
 					TiKV: &v1alpha1.TiKVSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					},
 					PD: &v1alpha1.PDSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV3Version),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4UpgradeVersion),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -365,7 +365,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					Name:      "newly-created",
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: utilimage.TiDBV3Version,
+					Version: utilimage.TiDBV4UpgradeVersion,
 					TiDB: &v1alpha1.TiDBSpec{
 						Replicas: 1,
 					},
@@ -445,9 +445,9 @@ var _ = ginkgo.Describe("[Serial]", func() {
 		})
 
 		ginkgo.It("should not change old TidbCluster", func() {
-			ginkgo.By(fmt.Sprintf("deploy original tc %q", utilimage.TiDBV3Version))
+			ginkgo.By(fmt.Sprintf("deploy original tc %q", utilimage.TiDBV4UpgradeVersion))
 			tcName := "tidbcluster"
-			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV3Version)
+			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4UpgradeVersion)
 			tcCfg.Resources["pd.replicas"] = "3"
 			tcCfg.Resources["tikv.replicas"] = "3"
 			tcCfg.Resources["tidb.replicas"] = "1"
@@ -618,7 +618,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			// TODO: resolve the duplication
 			framework.Skipf("duplicated test")
 			tcName := "basic"
-			cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV3Version)
+			cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4UpgradeVersion)
 			cluster.Resources["pd.replicas"] = "1"
 			cluster.Resources["tikv.replicas"] = "1"
 			cluster.Resources["tidb.replicas"] = "1"

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -259,13 +259,13 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					TiDB: &v1alpha1.TiDBSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4Prev),
 						},
 					},
 					TiKV: &v1alpha1.TiKVSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4Prev),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					PD: &v1alpha1.PDSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4Prev),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{

--- a/tests/e2e/tidbcluster/serial.go
+++ b/tests/e2e/tidbcluster/serial.go
@@ -146,11 +146,11 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			oa.CleanCRDOrDie()
 		})
 
-		ginkgo.It(fmt.Sprintf("should be able to upgrade TiDB Cluster from %s to %s", utilimage.TiDBV4Version, utilimage.TiDBV4UpgradeVersion), func() {
+		ginkgo.It(fmt.Sprintf("should be able to upgrade TiDB Cluster from %s to %s", utilimage.TiDBV4Prev, utilimage.TiDBV4), func() {
 			log.Logf("start to upgrade tidbcluster with pod admission webhook")
 			// deploy new cluster and test upgrade and scale-in/out with pod admission webhook
-			ginkgo.By(fmt.Sprintf("start initial TidbCluster %q", utilimage.TiDBV4Version))
-			tc := fixture.GetTidbCluster(ns, "admission", utilimage.TiDBV4Version)
+			ginkgo.By(fmt.Sprintf("start initial TidbCluster %q", utilimage.TiDBV4Prev))
+			tc := fixture.GetTidbCluster(ns, "admission", utilimage.TiDBV4Prev)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 3
 			tc.Spec.TiDB.Replicas = 2
@@ -163,25 +163,25 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			err = setPartitionAnnotation(ns, tc.Name, label.TiKVLabelVal, 1)
 			framework.ExpectNoError(err, "set tikv Partition annotation failed")
 
-			ginkgo.By(fmt.Sprintf("Upgrade TidbCluster version to %q", utilimage.TiDBV4UpgradeVersion))
+			ginkgo.By(fmt.Sprintf("Upgrade TidbCluster version to %q", utilimage.TiDBV4))
 			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-				tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
+				tc.Spec.Version = utilimage.TiDBV4
 				return nil
 			})
-			framework.ExpectNoError(err, "failed to update TidbCluster to upgrade tidb version to %v", utilimage.TiDBV4UpgradeVersion)
+			framework.ExpectNoError(err, "failed to update TidbCluster to upgrade tidb version to %v", utilimage.TiDBV4)
 
-			ginkgo.By(fmt.Sprintf("wait for tikv-1 pod upgrading to %q", utilimage.TiDBV4UpgradeVersion))
+			ginkgo.By(fmt.Sprintf("wait for tikv-1 pod upgrading to %q", utilimage.TiDBV4))
 			err = wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
 				tikvPod, err := c.CoreV1().Pods(ns).Get(fmt.Sprintf("%s-tikv-1", tc.Name), metav1.GetOptions{})
 				if err != nil {
 					return false, nil
 				}
-				if tikvPod.Spec.Containers[0].Image != fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion) {
+				if tikvPod.Spec.Containers[0].Image != fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4) {
 					return false, nil
 				}
 				return true, nil
 			})
-			framework.ExpectNoError(err, "failed to upgrade tikv-1 to %q", utilimage.TiDBV4UpgradeVersion)
+			framework.ExpectNoError(err, "failed to upgrade tikv-1 to %q", utilimage.TiDBV4)
 
 			ginkgo.By("Wait to see if tikv sts partition annotation remains 1 for 3 min")
 			// TODO: explain the purpose of this testing
@@ -259,13 +259,13 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					TiDB: &v1alpha1.TiDBSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4),
 						},
 					},
 					TiKV: &v1alpha1.TiKVSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					PD: &v1alpha1.PDSpec{
 						Replicas: 1,
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			oa.UpgradeOperatorOrDie(ocfg)
 			// now the webhook enabled
 			err = controller.GuaranteedUpdate(genericCli, legacyTc, func() error {
-				legacyTc.Spec.TiDB.Image = fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion)
+				legacyTc.Spec.TiDB.Image = fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4)
 				return nil
 			})
 			framework.ExpectNoError(err, "Update legacy TidbCluster should not be influenced by validating")
@@ -307,7 +307,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 				legacyTc.Spec.TiDB.BaseImage = "pingcap/tidb"
 				legacyTc.Spec.TiKV.BaseImage = "pingcap/tikv"
 				legacyTc.Spec.PD.BaseImage = "pingcap/pd"
-				legacyTc.Spec.PD.Version = pointer.StringPtr(utilimage.TiDBV4UpgradeVersion)
+				legacyTc.Spec.PD.Version = pointer.StringPtr(utilimage.TiDBV4)
 				return nil
 			})
 			framework.ExpectNoError(err, "failed to update TidbCluster")
@@ -330,12 +330,12 @@ var _ = ginkgo.Describe("[Serial]", func() {
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: &v1alpha1.TiDBSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/tidb:%s", utilimage.TiDBV4),
 						},
 					},
 					TiKV: &v1alpha1.TiKVSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/tikv:%s", utilimage.TiDBV4),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					},
 					PD: &v1alpha1.PDSpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
-							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4UpgradeVersion),
+							Image: fmt.Sprintf("pingcap/pd:%s", utilimage.TiDBV4),
 						},
 						ResourceRequirements: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -365,7 +365,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 					Name:      "newly-created",
 				},
 				Spec: v1alpha1.TidbClusterSpec{
-					Version: utilimage.TiDBV4UpgradeVersion,
+					Version: utilimage.TiDBV4,
 					TiDB: &v1alpha1.TiDBSpec{
 						Replicas: 1,
 					},
@@ -445,9 +445,9 @@ var _ = ginkgo.Describe("[Serial]", func() {
 		})
 
 		ginkgo.It("should not change old TidbCluster", func() {
-			ginkgo.By(fmt.Sprintf("deploy original tc %q", utilimage.TiDBV4UpgradeVersion))
+			ginkgo.By(fmt.Sprintf("deploy original tc %q", utilimage.TiDBV4))
 			tcName := "tidbcluster"
-			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4UpgradeVersion)
+			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4)
 			tcCfg.Resources["pd.replicas"] = "3"
 			tcCfg.Resources["tikv.replicas"] = "3"
 			tcCfg.Resources["tidb.replicas"] = "1"
@@ -525,7 +525,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 		ginkgo.It("should migrate tidbmonitor from deployment to sts", func() {
 			ginkgo.By("deploy initial tc")
 			tcName := "smooth-tidbcluster"
-			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "admin", utilimage.TiDBV4UpgradeVersion)
+			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "admin", utilimage.TiDBV4)
 			tcCfg.Resources["pd.replicas"] = "3"
 			tcCfg.Resources["tikv.replicas"] = "3"
 			tcCfg.Resources["tidb.replicas"] = "1"
@@ -618,7 +618,7 @@ var _ = ginkgo.Describe("[Serial]", func() {
 			// TODO: resolve the duplication
 			framework.Skipf("duplicated test")
 			tcName := "basic"
-			cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4UpgradeVersion)
+			cluster := newTidbClusterConfig(e2econfig.TestConfig, ns, tcName, "", utilimage.TiDBV4)
 			cluster.Resources["pd.replicas"] = "1"
 			cluster.Resources["tikv.replicas"] = "1"
 			cluster.Resources["tidb.replicas"] = "1"

--- a/tests/e2e/tidbcluster/stability-asts.go
+++ b/tests/e2e/tidbcluster/stability-asts.go
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			oa.CleanCRDOrDie()
 		}()
 
-		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV4)
+		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV4Prev)
 		tc.Spec.PD.Replicas = 5
 		tc.Spec.TiKV.Replicas = 4
 		tc.Spec.TiDB.Replicas = 3
@@ -467,12 +467,12 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
 		framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %v", tc)
 
-		ginkgo.By("Upgrding the cluster")
+		ginkgo.By("Upgrading the cluster")
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
 			tc.Spec.Version = utilimage.TiDBV4
 			return nil
 		})
-		framework.ExpectNoError(err, "failed to update TidbCluster %s/%s", ns, tc.Name)
+		framework.ExpectNoError(err, "failed to upgrade TidbCluster %s/%s", ns, tc.Name)
 		ginkgo.By("Checking for tidb cluster is ready")
 		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
 		framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %v", tc)

--- a/tests/e2e/tidbcluster/stability-asts.go
+++ b/tests/e2e/tidbcluster/stability-asts.go
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 		ginkgo.It("Scaling tidb cluster with advanced statefulset", func() {
 			clusterName := "scaling-with-asts"
-			tc := fixture.GetTidbClusterWithTiFlash(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbClusterWithTiFlash(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 5
 			tc.Spec.TiDB.Replicas = 5
@@ -346,7 +346,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			oa.CleanCRDOrDie()
 		}()
 
-		tc := fixture.GetTidbCluster(ns, "sts", utilimage.TiDBV4UpgradeVersion)
+		tc := fixture.GetTidbCluster(ns, "sts", utilimage.TiDBV4)
 		err = genericCli.Create(context.TODO(), tc)
 		framework.ExpectNoError(err, "failed to create TidbCluster: %v", tc)
 		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			oa.CleanCRDOrDie()
 		}()
 
-		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV4UpgradeVersion)
+		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV4)
 		tc.Spec.PD.Replicas = 5
 		tc.Spec.TiKV.Replicas = 4
 		tc.Spec.TiDB.Replicas = 3
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 		ginkgo.By("Upgrding the cluster")
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
+			tc.Spec.Version = utilimage.TiDBV4
 			return nil
 		})
 		framework.ExpectNoError(err, "failed to update TidbCluster %s/%s", ns, tc.Name)

--- a/tests/e2e/tidbcluster/stability-asts.go
+++ b/tests/e2e/tidbcluster/stability-asts.go
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 		ginkgo.It("Scaling tidb cluster with advanced statefulset", func() {
 			clusterName := "scaling-with-asts"
-			tc := fixture.GetTidbClusterWithTiFlash(ns, clusterName, utilimage.TiDBV4Version)
+			tc := fixture.GetTidbClusterWithTiFlash(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 5
 			tc.Spec.TiDB.Replicas = 5
@@ -346,7 +346,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			oa.CleanCRDOrDie()
 		}()
 
-		tc := fixture.GetTidbCluster(ns, "sts", utilimage.TiDBV3Version)
+		tc := fixture.GetTidbCluster(ns, "sts", utilimage.TiDBV4UpgradeVersion)
 		err = genericCli.Create(context.TODO(), tc)
 		framework.ExpectNoError(err, "failed to create TidbCluster: %v", tc)
 		err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			oa.CleanCRDOrDie()
 		}()
 
-		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV3Version)
+		tc := fixture.GetTidbCluster(ns, "upgrade-cluster", utilimage.TiDBV4UpgradeVersion)
 		tc.Spec.PD.Replicas = 5
 		tc.Spec.TiKV.Replicas = 4
 		tc.Spec.TiDB.Replicas = 3
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 		ginkgo.By("Upgrding the cluster")
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = utilimage.TiDBV3UpgradeVersion
+			tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
 			return nil
 		})
 		framework.ExpectNoError(err, "failed to update TidbCluster %s/%s", ns, tc.Name)

--- a/tests/e2e/tidbcluster/stability-br.go
+++ b/tests/e2e/tidbcluster/stability-br.go
@@ -196,7 +196,7 @@ func testBR(provider, ns string, fw portforward.PortForward, c clientset.Interfa
 	}
 
 	// create backup cluster
-	tcFrom := fixture.GetTidbCluster(ns, tcNameFrom, utilimage.TiDBV4UpgradeVersion)
+	tcFrom := fixture.GetTidbCluster(ns, tcNameFrom, utilimage.TiDBV4)
 	tcFrom.Spec.PD.Replicas = 1
 	tcFrom.Spec.TiKV.Replicas = 1
 	tcFrom.Spec.TiDB.Replicas = 1
@@ -207,7 +207,7 @@ func testBR(provider, ns string, fw portforward.PortForward, c clientset.Interfa
 	framework.ExpectNoError(err, "failed to create TidbCluster tcFrom: %v", tcFrom)
 
 	// create restore cluster
-	tcTo := fixture.GetTidbCluster(ns, tcNameTo, utilimage.TiDBV4UpgradeVersion)
+	tcTo := fixture.GetTidbCluster(ns, tcNameTo, utilimage.TiDBV4)
 	tcTo.Spec.PD.Replicas = 1
 	tcTo.Spec.TiKV.Replicas = 1
 	tcTo.Spec.TiDB.Replicas = 1
@@ -220,11 +220,11 @@ func testBR(provider, ns string, fw portforward.PortForward, c clientset.Interfa
 	// wait both tidbcluster ready
 	err = oa.WaitForTidbClusterReady(tcFrom, 30*time.Minute, 15*time.Second)
 	framework.ExpectNoError(err, "failed to wait for TidbCluster tcFrom ready")
-	clusterFrom := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameFrom, "", utilimage.TiDBV4UpgradeVersion)
+	clusterFrom := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameFrom, "", utilimage.TiDBV4)
 
 	err = oa.WaitForTidbClusterReady(tcTo, 30*time.Minute, 15*time.Second)
 	framework.ExpectNoError(err, "failed to wait for TidbCluster tcTo ready")
-	clusterTo := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameTo, "", utilimage.TiDBV4UpgradeVersion)
+	clusterTo := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameTo, "", utilimage.TiDBV4)
 
 	// import some data to sql with blockwriter
 	ginkgo.By(fmt.Sprintf("Begin inserting data into cluster %q", clusterFrom.ClusterName))

--- a/tests/e2e/tidbcluster/stability-br.go
+++ b/tests/e2e/tidbcluster/stability-br.go
@@ -207,7 +207,7 @@ func testBR(provider, ns string, fw portforward.PortForward, c clientset.Interfa
 	framework.ExpectNoError(err, "failed to create TidbCluster tcFrom: %v", tcFrom)
 
 	// create restore cluster
-	tcTo := fixture.GetTidbCluster(ns, tcNameTo, utilimage.TiDBV4Version)
+	tcTo := fixture.GetTidbCluster(ns, tcNameTo, utilimage.TiDBV4UpgradeVersion)
 	tcTo.Spec.PD.Replicas = 1
 	tcTo.Spec.TiKV.Replicas = 1
 	tcTo.Spec.TiDB.Replicas = 1
@@ -220,11 +220,11 @@ func testBR(provider, ns string, fw portforward.PortForward, c clientset.Interfa
 	// wait both tidbcluster ready
 	err = oa.WaitForTidbClusterReady(tcFrom, 30*time.Minute, 15*time.Second)
 	framework.ExpectNoError(err, "failed to wait for TidbCluster tcFrom ready")
-	clusterFrom := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameFrom, "", utilimage.TiDBV4Version)
+	clusterFrom := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameFrom, "", utilimage.TiDBV4UpgradeVersion)
 
 	err = oa.WaitForTidbClusterReady(tcTo, 30*time.Minute, 15*time.Second)
 	framework.ExpectNoError(err, "failed to wait for TidbCluster tcTo ready")
-	clusterTo := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameTo, "", utilimage.TiDBV4Version)
+	clusterTo := newTidbClusterConfig(e2econfig.TestConfig, ns, tcNameTo, "", utilimage.TiDBV4UpgradeVersion)
 
 	// import some data to sql with blockwriter
 	ginkgo.By(fmt.Sprintf("Begin inserting data into cluster %q", clusterFrom.ClusterName))

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		for _, test := range testCases {
 			ginkgo.It("tidb cluster should not be affected while "+test.name, func() {
 				clusterName := "test"
-				tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+				tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 				err := genericCli.Create(context.TODO(), tc)
 				framework.ExpectNoError(err, "failed to create TidbCluster: %v", tc)
 				err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 			ginkgo.By("Deploy a test cluster with 3 pd and tikv replicas")
 			clusterName := "test"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(0)
 			tc.Spec.TiDB.Replicas = 1
@@ -503,7 +503,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// See docs/design-proposals/tidb-stable-scheduling.md
 		ginkgo.It("[Feature: StableScheduling] TiDB pods should be scheduled to preivous nodes", func() {
 			clusterName := "tidb-scheduling"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 3
@@ -612,7 +612,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			defer utilcloud.EnableNodeAutoRepair()
 			utilcloud.DisableNodeAutoRepair()
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 1
@@ -703,7 +703,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">=", 3))
 
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 2
@@ -872,7 +872,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// https://github.com/pingcap/tidb-operator/issues/2739
 		ginkgo.It("[Feature: AutoFailover] Failover can work if a store fails to upgrade", func() {
 			clusterName := "scale"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 1
 			// By default, PD set the state of disconnected store to Down
 			// after 30 minutes. Use a short time in testing.
@@ -934,7 +934,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// https://github.com/pingcap/tidb-operator/issues/2739
 		ginkgo.It("[Feature: AutoFailover] Failover can work if a pd fails to upgrade", func() {
 			clusterName := "scale"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 1
@@ -1034,7 +1034,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">=", 3))
 
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.SchedulerName = ""
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.PD.Config.Set("schedule.max-store-down-time", "1m")

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		for _, test := range testCases {
 			ginkgo.It("tidb cluster should not be affected while "+test.name, func() {
 				clusterName := "test"
-				tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+				tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 				err := genericCli.Create(context.TODO(), tc)
 				framework.ExpectNoError(err, "failed to create TidbCluster: %v", tc)
 				err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 15*time.Second)
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 
 			ginkgo.By("Deploy a test cluster with 3 pd and tikv replicas")
 			clusterName := "test"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(0)
 			tc.Spec.TiDB.Replicas = 1
@@ -503,7 +503,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// See docs/design-proposals/tidb-stable-scheduling.md
 		ginkgo.It("[Feature: StableScheduling] TiDB pods should be scheduled to preivous nodes", func() {
 			clusterName := "tidb-scheduling"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 3
@@ -612,7 +612,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			defer utilcloud.EnableNodeAutoRepair()
 			utilcloud.DisableNodeAutoRepair()
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 1
@@ -703,7 +703,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">=", 3))
 
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 2
@@ -872,7 +872,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// https://github.com/pingcap/tidb-operator/issues/2739
 		ginkgo.It("[Feature: AutoFailover] Failover can work if a store fails to upgrade", func() {
 			clusterName := "scale"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 1
 			// By default, PD set the state of disconnected store to Down
 			// after 30 minutes. Use a short time in testing.
@@ -934,7 +934,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		// https://github.com/pingcap/tidb-operator/issues/2739
 		ginkgo.It("[Feature: AutoFailover] Failover can work if a pd fails to upgrade", func() {
 			clusterName := "scale"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 1
@@ -1034,7 +1034,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">=", 3))
 
 			clusterName := "failover"
-			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV3Version)
+			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.SchedulerName = ""
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.PD.Config.Set("schedule.max-store-down-time", "1m")

--- a/tests/e2e/tidbcluster/stability.go
+++ b/tests/e2e/tidbcluster/stability.go
@@ -870,7 +870,8 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		})
 
 		// https://github.com/pingcap/tidb-operator/issues/2739
-		ginkgo.It("[Feature: AutoFailover] Failover can work if a store fails to upgrade", func() {
+		// TODO: this should be a regression type
+		ginkgo.It("[Feature: AutoFailover] Failover can work if a store fails to update", func() {
 			clusterName := "scale"
 			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 1
@@ -899,14 +900,14 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			})
 			framework.ExpectNoError(err, "failed to wait for ")
 
-			ginkgo.By("Upgrade TiKV configuration")
+			ginkgo.By("Update TiKV configuration")
 			updateStrategy := v1alpha1.ConfigUpdateStrategyRollingUpdate
 			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
 				tc.Spec.TiKV.Config.Set("log-level", "info")
 				tc.Spec.TiKV.ConfigUpdateStrategy = &updateStrategy
 				return nil
 			})
-			framework.ExpectNoError(err, "failed to upgrade tikv configuration")
+			framework.ExpectNoError(err, "failed to update tikv configuration")
 
 			ginkgo.By("Waiting for the store to be put into failure stores")
 			err = utiltidbcluster.WaitForTidbClusterCondition(cli, tc.Namespace, tc.Name, time.Minute*5, func(tc *v1alpha1.TidbCluster) (bool, error) {
@@ -932,7 +933,8 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		})
 
 		// https://github.com/pingcap/tidb-operator/issues/2739
-		ginkgo.It("[Feature: AutoFailover] Failover can work if a pd fails to upgrade", func() {
+		// TODO: this should be a regression type
+		ginkgo.It("[Feature: AutoFailover] Failover can work if a pd fails to update", func() {
 			clusterName := "scale"
 			tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
@@ -958,14 +960,14 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			})
 			framework.ExpectNoError(err, "failed to wait for the pd to be in unhealthy state")
 
-			ginkgo.By("Upgrade PD configuration")
+			ginkgo.By("Update PD configuration")
 			updateStrategy := v1alpha1.ConfigUpdateStrategyRollingUpdate
 			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
 				tc.Spec.PD.Config.Set("log.level", "info")
 				tc.Spec.PD.ConfigUpdateStrategy = &updateStrategy
 				return nil
 			})
-			framework.ExpectNoError(err, "failed to upgrade pd configuration")
+			framework.ExpectNoError(err, "failed to update pd configuration")
 
 			ginkgo.By("Waiting for the pd to be put into failure members")
 			err = utiltidbcluster.WaitForTidbClusterCondition(cli, tc.Namespace, tc.Name, time.Minute*5, func(tc *v1alpha1.TidbCluster) (bool, error) {

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	// basic deploy, scale out, scale in, change configuration tests
 	ginkgo.Describe("when using version", func() {
-		versions := []string{utilimage.TiDBV3Version, utilimage.TiDBV4Version}
+		versions := []string{utilimage.TiDBV3UpgradeVersion, utilimage.TiDBV4UpgradeVersion}
 		for _, version := range versions {
 			version := version
 			versionDashed := strings.ReplaceAll(version, ".", "-")
@@ -237,7 +237,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		}
 
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "host-network", "", utilimage.TiDBV3Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "host-network", "", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	})
 
 	ginkgo.It("should upgrade TidbCluster with webhook enabled", func() {
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV3Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "3"
 
 		ginkgo.By("Creating webhook certs and self signing it")
@@ -274,9 +274,9 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		oa.CheckTidbClusterStatusOrDie(&tcCfg)
 		oa.CheckDisasterToleranceOrDie(&tcCfg)
 
-		ginkgo.By(fmt.Sprintf("Upgrading tidb cluster from %s to %s", tcCfg.ClusterVersion, utilimage.TiDBV3UpgradeVersion))
+		ginkgo.By(fmt.Sprintf("Upgrading tidb cluster from %s to %s", tcCfg.ClusterVersion, utilimage.TiDBV4UpgradeVersion))
 		ctx, cancel := context.WithCancel(context.Background())
-		tcCfg.UpgradeAll(utilimage.TiDBV3UpgradeVersion)
+		tcCfg.UpgradeAll(utilimage.TiDBV4UpgradeVersion)
 		oa.UpgradeTidbClusterOrDie(&tcCfg)
 		oa.CheckUpgradeOrDie(ctx, &tcCfg)
 		oa.CheckTidbClusterStatusOrDie(&tcCfg)
@@ -298,7 +298,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("should keep tidb service in sync", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "service", "admin", utilimage.TiDBV3Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "service", "admin", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	// TODO: Add pump configmap rolling-update case
 	ginkgo.It("should adopt helm created pump with TidbCluster CR", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "pump", "admin", utilimage.TiDBV3Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "pump", "admin", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
@@ -524,7 +524,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("should migrate from helm to CR", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "helm-migration", "admin", utilimage.TiDBV3Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "helm-migration", "admin", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
@@ -804,7 +804,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("can be paused and resumed", func() {
 		ginkgo.By("Deploy initial tc")
 		tcName := "paused"
-		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV3Version)
+		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4UpgradeVersion)
 		tc.Spec.PD.Replicas = 1
 		tc.Spec.TiKV.Replicas = 1
 		tc.Spec.TiDB.Replicas = 1
@@ -823,9 +823,9 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		})
 		framework.ExpectNoError(err, "failed to pause TidbCluster: %q", tc.Name)
 
-		ginkgo.By(fmt.Sprintf("change tc version to %q", utilimage.TiDBV3UpgradeVersion))
+		ginkgo.By(fmt.Sprintf("change tc version to %q", utilimage.TiDBV4UpgradeVersion))
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = utilimage.TiDBV3UpgradeVersion
+			tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
 			return nil
 		})
 		framework.ExpectNoError(err, "failed to upgrade TidbCluster version: %q", tc.Name)
@@ -868,7 +868,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		// TODO: explain purpose of this case
 		ginkgo.It("should clear TiDB failureMembers when scale TiDB to zero", func() {
 			ginkgo.By("Deploy initial tc with bad tidb pre-start script")
-			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "tidb-scale", "admin", utilimage.TiDBV3Version)
+			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "tidb-scale", "admin", utilimage.TiDBV4UpgradeVersion)
 			tcCfg.Resources["pd.replicas"] = "3"
 			tcCfg.Resources["tikv.replicas"] = "1"
 			tcCfg.Resources["tidb.replicas"] = "1"
@@ -945,7 +945,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 			ginkgo.By("Creating tidb cluster with TLS enabled")
 			dashTLSName := fmt.Sprintf("%s-dashboard-tls", tcName)
-			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4Version)
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4UpgradeVersion)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.PD.TLSClientSecretName = &dashTLSName
 			tc.Spec.TiKV.Replicas = 3
@@ -994,10 +994,10 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				Namespace:      ns,
 				ClusterName:    tcName,
 				OperatorTag:    cfg.OperatorTag,
-				ClusterVersion: utilimage.TiDBV4Version,
+				ClusterVersion: utilimage.TiDBV4UpgradeVersion,
 			}
 			targetTcName := "tls-target"
-			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4Version)
+			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4UpgradeVersion)
 			targetTc.Spec.PD.Replicas = 1
 			targetTc.Spec.TiKV.Replicas = 1
 			targetTc.Spec.TiDB.Replicas = 1
@@ -1200,10 +1200,10 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				Namespace:      ns,
 				ClusterName:    tcName,
 				OperatorTag:    cfg.OperatorTag,
-				ClusterVersion: utilimage.TiDBV4Version,
+				ClusterVersion: utilimage.TiDBV4UpgradeVersion,
 			}
 			targetTcName := "tls-target"
-			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4Version)
+			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4UpgradeVersion)
 			targetTc.Spec.PD.Replicas = 1
 			targetTc.Spec.TiKV.Replicas = 1
 			targetTc.Spec.TiDB.Replicas = 1
@@ -1248,7 +1248,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("should ensure changing TiDB service annotations won't change TiDB service type NodePort", func() {
 		ginkgo.By("Deploy initial tc")
 		// Create TidbCluster with NodePort to check whether node port would change
-		nodeTc := fixture.GetTidbCluster(ns, "nodeport", utilimage.TiDBV3Version)
+		nodeTc := fixture.GetTidbCluster(ns, "nodeport", utilimage.TiDBV4UpgradeVersion)
 		nodeTc.Spec.PD.Replicas = 1
 		nodeTc.Spec.TiKV.Replicas = 1
 		nodeTc.Spec.TiDB.Replicas = 1
@@ -1402,7 +1402,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("[Feature: CDC]", func() {
 		ginkgo.By("Creating cdc cluster")
-		fromTc := fixture.GetTidbCluster(ns, "cdc-source", utilimage.TiDBV4Version)
+		fromTc := fixture.GetTidbCluster(ns, "cdc-source", utilimage.TiDBV4UpgradeVersion)
 		fromTc.Spec.PD.Replicas = 3
 		fromTc.Spec.TiKV.Replicas = 3
 		fromTc.Spec.TiDB.Replicas = 2
@@ -1416,7 +1416,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		framework.ExpectNoError(err, "Expected TiDB cluster ready")
 
 		ginkgo.By("Creating cdc-sink cluster")
-		toTc := fixture.GetTidbCluster(ns, "cdc-sink", utilimage.TiDBV4Version)
+		toTc := fixture.GetTidbCluster(ns, "cdc-sink", utilimage.TiDBV4UpgradeVersion)
 		toTc.Spec.PD.Replicas = 1
 		toTc.Spec.TiKV.Replicas = 1
 		toTc.Spec.TiDB.Replicas = 1
@@ -1453,7 +1453,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.Context("when stores number is equal to 3", func() {
 		ginkgo.It("forbid to scale in TiKV and the state of all stores are up", func() {
 			ginkgo.By("Deploy initial tc")
-			tc := fixture.GetTidbCluster(ns, "scale-in-tikv", utilimage.TiDBV4Version)
+			tc := fixture.GetTidbCluster(ns, "scale-in-tikv", utilimage.TiDBV4UpgradeVersion)
 			tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 			framework.ExpectNoError(err, "Expected create tidbcluster")
 			err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
@@ -1486,7 +1486,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("TiKV should mount multiple pvc", func() {
 		ginkgo.By("Deploy initial tc with addition")
 		clusterName := "tidb-multiple-pvc-scale"
-		tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4Version)
+		tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
 		tc.Spec.TiKV.StorageVolumes = []v1alpha1.StorageVolume{
 			{
 				Name:        "wal",
@@ -1524,7 +1524,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		tc.Spec.TiDB.Config.Set("log.file.max-days", "1")
 		tc.Spec.TiKV.Config.Set("rocksdb.wal-dir", "/var/lib/wal")
 		tc.Spec.TiKV.Config.Set("titan.dirname", "/var/lib/titan")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, clusterName, "admin", utilimage.TiDBV4Version)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, clusterName, "admin", utilimage.TiDBV4UpgradeVersion)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "4"
 		tcCfg.Resources["tidb.replicas"] = "1"

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	})
 
 	ginkgo.It("should upgrade TidbCluster with webhook enabled", func() {
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV4)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV4Prev)
 		tcCfg.Resources["pd.replicas"] = "3"
 
 		ginkgo.By("Creating webhook certs and self signing it")
@@ -804,7 +804,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("can be paused and resumed", func() {
 		ginkgo.By("Deploy initial tc")
 		tcName := "paused"
-		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4)
+		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4Prev)
 		tc.Spec.PD.Replicas = 1
 		tc.Spec.TiKV.Replicas = 1
 		tc.Spec.TiDB.Replicas = 1
@@ -823,7 +823,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		})
 		framework.ExpectNoError(err, "failed to pause TidbCluster: %q", tc.Name)
 
-		ginkgo.By(fmt.Sprintf("change tc version to %q", utilimage.TiDBV4))
+		ginkgo.By(fmt.Sprintf("upgrade tc version to %q", utilimage.TiDBV4))
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
 			tc.Spec.Version = utilimage.TiDBV4
 			return nil

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	// basic deploy, scale out, scale in, change configuration tests
 	ginkgo.Describe("when using version", func() {
-		versions := []string{utilimage.TiDBV3UpgradeVersion, utilimage.TiDBV4UpgradeVersion}
+		versions := []string{utilimage.TiDBV3, utilimage.TiDBV4}
 		for _, version := range versions {
 			version := version
 			versionDashed := strings.ReplaceAll(version, ".", "-")
@@ -237,7 +237,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		}
 
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "host-network", "", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "host-network", "", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	})
 
 	ginkgo.It("should upgrade TidbCluster with webhook enabled", func() {
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "cluster", "admin", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "3"
 
 		ginkgo.By("Creating webhook certs and self signing it")
@@ -274,9 +274,9 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		oa.CheckTidbClusterStatusOrDie(&tcCfg)
 		oa.CheckDisasterToleranceOrDie(&tcCfg)
 
-		ginkgo.By(fmt.Sprintf("Upgrading tidb cluster from %s to %s", tcCfg.ClusterVersion, utilimage.TiDBV4UpgradeVersion))
+		ginkgo.By(fmt.Sprintf("Upgrading tidb cluster from %s to %s", tcCfg.ClusterVersion, utilimage.TiDBV4))
 		ctx, cancel := context.WithCancel(context.Background())
-		tcCfg.UpgradeAll(utilimage.TiDBV4UpgradeVersion)
+		tcCfg.UpgradeAll(utilimage.TiDBV4)
 		oa.UpgradeTidbClusterOrDie(&tcCfg)
 		oa.CheckUpgradeOrDie(ctx, &tcCfg)
 		oa.CheckTidbClusterStatusOrDie(&tcCfg)
@@ -298,7 +298,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("should keep tidb service in sync", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "service", "admin", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "service", "admin", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	// TODO: Add pump configmap rolling-update case
 	ginkgo.It("should adopt helm created pump with TidbCluster CR", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "pump", "admin", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "pump", "admin", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
@@ -524,7 +524,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("should migrate from helm to CR", func() {
 		ginkgo.By("Deploy initial tc")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "helm-migration", "admin", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "helm-migration", "admin", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "1"
 		tcCfg.Resources["tidb.replicas"] = "1"
@@ -636,7 +636,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("should manage tidb monitor normally", func() {
 		ginkgo.By("Deploy initial tc")
-		tc := fixture.GetTidbCluster(ns, "monitor-test", utilimage.TiDBV4UpgradeVersion)
+		tc := fixture.GetTidbCluster(ns, "monitor-test", utilimage.TiDBV4)
 		tc.Spec.PD.Replicas = 1
 		tc.Spec.TiKV.Replicas = 1
 		tc.Spec.TiDB.Replicas = 1
@@ -804,7 +804,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("can be paused and resumed", func() {
 		ginkgo.By("Deploy initial tc")
 		tcName := "paused"
-		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4UpgradeVersion)
+		tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4)
 		tc.Spec.PD.Replicas = 1
 		tc.Spec.TiKV.Replicas = 1
 		tc.Spec.TiDB.Replicas = 1
@@ -823,9 +823,9 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		})
 		framework.ExpectNoError(err, "failed to pause TidbCluster: %q", tc.Name)
 
-		ginkgo.By(fmt.Sprintf("change tc version to %q", utilimage.TiDBV4UpgradeVersion))
+		ginkgo.By(fmt.Sprintf("change tc version to %q", utilimage.TiDBV4))
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
+			tc.Spec.Version = utilimage.TiDBV4
 			return nil
 		})
 		framework.ExpectNoError(err, "failed to upgrade TidbCluster version: %q", tc.Name)
@@ -868,7 +868,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		// TODO: explain purpose of this case
 		ginkgo.It("should clear TiDB failureMembers when scale TiDB to zero", func() {
 			ginkgo.By("Deploy initial tc with bad tidb pre-start script")
-			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "tidb-scale", "admin", utilimage.TiDBV4UpgradeVersion)
+			tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, "tidb-scale", "admin", utilimage.TiDBV4)
 			tcCfg.Resources["pd.replicas"] = "3"
 			tcCfg.Resources["tikv.replicas"] = "1"
 			tcCfg.Resources["tidb.replicas"] = "1"
@@ -945,7 +945,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 			ginkgo.By("Creating tidb cluster with TLS enabled")
 			dashTLSName := fmt.Sprintf("%s-dashboard-tls", tcName)
-			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.PD.TLSClientSecretName = &dashTLSName
 			tc.Spec.TiKV.Replicas = 3
@@ -994,10 +994,10 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				Namespace:      ns,
 				ClusterName:    tcName,
 				OperatorTag:    cfg.OperatorTag,
-				ClusterVersion: utilimage.TiDBV4UpgradeVersion,
+				ClusterVersion: utilimage.TiDBV4,
 			}
 			targetTcName := "tls-target"
-			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4UpgradeVersion)
+			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4)
 			targetTc.Spec.PD.Replicas = 1
 			targetTc.Spec.TiKV.Replicas = 1
 			targetTc.Spec.TiDB.Replicas = 1
@@ -1061,7 +1061,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 			ginkgo.By("Upgrading tidb cluster")
 			err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-				tc.Spec.Version = utilimage.TiDBV4UpgradeVersion
+				tc.Spec.Version = utilimage.TiDBV4
 				return nil
 			})
 			framework.ExpectNoError(err, "failed to update TidbCluster: %q", tc.Name)
@@ -1101,7 +1101,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 			ginkgo.By("Creating tidb cluster")
 			dashTLSName := fmt.Sprintf("%s-dashboard-tls", tcName)
-			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.PD.TLSClientSecretName = &dashTLSName
 			tc.Spec.TiKV.Replicas = 1
@@ -1122,7 +1122,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			framework.ExpectNoError(err, "wait for TidbCluster ready timeout: %q", tc.Name)
 
 			ginkgo.By("Creating heterogeneous tidb cluster")
-			heterogeneousTc := fixture.GetTidbCluster(ns, heterogeneousTcName, utilimage.TiDBV4UpgradeVersion)
+			heterogeneousTc := fixture.GetTidbCluster(ns, heterogeneousTcName, utilimage.TiDBV4)
 			heterogeneousTc.Spec.PD = nil
 			heterogeneousTc.Spec.TiKV.Replicas = 1
 			heterogeneousTc.Spec.TiDB.Replicas = 1
@@ -1200,10 +1200,10 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				Namespace:      ns,
 				ClusterName:    tcName,
 				OperatorTag:    cfg.OperatorTag,
-				ClusterVersion: utilimage.TiDBV4UpgradeVersion,
+				ClusterVersion: utilimage.TiDBV4,
 			}
 			targetTcName := "tls-target"
-			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4UpgradeVersion)
+			targetTc := fixture.GetTidbCluster(ns, targetTcName, utilimage.TiDBV4)
 			targetTc.Spec.PD.Replicas = 1
 			targetTc.Spec.TiKV.Replicas = 1
 			targetTc.Spec.TiDB.Replicas = 1
@@ -1248,7 +1248,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("should ensure changing TiDB service annotations won't change TiDB service type NodePort", func() {
 		ginkgo.By("Deploy initial tc")
 		// Create TidbCluster with NodePort to check whether node port would change
-		nodeTc := fixture.GetTidbCluster(ns, "nodeport", utilimage.TiDBV4UpgradeVersion)
+		nodeTc := fixture.GetTidbCluster(ns, "nodeport", utilimage.TiDBV4)
 		nodeTc.Spec.PD.Replicas = 1
 		nodeTc.Spec.TiKV.Replicas = 1
 		nodeTc.Spec.TiDB.Replicas = 1
@@ -1344,7 +1344,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		ginkgo.It("should join heterogeneous cluster into an existing cluster", func() {
 			// Create TidbCluster with NodePort to check whether node port would change
 			ginkgo.By("Deploy origin tc")
-			originTc := fixture.GetTidbCluster(ns, "origin", utilimage.TiDBV4UpgradeVersion)
+			originTc := fixture.GetTidbCluster(ns, "origin", utilimage.TiDBV4)
 			originTc.Spec.PD.Replicas = 1
 			originTc.Spec.TiKV.Replicas = 1
 			originTc.Spec.TiDB.Replicas = 1
@@ -1354,7 +1354,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			framework.ExpectNoError(err, "Expected TiDB cluster ready")
 
 			ginkgo.By("Deploy heterogeneous tc")
-			heterogeneousTc := fixture.GetTidbCluster(ns, "heterogeneous", utilimage.TiDBV4UpgradeVersion)
+			heterogeneousTc := fixture.GetTidbCluster(ns, "heterogeneous", utilimage.TiDBV4)
 			heterogeneousTc.Spec.PD = nil
 			heterogeneousTc.Spec.TiKV.Replicas = 1
 			heterogeneousTc.Spec.TiDB.Replicas = 1
@@ -1402,7 +1402,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	ginkgo.It("[Feature: CDC]", func() {
 		ginkgo.By("Creating cdc cluster")
-		fromTc := fixture.GetTidbCluster(ns, "cdc-source", utilimage.TiDBV4UpgradeVersion)
+		fromTc := fixture.GetTidbCluster(ns, "cdc-source", utilimage.TiDBV4)
 		fromTc.Spec.PD.Replicas = 3
 		fromTc.Spec.TiKV.Replicas = 3
 		fromTc.Spec.TiDB.Replicas = 2
@@ -1416,7 +1416,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		framework.ExpectNoError(err, "Expected TiDB cluster ready")
 
 		ginkgo.By("Creating cdc-sink cluster")
-		toTc := fixture.GetTidbCluster(ns, "cdc-sink", utilimage.TiDBV4UpgradeVersion)
+		toTc := fixture.GetTidbCluster(ns, "cdc-sink", utilimage.TiDBV4)
 		toTc.Spec.PD.Replicas = 1
 		toTc.Spec.TiKV.Replicas = 1
 		toTc.Spec.TiDB.Replicas = 1
@@ -1453,7 +1453,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.Context("when stores number is equal to 3", func() {
 		ginkgo.It("forbid to scale in TiKV and the state of all stores are up", func() {
 			ginkgo.By("Deploy initial tc")
-			tc := fixture.GetTidbCluster(ns, "scale-in-tikv", utilimage.TiDBV4UpgradeVersion)
+			tc := fixture.GetTidbCluster(ns, "scale-in-tikv", utilimage.TiDBV4)
 			tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 			framework.ExpectNoError(err, "Expected create tidbcluster")
 			err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
@@ -1486,7 +1486,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	ginkgo.It("TiKV should mount multiple pvc", func() {
 		ginkgo.By("Deploy initial tc with addition")
 		clusterName := "tidb-multiple-pvc-scale"
-		tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4UpgradeVersion)
+		tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBV4)
 		tc.Spec.TiKV.StorageVolumes = []v1alpha1.StorageVolume{
 			{
 				Name:        "wal",
@@ -1524,7 +1524,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		tc.Spec.TiDB.Config.Set("log.file.max-days", "1")
 		tc.Spec.TiKV.Config.Set("rocksdb.wal-dir", "/var/lib/wal")
 		tc.Spec.TiKV.Config.Set("titan.dirname", "/var/lib/titan")
-		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, clusterName, "admin", utilimage.TiDBV4UpgradeVersion)
+		tcCfg := newTidbClusterConfig(e2econfig.TestConfig, ns, clusterName, "admin", utilimage.TiDBV4)
 		tcCfg.Resources["pd.replicas"] = "1"
 		tcCfg.Resources["tikv.replicas"] = "4"
 		tcCfg.Resources["tidb.replicas"] = "1"

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -945,7 +945,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 			ginkgo.By("Creating tidb cluster with TLS enabled")
 			dashTLSName := fmt.Sprintf("%s-dashboard-tls", tcName)
-			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4)
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV4Prev)
 			tc.Spec.PD.Replicas = 3
 			tc.Spec.PD.TLSClientSecretName = &dashTLSName
 			tc.Spec.TiKV.Replicas = 3
@@ -955,7 +955,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			tc.Spec.Pump = &v1alpha1.PumpSpec{
 				Replicas:             1,
 				BaseImage:            "pingcap/tidb-binlog",
-				ResourceRequirements: fixture.WithStorage(fixture.BurstbleSmall, "1Gi"),
+				ResourceRequirements: fixture.WithStorage(fixture.BurstableSmall, "1Gi"),
 				Config: tcconfig.New(map[string]interface{}{
 					"addr": "0.0.0.0:8250",
 				}),
@@ -1111,7 +1111,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			tc.Spec.Pump = &v1alpha1.PumpSpec{
 				Replicas:             1,
 				BaseImage:            "pingcap/tidb-binlog",
-				ResourceRequirements: fixture.WithStorage(fixture.BurstbleSmall, "1Gi"),
+				ResourceRequirements: fixture.WithStorage(fixture.BurstableSmall, "1Gi"),
 				Config: tcconfig.New(map[string]interface{}{
 					"addr": "0.0.0.0:8250",
 				}),

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	TiDBV3Prev                    = "v3.0.19"
 	TiDBV3                        = "v3.0.20"
 	TiDBV4Prev                    = "v4.0.9"
 	TiDBV4                        = "v4.0.10"
@@ -47,7 +46,6 @@ const (
 func ListImages() []string {
 	images := []string{}
 	versions := make([]string, 0)
-	versions = append(versions, TiDBV3Prev)
 	versions = append(versions, TiDBV3)
 	versions = append(versions, TiDBV4Prev)
 	versions = append(versions, TiDBV4)

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	TiDBV3Version                 = "v3.0.19"
-	TiDBV3UpgradeVersion          = "v3.0.20"
-	TiDBV4Version                 = "v4.0.9"
-	TiDBV4UpgradeVersion          = "v4.0.10"
+	TiDBV3Prev                    = "v3.0.19"
+	TiDBV3                        = "v3.0.20"
+	TiDBV4Prev                    = "v4.0.9"
+	TiDBV4                        = "v4.0.10"
 	TiDBNightlyVersion            = "nightly"
 	PrometheusImage               = "prom/prometheus"
 	PrometheusVersion             = "v2.18.1"
@@ -47,10 +47,10 @@ const (
 func ListImages() []string {
 	images := []string{}
 	versions := make([]string, 0)
-	versions = append(versions, TiDBV3Version)
-	versions = append(versions, TiDBV3UpgradeVersion)
-	versions = append(versions, TiDBV4Version)
-	versions = append(versions, TiDBV4UpgradeVersion)
+	versions = append(versions, TiDBV3Prev)
+	versions = append(versions, TiDBV3)
+	versions = append(versions, TiDBV4Prev)
+	versions = append(versions, TiDBV4)
 	versions = append(versions, TiDBNightlyVersion)
 	for _, v := range versions {
 		images = append(images, fmt.Sprintf("pingcap/pd:%s", v))

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -41,8 +41,8 @@ var (
 )
 
 var (
-	BestEffort    = corev1.ResourceRequirements{}
-	BurstbleSmall = corev1.ResourceRequirements{
+	BestEffort     = corev1.ResourceRequirements{}
+	BurstableSmall = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -52,7 +52,7 @@ var (
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		},
 	}
-	BurstbleMedium = corev1.ResourceRequirements{
+	BurstableMedium = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -110,7 +110,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 			PD: &v1alpha1.PDSpec{
 				Replicas:             3,
 				BaseImage:            "pingcap/pd",
-				ResourceRequirements: WithStorage(BurstbleSmall, "1Gi"),
+				ResourceRequirements: WithStorage(BurstableSmall, "1Gi"),
 				Config: func() *v1alpha1.PDConfigWraper {
 					c := v1alpha1.NewPDConfig()
 					c.Set("log.level", "info")
@@ -125,7 +125,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 			TiKV: &v1alpha1.TiKVSpec{
 				Replicas:             3,
 				BaseImage:            "pingcap/tikv",
-				ResourceRequirements: WithStorage(BurstbleMedium, "10Gi"),
+				ResourceRequirements: WithStorage(BurstableMedium, "10Gi"),
 				MaxFailoverCount:     pointer.Int32Ptr(3),
 				Config:               tikvConfig,
 				ComponentSpec: v1alpha1.ComponentSpec{
@@ -136,7 +136,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 			TiDB: &v1alpha1.TiDBSpec{
 				Replicas:             2,
 				BaseImage:            "pingcap/tidb",
-				ResourceRequirements: BurstbleMedium,
+				ResourceRequirements: BurstableMedium,
 				Service: &v1alpha1.TiDBServiceSpec{
 					ServiceSpec: v1alpha1.ServiceSpec{
 						Type: corev1.ServiceTypeClusterIP,
@@ -186,7 +186,7 @@ func GetTidbClusterWithTiFlash(ns, name, version string) *v1alpha1.TidbCluster {
 		MaxFailoverCount: pointer.Int32Ptr(3),
 		StorageClaims: []v1alpha1.StorageClaim{
 			{
-				Resources: WithStorage(BurstbleMedium, "10Gi"),
+				Resources: WithStorage(BurstableMedium, "10Gi"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
deployed tidb versions in e2e test cases are outdated

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
update tidb versions to the latest v4.
simplify version const variable names.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
