### PR TITLE
add design of tidb monitor 'path'

### DIFF
--- a/docs/design-proposals/2021-06-15-add-path-to-tidb-monitor.md
+++ b/docs/design-proposals/2021-06-15-add-path-to-tidb-monitor.md
@@ -1,0 +1,41 @@
+# Pause TiDB Cluster
+
+This document presents a design to add path of tidb monitor in
+operator.
+
+## Motivation
+
+At present, when we want to expose monitoring services (including grafana and prothumes) through Ingress, our design is to use different hosts for different tidb-monitors to distinguish which specific monitoring service is being accessed.This brings some inflexible experiences. If we want to distinguish between different monitoring services through one host but different paths, it is impossible to do it now, but in fact this is also a feasible solution
+
+## Proposal
+
+We can add path to the spec and apply it to the ingress spec application, which can bring us more flexible path parameters [spec code](https://github.com/pingcap/tidb-operator/blob/master/pkg/apis/pingcap/v1alpha1/types.go#L1709)
+
+### Spec
+
+Add a new field to `Path` to Ingress Spec:
+
+```
+    // Indicates ingress path variable
+    // +optional
+    Path string `json:"path,omitempty"`
+```
+
+### Implementation
+
+If not specified the value is '/'
+
+If value specified,it will take effect on [operator code](https://github.com/pingcap/tidb-operator/blob/master/pkg/monitor/monitor/util.go#L942)
+
+- tidb monitor ingress
+
+## Testing plan
+
+### TiDB cluster can be paused and unpaused
+
+- Deploy a tidb cluster
+- Deploy a have 'path' tidb monitor
+- Verify ingress spec
+- Verify monitor service connectivity
+
+## Open Questions


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?


### What is changed and how does it work?
This is a design about adding the variable path to the ingressspec of tidb monitor

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
NONE

```release-note

```
