### PR TITLE
[WIP] ensure crds exist before the controller starts

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -167,9 +167,11 @@ func main() {
 			deps.KubeInformerFactory,
 			deps.LabelFilterKubeInformerFactory,
 		}
+		waitCtx, cancel := context.WithTimeout(context.Background(), cliCfg.CacheSyncDuration)
+		defer cancel()
 		for _, f := range informerFactories {
 			f.Start(ctx.Done())
-			for v, synced := range f.WaitForCacheSync(wait.NeverStop) {
+			for v, synced := range f.WaitForCacheSync(waitCtx.Done()) {
 				if !synced {
 					klog.Fatalf("error syncing informer for %v", v)
 				}

--- a/pkg/controller/dependences.go
+++ b/pkg/controller/dependences.go
@@ -64,6 +64,7 @@ type CLIConfig struct {
 	RenewDeadline         time.Duration
 	RetryPeriod           time.Duration
 	WaitDuration          time.Duration
+	CacheSyncDuration     time.Duration
 	// ResyncDuration is the resync time of informer
 	ResyncDuration time.Duration
 	// Defines whether tidb operator run in test mode, test mode is
@@ -96,6 +97,7 @@ func DefaultCLIConfig() *CLIConfig {
 		RetryPeriod:            2 * time.Second,
 		WaitDuration:           5 * time.Second,
 		ResyncDuration:         30 * time.Second,
+		CacheSyncDuration:      30 * time.Second,
 		TiDBBackupManagerImage: "pingcap/tidb-backup-manager:latest",
 		TiDBDiscoveryImage:     "pingcap/tidb-operator:latest",
 		Selector:               "",
@@ -116,6 +118,7 @@ func (c *CLIConfig) AddFlag(_ *flag.FlagSet) {
 	flag.DurationVar(&c.MasterFailoverPeriod, "dm-master-failover-period", c.MasterFailoverPeriod, "dm-master failover period")
 	flag.DurationVar(&c.WorkerFailoverPeriod, "dm-worker-failover-period", c.WorkerFailoverPeriod, "dm-worker failover period")
 	flag.DurationVar(&c.ResyncDuration, "resync-duration", c.ResyncDuration, "Resync time of informer")
+	flag.DurationVar(&c.CacheSyncDuration, "cache-sync-duration", c.CacheSyncDuration, "Timeout of the cache sync")
 	flag.BoolVar(&c.TestMode, "test-mode", false, "whether tidb-operator run in test mode")
 	flag.StringVar(&c.TiDBBackupManagerImage, "tidb-backup-manager-image", c.TiDBBackupManagerImage, "The image of backup manager tool")
 	// TODO: actually we just want to use the same image with tidb-controller-manager, but DownwardAPI cannot get image ID, see if there is any better solution


### PR DESCRIPTION
Signed-off-by: zhucan <zhucan.k8s@gmail.com>

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
feat: ensure crds exists before controller start
Closes #3939 

### What is changed and how does it work?
Only crd installed that the controller can start

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
