### PR TITLE
correct `imagePullSecrets` usage of example

### DIFF
--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -34,7 +34,7 @@ spec:
   ## You can also set this in service account
   ## Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # imagePullSecrets:
-  #   - name: secretName
+  # - name: secretName
 
   ## Image used to do miscellaneous tasks as sidecar container, such as:
   ## - execute sysctls when PodSecurityContext is set for some components, requires `sysctl` installed
@@ -193,7 +193,7 @@ spec:
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
     # imagePullSecrets:
-    #   - name: secretName
+    # - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-pd
     # priorityClassName: system-cluster-critical
@@ -380,7 +380,7 @@ spec:
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
     # imagePullSecrets:
-    #   - name: secretName
+    # - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-tidb
     # priorityClassName: system-cluster-critical
@@ -586,7 +586,7 @@ spec:
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
     # imagePullSecrets:
-    #   - name: secretName
+    # - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-tikv
     # priorityClassName: system-cluster-critical
@@ -762,7 +762,7 @@ spec:
   #     memory: 2Gi
   #   imagePullPolicy: IfNotPresent
   #   imagePullSecrets:
-  #     - name: secretName
+  #   - name: secretName
   #   hostNetwork: false
   #   serviceAccount: advanced-tidb-pump
   #   priorityClassName: system-cluster-critical
@@ -803,7 +803,7 @@ spec:
   #     memory: 2Gi
   #   imagePullPolicy: IfNotPresent
   #   imagePullSecrets:
-  #     - name: secretName
+  #   - name: secretName
   #   hostNetwork: false
   #   serviceAccount: advanced-tidb-ticdc
   #   priorityClassName: system-cluster-critical
@@ -847,7 +847,7 @@ spec:
   #   #   memory: 2Gi
   #   imagePullPolicy: IfNotPresent
   #   imagePullSecrets:
-  #     - name: secretName
+  #   - name: secretName
 
   #   ##################################
   #   # Advanced TiFlash Configuration #

--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -33,7 +33,8 @@ spec:
   ## If private registry is used, imagePullSecrets may be set
   ## You can also set this in service account
   ## Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-  # imagePullSecrets: secretName
+  # imagePullSecrets:
+  #   - name: secretName
 
   ## Image used to do miscellaneous tasks as sidecar container, such as:
   ## - execute sysctls when PodSecurityContext is set for some components, requires `sysctl` installed
@@ -191,7 +192,8 @@ spec:
     ## The following block overwrites TiDB cluster-level configurations in `spec`
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
-    # imagePullSecrets: secretName
+    # imagePullSecrets:
+    #   - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-pd
     # priorityClassName: system-cluster-critical
@@ -377,7 +379,8 @@ spec:
     ## The following block overwrites TiDB cluster-level configurations in `spec`
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
-    # imagePullSecrets: secretName
+    # imagePullSecrets:
+    #   - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-tidb
     # priorityClassName: system-cluster-critical
@@ -582,7 +585,8 @@ spec:
     ## The following block overwrites TiDB cluster-level configurations in `spec`
     # version: "v5.1.0"
     # imagePullPolicy: IfNotPresent
-    # imagePullSecrets: secretName
+    # imagePullSecrets:
+    #   - name: secretName
     # hostNetwork: false
     # serviceAccount: advanced-tidb-tikv
     # priorityClassName: system-cluster-critical
@@ -757,7 +761,8 @@ spec:
   #     cpu: 2000m
   #     memory: 2Gi
   #   imagePullPolicy: IfNotPresent
-  #   imagePullSecrets: secretName
+  #   imagePullSecrets:
+  #     - name: secretName
   #   hostNetwork: false
   #   serviceAccount: advanced-tidb-pump
   #   priorityClassName: system-cluster-critical
@@ -797,7 +802,8 @@ spec:
   #     cpu: 2000m
   #     memory: 2Gi
   #   imagePullPolicy: IfNotPresent
-  #   imagePullSecrets: secretName
+  #   imagePullSecrets:
+  #     - name: secretName
   #   hostNetwork: false
   #   serviceAccount: advanced-tidb-ticdc
   #   priorityClassName: system-cluster-critical
@@ -840,7 +846,8 @@ spec:
   #   #   cpu: 2000m
   #   #   memory: 2Gi
   #   imagePullPolicy: IfNotPresent
-  #   imagePullSecrets: secretName
+  #   imagePullSecrets:
+  #     - name: secretName
 
   #   ##################################
   #   # Advanced TiFlash Configuration #


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

correct `imagePullSecrets` usage of example.

Ref: https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
