### PR TITLE
Support modify grafana dashboard.

### DIFF
--- a/examples/auto-scale/tidb-monitor.yaml
+++ b/examples/auto-scale/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/aws/tidb-monitor.yaml
+++ b/examples/aws/tidb-monitor.yaml
@@ -27,7 +27,7 @@ spec:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
       type: LoadBalancer
     username: admin
-    version: 6.1.6
+    version: 6.5.3
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: uhub.service.ucloud.cn/pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/basic-tls/tidb-monitor.yaml
+++ b/examples/basic-tls/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/dm/dm-monitor.yaml
+++ b/examples/dm/dm-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/gcp/tidb-monitor.yaml
+++ b/examples/gcp/tidb-monitor.yaml
@@ -25,7 +25,7 @@ spec:
       portName: http-grafana
       type: LoadBalancer
     username: admin
-    version: 6.1.6
+    version: 6.5.3
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/heterogeneous-tls/tidb-monitor.yaml
+++ b/examples/heterogeneous-tls/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/heterogeneous/tidb-monitor.yaml
+++ b/examples/heterogeneous/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-prom-remotewrite/tidb-monitor.yaml
+++ b/examples/monitor-prom-remotewrite/tidb-monitor.yaml
@@ -19,7 +19,7 @@ spec:
             action: replace
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
     additionalVolumeMounts:
       - name: customdashboard
         mountPath: /grafana-dashboard-definitions/tidb/dashboards/custom

--- a/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
@@ -17,7 +17,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
@@ -18,7 +18,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/monitor-with-thanos/tidb-monitor.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/namespaced/tidb-monitor.yaml
+++ b/examples/namespaced/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.0.1

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 6.5.3
     service:
       type: NodePort
   initializer:

--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -66,6 +66,7 @@ var (
             "options": {
                 "path": "/grafana-dashboard-definitions/tidb"
             },
+			"allowUiUpdates":true,
             "orgId": 1,
             "type": "file"
         }


### PR DESCRIPTION

### What problem does this PR solve?
#4022 



### What is changed and how does it work?
Grafana  support modify dashboard json in 6.5 version . Refer : https://github.com/grafana/grafana/pull/19820.
We need to enable  `allowUiUpdates` field  in  dashboard configuration.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

### Release Notes


```release-note
Support user modify grafana dashboard , enable `allowUiUpdates` field .
```
