### PR TITLE
Handle the PVC during scaling of TiDB

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -50,7 +50,7 @@ func NewController(deps *controller.Dependencies) *Controller {
 			deps.TiDBClusterControl,
 			mm.NewPDMemberManager(deps, mm.NewPDScaler(deps), mm.NewPDUpgrader(deps), mm.NewPDFailover(deps)),
 			mm.NewTiKVMemberManager(deps, mm.NewTiKVFailover(deps), mm.NewTiKVScaler(deps), mm.NewTiKVUpgrader(deps)),
-			mm.NewTiDBMemberManager(deps, mm.NewTiDBUpgrader(deps), mm.NewTiDBFailover(deps)),
+			mm.NewTiDBMemberManager(deps, mm.NewTiDBScaler(deps), mm.NewTiDBUpgrader(deps), mm.NewTiDBFailover(deps)),
 			meta.NewReclaimPolicyManager(deps),
 			meta.NewMetaManager(deps),
 			mm.NewOrphanPodsCleaner(deps),

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -808,6 +808,7 @@ func newFakeTiDBMemberManager() (*tidbMemberManager, *controller.FakeStatefulSet
 	fakeDeps := controller.NewFakeDependencies()
 	tmm := &tidbMemberManager{
 		deps:                         fakeDeps,
+		scaler:                       NewTiDBScaler(fakeDeps),
 		tidbUpgrader:                 NewFakeTiDBUpgrader(),
 		tidbFailover:                 NewFakeTiDBFailover(),
 		tidbStatefulSetIsUpgradingFn: tidbStatefulSetIsUpgrading,

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -209,7 +209,7 @@ func TestTiDBMemberManagerSyncUpdate(t *testing.T) {
 			err:                      false,
 			expectStatefulSetFn: func(g *GomegaWithT, set *apps.StatefulSet, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(int(*set.Spec.Replicas)).To(Equal(5))
+				g.Expect(int(*set.Spec.Replicas)).To(Equal(4)) // scale out one-by-one now
 			},
 		},
 		{

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -1994,10 +1994,22 @@ func TestTiDBMemberManagerScaleToZeroReplica(t *testing.T) {
 		ns := tc.GetNamespace()
 		tcName := tc.GetName()
 
-		tmm, fakeSetControl, _, _ := newFakeTiDBMemberManager()
+		tmm, fakeSetControl, _, indexer := newFakeTiDBMemberManager()
 
 		err := tmm.Sync(tc)
 		g.Expect(err).NotTo(HaveOccurred())
+
+		for i := int32(0); i < 5; i++ {
+			// add all 5 (3 + 2 failure) pods
+			indexer.pod.Add(&corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              tidbPodName(tc.GetName(), i),
+					Namespace:         corev1.NamespaceDefault,
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+				},
+			})
+		}
 
 		g.Expect(err).NotTo(HaveOccurred())
 		_, err = tmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))
@@ -2010,8 +2022,9 @@ func TestTiDBMemberManagerScaleToZeroReplica(t *testing.T) {
 		if test.errWhenUpdateStatefulSet {
 			fakeSetControl.SetUpdateStatefulSetError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
 		}
-		syncTiDBCluster(tmm, tc1, test)
-		syncTiDBCluster(tmm, tc1, test)
+		for i := 0; i < 5; i++ { // scale in 5 members
+			syncTiDBCluster(tmm, tc1, test)
+		}
 
 		if test.expectStatefulSetFn != nil {
 			set, err := tmm.deps.StatefulSetLister.StatefulSets(ns).Get(controller.TiDBMemberName(tcName))

--- a/pkg/manager/member/tidb_scaler.go
+++ b/pkg/manager/member/tidb_scaler.go
@@ -1,0 +1,113 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"fmt"
+
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/util"
+)
+
+type tidbScaler struct {
+	generalScaler
+}
+
+// NewTiDBScaler returns a TiDB Scaler.
+func NewTiDBScaler(deps *controller.Dependencies) *tidbScaler {
+	return &tidbScaler{generalScaler: generalScaler{deps: deps}}
+}
+
+// Scale scales in or out of the statefulset.
+func (s *tidbScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+	scaling, _, _, _ := scaleOne(oldSet, newSet)
+	if scaling > 0 {
+		return s.ScaleOut(meta, oldSet, newSet)
+	} else if scaling < 0 {
+		return s.ScaleIn(meta, oldSet, newSet)
+	}
+	return nil
+}
+
+// ScaleOut scales out of the statefulset.
+func (s *tidbScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+	_, ordinal, replicas, deleteSlots := scaleOne(oldSet, newSet)
+	resetReplicas(newSet, oldSet)
+	obj, ok := meta.(runtime.Object)
+	if !ok {
+		klog.Errorf("cluster[%s/%s] can't convert to runtime.Object", meta.GetNamespace(), meta.GetName())
+		return nil
+	}
+	klog.Infof("scaling out tidb statefulset %s/%s, ordinal: %d (replicas: %d, delete slots: %v)", oldSet.Namespace, oldSet.Name, ordinal, replicas, deleteSlots.List())
+	skipReason, err := s.deleteDeferDeletingPVC(obj, v1alpha1.TiDBMemberType, ordinal)
+	if err != nil {
+		return err
+	} else if len(skipReason) != 1 || skipReason[ordinalPodName(v1alpha1.TiDBMemberType, meta.GetName(), ordinal)] != skipReasonScalerPVCNotFound {
+		// wait for all PVCs to be deleted
+		return controller.RequeueErrorf("tidbScaler.ScaleOut, cluster %s/%s ready to scale out, skip reason %v, wait for next round", meta.GetNamespace(), meta.GetName(), skipReason)
+	}
+	setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
+	return nil
+}
+
+// ScaleIn scales in of the statefulset.
+func (s *tidbScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
+	ns := meta.GetNamespace()
+	tcName := meta.GetName()
+	// NOW, we can only remove one member at a time when scaling in
+	_, ordinal, replicas, deleteSlots := scaleOne(oldSet, newSet)
+	resetReplicas(newSet, oldSet)
+
+	klog.Infof("scaling in tidb statefulset %s/%s, ordinal: %d (replicas: %d, delete slots: %v)", oldSet.Namespace, oldSet.Name, ordinal, replicas, deleteSlots.List())
+	// We need to remove member from cluster before reducing statefulset replicas
+	var podName string
+	switch meta.(type) {
+	case *v1alpha1.TidbCluster:
+		podName = ordinalPodName(v1alpha1.TiDBMemberType, tcName, ordinal)
+	default:
+		klog.Errorf("tidbScaler.ScaleIn: failed to convert cluster %s/%s", meta.GetNamespace(), meta.GetName())
+		return nil
+	}
+	pod, err := s.deps.PodLister.Pods(ns).Get(podName)
+	if err != nil {
+		return fmt.Errorf("tidbScaler.ScaleIn: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
+	}
+
+	pvcs, err := util.ResolvePVCFromPod(pod, s.deps.PVCLister)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("tidbScaler.ScaleIn: failed to get pvcs for pod %s/%s in tc %s/%s, error: %s", ns, pod.Name, ns, tcName, err)
+	}
+	tc, _ := meta.(*v1alpha1.TidbCluster)
+	for _, pvc := range pvcs {
+		if err := addDeferDeletingAnnoToPVC(tc, pvc, s.deps.PVCControl); err != nil {
+			return err
+		}
+	}
+
+	setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
+	return nil
+}
+
+// SyncAutoScalerAnn would reclaim the auto-scaling out slots if the target pod is no longer existed
+// NOTE: this method should be removed later.
+func (s *tidbScaler) SyncAutoScalerAnn(_ metav1.Object, _ *apps.StatefulSet) error {
+	return nil
+}

--- a/pkg/manager/member/tidb_scaler_test.go
+++ b/pkg/manager/member/tidb_scaler_test.go
@@ -1,0 +1,323 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/label"
+)
+
+func TestTiDBScalerScaleOut(t *testing.T) {
+	g := NewGomegaWithT(t)
+	type testcase struct {
+		name          string
+		tidbUpgrading bool
+		hasPVC        bool
+		hasDeferAnn   bool
+		pvcDeleteErr  bool
+		annoIsNil     bool
+		errExpectFn   func(*GomegaWithT, error)
+		changed       bool
+	}
+
+	testFn := func(test testcase, t *testing.T) {
+		tc := newTidbClusterForPD()
+
+		if test.tidbUpgrading {
+			tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
+		}
+
+		oldSet := newStatefulSetForPDScale()
+		oldSet.Name = fmt.Sprintf("%s-tidb", tc.Name)
+		newSet := oldSet.DeepCopy()
+		newSet.Spec.Replicas = pointer.Int32Ptr(7)
+
+		scaler, pvcIndexer, _, pvcControl := newFakeTiDBScaler()
+
+		pvc := newPVCForStatefulSet(oldSet, v1alpha1.TiDBMemberType, tc.Name)
+		pvc.Name = ordinalPVCName(v1alpha1.TiDBMemberType, fmt.Sprintf("log-%s", oldSet.Name), *oldSet.Spec.Replicas)
+		if !test.annoIsNil {
+			pvc.Annotations = map[string]string{}
+		}
+
+		if test.hasDeferAnn {
+			pvc.Annotations = map[string]string{}
+			pvc.Annotations[label.AnnPVCDeferDeleting] = time.Now().Format(time.RFC3339)
+		}
+		if test.hasPVC {
+			pvcIndexer.Add(pvc)
+		}
+
+		if test.pvcDeleteErr {
+			pvcControl.SetDeletePVCError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
+		}
+
+		err := scaler.ScaleOut(tc, oldSet, newSet)
+		test.errExpectFn(g, err)
+		if test.changed {
+			g.Expect(int(*newSet.Spec.Replicas)).To(Equal(6))
+		} else {
+			g.Expect(int(*newSet.Spec.Replicas)).To(Equal(5))
+		}
+	}
+
+	tests := []testcase{
+		{
+			name:          "normal",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			hasDeferAnn:   false,
+			annoIsNil:     true,
+			pvcDeleteErr:  false,
+			errExpectFn:   errExpectNotNil,
+			changed:       false,
+		},
+		{
+			name:          "tidb is upgrading",
+			tidbUpgrading: true,
+			hasPVC:        true,
+			hasDeferAnn:   false,
+			annoIsNil:     true,
+			pvcDeleteErr:  false,
+			errExpectFn:   errExpectNotNil,
+			changed:       false,
+		},
+		{
+			name:          "cache don't have pvc",
+			tidbUpgrading: false,
+			hasPVC:        false,
+			hasDeferAnn:   false,
+			annoIsNil:     true,
+			pvcDeleteErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "pvc annotation is not nil but doesn't contain defer deletion annotation",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			hasDeferAnn:   false,
+			annoIsNil:     false,
+			pvcDeleteErr:  false,
+			errExpectFn:   errExpectNotNil,
+			changed:       false,
+		},
+		{
+			name:          "pvc annotations defer deletion is not nil, pvc delete failed",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			hasDeferAnn:   true,
+			pvcDeleteErr:  true,
+			errExpectFn:   errExpectNotNil,
+			changed:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFn(tt, t)
+		})
+	}
+}
+
+func TestTiDBScalerScaleIn(t *testing.T) {
+	g := NewGomegaWithT(t)
+	type testcase struct {
+		name          string
+		tidbUpgrading bool
+		hasPVC        bool
+		isPodReady    bool
+		hasSynced     bool
+		pvcUpdateErr  bool
+		errExpectFn   func(*GomegaWithT, error)
+		changed       bool
+	}
+
+	resyncDuration := time.Duration(0)
+
+	testFn := func(test testcase, t *testing.T) {
+		tc := newTidbClusterForPD()
+
+		if test.tidbUpgrading {
+			tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
+		}
+
+		oldSet := newStatefulSetForPDScale()
+		newSet := oldSet.DeepCopy()
+		newSet.Spec.Replicas = pointer.Int32Ptr(3)
+
+		pod := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              tidbPodName(tc.GetName(), 4),
+				Namespace:         corev1.NamespaceDefault,
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+			},
+		}
+
+		readyPodFunc(pod)
+		if !test.isPodReady {
+			notReadyPodFunc(pod)
+		}
+
+		if !test.hasSynced {
+			pod.CreationTimestamp = metav1.Time{Time: time.Now().Add(1 * time.Hour)}
+		}
+
+		scaler, pvcIndexer, podIndexer, pvcControl := newFakeTiDBScaler(resyncDuration)
+
+		if test.hasPVC {
+			pvc1 := newScaleInPVCForStatefulSet(oldSet, v1alpha1.TiDBMemberType, tc.Name)
+			pvc1.Name = ordinalPVCName(v1alpha1.TiDBMemberType, fmt.Sprintf("log-%s", oldSet.Name), *oldSet.Spec.Replicas-1)
+			pvc2 := pvc1.DeepCopy()
+			pvc1.Name = pvc1.Name + "-1"
+			pvc1.UID = pvc1.UID + "-1"
+			pvc2.Name = pvc2.Name + "-2"
+			pvc2.UID = pvc2.UID + "-2"
+			pvcIndexer.Add(pvc1)
+			pvcIndexer.Add(pvc2)
+			pod.Spec.Volumes = append(pod.Spec.Volumes,
+				corev1.Volume{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc1.Name,
+						},
+					},
+				}, corev1.Volume{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc2.Name,
+						},
+					},
+				})
+		}
+
+		pod.Labels = map[string]string{}
+		podIndexer.Add(pod)
+
+		if test.pvcUpdateErr {
+			pvcControl.SetUpdatePVCError(errors.NewInternalError(fmt.Errorf("API server failed")), 0)
+		}
+
+		err := scaler.ScaleIn(tc, oldSet, newSet)
+		test.errExpectFn(g, err)
+		if test.changed {
+			g.Expect(int(*newSet.Spec.Replicas)).To(Equal(4))
+		} else {
+			g.Expect(int(*newSet.Spec.Replicas)).To(Equal(5))
+		}
+	}
+
+	tests := []testcase{
+		{
+			name:          "able to scale in while not upgrading",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			isPodReady:    true,
+			hasSynced:     true,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "able to scale in while upgrading",
+			tidbUpgrading: true,
+			hasPVC:        true,
+			isPodReady:    true,
+			hasSynced:     true,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "tidb pod is not ready now, not sure if the status has been synced",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			isPodReady:    false,
+			hasSynced:     false,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "tidb pod is not ready now, make sure the status has been synced",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			isPodReady:    false,
+			hasSynced:     true,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "tidb pod is ready now, but the status has not been synced",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			isPodReady:    true,
+			hasSynced:     false,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "don't have pvc",
+			tidbUpgrading: false,
+			hasPVC:        false,
+			isPodReady:    true,
+			hasSynced:     true,
+			pvcUpdateErr:  false,
+			errExpectFn:   errExpectNil,
+			changed:       true,
+		},
+		{
+			name:          "update PVC failed",
+			tidbUpgrading: false,
+			hasPVC:        true,
+			isPodReady:    true,
+			hasSynced:     true,
+			pvcUpdateErr:  true,
+			errExpectFn:   errExpectNotNil,
+			changed:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFn(tt, t)
+		})
+	}
+}
+
+func newFakeTiDBScaler(resyncDuration ...time.Duration) (*tidbScaler, cache.Indexer, cache.Indexer, *controller.FakePVCControl) {
+	fakeDeps := controller.NewFakeDependencies()
+	if len(resyncDuration) > 0 {
+		fakeDeps.CLIConfig.ResyncDuration = resyncDuration[0]
+	}
+	pvcIndexer := fakeDeps.KubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer().GetIndexer()
+	podIndexer := fakeDeps.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	pvcControl := fakeDeps.PVCControl.(*controller.FakePVCControl)
+	return &tidbScaler{generalScaler{deps: fakeDeps}}, pvcIndexer, podIndexer, pvcControl
+}

--- a/pkg/manager/meta/meta_manager.go
+++ b/pkg/manager/meta/meta_manager.go
@@ -58,6 +58,7 @@ func (m *metaManager) Sync(tc *v1alpha1.TidbCluster) error {
 		components := map[string]struct{}{
 			label.PDLabelVal:      {},
 			label.TiKVLabelVal:    {},
+			label.TiDBLabelVal:    {},
 			label.TiFlashLabelVal: {},
 			label.TiCDCLabelVal:   {},
 			label.PumpLabelVal:    {},
@@ -66,7 +67,7 @@ func (m *metaManager) Sync(tc *v1alpha1.TidbCluster) error {
 
 		if _, ok := components[component]; !ok {
 			// Skip syncing meta info for pod that doesn't use PV
-			// Currently only PD/TiKV/TiFlash/TiCDC/Pump uses PV
+			// Currently only PD/TiKV/TiDB/TiFlash/TiCDC/Pump uses PV
 			continue
 		}
 		// update meta info for pvc

--- a/pkg/manager/meta/meta_manager_test.go
+++ b/pkg/manager/meta/meta_manager_test.go
@@ -67,8 +67,8 @@ func TestMetaManagerSync(t *testing.T) {
 		}
 
 		if !test.podRefPvc {
-			pod1.Spec = newPodSpec(v1alpha1.TiDBMemberType.String(), pvc1.GetName())
-			pod1.Labels[label.ComponentLabelKey] = v1alpha1.TiDBMemberType.String()
+			pod1.Spec = newPodSpec("no-ref-component", pvc1.GetName())
+			pod1.Labels[label.ComponentLabelKey] = "no-ref-component"
 		}
 
 		nmm, fakePodControl, fakePVCControl, fakePVControl, podIndexer, pvcIndexer, pvIndexer := newFakeMetaManager()
@@ -233,7 +233,7 @@ func TestMetaManagerSync(t *testing.T) {
 			pvChanged:        false,
 		},
 		{
-			name:             "the pod is not tikv and pd",
+			name:             "the pod is skipping syncing meta info",
 			podHasLabels:     true,
 			pvcHasLabels:     true,
 			pvcHasVolumeName: true,
@@ -392,8 +392,8 @@ func TestMetaManagerSyncMultiPVC(t *testing.T) {
 		}
 
 		if !test.podRefPvc {
-			pod1.Spec = newPodSpec(v1alpha1.TiDBMemberType.String(), pvc1.GetName())
-			pod1.Labels[label.ComponentLabelKey] = v1alpha1.TiDBMemberType.String()
+			pod1.Spec = newPodSpec("no-ref-component", pvc1.GetName())
+			pod1.Labels[label.ComponentLabelKey] = "no-ref-component"
 		}
 
 		nmm, fakePodControl, fakePVCControl, fakePVControl, podIndexer, pvcIndexer, pvIndexer := newFakeMetaManager()
@@ -603,7 +603,7 @@ func TestMetaManagerSyncMultiPVC(t *testing.T) {
 			pvChanged:        false,
 		},
 		{
-			name:             "the pod is not tikv and pd",
+			name:             "the pod is skipping syncing meta info",
 			podHasLabels:     true,
 			pvcHasLabels:     true,
 			pvcHasVolumeName: true,

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -1719,30 +1719,78 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		tc.Spec.TiKV.Config.Set("rocksdb.wal-dir", "/var/lib/wal")
 		tc.Spec.TiKV.Config.Set("titan.dirname", "/var/lib/titan")
 		tc.Spec.PD.Replicas = 1
-		tc.Spec.TiKV.Replicas = 3
-		tc.Spec.TiDB.Replicas = 1
+		tc.Spec.TiKV.Replicas = 4
+		tc.Spec.TiDB.Replicas = 2
 
 		utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc, 6*time.Minute, 5*time.Second)
 
-		ginkgo.By("Scale out multiple pvc tidb cluster")
+		ginkgo.By("Scale in multiple pvc tidb cluster")
 		// Scale
 		err := controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.TiKV.Replicas = 4
+			tc.Spec.TiKV.Replicas = 3
+			tc.Spec.TiDB.Replicas = 1
 			return nil
 		})
-		framework.ExpectNoError(err, "failed to scale out TiKV, TidbCluster: %q", tc.Name)
+		framework.ExpectNoError(err, "failed to scale in TiKV/TiDB, TidbCluster: %q", tc.Name)
 		err = oa.WaitForTidbClusterReady(tc, 3*time.Minute, 5*time.Second)
 		framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
 
-		ginkgo.By("Scale in multiple pvc tidb cluster")
+		ginkgo.By("Check PVC annotation tidb.pingcap.com/pvc-defer-deleting")
+		pvcUIDs := make(map[string]string)
+		ordinal := int32(1)
+		pvcSelector, err := member.GetPVCSelectorForPod(tc, v1alpha1.TiDBMemberType, ordinal)
+		framework.ExpectNoError(err, "failed to get PVC selector for tc %s/%s", tc.GetNamespace(), tc.GetName())
+		err = wait.Poll(10*time.Second, 3*time.Minute, func() (done bool, err error) {
+			pvcs, err := c.CoreV1().PersistentVolumeClaims(ns).List(metav1.ListOptions{LabelSelector: pvcSelector.String()})
+			framework.ExpectNoError(err, "failed to list PVCs with selector: %v", pvcSelector)
+			if len(pvcs.Items) == 0 {
+				log.Logf("no PVC found")
+				return false, nil
+			}
+			for _, pvc := range pvcs.Items {
+				annotations := pvc.GetObjectMeta().GetAnnotations()
+				log.Logf("pvc annotations: %+v", annotations)
+				_, ok := annotations["tidb.pingcap.com/pvc-defer-deleting"]
+				if !ok {
+					log.Logf("PVC %s/%s does not have annotation tidb.pingcap.com/pvc-defer-deleting", pvc.GetNamespace(), pvc.GetName())
+					return false, nil
+				}
+				pvcUIDs[pvc.Name] = string(pvc.UID)
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "expect PVCs of scaled in Pods to have annotation tidb.pingcap.com/pvc-defer-deleting")
+
+		ginkgo.By("Scale out multiple pvc tidb cluster")
 		// Scale
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
-			tc.Spec.TiKV.Replicas = 3
+			tc.Spec.TiKV.Replicas = 4
+			tc.Spec.TiDB.Replicas = 2
 			return nil
 		})
-		framework.ExpectNoError(err, "failed to scale in TiKV, TidbCluster: %q", tc.Name)
+		framework.ExpectNoError(err, "failed to scale out TiKV/TiDB, TidbCluster: %q", tc.Name)
 		err = oa.WaitForTidbClusterReady(tc, 3*time.Minute, 5*time.Second)
 		framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+
+		ginkgo.By("Check PVCs are recreated for newly scaled out TiDB")
+		err = wait.Poll(10*time.Second, 3*time.Minute, func() (done bool, err error) {
+			pvcs, err := c.CoreV1().PersistentVolumeClaims(ns).List(metav1.ListOptions{LabelSelector: pvcSelector.String()})
+			framework.ExpectNoError(err, "failed to list PVCs with selector: %v", pvcSelector)
+			if len(pvcs.Items) == 0 {
+				log.Logf("no PVC found")
+				return false, nil
+			}
+			for _, pvc := range pvcs.Items {
+				annotations := pvc.GetObjectMeta().GetAnnotations()
+				log.Logf("pvc annotations: %+v", annotations)
+				_, ok := annotations["tidb.pingcap.com/pvc-defer-deleting"]
+				framework.ExpectEqual(ok, false, "expect PVC %s/%s not to have annotation tidb.pingcap.com/pvc-defer-deleting", pvc.GetNamespace(), pvc.GetName())
+				pvcUIDString := pvcUIDs[pvc.Name]
+				framework.ExpectNotEqual(string(pvc.UID), pvcUIDString)
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "expect PVCs of scaled out Pods to be recreated")
 	})
 
 	// test cases for tc upgrade


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

close #3997

### What is changed and how does it work?

Handle the PVC during scaling of TiDB

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support to handle PVC during scaling of TiDB
```
