### PR TITLE
Bump operator version to v1.2.0-beta.1

### DIFF
--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -38,7 +38,7 @@ services:
     type: ClusterIP
 
 discovery:
-  image: pingcap/tidb-operator:v1.2.0-alpha.1
+  image: pingcap/tidb-operator:v1.2.0-beta.1
   imagePullPolicy: IfNotPresent
   resources:
     limits:

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -12,12 +12,12 @@ rbac:
 timezone: UTC
 
 # operatorImage is TiDB Operator image
-operatorImage: pingcap/tidb-operator:v1.2.0-alpha.1
+operatorImage: pingcap/tidb-operator:v1.2.0-beta.1
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 
 # tidbBackupManagerImage is tidb backup manager image
-tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.2.0-alpha.1
+tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.2.0-beta.1
 
 #
 # Enable or disable tidb-operator features:

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -10,7 +10,7 @@ variable "bastion_cpu_core_count" {
 
 variable "operator_version" {
   type    = string
-  default = "v1.2.0-alpha.1"
+  default = "v1.2.0-beta.1"
 }
 
 variable "operator_helm_values" {

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -19,7 +19,7 @@ variable "eks_version" {
 
 variable "operator_version" {
   description = "TiDB operator version"
-  default     = "v1.2.0-alpha.1"
+  default     = "v1.2.0-beta.1"
 }
 
 variable "operator_values" {

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -28,7 +28,7 @@ variable "tidb_version" {
 }
 
 variable "tidb_operator_version" {
-  default = "v1.2.0-alpha.1"
+  default = "v1.2.0-beta.1"
 }
 
 variable "tidb_operator_chart_version" {

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -22,8 +22,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # parameters
-OPERATOR_OLD="v1\.1\.9"
-OPERATOR_NEW="v1\.2\.0-alpha\.1"
+OPERATOR_OLD="v1\.2\.0-alpha\.1"
+OPERATOR_NEW="v1\.2\.0-beta\.1"
 TIDB_OLD="v4\.0\.9"
 TIDB_NEW="v4\.0\.10"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Bump operator to v1.2.0-beta.1

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
ref #3897
run script `hack/bump-version.sh` to bump TiDB Operator from v1.2.0-alpha.1 to v1.2.0-beta.1

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
NONE
```
