### PR TITLE
Share host debugfs, kernel modules and kernel sources path to container

### DIFF
--- a/pkg/tkctl/debug/launcher.go
+++ b/pkg/tkctl/debug/launcher.go
@@ -140,6 +140,12 @@ func (l *Launcher) createContainer(command []string) (*container.ContainerCreate
 		StdinOnce:  true,
 	}
 	hostConfig := &container.HostConfig{
+		// share host debugfs, kernel modules and kernel sources path to container for kernel debugging
+		Binds: []string{
+			"/sys/kernel/debug:/sys/kernel/debug:rw",
+			"/lib/modules/:/lib/modules:ro",
+			"/usr/src:/usr/src:ro",
+		},
 		NetworkMode: container.NetworkMode(containerMode(dockerContainerID)),
 		UsernsMode:  container.UsernsMode(containerMode(dockerContainerID)),
 		IpcMode:     container.IpcMode(containerMode(dockerContainerID)),


### PR DESCRIPTION
### What problem does this PR solve?

Many kernel debugging tools are based on debugfs.  Those tools, specifically the [linux tracing system](https://jvns.ca/blog/2017/07/05/linux-tracing-systems),  are quite useful to understand the system behavior as well as user-level behavior of tidb processes.  This PR shares host debugfs, kernel modules and kernel sources path to containers for kernel/user-space debugging.

Below example shows how to trace the latency distribution on tikv's `crocksdb_write_multi_batch` function.

```
$ tkctl debug tidb-cluster-tikv-0 --launcher-image 'mzhou/debug-launcher:latest' --image 'quay.io/iovisor/bpftrace:latest' --privileged

# bpftrace -e 'uprobe:/proc/1/root/tikv-server:crocksdb_write_multi_batch { @start[tid] = nsecs;} uretprobe:/proc/1/root/tikv-server:crocksdb_write_multi_batch /@start[tid]/ { @ns[comm] = hist(nsecs - @start[tid]); delete(@start[tid]); }'

@ns[apply-0]:
[64K, 128K)           33 |@@@                                                 |
[128K, 256K)         425 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        |
[256K, 512K)         495 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[512K, 1M)           421 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        |
[1M, 2M)             271 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@                        |
[2M, 4M)              35 |@@@                                                 |
[4M, 8M)               6 |                                                    |
[8M, 16M)              1 |                                                    |
@ns[apply-2]:
[64K, 128K)           29 |@@                                                  |
[128K, 256K)         452 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@         |
[256K, 512K)         538 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[512K, 1M)           438 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@          |
[1M, 2M)             283 |@@@@@@@@@@@@@@@@@@@@@@@@@@@                         |
[2M, 4M)              25 |@@                                                  |
[4M, 8M)               4 |                                                    |
[8M, 16M)              1 |                                                    |
@ns[apply-1]:
[64K, 128K)           32 |@@@                                                 |
[128K, 256K)         505 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@    |
[256K, 512K)         537 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[512K, 1M)           432 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@           |
[1M, 2M)             277 |@@@@@@@@@@@@@@@@@@@@@@@@@@                          |
[2M, 4M)              25 |@@                                                  |
[4M, 8M)               4 |                                                    |
[8M, 16M)              1 |                                                    |
```
From above we can observe that my tikv setup has 3 store threads, the latency for rocksdb batch write is around 128-1000 us.

### What is changed and how does it work?
This PR binds 3 host dirs to container: /sys/kernel/debug, /lib/modules, /usr/src

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test
- [x] E2E test
- [x] Manual test



