### PR TITLE
add test case: delete resources controlled by tc

### DIFF
--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -41,6 +41,7 @@ import (
 	utilpod "github.com/pingcap/tidb-operator/tests/e2e/util/pod"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/proxiedpdclient"
+	utiltc "github.com/pingcap/tidb-operator/tests/e2e/util/tidbcluster"
 	"github.com/pingcap/tidb-operator/tests/pkg/apimachinery"
 	"github.com/pingcap/tidb-operator/tests/pkg/blockwriter"
 	"github.com/pingcap/tidb-operator/tests/pkg/fixture"
@@ -63,7 +64,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/utils"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlCli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = ginkgo.Describe("TiDBCluster", func() {
@@ -79,7 +80,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	var cfg *tests.Config
 	var config *restclient.Config
 	var ocfg *tests.OperatorConfig
-	var genericCli client.Client
+	var genericCli ctrlCli.Client
 	var fwCancel context.CancelFunc
 	var fw portforward.PortForward
 	/**
@@ -98,7 +99,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		framework.ExpectNoError(err, "failed to create clientset for pingcap")
 		asCli, err = asclientset.NewForConfig(config)
 		framework.ExpectNoError(err, "failed to create clientset for advanced-statefulset")
-		genericCli, err = client.New(config, client.Options{Scheme: scheme.Scheme})
+		genericCli, err = ctrlCli.New(config, ctrlCli.Options{Scheme: scheme.Scheme})
 		framework.ExpectNoError(err, "failed to create clientset for controller-runtime")
 		aggrCli, err = aggregatorclient.NewForConfig(config)
 		framework.ExpectNoError(err, "failed to create clientset kube-aggregator")
@@ -1557,6 +1558,35 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		tcCfg.ScaleTiKV(4)
 		oa.UpgradeTidbClusterOrDie(&tcCfg)
 		oa.CheckTidbClusterStatusOrDie(&tcCfg)
+	})
+
+	ginkgo.It("Deleted objects controlled by TidbCluster will be recovered by Operator", func() {
+		ginkgo.By("Deploy initial tc")
+		tc := fixture.GetTidbCluster(ns, "delete-objects", utilimage.TiDBV4)
+		utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc, 5*time.Minute, 10*time.Second)
+
+		ginkgo.By("Delete StatefulSet/ConfigMap/Service of PD")
+		// TODO: make a local function, variables are pd/tikv/tidb member name
+		deleteResourcesForComponent := func(memberName string) {
+			sts, err := stsGetter.StatefulSets(ns).Get(memberName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get StatefulSet %s/%s", ns, memberName)
+			err = stsGetter.StatefulSets(ns).Delete(memberName, &metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete StatefulSet %s/%s", ns, memberName)
+			cmName := member.FindConfigMapVolume(&sts.Spec.Template.Spec, func(name string) bool {
+				return strings.HasPrefix(name, memberName)
+			})
+			err = c.CoreV1().ConfigMaps(ns).Delete(cmName, &metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete ConfigMap %s/%s", ns, cmName)
+			err = c.CoreV1().Services(ns).Delete(memberName, &metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete Service %s/%s", ns, memberName)
+		}
+		deleteResourcesForComponent(controller.PDMemberName(tc.Name))
+		deleteResourcesForComponent(controller.TiKVMemberName(tc.Name))
+		deleteResourcesForComponent(controller.TiDBMemberName(tc.Name))
+
+		ginkgo.By("Wait for TidbCluster components ready again")
+		err := oa.WaitForTidbClusterReady(tc, 10*time.Minute, 10*time.Second)
+		framework.ExpectNoError(err, "failed to wait for TidbCluster %s/%s components ready", tc.Namespace, tc.Name)
 	})
 })
 

--- a/tests/e2e/util/tidbcluster/tidbcluster.go
+++ b/tests/e2e/util/tidbcluster/tidbcluster.go
@@ -75,7 +75,7 @@ func WaitForTidbClusterReady(c versioned.Interface, ns, name string, timeout tim
 }
 
 // MustCreateTCWithComponentsReady create TidbCluster and wait for components ready
-func MustCreateTCWithComponentsReady(cli ctrlCli.Client, oa tests.OperatorActions, tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) {
+func MustCreateTCWithComponentsReady(cli ctrlCli.Client, oa *tests.OperatorActions, tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) {
 	err := cli.Create(context.TODO(), tc)
 	framework.ExpectNoError(err, "failed to create TidbCluster %s/%s", tc.Namespace, tc.Name)
 	err = oa.WaitForTidbClusterReady(tc, timeout, pollInterval)


### PR DESCRIPTION
Signed-off-by: Li Yilong <liyilongko@gmail.com>

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Add e2e case: delete resources controlled by tc.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
