### PR TITLE
try to fix GIT_COMMIT env after PR merged in CI

### DIFF
--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -212,7 +212,6 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
                                 sh """#!/bin/bash
-                                # try to read the git SHA back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
                                 ls
                                 if [ -z "${GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: list all coverage files"

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -191,9 +191,9 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                             sh """
                             if [ "${env.GIT_COMMIT}" = "" ]; then echo "iffffffffffffffff"; fi
-                            echo "GIT_COMMIT aaaaaaaa $${env.GIT_COMMIT}"
+                            echo "GIT_COMMIT aaaaaaaa ${env.GIT_COMMIT}"
                             if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
-                            echo "GIT_COMMIT bbbbbbbb $${env.GIT_COMMIT}"
+                            echo "GIT_COMMIT bbbbbbbb ${env.GIT_COMMIT}"
                             echo "====== shell env ======"
                             echo "pwd: \$(pwd)"
                             env

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -181,8 +181,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                         unstash 'tidb-operator'
                         stage("Debug Info") {
                             sh """
-                            echo "print env"
-                            printenv
+                            echo "GIT_COMMIT=$GIT_COMMIT"
                             """
                             println "debug host: 172.16.5.15"
                             println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
@@ -198,8 +197,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                         }
                         stage('Run') {
                             sh """
-                            echo "print env"
-                            printenv
+                            echo "GIT_COMMIT=$GIT_COMMIT"
                             """
                             sh """#!/bin/bash
                             export GOPATH=${WORKSPACE}/go
@@ -220,10 +218,10 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
                                 sh """
-                                echo "print env"
-                                printenv
+                                echo "GIT_COMMIT=$GIT_COMMIT"
                                 """
                                 sh """#!/bin/bash
+                                export GIT_COMMIT=${GIT_COMMIT}
                                 echo "info: list all coverage files"
                                 ls -dla /kind-data/control-plane/coverage/*
                                 ls -dla /kind-data/worker1/coverage/*
@@ -344,8 +342,8 @@ try {
                         }
 
                         sh """
-                        echo "print env"
-                        printenv
+                        export GIT_COMMIT=${GIT_COMMIT}
+                        echo "GIT_COMMIT=$GIT_COMMIT"
                         """
                     }
 

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -230,7 +230,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
-                                if [ ! "${env.GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
+                                if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -191,9 +191,9 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                             sh """
                             if [ "${env.GIT_COMMIT}" = "" ]; then echo "iffffffffffffffff"; fi
-                            echo "GIT_COMMIT aaaaaaaa $GIT_COMMIT"
+                            echo "GIT_COMMIT aaaaaaaa $${env.GIT_COMMIT}"
                             if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
-                            echo "GIT_COMMIT bbbbbbbb $GIT_COMMIT"
+                            echo "GIT_COMMIT bbbbbbbb $${env.GIT_COMMIT}"
                             echo "====== shell env ======"
                             echo "pwd: \$(pwd)"
                             env

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -190,6 +190,10 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             println "debug host: 172.16.5.15"
                             println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                             sh """
+                            if [ "${env.GIT_COMMIT}" = "" ]; then echo "iffffffffffffffff"; fi
+                            echo "GIT_COMMIT aaaaaaaa $GIT_COMMIT"
+                            if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
+                            echo "GIT_COMMIT bbbbbbbb $GIT_COMMIT"
                             echo "====== shell env ======"
                             echo "pwd: \$(pwd)"
                             env
@@ -230,7 +234,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
-                                if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
+                                # if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -16,6 +16,13 @@ env.DEFAULT_GINKGO_NODES = env.DEFAULT_GINKGO_NODES ?: '8'
 env.DEFAULT_E2E_ARGS = env.DEFAULT_E2E_ARGS ?: ''
 env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE = env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE ?: 'true'
 
+def GIT_COMMIT
+if (!env.ghprbActualCommit) {
+    GIT_COMMIT = ""
+} else {
+    GIT_COMMIT = env.ghprbActualCommit
+}
+
 properties([
     parameters([
         string(name: 'GIT_URL', defaultValue: 'https://github.com/pingcap/tidb-operator', description: 'git repo url'),
@@ -213,6 +220,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             ]) {
                                 sh """#!/bin/bash
                                 # try to read the git SHA back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
+                                cat EXPORT_GIT_COMMIT || true
                                 ls
                                 if [ -z "${GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: list all coverage files"
@@ -344,6 +352,7 @@ try {
                             set -eu
                             echo "save GTI_COMMIT export script into file"
                             echo "export GIT_COMMIT=\$(git rev-parse HEAD)" > EXPORT_GIT_COMMIT
+                            cat EXPORT_GIT_COMMIT || true
                             echo "info: logging into hub.pingcap.net"
                             docker login -u \$USERNAME --password-stdin hub.pingcap.net <<< \$PASSWORD
                             echo "info: build and push images for e2e"

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -211,10 +211,10 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             withCredentials([
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
-                                // try to read the git HASH back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
-                                GIT_HASH = readFile('GIT_HASH').trim()
                                 sh """#!/bin/bash
-                                if [ -z "${GIT_COMMIT}" ]; then export GIT_COMMIT=${GIT_HASH}; fi
+                                # try to read the git SHA back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
+                                ls
+                                if [ -z "${GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: list all coverage files"
                                 ls -dla /kind-data/control-plane/coverage/*
                                 ls -dla /kind-data/worker1/coverage/*
@@ -342,8 +342,8 @@ try {
                         withCredentials([usernamePassword(credentialsId: 'TIDB_OPERATOR_HUB_AUTH', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                             sh """#!/bin/bash
                             set -eu
-                            echo "save GIT_HASH into file"
-                            git rev-parse HEAD > GIT_HASH
+                            echo "save GTI_COMMIT export script into file"
+                            echo "export GIT_COMMIT=$(git rev-parse HEAD)" > EXPORT_GIT_COMMIT
                             echo "info: logging into hub.pingcap.net"
                             docker login -u \$USERNAME --password-stdin hub.pingcap.net <<< \$PASSWORD
                             echo "info: build and push images for e2e"
@@ -356,6 +356,7 @@ try {
                             # we run as root in our pods, this is required
                             # otherwise jenkins agent will fail because of the lack of permission
                             chown -R 1000:1000 .
+                            ls
                             """
                         }
                         stash excludes: "vendor/**,deploy/**,tests/**", name: "tidb-operator"

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -219,10 +219,6 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
                                 sh """#!/bin/bash
-                                # try to read the git SHA back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
-                                cat EXPORT_GIT_COMMIT || true
-                                ls
-                                if [ -z "${GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: list all coverage files"
                                 ls -dla /kind-data/control-plane/coverage/*
                                 ls -dla /kind-data/worker1/coverage/*
@@ -234,6 +230,8 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
+                                cat EXPORT_GIT_COMMIT || true
+                                ls
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -232,6 +232,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
                                 cat EXPORT_GIT_COMMIT || true
                                 ls
+                                source EXPORT_GIT_COMMIT
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -16,13 +16,6 @@ env.DEFAULT_GINKGO_NODES = env.DEFAULT_GINKGO_NODES ?: '8'
 env.DEFAULT_E2E_ARGS = env.DEFAULT_E2E_ARGS ?: ''
 env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE = env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE ?: 'true'
 
-def GIT_COMMIT
-if (!env.ghprbActualCommit) {
-    GIT_COMMIT = ""
-} else {
-    GIT_COMMIT = env.ghprbActualCommit
-}
-
 properties([
     parameters([
         string(name: 'GIT_URL', defaultValue: 'https://github.com/pingcap/tidb-operator', description: 'git repo url'),
@@ -190,10 +183,6 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             println "debug host: 172.16.5.15"
                             println "debug command: kubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
                             sh """
-                            if [ "${env.GIT_COMMIT}" = "" ]; then echo "iffffffffffffffff"; fi
-                            echo "GIT_COMMIT aaaaaaaa ${env.GIT_COMMIT}"
-                            if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
-                            echo "GIT_COMMIT bbbbbbbb ${env.GIT_COMMIT}"
                             echo "====== shell env ======"
                             echo "pwd: \$(pwd)"
                             env
@@ -234,7 +223,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
-                                # if [ "${env.GIT_COMMIT}" = "" ]; then source EXPORT_GIT_COMMIT; fi
+                                source EXPORT_GIT_COMMIT
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -230,7 +230,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
-                                if [ ! "$GIT_COMMIT" ]; then source EXPORT_GIT_COMMIT; fi
+                                if [ ! "${env.GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -230,9 +230,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 cp /kind-data/worker2/coverage/*.cov /tmp
                                 cp /kind-data/worker3/coverage/*.cov /tmp
                                 ./bin/gocovmerge /tmp/*.cov > /tmp/coverage.txt
-                                cat EXPORT_GIT_COMMIT || true
-                                ls
-                                source EXPORT_GIT_COMMIT
+                                if [ ! "$GIT_COMMIT" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: uploading coverage to codecov"
                                 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -F e2e -n tidb-operator -f /tmp/coverage.txt
                                 """
@@ -351,7 +349,6 @@ try {
                             set -eu
                             echo "save GTI_COMMIT export script into file"
                             echo "export GIT_COMMIT=\$(git rev-parse HEAD)" > EXPORT_GIT_COMMIT
-                            cat EXPORT_GIT_COMMIT || true
                             echo "info: logging into hub.pingcap.net"
                             docker login -u \$USERNAME --password-stdin hub.pingcap.net <<< \$PASSWORD
                             echo "info: build and push images for e2e"
@@ -364,7 +361,6 @@ try {
                             # we run as root in our pods, this is required
                             # otherwise jenkins agent will fail because of the lack of permission
                             chown -R 1000:1000 .
-                            ls
                             """
                         }
                         stash excludes: "vendor/**,deploy/**,tests/**", name: "tidb-operator"

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -217,7 +217,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                             withCredentials([
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
-                                if GIT_COMMIT == "" {
+                                if (GIT_COMMIT == "") {
                                     // try to fix env after PR merged into a branch.
                                     GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
                                 }

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -212,6 +212,7 @@ def build(String name, String code, Map resources = e2ePodResources) {
                                 string(credentialsId: "tp-codecov-token", variable: 'CODECOV_TOKEN')
                             ]) {
                                 sh """#!/bin/bash
+                                # try to read the git SHA back as GIT_COMMIT if not exists (like triggered after a PR merged into a branch).
                                 ls
                                 if [ -z "${GIT_COMMIT}" ]; then source EXPORT_GIT_COMMIT; fi
                                 echo "info: list all coverage files"
@@ -342,7 +343,7 @@ try {
                             sh """#!/bin/bash
                             set -eu
                             echo "save GTI_COMMIT export script into file"
-                            echo "export GIT_COMMIT=$(git rev-parse HEAD)" > EXPORT_GIT_COMMIT
+                            echo "export GIT_COMMIT=\$(git rev-parse HEAD)" > EXPORT_GIT_COMMIT
                             echo "info: logging into hub.pingcap.net"
                             docker login -u \$USERNAME --password-stdin hub.pingcap.net <<< \$PASSWORD
                             echo "info: build and push images for e2e"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

when the CI triggered after a PR merged, the `GIT_COMMIT` is not valid, then the E2E coverage report can't be uploaded.

### What is changed and how does it work?

always set `GIT_COMMIT` as the head SHA.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
