### PR TITLE
tune and suppport configuration about LeaderElection

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -75,6 +75,15 @@ spec:
           {{- $label := join "," .Values.controllerManager.selector }}
           - -selector={{ $label }}
           {{- end }}
+         {{- if .Values.controllerManager.leaderLeaseDuration }}
+          - -leader-lease-duration={{ .Values.controllerManager.leaderLeaseDuration }}
+         {{- end }}
+         {{- if .Values.controllerManager.leaderRenewDeadline }}
+          - -leader-renew-deadline={{ .Values.controllerManager.leaderRenewDeadline }}
+         {{- end }}
+         {{- if .Values.controllerManager.leaderRetryPeriod }}
+          - -leader-retry-period={{ .Values.controllerManager.leaderRetryPeriod }}
+         {{- end }}
         env:
           - name: NAMESPACE
             valueFrom:

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -53,6 +53,15 @@ controllerManager:
       memory: 50Mi
 #  # REF: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 #  priorityClassName: system-cluster-critical
+#
+
+  # REF: https://pkg.go.dev/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig
+  ## leaderLeaseDuration is the duration that non-leader candidates will wait to force acquire leadership
+  # leaderLeaseDuration: 15s
+  ## leaderRenewDeadline is the duration that the acting master will retry refreshing leadership before giving up
+  # leaderRenewDeadline: 10s
+  ## leaderRetryPeriod is the duration the LeaderElector clients should wait between tries of actions
+  # leaderRetryPeriod: 2s
 
   # autoFailover is whether tidb-operator should auto failover when failure occurs
   autoFailover: true

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -204,7 +204,7 @@ func main() {
 				},
 			},
 			LeaseDuration: cliCfg.LeaseDuration,
-			RenewDeadline: cliCfg.RenewDuration,
+			RenewDeadline: cliCfg.RenewDeadline,
 			RetryPeriod:   cliCfg.RetryPeriod,
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: onStarted,

--- a/pkg/controller/dependences.go
+++ b/pkg/controller/dependences.go
@@ -60,7 +60,7 @@ type CLIConfig struct {
 	MasterFailoverPeriod  time.Duration
 	WorkerFailoverPeriod  time.Duration
 	LeaseDuration         time.Duration
-	RenewDuration         time.Duration
+	RenewDeadline         time.Duration
 	RetryPeriod           time.Duration
 	WaitDuration          time.Duration
 	// ResyncDuration is the resync time of informer
@@ -91,8 +91,8 @@ func DefaultCLIConfig() *CLIConfig {
 		MasterFailoverPeriod:   5 * time.Minute,
 		WorkerFailoverPeriod:   5 * time.Minute,
 		LeaseDuration:          15 * time.Second,
-		RenewDuration:          5 * time.Second,
-		RetryPeriod:            3 * time.Second,
+		RenewDeadline:          10 * time.Second,
+		RetryPeriod:            2 * time.Second,
 		WaitDuration:           5 * time.Second,
 		ResyncDuration:         30 * time.Second,
 		TiDBBackupManagerImage: "pingcap/tidb-backup-manager:latest",
@@ -121,6 +121,11 @@ func (c *CLIConfig) AddFlag(_ *flag.FlagSet) {
 	flag.StringVar(&c.TiDBDiscoveryImage, "tidb-discovery-image", c.TiDBDiscoveryImage, "The image of the tidb discovery service")
 	flag.BoolVar(&c.PodWebhookEnabled, "pod-webhook-enabled", false, "Whether Pod admission webhook is enabled")
 	flag.StringVar(&c.Selector, "selector", c.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='")
+
+	// see https://pkg.go.dev/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig for the config
+	flag.DurationVar(&c.LeaseDuration, "leader-lease-duration", c.LeaseDuration, "leader-lease-duration is the duration that non-leader candidates will wait to force acquire leadership")
+	flag.DurationVar(&c.RenewDeadline, "leader-renew-deadline", c.RenewDeadline, "leader-renew-deadline is the duration that the acting master will retry refreshing leadership before giving up")
+	flag.DurationVar(&c.RetryPeriod, "leader-retry-period", c.RetryPeriod, "leader-retry-period is the duration the LeaderElector clients should wait between tries of actions")
 }
 
 type Controls struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?


For some maybe performance issues due to the cluster, it may be slow to respond for acquiring or renew the lease.

like this, it takes roughly 4s to acquire the lock
```
 30 I0218 10:45:15.603307       1 leaderelection.go:241] attempting to acquire leader lease  tidb-operator/tidb-controller-manager...
 31 I0218 10:45:19.553068       1 leaderelection.go:251] successfully acquired lease tidb-operator/tidb-controller-manager
```


And we are setting `RenewDeadline` as the only 5s, so it will easy fail to acquire or renew the lock.


### What is changed and how does it work?

change the values to  defaults as the core client(enlarge `RenewDeadline` from 5s to 10s)
also support user configuration

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

build a image to use myself
change the added items as some value and use the custom image
run `helm install tidb-operator charts/tidb-operator --namespace=tidb-admin  -f ${HOME}/tidb-operator/values-tidb-operator.yaml`
check log of controller:
```
 11 I0222 09:30:33.015161       1 main.go:69] FLAG: --leader-lease-duration="16s"
 12 I0222 09:30:33.015163       1 main.go:69] FLAG: --leader-renew-deadline="11s"
 13 I0222 09:30:33.015165       1 main.go:69] FLAG: --leader-retry-period="4s"
```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support user configuration about LeaderLease
```
