### PR TITLE
Fix support for multiple pvc for tikv

### DIFF
--- a/pkg/manager/member/pd_failover_test.go
+++ b/pkg/manager/member/pd_failover_test.go
@@ -520,6 +520,7 @@ func TestPDFailoverFailover(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Log(test.name)
 			tc := newTidbClusterForPD()
 			tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(test.maxFailoverCount)
 			test.update(tc)

--- a/pkg/manager/member/pd_failover_test.go
+++ b/pkg/manager/member/pd_failover_test.go
@@ -520,7 +520,6 @@ func TestPDFailoverFailover(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Log(test.name)
 			tc := newTidbClusterForPD()
 			tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(test.maxFailoverCount)
 			test.update(tc)

--- a/pkg/manager/member/pd_scaler_test.go
+++ b/pkg/manager/member/pd_scaler_test.go
@@ -570,6 +570,7 @@ func newScaleInPVCForStatefulSet(set *apps.StatefulSet, memberType v1alpha1.Memb
 		l = label.New().Instance(name)
 	}
 	l[label.AnnPodNameKey] = podName
+	fmt.Printf("newScaleInPVCForStatefulSet: pvc %s\n", ordinalPVCName(memberType, set.GetName(), *set.Spec.Replicas-1))
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ordinalPVCName(memberType, set.GetName(), *set.Spec.Replicas-1),

--- a/pkg/manager/member/scaler.go
+++ b/pkg/manager/member/scaler.go
@@ -213,7 +213,7 @@ func scaleOne(actual *apps.StatefulSet, desired *apps.StatefulSet) (scaling int,
 		// we always do scaling out before scaling in to maintain maximum avaiability
 		scaling = 1
 		ordinal = additions.List()[0]
-		replicas += 1
+		replicas++
 		if !desiredDeleteSlots.Has(ordinal) {
 			// not in desired delete slots, remove it from actual delete slots
 			actualDeleteSlots.Delete(ordinal)
@@ -223,7 +223,7 @@ func scaleOne(actual *apps.StatefulSet, desired *apps.StatefulSet) (scaling int,
 		scaling = -1
 		deletionsList := deletions.List()
 		ordinal = deletionsList[len(deletionsList)-1]
-		replicas -= 1
+		replicas--
 		if desiredDeleteSlots.Has(ordinal) {
 			// in desired delete slots, add it in actual delete slots
 			actualDeleteSlots.Insert(ordinal)

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -211,8 +211,8 @@ func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 			}
 			klog.Infof("pod %s not ready, tikv scale in: set pvc %s/%s annotation: %s to %s", podName, ns, pvc.Name, label.AnnPVCDeferDeleting, now)
 			setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
-			return nil
 		}
+		return nil
 	}
 	return fmt.Errorf("TiKV %s/%s not found in cluster", ns, podName)
 }

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -114,7 +114,7 @@ func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 		return nil
 	}
 
-	// call pd to delete store of the will-be-scaled-in tikv pod
+	// call PD API to delete the store of the TiKV Pod to be scaled in
 	for _, store := range tc.Status.TiKV.Stores {
 		if store.PodName == podName {
 			state := store.State
@@ -133,7 +133,7 @@ func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 		}
 	}
 
-	// annotate tikv pods with tomestone store
+	// If the store state turns to Tombstone, add defer deleting annotation to the PVCs of the Pod
 	for storeID, store := range tc.Status.TiKV.TombstoneStores {
 		if store.PodName == podName && pod.Labels[label.StoreIDLabelKey] == storeID {
 			id, err := strconv.ParseUint(store.ID, 10, 64)

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -149,7 +149,7 @@ func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 				return fmt.Errorf("tikvScaler.ScaleIn: failed to get pvcs for pod %s/%s in tc %s/%s, error: %s", ns, pod.Name, ns, tcName, err)
 			}
 			for _, pvc := range pvcs {
-				if err := AnnotatePVCDeferDeletingLabel(tc, pvc, s.deps.PVCControl); err != nil {
+				if err := addDeferDeletingAnnoToPVC(tc, pvc, s.deps.PVCControl); err != nil {
 					return err
 				}
 			}
@@ -190,7 +190,7 @@ func (s *tikvScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 			return fmt.Errorf("tikvScaler.ScaleIn: failed to get pvcs for pod %s/%s in tc %s/%s, error: %s", ns, pod.Name, ns, tcName, err)
 		}
 		for _, pvc := range pvcs {
-			if err := AnnotatePVCDeferDeletingLabel(tc, pvc, s.deps.PVCControl); err != nil {
+			if err := addDeferDeletingAnnoToPVC(tc, pvc, s.deps.PVCControl); err != nil {
 				return err
 			}
 		}

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -60,7 +60,6 @@ func TestTiKVScalerScaleOut(t *testing.T) {
 		scaler, _, pvcIndexer, _, pvcControl := newFakeTiKVScaler()
 
 		pvc := newPVCForStatefulSet(oldSet, v1alpha1.TiKVMemberType, tc.Name)
-		pvc.Name = ordinalPVCName(v1alpha1.TiKVMemberType, oldSet.GetName(), *oldSet.Spec.Replicas)
 		if !test.annoIsNil {
 			pvc.Annotations = map[string]string{}
 		}

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -197,15 +197,26 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 		scaler, pdControl, pvcIndexer, podIndexer, pvcControl := newFakeTiKVScaler(resyncDuration)
 
 		if test.hasPVC {
-			pvc := newScaleInPVCForStatefulSet(oldSet, v1alpha1.TiKVMemberType, tc.Name)
-			pvcIndexer.Add(pvc)
-			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: pvc.Name,
+			pvc1 := newScaleInPVCForStatefulSet(oldSet, v1alpha1.TiKVMemberType, tc.Name)
+			pvc2 := pvc1.DeepCopy()
+			pvc1.Name = pvc1.Name + "1"
+			pvc2.Name = pvc2.Name + "2"
+			pvcIndexer.Add(pvc1)
+			pvcIndexer.Add(pvc2)
+			pod.Spec.Volumes = append(pod.Spec.Volumes,
+				corev1.Volume{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc1.Name,
+						},
 					},
-				},
-			})
+				}, corev1.Volume{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc2.Name,
+						},
+					},
+				})
 		}
 
 		pod.Labels = map[string]string{}

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -200,6 +200,13 @@ func TestTiKVScalerScaleIn(t *testing.T) {
 		if test.hasPVC {
 			pvc := newScaleInPVCForStatefulSet(oldSet, v1alpha1.TiKVMemberType, tc.Name)
 			pvcIndexer.Add(pvc)
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvc.Name,
+					},
+				},
+			})
 		}
 
 		pod.Labels = map[string]string{}

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -260,7 +260,7 @@ func MapContainers(podSpec *corev1.PodSpec) map[string]corev1.Container {
 	return m
 }
 
-// updateStatefulSet is a template function to update the statefulset of components
+// UpdateStatefulSet is a template function to update the statefulset of components
 func UpdateStatefulSet(setCtl controller.StatefulSetControlInterface, object runtime.Object, newSet, oldSet *apps.StatefulSet) error {
 	isOrphan := metav1.GetControllerOf(oldSet) == nil
 	if newSet.Annotations == nil {

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -503,8 +503,8 @@ func CreateOrUpdateService(serviceLister corelisters.ServiceLister, serviceContr
 	return nil
 }
 
-// AnnotatePVCDeferDeletingLabel set the label
-func AnnotatePVCDeferDeletingLabel(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pvcControl controller.PVCControlInterface) error {
+// addDeferDeletingAnnoToPVC set the label
+func addDeferDeletingAnnoToPVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pvcControl controller.PVCControlInterface) error {
 	if pvc.Annotations == nil {
 		pvc.Annotations = map[string]string{}
 	}

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -499,5 +500,20 @@ func CreateOrUpdateService(serviceLister corelisters.ServiceLister, serviceContr
 		_, err = serviceControl.UpdateService(obj, &svc)
 		return err
 	}
+	return nil
+}
+
+// AnnotatePVCDeferDeletingLabel set the label
+func AnnotatePVCDeferDeletingLabel(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentVolumeClaim, pvcControl controller.PVCControlInterface) error {
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	now := time.Now().Format(time.RFC3339)
+	pvc.Annotations[label.AnnPVCDeferDeleting] = now
+	if _, err := pvcControl.UpdatePVC(tc, pvc); err != nil {
+		klog.Errorf("failed to set PVC %s/%s annotation %q to %q", tc.Namespace, pvc.Name, label.AnnPVCDeferDeleting, now)
+		return err
+	}
+	klog.Infof("set PVC %s/%s annotationq %q to %q successfully", tc.Namespace, pvc.Name, label.AnnPVCDeferDeleting, now)
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -437,7 +437,7 @@ func ResolvePVCFromPod(pod *corev1.Pod, pvcLister corelisterv1.PersistentVolumeC
 		}
 	}
 	if len(pvcs) == 0 {
-		klog.Errorf("no pvc found for pod %s", pod.Name)
+		klog.Errorf("no pvc found for pod %s/%s", pod.Namespace, pod.Name)
 		return nil, errors.NewNotFound(corev1.Resource("pvc"), "")
 	}
 	return pvcs, nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -436,7 +437,8 @@ func ResolvePVCFromPod(pod *corev1.Pod, pvcLister corelisterv1.PersistentVolumeC
 		}
 	}
 	if len(pvcs) == 0 {
-		return nil, fmt.Errorf("no pvc found for pod %s", pod.Name)
+		klog.Errorf("no pvc found for pod %s", pod.Name)
+		return nil, errors.NewNotFound(corev1.Resource("pvc"), "")
 	}
 	return pvcs, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -436,7 +437,9 @@ func ResolvePVCFromPod(pod *corev1.Pod, pvcLister corelisterv1.PersistentVolumeC
 		}
 	}
 	if len(pvcs) == 0 {
-		return nil, fmt.Errorf("no pvc found for pod %s/%s", pod.Namespace, pod.Name)
+		err := errors.NewNotFound(corev1.Resource("pvc"), "")
+		err.ErrStatus.Message = fmt.Sprintf("no pvc found for pod %s/%s", pod.Namespace, pod.Name)
+		return pvcs, err
 	}
 	return pvcs, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,7 +29,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -437,8 +436,7 @@ func ResolvePVCFromPod(pod *corev1.Pod, pvcLister corelisterv1.PersistentVolumeC
 		}
 	}
 	if len(pvcs) == 0 {
-		klog.Errorf("no pvc found for pod %s/%s", pod.Namespace, pod.Name)
-		return nil, errors.NewNotFound(corev1.Resource("pvc"), "")
+		return nil, fmt.Errorf("no pvc found for pod %s/%s", pod.Namespace, pod.Name)
 	}
 	return pvcs, nil
 }

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -858,14 +858,16 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		listOptions := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(label.New().Instance(tcName).Component(label.TiKVLabelVal).Labels()).String(),
 		}
-		err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+		err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
 			podList, err := c.CoreV1().Pods(ns).List(listOptions)
 			if err != nil && !apierrors.IsNotFound(err) {
+				log.Logf("failed to list pods: %+v", err)
 				return false, err
 			}
 			for _, pod := range podList.Items {
 				for _, c := range pod.Spec.Containers {
 					if c.Name == v1alpha1.TiKVMemberType.String() {
+						log.Logf("c.Image: %s", c.Image)
 						if c.Image == tc.TiKVImage() {
 							return true, nil
 						}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
ref: #3802

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Change tikv related code to support multiple pvc from pod spec, instead of constructing a single pvc name from tc name and ordinal.

Also refactored related util functions for brevity.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    1. deploy a tc
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
        name: basic
    spec:
        version: v4.0.10
        timezone: UTC
        pvReclaimPolicy: Delete
        configUpdateStrategy: RollingUpdate
        discovery: {}
        pd:
            baseImage: pingcap/pd
            replicas: 3
            requests:
                storage: "1Gi"
            config: {}
        tikv:
            baseImage: pingcap/tikv
            replicas: 4
            requests:
                storage: "1Gi"
            storageVolumes:
                - name: additional
                storageSize: "1Gi"
                mountPath: /mnt
            config: {}
        tidb:
            baseImage: pingcap/tidb
            replicas: 1
            config: {}
    ```
    2. check pvc with `kubectl get pvc`
    ```
    NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    pd-basic-pd-0                  Bound    pvc-8d98e8d5-93de-432a-9d19-b2b3e8826282   1Gi        RWO            standard       103m
    pd-basic-pd-1                  Bound    pvc-69458bd2-290b-49a7-aff8-029408498ac4   1Gi        RWO            standard       103m
    pd-basic-pd-2                  Bound    pvc-a571b440-b7dd-4f1e-bd99-327e46b2b843   1Gi        RWO            standard       103m
    tikv-additional-basic-tikv-0   Bound    pvc-eb8ec28f-b78e-4f83-89b1-e1e1e172f127   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-1   Bound    pvc-ed541ee0-5bee-40bb-ab94-34eaa65478df   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-2   Bound    pvc-45eab6ed-16e0-42fb-9f96-8f9e9d2db97e   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-3   Bound    pvc-70699ee8-d350-4208-99ba-68d837e99eeb   1Gi        RWO            standard       102m
    tikv-basic-tikv-0              Bound    pvc-8b3a8886-1804-4b68-b337-1304758ba3f8   1Gi        RWO            standard       102m
    tikv-basic-tikv-1              Bound    pvc-6a3fd2cd-99a4-4b2b-b5c6-1a43460fed1a   1Gi        RWO            standard       102m
    tikv-basic-tikv-2              Bound    pvc-8046ef23-b6e5-44e1-8813-cb0fe0913985   1Gi        RWO            standard       102m
    tikv-basic-tikv-3              Bound    pvc-9013e429-6037-4984-83f3-f2310f71b0a6   1Gi        RWO            standard       102m
    ```
    3. scale in tikv to 3 replicas, check pvc again, returns same results as in step 2, because PVCs are retained by default.
    ```
    NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    pd-basic-pd-0                  Bound    pvc-8d98e8d5-93de-432a-9d19-b2b3e8826282   1Gi        RWO            standard       103m
    pd-basic-pd-1                  Bound    pvc-69458bd2-290b-49a7-aff8-029408498ac4   1Gi        RWO            standard       103m
    pd-basic-pd-2                  Bound    pvc-a571b440-b7dd-4f1e-bd99-327e46b2b843   1Gi        RWO            standard       103m
    tikv-additional-basic-tikv-0   Bound    pvc-eb8ec28f-b78e-4f83-89b1-e1e1e172f127   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-1   Bound    pvc-ed541ee0-5bee-40bb-ab94-34eaa65478df   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-2   Bound    pvc-45eab6ed-16e0-42fb-9f96-8f9e9d2db97e   1Gi        RWO            standard       102m
    tikv-additional-basic-tikv-3   Bound    pvc-70699ee8-d350-4208-99ba-68d837e99eeb   1Gi        RWO            standard       102m
    tikv-basic-tikv-0              Bound    pvc-8b3a8886-1804-4b68-b337-1304758ba3f8   1Gi        RWO            standard       102m
    tikv-basic-tikv-1              Bound    pvc-6a3fd2cd-99a4-4b2b-b5c6-1a43460fed1a   1Gi        RWO            standard       102m
    tikv-basic-tikv-2              Bound    pvc-8046ef23-b6e5-44e1-8813-cb0fe0913985   1Gi        RWO            standard       102m
    tikv-basic-tikv-3              Bound    pvc-9013e429-6037-4984-83f3-f2310f71b0a6   1Gi        RWO            standard       102m
    ```
    4. scale out tikv to 4 replicas, check pvc again, found that `tikv-basic-tikv-3` and `tikv-additional-basic-tikv-3` has changed, because the old PVC is deleted and new one is created with the same name. we can tell from the different `VOLUME` name.
    ```
    NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    pd-basic-pd-0                  Bound    pvc-8d98e8d5-93de-432a-9d19-b2b3e8826282   1Gi        RWO            standard       104m
    pd-basic-pd-1                  Bound    pvc-69458bd2-290b-49a7-aff8-029408498ac4   1Gi        RWO            standard       104m
    pd-basic-pd-2                  Bound    pvc-a571b440-b7dd-4f1e-bd99-327e46b2b843   1Gi        RWO            standard       104m
    tikv-additional-basic-tikv-0   Bound    pvc-eb8ec28f-b78e-4f83-89b1-e1e1e172f127   1Gi        RWO            standard       103m
    tikv-additional-basic-tikv-1   Bound    pvc-ed541ee0-5bee-40bb-ab94-34eaa65478df   1Gi        RWO            standard       103m
    tikv-additional-basic-tikv-2   Bound    pvc-45eab6ed-16e0-42fb-9f96-8f9e9d2db97e   1Gi        RWO            standard       103m
    tikv-additional-basic-tikv-3   Bound    pvc-2911848a-03f9-4406-8495-502f418d2fd6   1Gi        RWO            standard       6s
    tikv-basic-tikv-0              Bound    pvc-8b3a8886-1804-4b68-b337-1304758ba3f8   1Gi        RWO            standard       103m
    tikv-basic-tikv-1              Bound    pvc-6a3fd2cd-99a4-4b2b-b5c6-1a43460fed1a   1Gi        RWO            standard       103m
    tikv-basic-tikv-2              Bound    pvc-8046ef23-b6e5-44e1-8813-cb0fe0913985   1Gi        RWO            standard       103m
    tikv-basic-tikv-3              Bound    pvc-4fb8a2b2-8b07-4603-95ef-c71df247cc84   1Gi        RWO            standard       6s
    ```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix support for multiple PVC for TiKV.
```
