### PR TITLE
Add delve into tidb-debug

### DIFF
--- a/misc/images/tidb-debug/Dockerfile
+++ b/misc/images/tidb-debug/Dockerfile
@@ -49,6 +49,9 @@ ENV GOPATH /go
 ENV GOROOT /usr/local/go
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 
+# build delve
+RUN go get github.com/go-delve/delve/cmd/dlv
+
 ADD banner /etc/banner
 ADD profile  /etc/profile
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Currently tidb-debug image only  includes `gdb` for debugging. It's not convenient as `delve`. This PR burns `delve` into the image so that developer also can debug tidb through delve.


### What is changed and how does it work?
This PR just add a single line to build delve into the image.

### Code changes

- [ ] Has Go code change
- [x] Has CI related scripts change

### Tests
- [x] E2E test 
- [x] Manual test


