### PR TITLE
Add retry for DNS lookup failure exception in TiDBInitializer

### DIFF
--- a/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
@@ -1,0 +1,32 @@
+apiVersion: pingcap.com/v1alpha1
+kind: TidbMonitor
+metadata:
+  name: basic
+spec:
+  clusters:
+  - name: basic
+  thanos:
+    baseImage: thanosio/thanos
+    version: v0.17.2
+    objectStorageConfigFile: /etc/thanos/objectstorage.yaml
+    additionalVolumeMounts:
+      - name: objectstorage
+        mountPath: "/etc/thanos/"
+        readOnly: true
+  prometheus:
+    baseImage: prom/prometheus
+    version: v2.11.1
+  grafana:
+    baseImage: grafana/grafana
+    version: 6.1.6
+  initializer:
+    baseImage: pingcap/tidb-monitor-initializer
+    version: v4.0.10
+  reloader:
+    baseImage: pingcap/tidb-monitor-reloader
+    version: v1.0.1
+  imagePullPolicy: IfNotPresent
+  additionalVolumes:
+    - name: objectstorage
+      secret:
+        secretName: thanos-objectstorage

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -341,11 +341,19 @@ var tidbInitStartScriptTpl = template.Must(template.New("tidb-init-start-script"
 host = '{{ .ClusterName }}-tidb'
 permit_host = '{{ .PermitHost }}'
 port = 4000
+for i in range(0, 10):
+    while True:
+        try:
 {{- if .TLS }}
-conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
+			conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
 {{- else }}
-conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
+			conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
 {{- end }}
+        except MySQLdb.OperationalError as e:
+            print(e)
+            time.sleep(3)
+            continue
+        break
 {{- if .PasswordSet }}
 password_dir = '/etc/tidb/password'
 for file in os.listdir(password_dir):

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -342,18 +342,17 @@ host = '{{ .ClusterName }}-tidb'
 permit_host = '{{ .PermitHost }}'
 port = 4000
 for i in range(0, 10):
-    while True:
-        try:
+    try:
 {{- if .TLS }}
-            conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
+        conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
 {{- else }}
-            conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
+        conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
 {{- end }}
-        except MySQLdb.OperationalError as e:
-            print(e)
-            time.sleep(1)
-            continue
-        break
+    except MySQLdb.OperationalError as e:
+        print(e)
+        time.sleep(1)
+        continue
+    break
 {{- if .PasswordSet }}
 password_dir = '/etc/tidb/password'
 for file in os.listdir(password_dir):

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -345,13 +345,13 @@ for i in range(0, 10):
     while True:
         try:
 {{- if .TLS }}
-			conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
+            conn = MySQLdb.connect(host=host, port=port, user='root', charset='utf8mb4',connect_timeout=5, ssl={'ca': '{{ .CAPath }}', 'cert': '{{ .CertPath }}', 'key': '{{ .KeyPath }}'})
 {{- else }}
-			conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
+            conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
 {{- end }}
         except MySQLdb.OperationalError as e:
             print(e)
-            time.sleep(3)
+            time.sleep(1)
             continue
         break
 {{- if .PasswordSet }}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Sometimes when DNS service is not stable, in-pod DNS lookup requests will fail. We need to add the retry logic for the related exception.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

Manual test:
1. Deploy a basic TiDB cluster
2. Create TidbInitializer.
```yaml 
apiVersion: pingcap.com/v1alpha1
kind: TidbInitializer
metadata:
  name: initialize-demo
spec:
  image: tnir/mysqlclient
  imagePullPolicy: IfNotPresent
  cluster:
    name: initialize-demo
  initSql: "create database hello;"
```
3. The initialization succeeded.
```output
cluster1-tidb-initializer-tpq5h            0/1     Completed   0          13mcluster1-tidb-initializer-tpq5h            0/1     Completed   0          13m
```
4. The startup script in configMap shows as below:

```python
import os, sys, time, MySQLdb
host = 'cluster1-tidb'
permit_host = '%'
port = 4000
retry_count = 0
for i in range(0, 10):
    try:
        conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5, charset='utf8mb4')
    except MySQLdb.OperationalError as e:
        print(e)
        retry_count += 1
        time.sleep(1)
        continue
    break
if retry_count == 10:
    sys.exit(1)
with open('/data/init.sql', 'r') as sql:
    for line in sql.readlines():
        conn.cursor().execute(line)
        conn.commit()
if permit_host != '%%':
    conn.cursor().execute("update mysql.user set Host=%s where User='root';", (permit_host,))
conn.cursor().execute("flush privileges;")
conn.commit()
conn.close()
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
