### PR TITLE
[WIP] Fix support for multiple pvc for DM

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1920,11 +1920,12 @@ type MasterMember struct {
 
 // MasterFailureMember is the dm-master failure member information
 type MasterFailureMember struct {
-	PodName       string      `json:"podName,omitempty"`
-	MemberID      string      `json:"memberID,omitempty"`
-	PVCUID        types.UID   `json:"pvcUID,omitempty"`
-	MemberDeleted bool        `json:"memberDeleted,omitempty"`
-	CreatedAt     metav1.Time `json:"createdAt,omitempty"`
+	PodName       string                 `json:"podName,omitempty"`
+	MemberID      string                 `json:"memberID,omitempty"`
+	PVCUID        types.UID              `json:"pvcUID,omitempty"`
+	PVCUIDSet     map[types.UID]struct{} `json:"pvcUIDSet,omitempty"`
+	MemberDeleted bool                   `json:"memberDeleted,omitempty"`
+	CreatedAt     metav1.Time            `json:"createdAt,omitempty"`
 }
 
 // WorkerStatus is dm-worker status

--- a/pkg/manager/member/dm_master_scaler_test.go
+++ b/pkg/manager/member/dm_master_scaler_test.go
@@ -391,7 +391,7 @@ func newFakeMasterScaler() (*masterScaler, *dmapi.FakeMasterControl, cache.Index
 func newStatefulSetForDMScale() *apps.StatefulSet {
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scaler",
+			Name:      "test",
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: apps.StatefulSetSpec{

--- a/pkg/manager/member/dm_worker_scaler.go
+++ b/pkg/manager/member/dm_worker_scaler.go
@@ -15,9 +15,8 @@ package member
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/pingcap/tidb-operator/pkg/label"
+	"github.com/pingcap/tidb-operator/pkg/util"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
@@ -101,26 +100,21 @@ func (s *workerScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	//	return nil
 	//}
 
-	pvcName := ordinalPVCName(v1alpha1.DMWorkerMemberType, setName, ordinal)
-	pvc, err := s.deps.PVCLister.PersistentVolumeClaims(ns).Get(pvcName)
+	podName := ordinalPodName(v1alpha1.DMWorkerMemberType, setName, ordinal)
+	pod, err := s.deps.PodLister.Pods(ns).Get(podName)
 	if err != nil {
-		return fmt.Errorf("dm-worker.ScaleIn: failed to get pvc %s for cluster %s/%s, error: %s", pvcName, ns, dcName, err)
+		return fmt.Errorf("dm-worker.ScaleIn: failed to get pod %s/%s, error: %s", ns, podName, err)
 	}
 
-	if pvc.Annotations == nil {
-		pvc.Annotations = map[string]string{}
-	}
-	now := time.Now().Format(time.RFC3339)
-	pvc.Annotations[label.AnnPVCDeferDeleting] = now
-
-	_, err = s.deps.PVCControl.UpdatePVC(dc, pvc)
+	pvcs, err := util.ResolvePVCFromPod(pod, s.deps.PVCLister)
 	if err != nil {
-		klog.Errorf("dm-worker scale in: failed to set pvc %s/%s annotation: %s to %s",
-			ns, pvcName, label.AnnPVCDeferDeleting, now)
-		return err
+		return fmt.Errorf("dm-worker.ScaleIn: failed to get pvcs for pod %s/%s for dc %s/%s, error: %s", ns, podName, ns, dcName, err)
 	}
-	klog.Infof("dm-worker scale in: set pvc %s/%s annotation: %s to %s",
-		ns, pvcName, label.AnnPVCDeferDeleting, now)
+	for _, pvc := range pvcs {
+		if err := addDeferDeletingAnnoToPVC(dc, pvc, s.deps.PVCControl); err != nil {
+			return err
+		}
+	}
 
 	setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
 	return nil

--- a/pkg/manager/member/dm_worker_scaler_test.go
+++ b/pkg/manager/member/dm_worker_scaler_test.go
@@ -20,12 +20,14 @@ import (
 
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/dmapi"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/label"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -51,10 +53,9 @@ func TestWorkerScalerScaleOut(t *testing.T) {
 		newSet := oldSet.DeepCopy()
 		newSet.Spec.Replicas = pointer.Int32Ptr(7)
 
-		scaler, _, pvcIndexer, pvcControl := newFakeWorkerScaler()
+		scaler, _, pvcIndexer, _, pvcControl := newFakeWorkerScaler()
 
 		pvc := newPVCForStatefulSet(oldSet, v1alpha1.DMWorkerMemberType, dc.Name)
-		pvc.Name = ordinalPVCName(v1alpha1.DMWorkerMemberType, oldSet.GetName(), *oldSet.Spec.Replicas)
 		if !test.annoIsNil {
 			pvc.Annotations = map[string]string{}
 		}
@@ -169,11 +170,29 @@ func TestWorkerScalerScaleIn(t *testing.T) {
 		newSet := oldSet.DeepCopy()
 		newSet.Spec.Replicas = pointer.Int32Ptr(3)
 
-		scaler, _, pvcIndexer, pvcControl := newFakeWorkerScaler()
+		scaler, _, pvcIndexer, podIndexer, pvcControl := newFakeWorkerScaler()
+
+		pod := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              DMWorkerPodName(dc.GetName(), 4),
+				Namespace:         corev1.NamespaceDefault,
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+			},
+		}
+
+		podIndexer.Add(pod)
 
 		if test.hasPVC {
 			pvc := newScaleInPVCForStatefulSet(oldSet, v1alpha1.DMWorkerMemberType, dc.Name)
 			pvcIndexer.Add(pvc)
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvc.Name,
+					},
+				},
+			})
 		}
 
 		if test.pvcUpdateErr {
@@ -240,13 +259,14 @@ func TestWorkerScalerScaleIn(t *testing.T) {
 	}
 }
 
-func newFakeWorkerScaler() (*workerScaler, *dmapi.FakeMasterControl, cache.Indexer, *controller.FakePVCControl) {
+func newFakeWorkerScaler() (*workerScaler, *dmapi.FakeMasterControl, cache.Indexer, cache.Indexer, *controller.FakePVCControl) {
 	fakeDeps := controller.NewFakeDependencies()
 	scaler := &workerScaler{generalScaler{deps: fakeDeps}}
 	masterControl := fakeDeps.DMMasterControl.(*dmapi.FakeMasterControl)
 	pvcIndexer := fakeDeps.KubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer().GetIndexer()
+	podIndexer := fakeDeps.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 	pvcControl := fakeDeps.PVCControl.(*controller.FakePVCControl)
-	return scaler, masterControl, pvcIndexer, pvcControl
+	return scaler, masterControl, pvcIndexer, podIndexer, pvcControl
 }
 
 func normalWorkerMember(dc *v1alpha1.DMCluster) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
ref: #3802

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Change DM related code to support multiple pvc from pod spec, instead of constructing a single pvc name from dc name and ordinal.

Similar to #3816.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    1. deploy a tc and DM cluster
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
        name: basic
    spec:
        version: v4.0.10
        timezone: UTC
        pvReclaimPolicy: Delete
        configUpdateStrategy: RollingUpdate
        discovery: {}
        pd:
            baseImage: pingcap/pd
            replicas: 1
            requests:
                storage: "1Gi"
            config: {}
        tikv:
            baseImage: pingcap/tikv
            replicas: 1
            requests:
                storage: "1Gi"
            config: {}
        tidb:
            baseImage: pingcap/tidb
            replicas: 1
            config: {}
    ---
    apiVersion: pingcap.com/v1alpha1
    kind: DMCluster
    metadata:
        name: basic
    spec:
        version: v2.0.0
        discovery:
            address: "http://basic-discovery.default:10261"
        master:
            baseImage: pingcap/dm
            replicas: 2
            storageSize: "1Gi"
            requests: {}
            config: {}
        worker:
            baseImage: pingcap/dm
            replicas: 2
            storageSize: "1Gi"
            requests: {}
            config: {}
    ```
    2. check pvc with `kubectl get pvc`
    ```
    NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    dm-master-basic-dm-master-0   Bound    pvc-335ded88-868e-44c1-95b8-f0a8f7892c50   1Gi        RWO            standard       29s
    dm-master-basic-dm-master-1   Bound    pvc-7b1c97e2-bc41-4626-86a0-f6cd975eace2   1Gi        RWO            standard       29s
    dm-worker-basic-dm-worker-0   Bound    pvc-da10b723-7b2f-4ff6-885e-5c6e6b1a6718   1Gi        RWO            standard       5s
    dm-worker-basic-dm-worker-1   Bound    pvc-5597d031-5ec3-4b5d-9fd5-40ce727c78ed   1Gi        RWO            standard       5s
    pd-basic-pd-0                 Bound    pvc-53ad215c-3539-40b8-80c4-0b569cd238db   1Gi        RWO            standard       62s
    tikv-basic-tikv-0             Bound    pvc-132cb812-0643-4bef-a41f-84de9e1a5887   1Gi        RWO            standard       39s
    ```
    3. scale in DM master and worker to 1 replicas, check pvc again, returns same results as in step 2, because PVCs are retained by default.
    ```
    NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    dm-master-basic-dm-master-0   Bound    pvc-335ded88-868e-44c1-95b8-f0a8f7892c50   1Gi        RWO            standard       4m4s
    dm-master-basic-dm-master-1   Bound    pvc-7b1c97e2-bc41-4626-86a0-f6cd975eace2   1Gi        RWO            standard       4m4s
    dm-worker-basic-dm-worker-0   Bound    pvc-da10b723-7b2f-4ff6-885e-5c6e6b1a6718   1Gi        RWO            standard       3m40s
    dm-worker-basic-dm-worker-1   Bound    pvc-5597d031-5ec3-4b5d-9fd5-40ce727c78ed   1Gi        RWO            standard       3m40s
    pd-basic-pd-0                 Bound    pvc-53ad215c-3539-40b8-80c4-0b569cd238db   1Gi        RWO            standard       4m37s
    tikv-basic-tikv-0             Bound    pvc-132cb812-0643-4bef-a41f-84de9e1a5887   1Gi        RWO            standard       4m14s
    ```
    4. scale out DM master and worker to 2 replicas, check pvc again, found that `dm-master-basic-dm-master-1` and `dm-worker-basic-dm-worker-1` has changed, because the old PVCs are deleted and new ones are created with the same name. we can tell from the different `VOLUME` name.
    ```
    NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    dm-master-basic-dm-master-0   Bound    pvc-335ded88-868e-44c1-95b8-f0a8f7892c50   1Gi        RWO            standard       5m30s
    dm-master-basic-dm-master-1   Bound    pvc-476440ca-c103-4389-b643-6f74fd298ac8   1Gi        RWO            standard       26s
    dm-worker-basic-dm-worker-0   Bound    pvc-da10b723-7b2f-4ff6-885e-5c6e6b1a6718   1Gi        RWO            standard       5m6s
    dm-worker-basic-dm-worker-1   Bound    pvc-fe88419c-27f7-4cc7-a621-912bbe31e3e9   1Gi        RWO            standard       6s
    pd-basic-pd-0                 Bound    pvc-53ad215c-3539-40b8-80c4-0b569cd238db   1Gi        RWO            standard       6m3s
    tikv-basic-tikv-0             Bound    pvc-132cb812-0643-4bef-a41f-84de9e1a5887   1Gi        RWO            standard       5m40s
    ```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix support for multiple PVC for DM.
```
