### PR TITLE
Operator add liveness readiness probe

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -50,16 +50,12 @@ spec:
         resources:
 {{ toYaml .Values.controllerManager.resources | indent 12 }}
         {{- end }}
-        readinessProbe:
-          tcpSocket:
-            port: 6060
-          initialDelaySeconds: 10
-          periodSeconds: 10
         livenessProbe:
           tcpSocket:
             port: 6060
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
           periodSeconds: 10
+          failureThreshold: 10
         command:
           - /usr/local/bin/tidb-controller-manager
           {{- if .Values.tidbBackupManagerImage }}

--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -41,35 +41,35 @@ spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
   {{ toYaml .Values.imagePullSecrets | indent 6 }}
-  {{- end }}
-containers:
-  - name: tidb-operator
-    image: {{ .Values.operatorImage }}
-    imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
-    {{- if .Values.controllerManager.resources }}
-    resources:
-  {{ toYaml .Values.controllerManager.resources | indent 12 }}
-  {{- end }}
-readinessProbe:
-  tcpSocket:
-    port: 6060
-  initialDelaySeconds: 10
-  periodSeconds: 10
-livenessProbe:
-  tcpSocket:
-    port: 6060
-  initialDelaySeconds: 15
-  periodSeconds: 10
-command:
-  - /usr/local/bin/tidb-controller-manager
-  {{- if .Values.tidbBackupManagerImage }}
-  - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
-  {{- end }}
-  - -tidb-discovery-image={{ .Values.operatorImage }}
-  - -cluster-scoped={{ .Values.clusterScoped }}
-  - -cluster-permission-node={{ include "controller-manager.cluster-permissions.nodes" . | trim }}
-  - -cluster-permission-pv={{ include "controller-manager.cluster-permissions.persistentvolumes" . | trim }}
-  - -cluster-permission-sc={{ include "controller-manager.cluster-permissions.storageclasses" . | trim }}
+    {{- end }}
+      containers:
+      - name: tidb-operator
+        image: {{ .Values.operatorImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
+        {{- if .Values.controllerManager.resources }}
+        resources:
+{{ toYaml .Values.controllerManager.resources | indent 12 }}
+        {{- end }}
+        readinessProbe:
+          tcpSocket:
+            port: 6060
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 6060
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        command:
+          - /usr/local/bin/tidb-controller-manager
+          {{- if .Values.tidbBackupManagerImage }}
+          - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
+          {{- end }}
+          - -tidb-discovery-image={{ .Values.operatorImage }}
+          - -cluster-scoped={{ .Values.clusterScoped }}
+          - -cluster-permission-node={{ include "controller-manager.cluster-permissions.nodes" . | trim }}
+          - -cluster-permission-pv={{ include "controller-manager.cluster-permissions.persistentvolumes" . | trim }}
+          - -cluster-permission-sc={{ include "controller-manager.cluster-permissions.storageclasses" . | trim }}
          {{- if eq .Values.controllerManager.autoFailover true }}
           - -auto-failover=true
          {{- end }}

--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -41,25 +41,35 @@ spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
   {{ toYaml .Values.imagePullSecrets | indent 6 }}
-    {{- end }}
-      containers:
-      - name: tidb-operator
-        image: {{ .Values.operatorImage }}
-        imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
-        {{- if .Values.controllerManager.resources }}
-        resources:
-{{ toYaml .Values.controllerManager.resources | indent 12 }}
-        {{- end }}
-        command:
-          - /usr/local/bin/tidb-controller-manager
-          {{- if .Values.tidbBackupManagerImage }}
-          - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
-          {{- end }}
-          - -tidb-discovery-image={{ .Values.operatorImage }}
-          - -cluster-scoped={{ .Values.clusterScoped }}
-          - -cluster-permission-node={{ include "controller-manager.cluster-permissions.nodes" . | trim }}
-          - -cluster-permission-pv={{ include "controller-manager.cluster-permissions.persistentvolumes" . | trim }}
-          - -cluster-permission-sc={{ include "controller-manager.cluster-permissions.storageclasses" . | trim }}
+  {{- end }}
+containers:
+  - name: tidb-operator
+    image: {{ .Values.operatorImage }}
+    imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
+    {{- if .Values.controllerManager.resources }}
+    resources:
+  {{ toYaml .Values.controllerManager.resources | indent 12 }}
+  {{- end }}
+readinessProbe:
+  tcpSocket:
+    port: 6060
+  initialDelaySeconds: 10
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: 6060
+  initialDelaySeconds: 15
+  periodSeconds: 10
+command:
+  - /usr/local/bin/tidb-controller-manager
+  {{- if .Values.tidbBackupManagerImage }}
+  - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}
+  {{- end }}
+  - -tidb-discovery-image={{ .Values.operatorImage }}
+  - -cluster-scoped={{ .Values.clusterScoped }}
+  - -cluster-permission-node={{ include "controller-manager.cluster-permissions.nodes" . | trim }}
+  - -cluster-permission-pv={{ include "controller-manager.cluster-permissions.persistentvolumes" . | trim }}
+  - -cluster-permission-sc={{ include "controller-manager.cluster-permissions.storageclasses" . | trim }}
          {{- if eq .Values.controllerManager.autoFailover true }}
           - -auto-failover=true
          {{- end }}


### PR DESCRIPTION
### What problem does this PR solve?
Fix #3799 
### What is changed and how does it work?

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes


```release-note
TiDB Operator add liveness readiness probe.
```
