### PR TITLE
shutdown controll-manager if leader election lost

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -237,7 +237,6 @@ func main() {
 		if err2 := srv.Shutdown(context.Background()); err2 != nil {
 			klog.Fatal("fail to shutdown the HTTP server", err2)
 		}
-		close(sc)
 	}()
 
 	if err = srv.ListenAndServe(); err != http.ErrServerClosed {

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -116,7 +116,6 @@ func main() {
 		if err2 := srv.Shutdown(context.Background()); err2 != nil {
 			klog.Fatal("fail to shutdown the HTTP server", err2)
 		}
-		close(sc)
 	}()
 
 	if err = srv.ListenAndServe(); err != http.ErrServerClosed {

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -93,7 +93,6 @@ func main() {
 		if err2 := srv.Shutdown(context.Background()); err2 != nil {
 			klog.Fatal("fail to shutdown the HTTP server", err2)
 		}
-		close(sc)
 	}()
 
 	if err = srv.ListenAndServe(); err != http.ErrServerClosed {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

fix #3850 

### What is changed and how does it work?

- do not retry after leader election lost (remove `wait.Forever`)
- shutdown the HTTP server after leader election lost

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
```
