### PR TITLE
Fix pvc resize support for tidb

### DIFF
--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -87,14 +87,14 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 		return err
 	}
 
-	// First we compose a map, with PVC name prefix for current component as keys,
+	// For each component, we compose a map called pvcPrefix2Quantity, with PVC name prefix for current component as keys,
 	// for example "pd-${tcName}-pd" (for tc.Spec.PD.Requests) or "pd-log-${tcName}-pd" (for tc.Spec.PD.storageVolumes elements with name "log").
 	// Reference implementation of BuildStorageVolumeAndVolumeMount().
 	// Note: for TiFlash, it is currently "data0-${tcName}-tiflash" (for tc.Spec.TiFlash.StorageClaims elements, in list definition order)
-	pvcPrefix2Quantity := make(map[string]resource.Quantity)
 
 	// patch PD PVCs
 	if tc.Spec.PD != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		pdMemberType := v1alpha1.PDMemberType.String()
 		if quantity, ok := tc.Spec.PD.Requests[corev1.ResourceStorage]; ok {
 			key := fmt.Sprintf("%s-%s-%s", pdMemberType, tc.Name, pdMemberType)
@@ -114,6 +114,7 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 	}
 	// patch TiDB PVCs
 	if tc.Spec.TiDB != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		tidbMemberType := v1alpha1.TiDBMemberType.String()
 		for _, sv := range tc.Spec.TiDB.StorageVolumes {
 			key := fmt.Sprintf("%s-%s-%s-%s", tidbMemberType, sv.Name, tc.Name, tidbMemberType)
@@ -129,6 +130,7 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 	}
 	// patch TiKV PVCs
 	if tc.Spec.TiKV != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		tikvMemberType := v1alpha1.TiKVMemberType.String()
 		if quantity, ok := tc.Spec.TiKV.Requests[corev1.ResourceStorage]; ok {
 			key := fmt.Sprintf("%s-%s-%s", tikvMemberType, tc.Name, tikvMemberType)
@@ -148,6 +150,7 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 	}
 	// patch TiFlash PVCs
 	if tc.Spec.TiFlash != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		tiflashMemberType := v1alpha1.TiFlashMemberType.String()
 		for i, claim := range tc.Spec.TiFlash.StorageClaims {
 			key := fmt.Sprintf("data%d-%s-%s", i, tc.Name, tiflashMemberType)
@@ -161,6 +164,7 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 	}
 	// patch Pump PVCs
 	if tc.Spec.Pump != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		pumpMemberType := v1alpha1.PumpMemberType.String()
 		if quantity, ok := tc.Spec.Pump.Requests[corev1.ResourceStorage]; ok {
 			key := fmt.Sprintf("data-%s-%s", tc.Name, pumpMemberType)
@@ -180,20 +184,23 @@ func (p *pvcResizer) ResizeDM(dc *v1alpha1.DMCluster) error {
 	if err != nil {
 		return err
 	}
-	pvcPrefix2Quantity := make(map[string]resource.Quantity)
 
 	// patch dm-master PVCs
-	if quantity, err := resource.ParseQuantity(dc.Spec.Master.StorageSize); err == nil {
-		dmMasterMemberType := v1alpha1.DMMasterMemberType.String()
-		key := fmt.Sprintf("%s-%s-%s", dmMasterMemberType, dc.Name, dmMasterMemberType)
-		pvcPrefix2Quantity[key] = quantity
-	}
-	if err := p.patchPVCs(ns, selector.Add(*dmMasterRequirement), pvcPrefix2Quantity); err != nil {
-		return err
+	{
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
+		if quantity, err := resource.ParseQuantity(dc.Spec.Master.StorageSize); err == nil {
+			dmMasterMemberType := v1alpha1.DMMasterMemberType.String()
+			key := fmt.Sprintf("%s-%s-%s", dmMasterMemberType, dc.Name, dmMasterMemberType)
+			pvcPrefix2Quantity[key] = quantity
+		}
+		if err := p.patchPVCs(ns, selector.Add(*dmMasterRequirement), pvcPrefix2Quantity); err != nil {
+			return err
+		}
 	}
 
 	// patch dm-worker PVCs
 	if dc.Spec.Worker != nil {
+		pvcPrefix2Quantity := make(map[string]resource.Quantity)
 		if quantity, err := resource.ParseQuantity(dc.Spec.Worker.StorageSize); err == nil {
 			dmWorkerMemberType := v1alpha1.DMWorkerMemberType.String()
 			key := fmt.Sprintf("%s-%s-%s", dmWorkerMemberType, dc.Name, dmWorkerMemberType)

--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -115,10 +115,6 @@ func (p *pvcResizer) Resize(tc *v1alpha1.TidbCluster) error {
 	// patch TiDB PVCs
 	if tc.Spec.TiDB != nil {
 		tidbMemberType := v1alpha1.TiDBMemberType.String()
-		if quantity, ok := tc.Spec.TiDB.Requests[corev1.ResourceStorage]; ok {
-			key := fmt.Sprintf("%s-%s-%s", tidbMemberType, tc.Name, tidbMemberType)
-			pvcPrefix2Quantity[key] = quantity
-		}
 		for _, sv := range tc.Spec.TiDB.StorageVolumes {
 			key := fmt.Sprintf("%s-%s-%s-%s", tidbMemberType, sv.Name, tc.Name, tidbMemberType)
 			if quantity, err := resource.ParseQuantity(sv.StorageSize); err == nil {

--- a/pkg/manager/member/pvc_resizer_test.go
+++ b/pkg/manager/member/pvc_resizer_test.go
@@ -127,6 +127,47 @@ func TestPVCResizer(t *testing.T) {
 			},
 		},
 		{
+			name: "resize TiDB PVCs",
+			tc: &v1alpha1.TidbCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1.NamespaceDefault,
+					Name:      "tc",
+				},
+				Spec: v1alpha1.TidbClusterSpec{
+					TiDB: &v1alpha1.TiDBSpec{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceStorage: resource.MustParse("2Gi"),
+							},
+						},
+						StorageVolumes: []v1alpha1.StorageVolume{
+							{
+								Name:        "log",
+								StorageSize: "2Gi",
+							},
+						},
+					},
+				},
+			},
+			sc: newStorageClass("sc", true),
+			pvcs: []*v1.PersistentVolumeClaim{
+				newPVCWithStorage("tidb-tc-tidb-0", label.TiDBLabelVal, "sc", "1Gi"),
+				newPVCWithStorage("tidb-tc-tidb-1", label.TiDBLabelVal, "sc", "1Gi"),
+				newPVCWithStorage("tidb-tc-tidb-2", label.TiDBLabelVal, "sc", "1Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-0", label.TiDBLabelVal, "sc", "1Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-1", label.TiDBLabelVal, "sc", "1Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-2", label.TiDBLabelVal, "sc", "1Gi"),
+			},
+			wantPVCs: []*v1.PersistentVolumeClaim{
+				newPVCWithStorage("tidb-tc-tidb-0", label.TiDBLabelVal, "sc", "2Gi"),
+				newPVCWithStorage("tidb-tc-tidb-1", label.TiDBLabelVal, "sc", "2Gi"),
+				newPVCWithStorage("tidb-tc-tidb-2", label.TiDBLabelVal, "sc", "2Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-0", label.TiDBLabelVal, "sc", "2Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-1", label.TiDBLabelVal, "sc", "2Gi"),
+				newPVCWithStorage("tidb-log-tc-tidb-2", label.TiDBLabelVal, "sc", "2Gi"),
+			},
+		},
+		{
 			name: "resize TiKV PVCs",
 			tc: &v1alpha1.TidbCluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manager/member/pvc_resizer_test.go
+++ b/pkg/manager/member/pvc_resizer_test.go
@@ -135,11 +135,6 @@ func TestPVCResizer(t *testing.T) {
 				},
 				Spec: v1alpha1.TidbClusterSpec{
 					TiDB: &v1alpha1.TiDBSpec{
-						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse("2Gi"),
-							},
-						},
 						StorageVolumes: []v1alpha1.StorageVolume{
 							{
 								Name:        "log",
@@ -151,17 +146,11 @@ func TestPVCResizer(t *testing.T) {
 			},
 			sc: newStorageClass("sc", true),
 			pvcs: []*v1.PersistentVolumeClaim{
-				newPVCWithStorage("tidb-tc-tidb-0", label.TiDBLabelVal, "sc", "1Gi"),
-				newPVCWithStorage("tidb-tc-tidb-1", label.TiDBLabelVal, "sc", "1Gi"),
-				newPVCWithStorage("tidb-tc-tidb-2", label.TiDBLabelVal, "sc", "1Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-0", label.TiDBLabelVal, "sc", "1Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-1", label.TiDBLabelVal, "sc", "1Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-2", label.TiDBLabelVal, "sc", "1Gi"),
 			},
 			wantPVCs: []*v1.PersistentVolumeClaim{
-				newPVCWithStorage("tidb-tc-tidb-0", label.TiDBLabelVal, "sc", "2Gi"),
-				newPVCWithStorage("tidb-tc-tidb-1", label.TiDBLabelVal, "sc", "2Gi"),
-				newPVCWithStorage("tidb-tc-tidb-2", label.TiDBLabelVal, "sc", "2Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-0", label.TiDBLabelVal, "sc", "2Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-1", label.TiDBLabelVal, "sc", "2Gi"),
 				newPVCWithStorage("tidb-log-tc-tidb-2", label.TiDBLabelVal, "sc", "2Gi"),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #3851

Fix unresolved issues in #3858

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    1. deploy tc and dm-cluster
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
      name: basic
    spec:
      configUpdateStrategy: RollingUpdate
      discovery: {}
      enablePVReclaim: false
      imagePullPolicy: IfNotPresent
      pd:
        affinity: {}
        baseImage: pingcap/pd
        config:
          dashboard:
            internal-proxy: true
          replication:
            location-labels:
            - region
            - zone
            - rack
            - host
          log:
            file:
              filename: /var/log/pdlog/pd.log
            level: "warn"
          schedule:
            enable-cross-table-merge: true
        storageVolumes:
          - name: log
            storageSize: "2Gi"
            mountPath: "/var/log/pdlog"
        imagePullPolicy: IfNotPresent
        maxFailoverCount: 3
        replicas: 1
        requests:
          storage: 1Gi
        # storageClassName: local-storage
      pvReclaimPolicy: Delete
      schedulerName: default-scheduler
      services:
      - name: pd
        type: ClusterIP
      ticdc:
        baseImage: pingcap/ticdc
        replicas: 1
      tidb:
        affinity: {}
        baseImage: pingcap/tidb
        config:
          log:
            file:
              filename: /var/log/tidblog/tidb.log
            level: "warn"
        storageVolumes:
          - name: log
            storageSize: "2Gi"
            mountPath: "/var/log/tidblog"
        imagePullPolicy: IfNotPresent
        maxFailoverCount: 3
        replicas: 1
        separateSlowLog: true
        service:
          type: ClusterIP
        slowLogTailer:
          image: busybox:1.26.2
          imagePullPolicy: IfNotPresent
          limits:
            cpu: 100m
            memory: 50Mi
          requests:
            cpu: 20m
            memory: 5Mi
      tiflash:
        baseImage: pingcap/tiflash
        config:
          config: |
            [logger]
              count = 5
              errorlog = "/data0/logs/error.log"
        maxFailoverCount: 3
        replicas: 1
        storageClaims:
        - resources:
            requests:
              storage: 10Gi
          # storageClassName: local-storage
        - resources:
            requests:
              storage: 10Gi
          # storageClassName: local-storage
      tikv:
        affinity: {}
        baseImage: pingcap/tikv
        config:
          storage:
            reserve-space: "0MB"
          rocksdb:
            wal-dir: "/data_sbi/tikv/wal"
            info-log-dir: "/data_sbk/"
          raftdb:
            info-log-dir: "/data_sbj/"
        storageVolumes:
          - name: wal
            storageSize: "2Gi"
            mountPath: "/data_sbi"
          - name: rocks
            storageSize: "2Gi"
            mountPath: "/data_sbk/"
          - name: raft
            storageSize: "2Gi"
            mountPath: "/data_sbj/"
        imagePullPolicy: IfNotPresent
        maxFailoverCount: 3
        replicas: 1
        requests:
          storage: 10Gi
        # storageClassName: local-storage
      pump:
        replicas: 1
        config: {}
        requests:
          storage: 1Gi
      tlsCluster: {}
      version: v4.0.8
    ---
    apiVersion: pingcap.com/v1alpha1
    kind: DMCluster
    metadata:
      name: basic
    spec:
      version: v2.0.0
      discovery:
        address: "http://basic-discovery:10261"
      master:
        baseImage: pingcap/dm
        replicas: 1
        storageSize: "1Gi"
        requests: {}
        config: {}
      worker:
        baseImage: pingcap/dm
        replicas: 1
        storageSize: "1Gi"
        requests: {}
        config: {}
    ```

    2. `kubectl get pod`
    ```
    NAME                                       READY   STATUS      RESTARTS   AGE
    basic-discovery-6b7d565b98-gq8bx           1/1     Running     0          33m
    basic-dm-master-0                          1/1     Running     0          33m
    basic-dm-worker-0                          1/1     Running     0          33m
    basic-pd-0                                 1/1     Running     0          33m
    basic-pump-0                               1/1     Running     0          32m
    basic-ticdc-0                              1/1     Running     0          32m
    basic-tidb-0                               2/2     Running     0          32m
    basic-tidb-initializer-r8gjn               0/1     Completed   0          33m
    basic-tiflash-0                            4/4     Running     0          32m
    basic-tikv-0                               1/1     Running     0          32m
    tidb-controller-manager-69548c7756-56587   1/1     Running     0          39m
    tidb-scheduler-685f7d6f94-zwrl4            2/2     Running     0          39m
    ```

    3. check `tidb-controller-manager` log, and grep for `pvc_resizer.go`, find that the size are in sync
    ```
    I0401 09:21:12.383146       1 pvc_resizer.go:285] PVC pingcap/dm-master-basic-dm-master-0 storage request is already 1Gi, skipped
    I0401 09:21:12.383214       1 pvc_resizer.go:285] PVC pingcap/dm-worker-basic-dm-worker-0 storage request is already 1Gi, skipped
    I0401 09:21:13.356570       1 pvc_resizer.go:285] PVC pingcap/pd-basic-pd-0 storage request is already 1Gi, skipped
    I0401 09:21:13.356598       1 pvc_resizer.go:285] PVC pingcap/pd-log-basic-pd-0 storage request is already 2Gi, skipped
    I0401 09:21:13.356619       1 pvc_resizer.go:285] PVC pingcap/tidb-log-basic-tidb-0 storage request is already 2Gi, skipped
    I0401 09:21:13.356647       1 pvc_resizer.go:285] PVC pingcap/tikv-raft-basic-tikv-0 storage request is already 2Gi, skipped
    I0401 09:21:13.356657       1 pvc_resizer.go:285] PVC pingcap/tikv-rocks-basic-tikv-0 storage request is already 2Gi, skipped
    I0401 09:21:13.356660       1 pvc_resizer.go:285] PVC pingcap/tikv-basic-tikv-0 storage request is already 10Gi, skipped
    I0401 09:21:13.356663       1 pvc_resizer.go:285] PVC pingcap/tikv-wal-basic-tikv-0 storage request is already 2Gi, skipped
    I0401 09:21:13.356692       1 pvc_resizer.go:285] PVC pingcap/data1-basic-tiflash-0 storage request is already 10Gi, skipped
    I0401 09:21:13.356726       1 pvc_resizer.go:285] PVC pingcap/data0-basic-tiflash-0 storage request is already 10Gi, skipped
    I0401 09:21:13.356755       1 pvc_resizer.go:285] PVC pingcap/data-basic-pump-0 storage request is already 1Gi, skipped
    ```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix PVC resize for TiDB.
```
