### PR TITLE
use new serviceaccount when release suffix is appended

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -28,7 +28,11 @@ spec:
         app.kubernetes.io/component: controller-manager
     spec:
     {{- if .Values.controllerManager.serviceAccount }}
+      {{- if eq .Values.appendReleaseSuffix true}}
+      serviceAccount: {{ .Values.controllerManager.serviceAccount }}-{{ .Release.Name }}
+      {{- else }}
       serviceAccount: {{ .Values.controllerManager.serviceAccount }}
+      {{- end }}       
     {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/tidb-operator/templates/controller-manager-rbac.yaml
+++ b/charts/tidb-operator/templates/controller-manager-rbac.yaml
@@ -107,7 +107,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.controllerManager.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.controllerManager.serviceAccount }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -188,7 +192,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}} 
+  name: {{ .Values.controllerManager.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.controllerManager.serviceAccount }}
+  {{- end }}
 roleRef:
   kind: Role
   name: {{ .Release.Name }}:tidb-controller-manager

--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -28,7 +28,11 @@ spec:
         app.kubernetes.io/component: scheduler
     spec:
     {{- if .Values.scheduler.serviceAccount }}
+      {{- if eq .Values.appendReleaseSuffix true}}
+      serviceAccount: {{ .Values.scheduler.serviceAccount }}-{{ .Release.Name }}
+      {{- else }}
       serviceAccount: {{ .Values.scheduler.serviceAccount }}
+      {{- end }}    
     {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/tidb-operator/templates/scheduler-rbac.yaml
+++ b/charts/tidb-operator/templates/scheduler-rbac.yaml
@@ -66,7 +66,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.scheduler.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.scheduler.serviceAccount }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -126,7 +130,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.scheduler.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.scheduler.serviceAccount }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
@@ -146,7 +154,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.scheduler.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.scheduler.serviceAccount }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -165,7 +177,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 subjects:
 - kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.scheduler.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
   name: {{ .Values.scheduler.serviceAccount }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fix the following issue:

1. Deploy TiDB Operator
2. Deploy another TiDB Operator in the same namespace with `appendReleaseSuffix: true`
3. Delete the TiDB Operator deployed in step 1
Then the TiDB Operator deployed in step 2 cannot work because the service accounts it uses have been deleted in step 3.
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Use new service account when release suffix is appended.
### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  1. Deploy TiDB Operator
  2. Deploy another TiDB Operator in the same namespace with `appendReleaseSuffix: true`
  3. Delete the TiDB Operator deployed in step 1 and check that the TiDB Operator deployed in step 2 still work normally
  4. Deploy TiDB Operator as in step 1
  5. Delete the TiDB Operator deployed in step 2 and check that the TiDB Operator deployed in step 4 still work normally

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
The resources in the tidb-operator chart use the new service account when `appendReleaseSuffix` is set to `true`
```
