### PR TITLE
Add TiFlash rolling upgrade logic

### DIFF
--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -224,7 +224,7 @@ func (m *tiflashMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
 		}
 	}
 
-	if !templateEqual(newSet, oldSet) {
+	if !templateEqual(newSet, oldSet) || tc.Status.TiFlash.Phase == v1alpha1.UpgradePhase {
 		if err := m.upgrader.Upgrade(tc, oldSet, newSet); err != nil {
 			return err
 		}
@@ -420,6 +420,11 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 	capacity := controller.TiKVCapacity(tc.Spec.TiFlash.Limits)
 	headlessSvcName := controller.TiFlashPeerMemberName(tcName)
 
+	deleteSlotsNumber, err := util.GetDeleteSlotsNumber(stsAnnotations)
+	if err != nil {
+		return nil, fmt.Errorf("get delete slots number of statefulset %s/%s failed, err:%v", ns, setName, err)
+	}
+
 	env := []corev1.EnvVar{
 		{
 			Name: "NAMESPACE",
@@ -516,6 +521,16 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 		podSpec.ServiceAccountName = tc.Spec.ServiceAccount
 	}
 
+	updateStrategy := apps.StatefulSetUpdateStrategy{}
+	if baseTiFlashSpec.StatefulSetUpdateStrategy() == apps.OnDeleteStatefulSetStrategyType {
+		updateStrategy.Type = apps.OnDeleteStatefulSetStrategyType
+	} else {
+		updateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
+		updateStrategy.RollingUpdate = &apps.RollingUpdateStatefulSetStrategy{
+			Partition: pointer.Int32Ptr(tc.TiFlashStsDesiredReplicas() + deleteSlotsNumber),
+		}
+	}
+
 	tiflashset := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            setName,
@@ -537,9 +552,7 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			VolumeClaimTemplates: pvcs,
 			ServiceName:          headlessSvcName,
 			PodManagementPolicy:  apps.ParallelPodManagement,
-			UpdateStrategy: apps.StatefulSetUpdateStrategy{
-				Type: baseTiFlashSpec.StatefulSetUpdateStrategy(),
-			},
+			UpdateStrategy:       updateStrategy,
 		},
 	}
 	return tiflashset, nil

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -50,7 +50,7 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 	}
 
 	if !tc.Status.TiFlash.Synced {
-		return fmt.Errorf("cluster: [%s/%s]'s TiFlash status sync failed, can not to be upgraded", ns, tcName)
+		return fmt.Errorf("cluster: [%s/%s]'s TiFlash status is not synced, can not upgrade", ns, tcName)
 	}
 
 	tc.Status.TiFlash.Phase = v1alpha1.UpgradePhase
@@ -96,14 +96,9 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 				return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded TiFlash pod: [%s] is not ready", ns, tcName, podName)
 			}
 			if store.State != v1alpha1.TiKVStateUp {
-				return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded TiFlash pod: [%s] is not all ready", ns, tcName, podName)
+				return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded TiFlash pod: [%s], store state is not UP", ns, tcName, podName)
 			}
 			continue
-		}
-
-		if u.deps.CLIConfig.PodWebhookEnabled {
-			setUpgradePartition(newSet, i)
-			return nil
 		}
 
 		setUpgradePartition(newSet, i)

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
+
 type tiflashUpgrader struct {
 	deps *controller.Dependencies
 }

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -24,6 +24,10 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
+type TiFlashUpgrader interface {
+	Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error
+}
+
 type tiflashUpgrader struct {
 	deps *controller.Dependencies
 }

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -23,11 +23,6 @@ import (
 	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
-
-type TiFlashUpgrader interface {
-	Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error
-}
-
 type tiflashUpgrader struct {
 	deps *controller.Dependencies
 }

--- a/pkg/manager/member/tiflash_upgrader_test.go
+++ b/pkg/manager/member/tiflash_upgrader_test.go
@@ -1,0 +1,404 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/pdapi"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	podinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestTiFlashUpgraderUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name         string
+		changeFn     func(*v1alpha1.TidbCluster)
+		changeOldSet func(set *apps.StatefulSet)
+		changePods   func([]*corev1.Pod)
+		updatePodErr bool
+		errExpectFn  func(*GomegaWithT, error)
+		expectFn     func(*GomegaWithT, *v1alpha1.TidbCluster, *apps.StatefulSet, map[string]*corev1.Pod)
+	}
+
+	testFn := func(test *testcase, t *testing.T) {
+		t.Log(test.name)
+		upgrader, _, podControl, podInformer := newTiFlashUpgrader()
+
+		tc := newTidbClusterForTiFlashUpgrader()
+		if test.changeFn != nil {
+			test.changeFn(tc)
+		}
+
+		oldSet := oldStatefulSetForTiFlashUpgrader()
+		if test.changeOldSet != nil {
+			test.changeOldSet(oldSet)
+		}
+		newSet := newStatefulSetForTiFlashUpgrader()
+
+		tiflashPods := getTiFlashPods(oldSet)
+		if test.changePods != nil {
+			test.changePods(tiflashPods)
+		}
+		for _, pod := range tiflashPods {
+			podInformer.Informer().GetIndexer().Add(pod)
+		}
+
+		if test.updatePodErr {
+			podControl.SetUpdatePodError(fmt.Errorf("failed to update pod"), 0)
+		}
+
+		err := upgrader.Upgrade(tc, oldSet, newSet)
+		test.errExpectFn(g, err)
+		l, err := label.New().Instance(upgradeInstanceName).TiFlash().Selector()
+		g.Expect(err).NotTo(HaveOccurred())
+		tiflashPods, err = podInformer.Lister().Pods(tc.Namespace).List(l)
+		g.Expect(err).NotTo(HaveOccurred())
+		pods := map[string]*corev1.Pod{}
+		for _, pod := range tiflashPods {
+			pods[pod.GetName()] = pod
+		}
+		test.expectFn(g, tc, newSet, pods)
+	}
+
+	tests := []*testcase{
+		{
+			name:     "modify oldSet update strategy to OnDelete",
+			changeFn: nil,
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+				oldSet.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+					Type: apps.OnDeleteStatefulSetStrategyType,
+				}
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy).To(Equal(apps.StatefulSetUpdateStrategy{Type: apps.OnDeleteStatefulSetStrategyType}))
+			},
+		},
+		{
+			name:     "set oldSet's RollingUpdate strategy to nil",
+			changeFn: nil,
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+				oldSet.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+				}
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy).To(Equal(apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType}))
+			},
+		},
+		{
+			name: "to upgrade the pod which ordinal is 2",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+				// set leader to 0
+				store := tc.Status.TiFlash.Stores["3"]
+				store.LeaderCount = 0
+				tc.Status.TiFlash.Stores["3"] = store
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(2)))
+			},
+		},
+		{
+			name: "to upgrade the pod which ordinal is 1",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Phase = v1alpha1.UpgradePhase
+				tc.Status.TiFlash.Synced = true
+				tc.Status.TiFlash.StatefulSet.CurrentReplicas = 2
+				tc.Status.TiFlash.StatefulSet.UpdatedReplicas = 1
+				// set leader to 0
+				store := tc.Status.TiFlash.Stores["2"]
+				store.LeaderCount = 0
+				tc.Status.TiFlash.Stores["2"] = store
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+				oldSet.Status.CurrentReplicas = 2
+				oldSet.Status.UpdatedReplicas = 1
+				oldSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(2)
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(1)))
+			},
+		},
+		{
+			name: "newSet template changed",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				oldSet.Spec.Template.Spec.Containers[0].Image = "old-image"
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
+			name: "update revision equals current revision",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+				tc.Status.TiFlash.StatefulSet.UpdateRevision = tc.Status.TiFlash.StatefulSet.CurrentRevision
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
+			name: "tiflash can not upgrade when pd is upgrading",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.UpgradePhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
+			name: "get last apply config error",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PD.Phase = v1alpha1.UpgradePhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) {
+				oldSet.SetAnnotations(map[string]string{LastAppliedConfigAnnotation: "fake apply config"})
+			},
+			changePods:   nil,
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(tc.Status.TiFlash.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testFn(test, t)
+	}
+}
+
+func newTiFlashUpgrader() (TiFlashUpgrader, *pdapi.FakePDControl, *controller.FakePodControl, podinformers.PodInformer) {
+	fakeDeps := controller.NewFakeDependencies()
+	pdControl := fakeDeps.PDControl.(*pdapi.FakePDControl)
+	podControl := fakeDeps.PodControl.(*controller.FakePodControl)
+	podInformer := fakeDeps.KubeInformerFactory.Core().V1().Pods()
+	return &tiflashUpgrader{deps: fakeDeps}, pdControl, podControl, podInformer
+}
+
+func newStatefulSetForTiFlashUpgrader() *apps.StatefulSet {
+	return &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrader-tiflash",
+			Namespace: metav1.NamespaceDefault,
+			Labels:    label.New().Instance(upgradeInstanceName).TiFlash().Labels(),
+		},
+		Spec: apps.StatefulSetSpec{
+			Replicas: pointer.Int32Ptr(3),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "tiflash",
+							Image: "tiflash-test-image",
+						},
+					},
+				},
+			},
+			UpdateStrategy: apps.StatefulSetUpdateStrategy{
+				Type: apps.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+					Partition: pointer.Int32Ptr(3),
+				}},
+		},
+	}
+}
+
+func oldStatefulSetForTiFlashUpgrader() *apps.StatefulSet {
+	set := newStatefulSetForTiFlashUpgrader()
+	set.Status = apps.StatefulSetStatus{
+		Replicas:        3,
+		CurrentReplicas: 3,
+		UpdatedReplicas: 0,
+		CurrentRevision: "1",
+		UpdateRevision:  "2",
+	}
+	return set
+}
+
+func newTidbClusterForTiFlashUpgrader() *v1alpha1.TidbCluster {
+	return &v1alpha1.TidbCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TidbCluster",
+			APIVersion: "pingcap.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      upgradeTcName,
+			Namespace: corev1.NamespaceDefault,
+			UID:       types.UID(upgradeTcName),
+			Labels:    label.New().Instance(upgradeInstanceName).TiFlash().Labels(),
+		},
+		Spec: v1alpha1.TidbClusterSpec{
+			PD: &v1alpha1.PDSpec{
+				ComponentSpec: v1alpha1.ComponentSpec{
+					Image: "pd-test-image",
+				},
+				Replicas:         3,
+				StorageClassName: pointer.StringPtr("my-storage-class"),
+			},
+			TiFlash: &v1alpha1.TiFlashSpec{
+				ComponentSpec: v1alpha1.ComponentSpec{
+					Image: "tiflash-test-image",
+				},
+				Replicas: 3,
+			},
+		},
+		Status: v1alpha1.TidbClusterStatus{
+			TiFlash: v1alpha1.TiFlashStatus{
+				Synced: true,
+				Phase:  v1alpha1.UpgradePhase,
+				StatefulSet: &apps.StatefulSetStatus{
+					Replicas:        3,
+					CurrentReplicas: 3,
+					UpdatedReplicas: 0,
+					CurrentRevision: "1",
+					UpdateRevision:  "2",
+				},
+				Stores: map[string]v1alpha1.TiKVStore{
+					"1": {
+						ID:          "1",
+						PodName:     TiFlashPodName(upgradeTcName, 0),
+						LeaderCount: 10,
+						State:       "Up",
+					},
+					"2": {
+						ID:          "2",
+						PodName:     TiFlashPodName(upgradeTcName, 1),
+						LeaderCount: 10,
+						State:       "Up",
+					},
+					"3": {
+						ID:          "3",
+						PodName:     TiFlashPodName(upgradeTcName, 2),
+						LeaderCount: 10,
+						State:       "Up",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTiFlashPods(set *apps.StatefulSet) []*corev1.Pod {
+	var pods []*corev1.Pod
+	for i := 0; i < int(set.Status.Replicas); i++ {
+		l := label.New().Instance(upgradeInstanceName).TiFlash().Labels()
+		if i+1 <= int(set.Status.CurrentReplicas) {
+			l[apps.ControllerRevisionHashLabelKey] = set.Status.CurrentRevision
+		} else {
+			l[apps.ControllerRevisionHashLabelKey] = set.Status.UpdateRevision
+		}
+		l[label.StoreIDLabelKey] = strconv.Itoa(i + 1)
+		pods = append(pods, &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TiFlashPodName(upgradeTcName, int32(i)),
+				Namespace: corev1.NamespaceDefault,
+				Labels:    l,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		})
+	}
+	return pods
+}

--- a/pkg/manager/member/tiflash_upgrader_test.go
+++ b/pkg/manager/member/tiflash_upgrader_test.go
@@ -261,7 +261,7 @@ func TestTiFlashUpgraderUpgrade(t *testing.T) {
 	}
 }
 
-func newTiFlashUpgrader() (TiFlashUpgrader, *pdapi.FakePDControl, *controller.FakePodControl, podinformers.PodInformer) {
+func newTiFlashUpgrader() (Upgrader, *pdapi.FakePDControl, *controller.FakePodControl, podinformers.PodInformer) {
 	fakeDeps := controller.NewFakeDependencies()
 	pdControl := fakeDeps.PDControl.(*pdapi.FakePDControl)
 	podControl := fakeDeps.PodControl.(*controller.FakePodControl)

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -133,6 +133,10 @@ func MemberPodName(controllerName, controllerKind string, ordinal int32, memberT
 	}
 }
 
+func TiFlashPodName(tcName string, ordinal int32) string {
+	return fmt.Sprintf("%s-%d", controller.TiFlashMemberName(tcName), ordinal)
+}
+
 func TikvPodName(tcName string, ordinal int32) string {
 	return fmt.Sprintf("%s-%d", controller.TiKVMemberName(tcName), ordinal)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fixes #3786
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Add rolling upgrade logic for TiFlash component.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

1. Create a cluster with TiFlash

> Note: The replicas of TiKV should be more than TiFlash.
```yaml
tikv:
    baseImage: registry.cn-beijing.aliyuncs.com/tidb/tikv
    version: v4.0.8
    replicas: 3
    requests:
      storage: "5Gi"
    config: {}
tiflash:
    baseImage: registry.cn-beijing.aliyuncs.com/tidb/tiflash
    version: v4.0.8
    maxFailoverCount: 3
    annotations:
      tidb.pingcap.com/sysctl-init: "true"
    replicas: 2
    storageClaims:
      - resources:
          requests:
            storage: 1Gi
```

3. Use go-tpc tpch to generate data into the TiFlash

```bash
go-tpc tpch -H 10.96.138.6 --tiflash --sf=50 prepare 
```

Modify the TiFlash replicas of the tables in SQL.

```sql
ALTER TABLE `test`.`nation` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`region` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`lineitem` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`supplier` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`customer` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`orders` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`partsupp` SET TIFLASH REPLICA 2;
ALTER TABLE `test`.`part` SET TIFLASH REPLICA 2;
```

4. Use command to check if TiFlash is working as expected.

```sql
SELECT * FROM information_schema.tiflash_replica;
```

If `available` is 1, it shows that TiFlash is working. You can see the TiFlash working status from TiDBMonitor.

5. Change tidbcluster CR to upgrade TiFlash, and monitor TiFlash with `select` query and the TiFlash metrics panel in Grafana.

```bash
kubectl patch tc cluster1 --type merge -p '{"spec":{"tiflash":{"version":"v4.0.9"}}}'
```

Continuely counting from `test.lineitem` to check if TiFlash working normally.

```bash
watch "mysql -h10.96.138.6 -P4000 -e'select count(*) from test.lineitem';"
```

Watch the Grafana panel to verify the fixes are working as expected. Before we add rolling upgrade logic, the pod cluster1-tiflash-0 will immediately terminate after the pod cluster1-tiflash-1 is launched.

![image](https://user-images.githubusercontent.com/2058782/108885613-fe390180-7642-11eb-98d9-51cc3a78c2c1.png)

We can verify this in the `Memory` panel. The memory usage of cluster1-tiflash-0 and cluster1-tiflash-1 cross at the bottom of the panel.

After we add rolling upgrade logic, the pod cluster1-tiflash-1 will first restart, and after the store state is up, the pod cluster1-tiflash-0 will restart later, which shows in Grafana that the memory usage of the pod cluster1-tiflash-1 will rise from the bottom to the peak for a while, then the pod cluster1-tiflash-1 will restart.

![image](https://user-images.githubusercontent.com/2058782/108885571-f4170300-7642-11eb-9d46-1c8295d7b4c3.png)

After the fix, we can see that there are two stores in Up status while there are only 1 TiFlash pod upgraded, and the `select` query is still working, There is an upgrading gap between 2 TiFlash pods.

![image](https://user-images.githubusercontent.com/2058782/108885673-0d1fb400-7643-11eb-98c5-3cbf041b1a10.png)

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Add TiFlash rolling upgrade logic to avoid all TiFlash stores unavailable.
```
