### PR TITLE
Fixed potential nil pointer issues

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -116,7 +116,7 @@ func (tc *TidbCluster) TiKVImage() string {
 	return image
 }
 
-// TiKVVersion return the image used by TiKV.
+// TiKVVersion return the image version used by TiKV.
 //
 // If TiKV isn't specified, return empty string.
 func (tc *TidbCluster) TiKVVersion() string {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -49,7 +49,14 @@ var (
 	defaultHelperSpec = HelperSpec{}
 )
 
+// PDImage return the image used by PD.
+//
+// If PD isn't specified, return empty string.
 func (tc *TidbCluster) PDImage() string {
+	if tc.Spec.PD == nil {
+		return ""
+	}
+
 	image := tc.Spec.PD.Image
 	baseImage := tc.Spec.PD.BaseImage
 	// base image takes higher priority
@@ -67,7 +74,14 @@ func (tc *TidbCluster) PDImage() string {
 	return image
 }
 
+// PDVersion return the image version used by PD.
+//
+// If PD isn't specified, return empty string.
 func (tc *TidbCluster) PDVersion() string {
+	if tc.Spec.PD == nil {
+		return ""
+	}
+
 	image := tc.PDImage()
 	colonIdx := strings.LastIndexByte(image, ':')
 	if colonIdx >= 0 {
@@ -77,7 +91,14 @@ func (tc *TidbCluster) PDVersion() string {
 	return "latest"
 }
 
+// TiKVImage return the image used by TiKV.
+//
+// If TiKV isn't specified, return empty string.
 func (tc *TidbCluster) TiKVImage() string {
+	if tc.Spec.TiKV == nil {
+		return ""
+	}
+
 	image := tc.Spec.TiKV.Image
 	baseImage := tc.Spec.TiKV.BaseImage
 	// base image takes higher priority
@@ -95,7 +116,14 @@ func (tc *TidbCluster) TiKVImage() string {
 	return image
 }
 
+// TiKVVersion return the image used by TiKV.
+//
+// If TiKV isn't specified, return empty string.
 func (tc *TidbCluster) TiKVVersion() string {
+	if tc.Spec.TiKV == nil {
+		return ""
+	}
+
 	image := tc.TiKVImage()
 	colonIdx := strings.LastIndexByte(image, ':')
 	if colonIdx >= 0 {
@@ -106,7 +134,7 @@ func (tc *TidbCluster) TiKVVersion() string {
 }
 
 func (tc *TidbCluster) TiKVContainerPrivilege() *bool {
-	if tc.Spec.TiKV.Privileged == nil {
+	if tc.Spec.TiKV == nil || tc.Spec.TiKV.Privileged == nil {
 		pri := false
 		return &pri
 	}
@@ -114,7 +142,7 @@ func (tc *TidbCluster) TiKVContainerPrivilege() *bool {
 }
 
 func (tc *TidbCluster) TiKVEvictLeaderTimeout() time.Duration {
-	if tc.Spec.TiKV.EvictLeaderTimeout != nil {
+	if tc.Spec.TiKV != nil && tc.Spec.TiKV.EvictLeaderTimeout != nil {
 		d, err := time.ParseDuration(*tc.Spec.TiKV.EvictLeaderTimeout)
 		if err == nil {
 			return d
@@ -123,7 +151,14 @@ func (tc *TidbCluster) TiKVEvictLeaderTimeout() time.Duration {
 	return defaultEvictLeaderTimeout
 }
 
+// TiFlashImage return the image used by TiFlash.
+//
+// If TiFlash isn't specified, return empty string.
 func (tc *TidbCluster) TiFlashImage() string {
+	if tc.Spec.TiFlash == nil {
+		return ""
+	}
+
 	image := tc.Spec.TiFlash.Image
 	baseImage := tc.Spec.TiFlash.BaseImage
 	// base image takes higher priority
@@ -141,7 +176,14 @@ func (tc *TidbCluster) TiFlashImage() string {
 	return image
 }
 
+// TiCDCImage return the image used by TiCDC.
+//
+// If TiCDC isn't specified, return empty string.
 func (tc *TidbCluster) TiCDCImage() string {
+	if tc.Spec.TiCDC == nil {
+		return ""
+	}
+
 	image := tc.Spec.TiCDC.Image
 	baseImage := tc.Spec.TiCDC.BaseImage
 	// base image takes higher priority
@@ -160,14 +202,21 @@ func (tc *TidbCluster) TiCDCImage() string {
 }
 
 func (tc *TidbCluster) TiFlashContainerPrivilege() *bool {
-	if tc.Spec.TiFlash.Privileged == nil {
+	if tc.Spec.TiFlash == nil || tc.Spec.TiFlash.Privileged == nil {
 		pri := false
 		return &pri
 	}
 	return tc.Spec.TiFlash.Privileged
 }
 
+// TiDBImage return the image used by TiDB.
+//
+// If TiDB isn't specified, return empty string.
 func (tc *TidbCluster) TiDBImage() string {
+	if tc.Spec.TiDB == nil {
+		return ""
+	}
+
 	image := tc.Spec.TiDB.Image
 	baseImage := tc.Spec.TiDB.BaseImage
 	// base image takes higher priority
@@ -185,10 +234,14 @@ func (tc *TidbCluster) TiDBImage() string {
 	return image
 }
 
+// PumpImage return the image used by Pump.
+//
+// If Pump isn't specified, return nil.
 func (tc *TidbCluster) PumpImage() *string {
 	if tc.Spec.Pump == nil {
 		return nil
 	}
+
 	image := tc.Spec.Pump.Image
 	baseImage := tc.Spec.Pump.BaseImage
 	// base image takes higher priority
@@ -208,7 +261,7 @@ func (tc *TidbCluster) PumpImage() *string {
 
 func (tc *TidbCluster) HelperImage() string {
 	image := tc.GetHelperSpec().Image
-	if image == nil {
+	if image == nil && tc.Spec.TiDB != nil {
 		// for backward compatibility
 		image = tc.Spec.TiDB.GetSlowLogTailerSpec().Image
 	}
@@ -220,7 +273,7 @@ func (tc *TidbCluster) HelperImage() string {
 
 func (tc *TidbCluster) HelperImagePullPolicy() corev1.PullPolicy {
 	pp := tc.GetHelperSpec().ImagePullPolicy
-	if pp == nil {
+	if pp == nil && tc.Spec.TiDB != nil {
 		// for backward compatibility
 		pp = tc.Spec.TiDB.GetSlowLogTailerSpec().ImagePullPolicy
 	}
@@ -308,11 +361,24 @@ func (tc *TidbCluster) getDeleteSlots(component string) (deleteSlots sets.Int32)
 	return
 }
 
+// PDAllPodsStarted return whether all pods of PD are started.
+//
+// If PD isn't specified, return false.
 func (tc *TidbCluster) PDAllPodsStarted() bool {
+	if tc.Spec.PD == nil {
+		return false
+	}
 	return tc.PDStsDesiredReplicas() == tc.PDStsActualReplicas()
 }
 
+// PDAllMembersReady return whether all members of PD are ready.
+//
+// If PD isn't specified, return false.
 func (tc *TidbCluster) PDAllMembersReady() bool {
+	if tc.Spec.PD == nil {
+		return false
+	}
+
 	if int(tc.PDStsDesiredReplicas()) != len(tc.Status.PD.Members) {
 		return false
 	}
@@ -349,6 +415,9 @@ func (tc *TidbCluster) GetPDDeletedFailureReplicas() int32 {
 }
 
 func (tc *TidbCluster) PDStsDesiredReplicas() int32 {
+	if tc.Spec.PD == nil {
+		return 0
+	}
 	return tc.Spec.PD.Replicas + tc.GetPDDeletedFailureReplicas()
 }
 
@@ -361,6 +430,9 @@ func (tc *TidbCluster) PDStsActualReplicas() int32 {
 }
 
 func (tc *TidbCluster) PDStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	if tc.Spec.PD == nil {
+		return sets.Int32{}
+	}
 	replicas := tc.Spec.PD.Replicas
 	if !excludeFailover {
 		replicas = tc.PDStsDesiredReplicas()
@@ -368,11 +440,24 @@ func (tc *TidbCluster) PDStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
 	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.PDLabelVal))
 }
 
+// TiKVAllPodsStarted return whether all pods of TiKV are started.
+//
+// If TiKV isn't specified, return false.
 func (tc *TidbCluster) TiKVAllPodsStarted() bool {
+	if tc.Spec.TiKV == nil {
+		return false
+	}
 	return tc.TiKVStsDesiredReplicas() == tc.TiKVStsActualReplicas()
 }
 
+// TiKVAllStoresReady return whether all stores of TiKV are ready.
+//
+// If TiKV isn't specified, return false.
 func (tc *TidbCluster) TiKVAllStoresReady() bool {
+	if tc.Spec.TiKV == nil {
+		return false
+	}
+
 	if int(tc.TiKVStsDesiredReplicas()) != len(tc.Status.TiKV.Stores) {
 		return false
 	}
@@ -387,6 +472,9 @@ func (tc *TidbCluster) TiKVAllStoresReady() bool {
 }
 
 func (tc *TidbCluster) TiKVStsDesiredReplicas() int32 {
+	if tc.Spec.TiKV == nil {
+		return 0
+	}
 	return tc.Spec.TiKV.Replicas + int32(len(tc.Status.TiKV.FailureStores))
 }
 
@@ -399,6 +487,9 @@ func (tc *TidbCluster) TiKVStsActualReplicas() int32 {
 }
 
 func (tc *TidbCluster) TiKVStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	if tc.Spec.TiKV == nil {
+		return sets.Int32{}
+	}
 	replicas := tc.Spec.TiKV.Replicas
 	if !excludeFailover {
 		replicas = tc.TiKVStsDesiredReplicas()
@@ -406,11 +497,24 @@ func (tc *TidbCluster) TiKVStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
 	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiKVLabelVal))
 }
 
+// TiFlashAllPodsStarted return whether all pods of TiFlash are started.
+//
+// If TiFlash isn't specified, return false.
 func (tc *TidbCluster) TiFlashAllPodsStarted() bool {
+	if tc.Spec.TiFlash == nil {
+		return false
+	}
 	return tc.TiFlashStsDesiredReplicas() == tc.TiFlashStsActualReplicas()
 }
 
+// TiFlashAllPodsStarted return whether all stores of TiFlash are ready.
+//
+// If TiFlash isn't specified, return false.
 func (tc *TidbCluster) TiFlashAllStoresReady() bool {
+	if tc.Spec.TiFlash == nil {
+		return false
+	}
+
 	if int(tc.TiFlashStsDesiredReplicas()) != len(tc.Status.TiFlash.Stores) {
 		return false
 	}
@@ -458,11 +562,24 @@ func (tc *TidbCluster) TiFlashStsDesiredOrdinals(excludeFailover bool) sets.Int3
 	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiFlashLabelVal))
 }
 
+// TiDBAllPodsStarted return whether all pods of TiDB are started.
+//
+// If TiDB isn't specified, return false.
 func (tc *TidbCluster) TiDBAllPodsStarted() bool {
+	if tc.Spec.TiDB == nil {
+		return false
+	}
 	return tc.TiDBStsDesiredReplicas() == tc.TiDBStsActualReplicas()
 }
 
+// TiDBAllMembersReady return whether all members of TiDB are ready.
+//
+// If TiDB isn't specified, return false.
 func (tc *TidbCluster) TiDBAllMembersReady() bool {
+	if tc.Spec.TiDB == nil {
+		return false
+	}
+
 	if int(tc.TiDBStsDesiredReplicas()) != len(tc.Status.TiDB.Members) {
 		return false
 	}
@@ -477,6 +594,9 @@ func (tc *TidbCluster) TiDBAllMembersReady() bool {
 }
 
 func (tc *TidbCluster) TiDBStsDesiredReplicas() int32 {
+	if tc.Spec.TiDB == nil {
+		return 0
+	}
 	return tc.Spec.TiDB.Replicas + int32(len(tc.Status.TiDB.FailureMembers))
 }
 
@@ -489,6 +609,9 @@ func (tc *TidbCluster) TiDBStsActualReplicas() int32 {
 }
 
 func (tc *TidbCluster) TiDBStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
+	if tc.Spec.TiDB == nil {
+		return sets.Int32{}
+	}
 	replicas := tc.Spec.TiDB.Replicas
 	if !excludeFailover {
 		replicas = tc.TiDBStsDesiredReplicas()
@@ -496,12 +619,15 @@ func (tc *TidbCluster) TiDBStsDesiredOrdinals(excludeFailover bool) sets.Int32 {
 	return helper.GetPodOrdinalsFromReplicasAndDeleteSlots(replicas, tc.getDeleteSlots(label.TiDBLabelVal))
 }
 
+// PDIsAvailable return whether PD is available.
+//
+// If PD isn't specified, return true.
 func (tc *TidbCluster) PDIsAvailable() bool {
 	if tc.Spec.PD == nil {
 		return true
 	}
-	lowerLimit := (tc.Spec.PD.Replicas+int32(len(tc.Status.PD.PeerMembers)))/2 + 1
 
+	lowerLimit := (tc.Spec.PD.Replicas+int32(len(tc.Status.PD.PeerMembers)))/2 + 1
 	if int32(len(tc.Status.PD.Members)+len(tc.Status.PD.PeerMembers)) < lowerLimit {
 		return false
 	}
@@ -606,7 +732,11 @@ func (tc *TidbCluster) IsPVReclaimEnabled() bool {
 }
 
 func (tc *TidbCluster) IsTiDBBinlogEnabled() bool {
-	binlogEnabled := tc.Spec.TiDB.BinlogEnabled
+	var binlogEnabled *bool
+	if tc.Spec.TiDB != nil {
+		binlogEnabled = tc.Spec.TiDB.BinlogEnabled
+	}
+
 	if binlogEnabled == nil {
 		isPumpCreated := tc.Spec.Pump != nil
 		return isPumpCreated

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
@@ -405,32 +405,62 @@ func (tc *TidbCluster) BaseDiscoverySpec() ComponentAccessor {
 
 // BaseTiDBSpec returns the base spec of TiDB servers
 func (tc *TidbCluster) BaseTiDBSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentTiDB, tc, &tc.Spec.TiDB.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.TiDB != nil {
+		spec = &tc.Spec.TiDB.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentTiDB, tc, spec)
 }
 
 // BaseTiKVSpec returns the base spec of TiKV servers
 func (tc *TidbCluster) BaseTiKVSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentTiKV, tc, &tc.Spec.TiKV.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.TiKV != nil {
+		spec = &tc.Spec.TiKV.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentTiKV, tc, spec)
 }
 
 // BaseTiFlashSpec returns the base spec of TiFlash servers
 func (tc *TidbCluster) BaseTiFlashSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentTiFlash, tc, &tc.Spec.TiFlash.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.TiFlash != nil {
+		spec = &tc.Spec.TiFlash.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentTiFlash, tc, spec)
 }
 
 // BaseTiCDCSpec returns the base spec of TiCDC servers
 func (tc *TidbCluster) BaseTiCDCSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentTiCDC, tc, &tc.Spec.TiCDC.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.TiCDC != nil {
+		spec = &tc.Spec.TiCDC.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentTiCDC, tc, spec)
 }
 
 // BasePDSpec returns the base spec of PD servers
 func (tc *TidbCluster) BasePDSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentPD, tc, &tc.Spec.PD.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.PD != nil {
+		spec = &tc.Spec.PD.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentPD, tc, spec)
 }
 
 // BasePumpSpec returns the base spec of Pump:
 func (tc *TidbCluster) BasePumpSpec() ComponentAccessor {
-	return buildTidbClusterComponentAccessor(ComponentPump, tc, &tc.Spec.Pump.ComponentSpec)
+	var spec *ComponentSpec
+	if tc.Spec.Pump != nil {
+		spec = &tc.Spec.Pump.ComponentSpec
+	}
+
+	return buildTidbClusterComponentAccessor(ComponentPump, tc, spec)
 }
 
 func (dc *DMCluster) BaseDiscoverySpec() ComponentAccessor {
@@ -442,5 +472,10 @@ func (dc *DMCluster) BaseMasterSpec() ComponentAccessor {
 }
 
 func (dc *DMCluster) BaseWorkerSpec() ComponentAccessor {
-	return buildDMClusterComponentAccessor(ComponentDMWorker, dc, &dc.Spec.Worker.ComponentSpec)
+	var spec *ComponentSpec
+	if dc.Spec.Worker != nil {
+		spec = &dc.Spec.Worker.ComponentSpec
+	}
+
+	return buildDMClusterComponentAccessor(ComponentDMWorker, dc, spec)
 }

--- a/pkg/apis/pingcap/v1alpha1/validation/validation.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation.go
@@ -459,25 +459,29 @@ func ValidateUpdateTidbCluster(old, tc *v1alpha1.TidbCluster) field.ErrorList {
 // TODO(aylei): call this in ValidateTidbCluster after we deprecated the old versions of helm chart officially
 func validateNewTidbClusterSpec(spec *v1alpha1.TidbClusterSpec, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	pdSpecified := spec.PD != nil
+	tidbSpecified := spec.TiDB != nil
+	tikvSpecified := spec.TiKV != nil
+
 	if spec.Version == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("version"), spec.Version, "version must not be empty"))
 	}
-	if spec.TiDB.BaseImage == "" {
+	if tidbSpecified && spec.TiDB.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tidb.baseImage"), spec.TiDB.BaseImage, "baseImage of TiDB must not be empty"))
 	}
-	if spec.PD.BaseImage == "" {
+	if pdSpecified && spec.PD.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("pd.baseImage"), spec.PD.BaseImage, "baseImage of PD must not be empty"))
 	}
-	if spec.TiKV.BaseImage == "" {
+	if tikvSpecified && spec.TiKV.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tikv.baseImage"), spec.TiKV.BaseImage, "baseImage of TiKV must not be empty"))
 	}
-	if spec.TiDB.Image != "" {
+	if tidbSpecified && spec.TiDB.Image != "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tidb.image"), spec.TiDB.Image, "image has been deprecated, use baseImage instead"))
 	}
-	if spec.TiKV.Image != "" {
+	if tikvSpecified && spec.TiKV.Image != "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tikv.image"), spec.TiKV.Image, "image has been deprecated, use baseImage instead"))
 	}
-	if spec.PD.Image != "" {
+	if pdSpecified && spec.PD.Image != "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("pd.image"), spec.PD.Image, "image has been deprecated, use baseImage instead"))
 	}
 	return allErrs
@@ -488,25 +492,29 @@ func validateNewTidbClusterSpec(spec *v1alpha1.TidbClusterSpec, path *field.Path
 func disallowUsingLegacyAPIInNewCluster(old, tc *v1alpha1.TidbCluster) field.ErrorList {
 	allErrs := field.ErrorList{}
 	path := field.NewPath("spec")
+	pdSpecified := old.Spec.PD != nil && tc.Spec.PD != nil
+	tidbSpecified := old.Spec.TiDB != nil && tc.Spec.TiDB != nil
+	tikvSpecified := old.Spec.TiKV != nil && tc.Spec.TiKV != nil
+
 	if old.Spec.Version != "" && tc.Spec.Version == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("version"), tc.Spec.Version, "version must not be empty"))
 	}
-	if old.Spec.TiDB.BaseImage != "" && tc.Spec.TiDB.BaseImage == "" {
+	if tidbSpecified && old.Spec.TiDB.BaseImage != "" && tc.Spec.TiDB.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tidb.baseImage"), tc.Spec.TiDB.BaseImage, "baseImage of TiDB must not be empty"))
 	}
-	if old.Spec.PD.BaseImage != "" && tc.Spec.PD.BaseImage == "" {
+	if pdSpecified && old.Spec.PD.BaseImage != "" && tc.Spec.PD.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("pd.baseImage"), tc.Spec.PD.BaseImage, "baseImage of PD must not be empty"))
 	}
-	if old.Spec.TiKV.BaseImage != "" && tc.Spec.TiKV.BaseImage == "" {
+	if tikvSpecified && old.Spec.TiKV.BaseImage != "" && tc.Spec.TiKV.BaseImage == "" {
 		allErrs = append(allErrs, field.Invalid(path.Child("tikv.baseImage"), tc.Spec.TiKV.BaseImage, "baseImage of TiKV must not be empty"))
 	}
-	if old.Spec.TiDB.Config != nil && tc.Spec.TiDB.Config == nil {
+	if tidbSpecified && old.Spec.TiDB.Config != nil && tc.Spec.TiDB.Config == nil {
 		allErrs = append(allErrs, field.Invalid(path.Child("tidb.config"), tc.Spec.TiDB.Config, "tidb.config must not be nil"))
 	}
-	if old.Spec.TiKV.Config != nil && tc.Spec.TiKV.Config == nil {
+	if tikvSpecified && old.Spec.TiKV.Config != nil && tc.Spec.TiKV.Config == nil {
 		allErrs = append(allErrs, field.Invalid(path.Child("tikv.config"), tc.Spec.TiKV.Config, "TiKV.config must not be nil"))
 	}
-	if old.Spec.PD.Config != nil && tc.Spec.PD.Config == nil {
+	if pdSpecified && old.Spec.PD.Config != nil && tc.Spec.PD.Config == nil {
 		allErrs = append(allErrs, field.Invalid(path.Child("pd.config"), tc.Spec.PD.Config, "PD.config must not be nil"))
 	}
 	return allErrs

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -403,7 +403,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, s
 		})
 	}
 
-	if backup.Spec.From != nil && tc.Spec.TiDB.TLSClient != nil && tc.Spec.TiDB.TLSClient.Enabled && !tc.SkipTLSWhenConnectTiDB() {
+	if backup.Spec.From != nil && tc.Spec.TiDB != nil && tc.Spec.TiDB.TLSClient != nil && tc.Spec.TiDB.TLSClient.Enabled && !tc.SkipTLSWhenConnectTiDB() {
 		args = append(args, "--client-tls=true")
 		clientSecretName := util.TiDBClientTLSSecretName(backup.Spec.BR.Cluster)
 		if backup.Spec.From.TLSClientSecretName != nil {

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -375,7 +375,7 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		})
 	}
 
-	if restore.Spec.To != nil && tc.Spec.TiDB.TLSClient != nil && tc.Spec.TiDB.TLSClient.Enabled && !tc.SkipTLSWhenConnectTiDB() {
+	if restore.Spec.To != nil && tc.Spec.TiDB != nil && tc.Spec.TiDB.TLSClient != nil && tc.Spec.TiDB.TLSClient.Enabled && !tc.SkipTLSWhenConnectTiDB() {
 		args = append(args, "--client-tls=true")
 		clientSecretName := util.TiDBClientTLSSecretName(restore.Spec.BR.Cluster)
 		if restore.Spec.To.TLSClientSecretName != nil {

--- a/pkg/controller/tidbcluster/tidb_cluster_condition_updater.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_condition_updater.go
@@ -68,7 +68,7 @@ func (u *tidbClusterConditionUpdater) updateReadyCondition(tc *v1alpha1.TidbClus
 	case tc.Spec.TiDB != nil && !tc.TiDBAllMembersReady():
 		reason = utiltidbcluster.TiDBUnhealthy
 		message = "TiDB(s) are not healthy"
-	case !tc.TiFlashAllStoresReady():
+	case tc.Spec.TiFlash != nil && !tc.TiFlashAllStoresReady():
 		reason = utiltidbcluster.TiFlashStoreNotUp
 		message = "TiFlash store(s) are not up"
 	default:

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -112,7 +112,7 @@ func (m *ticdcMemberManager) syncTiCDCConfigMap(tc *v1alpha1.TidbCluster, set *a
 
 	klog.V(3).Info("get ticdc in use config map name: ", inUseName)
 
-	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, tc.BaseTiDBSpec().ConfigUpdateStrategy(), inUseName, newCm)
+	err = updateConfigMapIfNeed(m.deps.ConfigMapLister, tc.BaseTiCDCSpec().ConfigUpdateStrategy(), inUseName, newCm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tkctl/cmd/info/info.go
+++ b/pkg/tkctl/cmd/info/info.go
@@ -157,7 +157,7 @@ func renderTidbCluster(tc *v1alpha1.TidbCluster, svc *v1.Service, podList *v1.Po
 	var pdCPU resource.Quantity
 	var pdMemory resource.Quantity
 	var pdStorage resource.Quantity
-	if tc.Spec.PD.Requests != nil {
+	if tc.Spec.PD != nil && tc.Spec.PD.Requests != nil {
 		if cpu := tc.Spec.PD.Requests.Cpu(); cpu != nil {
 			pdCPU = *cpu
 		}
@@ -171,7 +171,7 @@ func renderTidbCluster(tc *v1alpha1.TidbCluster, svc *v1.Service, podList *v1.Po
 	var tikvCPU resource.Quantity
 	var tikvMemory resource.Quantity
 	var tikvStorage resource.Quantity
-	if tc.Spec.TiKV.Requests != nil {
+	if tc.Spec.TiKV != nil && tc.Spec.TiKV.Requests != nil {
 		if cpu := tc.Spec.TiKV.Requests.Cpu(); cpu != nil {
 			tikvCPU = *cpu
 		}
@@ -185,7 +185,7 @@ func renderTidbCluster(tc *v1alpha1.TidbCluster, svc *v1.Service, podList *v1.Po
 	var tidbCPU resource.Quantity
 	var tidbMemory resource.Quantity
 	var tidbStorage resource.Quantity
-	if tc.Spec.TiDB.Requests != nil {
+	if tc.Spec.TiDB != nil && tc.Spec.TiDB.Requests != nil {
 		if cpu := tc.Spec.TiDB.Requests.Cpu(); cpu != nil {
 			tidbCPU = *cpu
 		}

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	tidbReadyTimeout       = time.Minute * 5
+	tidbReadyTimeout       = time.Minute * 15
 	backupCompleteTimeout  = time.Minute * 3
 	restoreCompleteTimeout = time.Minute * 3
 )

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	tidbReadyTimeout       = time.Minute * 15
+	tidbReadyTimeout       = time.Minute * 5
 	backupCompleteTimeout  = time.Minute * 3
 	restoreCompleteTimeout = time.Minute * 3
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fix #4051
Fixed potential nil pointer issues.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

* Test upgrade
  1. Upgrade `TiDB-Opertaor` and check the cluster is normal.
* Test depolyment
  * Deploy new cluster and monitor, then check function.
  * Deploy  new cluster without `PD` ,  then check pods and watch logs of `TiDB-Operator`.
     ```shell
     NAME                                READY   STATUS    RESTARTS   AGE
     my-tidb-cluster-dev-pump-0          0/1     Running   1          114s
     my-tidb-cluster-dev-ticdc-0         1/1     Running   0          114s
     my-tidb-cluster-dev-ticdc-1         1/1     Running   0          114s
     my-tidb-cluster-dev-ticdc-2         1/1     Running   0          114s
     my-tidb-cluster-dev-tiflash-0       4/4     Running   0          114s
     my-tidb-cluster-dev-tikv-0          3/3     Running   0          114s
     my-tidb-cluster-dev-tikv-1          3/3     Running   0          114s
     my-tidb-cluster-dev-tikv-2          3/3     Running   0          114s
     my-tidb-cluster-monitor-monitor-0   4/4     Running   0          26m
     ```
  * Deploy  new cluster without `TiDB`,  then check pods and watch logs of `TiDB-Operator`.
    ```shell
    NAME                                             READY   STATUS    RESTARTS   AGE
    my-tidb-cluster-dev-discovery-85b8698c6c-tfgcs   1/1     Running   0          3m2s
    my-tidb-cluster-dev-pd-0                         1/1     Running   0          3m1s
    my-tidb-cluster-dev-pd-1                         1/1     Running   0          3m1s
    my-tidb-cluster-dev-pd-2                         1/1     Running   0          3m1s
    my-tidb-cluster-dev-pump-0                       1/1     Running   0          2m18s
    my-tidb-cluster-dev-pump-1                       1/1     Running   0          2m16s
    my-tidb-cluster-dev-pump-2                       1/1     Running   0          2m14s
    my-tidb-cluster-dev-ticdc-0                      1/1     Running   0          2m15s
    my-tidb-cluster-dev-ticdc-1                      1/1     Running   0          2m15s
    my-tidb-cluster-dev-ticdc-2                      1/1     Running   0          2m15s
    my-tidb-cluster-dev-tiflash-0                    4/4     Running   0          2m15s
    my-tidb-cluster-dev-tikv-0                       3/3     Running   0          2m18s
    my-tidb-cluster-dev-tikv-1                       3/3     Running   0          2m18s
    my-tidb-cluster-dev-tikv-2                       3/3     Running   0          2m18s
    my-tidb-cluster-monitor-monitor-0                4/4     Running   0          163m
    ```
  * Deploy  new cluster without `TiKV` ,  then check pods and watch logs of `TiDB-Operator`.
     ```shell
     kubectl get pods
    NAME                                             READY   STATUS    RESTARTS   AGE
    my-tidb-cluster-dev-discovery-85b8698c6c-bjf6m   1/1     Running   0          4m27s
    my-tidb-cluster-dev-pd-0                         1/1     Running   0          4m26s
    my-tidb-cluster-dev-pd-1                         1/1     Running   0          4m26s
    my-tidb-cluster-dev-pd-2                         1/1     Running   0          4m26s
    my-tidb-cluster-dev-pump-0                       1/1     Running   0          3m41s
    my-tidb-cluster-dev-pump-1                       1/1     Running   0          3m39s
    my-tidb-cluster-dev-pump-2                       1/1     Running   0          3m36s
    my-tidb-cluster-dev-ticdc-0                      1/1     Running   0          3m40s
    my-tidb-cluster-dev-ticdc-1                      1/1     Running   0          3m40s
    my-tidb-cluster-dev-ticdc-2                      1/1     Running   0          3m40s
    my-tidb-cluster-dev-tidb-0                       1/2     Running   1          3m37s
    my-tidb-cluster-dev-tidb-1                       1/2     Running   1          3m37s
    my-tidb-cluster-dev-tidb-2                       1/2     Running   1          3m37s
    my-tidb-cluster-dev-tiflash-0                    4/4     Running   0          3m40s
    my-tidb-cluster-monitor-monitor-0                4/4     Running   0          20m
    ```
  * Deploy  new cluster without `Pump` ,  then check pods and watch logs of `TiDB-Operator`.
  * Deploy  new cluster without `TiFlash` ,  then check pods and watch logs of `TiDB-Operator`.
  * Deploy  new cluster without `TiCDC` ,  then check pods and watch logs of `TiDB-Operator`.
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that TiDB Operator may panic when heterogeneous clusters are deployed
```
