### PR TITLE
Fix backup manager scripts to competite with some shell 

### DIFF
--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -52,7 +52,7 @@ else
 fi
 
 BACKUP_BIN=/tidb-backup-manager
-if [[ -n "${AWS_DEFAULT_REGION}"]]; then
+if [[ -n "${AWS_DEFAULT_REGION}" ]]; then
 	EXEC_COMMAND="exec"
 else
 	EXEC_COMMAND="/usr/local/bin/shush exec --"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Fixes #3807
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

Create a backup CR to backup data from TiDB to minio. The job output shows:

```log
Create rclone.conf file.
/tidb-backup-manager backup --namespace=pingcap --backupName=demo1-backup-s3 --tikvVersion=v4.0.8
I0225 04:12:56.658268      11 backup.go:71] start to process backup pingcap/demo1-backup-s3
I0225 04:12:56.677715      11 backup_status_updater.go:84] Backup: [pingcap/demo1-backup-s3] updated successfully
...
I0225 04:12:56.834287      11 backup.go:93] [2021/02/25 04:12:56.834 +00:00] [INFO] [client.go:205] ["save backup meta"] [path=s3://my-bucket/my-folder] [size=16]
I0225 04:12:56.846596      11 backup.go:93] [2021/02/25 04:12:56.846 +00:00] [INFO] [ddl.go:391] ["[ddl] DDL closed"] [ID=8646920c-ccaa-42fa-9050-2f9a3ad90e82] ["take time"=514.268µs]
I0225 04:12:56.846608      11 backup.go:93] [2021/02/25 04:12:56.846 +00:00] [INFO] [ddl.go:304] ["[ddl] stop DDL"] [ID=8646920c-ccaa-42fa-9050-2f9a3ad90e82]
I0225 04:12:56.847266      11 backup.go:93] [2021/02/25 04:12:56.847 +00:00] [INFO] [domain.go:457] ["infoSyncerKeeper exited."]
I0225 04:12:56.847277      11 backup.go:93] [2021/02/25 04:12:56.847 +00:00] [INFO] [domain.go:516] ["loadSchemaInLoop exited."]
I0225 04:12:56.847946      11 backup.go:93] [2021/02/25 04:12:56.847 +00:00] [INFO] [domain.go:428] ["topNSlowQueryLoop exited."]
I0225 04:12:56.847957      11 backup.go:93] [2021/02/25 04:12:56.847 +00:00] [INFO] [domain.go:637] ["domain closed"] ["take time"=1.595757ms]
I0225 04:12:56.847970      11 backup.go:93] [2021/02/25 04:12:56.847 +00:00] [INFO] [collector.go:187] ["Full backup Failed summary : total backup ranges: 0, total success: 0, total failed: 0"] [BackupTS=423159759322218497]
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
