### PR TITLE
backup-manager: avoid logging the database password

### DIFF
--- a/cmd/backup-manager/app/export/export.go
+++ b/cmd/backup-manager/app/export/export.go
@@ -84,7 +84,16 @@ func (bo *Options) dumpTidbClusterData(ctx context.Context, backup *v1alpha1.Bac
 		binPath = path.Join(util.DumplingBinPath, "dumpling")
 	}
 
-	klog.Infof("The dump process is ready, command \"%s %s\"", binPath, strings.Join(args, " "))
+	args_redacted := []string{}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--password=") {
+			args_redacted = append(args_redacted, "--password=******")
+		} else {
+			args_redacted = append(args_redacted, arg)
+		}
+	}
+
+	klog.Infof("The dump process is ready, command \"%s %s\"", binPath, strings.Join(args_redacted, " "))
 
 	output, err := exec.CommandContext(ctx, binPath, args...).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

This masks the password in the logging of a backup.

example from a dumpling backup:
```
I0518 12:12:42.930173       1 export.go:87] The dump process is ready, command "/dumpling --output=/backup/dvaneeden-test-s3/backup-2021-05-18T12:12:42Z --host=10.100.144.207 --port=4000 --user=tidb-backup --password=af73fa3sFud0 --filter *.* --filter !/^(mysql|test|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.* --threads=16 --rows=10000"
```

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->


<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

It iterates over `args` and creates `args_redacted` where it replaced the arg with `--password=******` if it starts with `--password=` and uses this for log message.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

Create a dumpling backup and inspect the logging of the pod.

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Masks the backup password in logging
```
