### PR TITLE
e2e: dump tidb-operator's log before uninstall tidb-operator

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -339,25 +340,42 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	err := tidbcluster.DeleteCertManager(kubeCli)
 	framework.ExpectNoError(err, "failed to delete cert-manager")
 
-	if !ginkgo.CurrentGinkgoTestDescription().Failed {
-		// kubetest2 can only dump running pods' log (copy from container log directory),
-		// but if we want to get test coverage reports for tidb-operator, we need to shutdown the processes/pods),
-		// so we choose to:
-		// - dump logs if the test failed.
-		// - generate test coverage reports if the test passed.
-		ginkgo.By("Uninstalling tidb-operator")
-		ocfg := e2econfig.NewDefaultOperatorConfig(e2econfig.TestConfig)
-		err = tests.CleanOperator(ocfg)
-		framework.ExpectNoError(err, "failed to uninstall operator")
+	ocfg := e2econfig.NewDefaultOperatorConfig(e2econfig.TestConfig)
 
-		ginkgo.By("Wait for tidb-operator to be uninstalled")
-		err = wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
-			podList, err2 := kubeCli.CoreV1().Pods(ocfg.Namespace).List(metav1.ListOptions{})
-			framework.ExpectNoError(err2, "failed to list pods for tidb-operator")
-			return len(podList.Items) == 0, nil
-		})
-		framework.ExpectNoError(err, "failed to wait for tidb-operator to be uninstalled")
+	// kubetest2 can only dump running pods' log (copy from container log directory),
+	// but if we want to get test coverage reports for tidb-operator, we need to shutdown the processes/pods),
+	// so we choose to copy logs before uninstall tidb-operator.
+	// NOTE: if we can get the whole test result from all parallel Ginkgo nodes with Ginkgo v2 later, we can also choose to:
+	// - dump logs if the test failed.
+	// - (uninstall tidb-operator and) generate test coverage reports if the test passed.
+	// ref: https://github.com/onsi/ginkgo/issues/361#issuecomment-814203240
+
+	if framework.TestContext.ReportDir != "" {
+		ginkgo.By("Dumping logs for tidb-operator")
+		logPath := filepath.Join(framework.TestContext.ReportDir, "logs", "tidb-operator")
+		// full permission (0777) for the log directory to avoid "permission denied" for later kubetest2 log dump.
+		framework.ExpectNoError(os.MkdirAll(logPath, 0777), "failed to create log directory for tidb-operator components")
+
+		podList, err2 := kubeCli.CoreV1().Pods(ocfg.Namespace).List(metav1.ListOptions{})
+		framework.ExpectNoError(err2, "failed to list pods for tidb-operator")
+		for _, pod := range podList.Items {
+			log.Logf("dumping logs for pod %s/%s", pod.Namespace, pod.Name)
+			err2 = tests.DumpPod(logPath, &pod)
+			framework.ExpectNoError(err2, "failed to dump log for pod %s/%s", pod.Namespace, pod.Name)
+		}
 	}
+
+	ginkgo.By("Uninstalling tidb-operator")
+	err = tests.CleanOperator(ocfg)
+	framework.ExpectNoError(err, "failed to uninstall operator")
+
+	ginkgo.By("Wait for tidb-operator to be uninstalled")
+	err = wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+		podList, err2 := kubeCli.CoreV1().Pods(ocfg.Namespace).List(metav1.ListOptions{})
+		framework.ExpectNoError(err2, "failed to list pods for tidb-operator")
+		return len(podList.Items) == 0, nil
+	})
+	framework.ExpectNoError(err, "failed to wait for tidb-operator to be uninstalled")
 })
 
 // RunE2ETests checks configuration parameters (specified through flags) and then runs

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -185,7 +185,6 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					tc.Spec.PD.Replicas = 5
 					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)
-					framework.Failf("injected fail for dumpling container logs")
 					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 30*time.Second)
 					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
 					err = crdUtil.CheckDisasterTolerance(tc)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -185,6 +185,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					tc.Spec.PD.Replicas = 5
 					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(tc)
 					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)
+					framework.Failf("injected fail for dumpling container logs")
 					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 30*time.Second)
 					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
 					err = crdUtil.CheckDisasterTolerance(tc)

--- a/tests/log_dump.go
+++ b/tests/log_dump.go
@@ -59,7 +59,7 @@ func (oa *OperatorActions) DumpAllLogs(operatorInfo *OperatorConfig, testCluster
 		return err
 	}
 	for _, pod := range operatorPods.Items {
-		err := dumpPod(logPath, &pod)
+		err := DumpPod(logPath, &pod)
 		if err != nil {
 			return err
 		}
@@ -74,7 +74,7 @@ func (oa *OperatorActions) DumpAllLogs(operatorInfo *OperatorConfig, testCluster
 				return err
 			}
 			for _, pod := range clusterPodList.Items {
-				err := dumpPod(logPath, &pod)
+				err := DumpPod(logPath, &pod)
 				if err != nil {
 					return err
 				}
@@ -86,7 +86,8 @@ func (oa *OperatorActions) DumpAllLogs(operatorInfo *OperatorConfig, testCluster
 	return nil
 }
 
-func dumpPod(logPath string, pod *corev1.Pod) error {
+// DumpPod dumps logs for a pod.
+func DumpPod(logPath string, pod *corev1.Pod) error {
 	logFile, err := os.Create(filepath.Join(logPath, fmt.Sprintf("%s-%s.log", pod.Name, pod.Namespace)))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

kubetest2 can only dump logs for living pods, but in order to get test coverage for tidb-operator, we need to uninstall them (to trigger the process exit)

### What is changed and how does it work?

dump tidb-operator's log before uninstall tidb-operator

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
