### PR TITLE
upgrade tiflash after pd

### DIFF
--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -168,19 +168,6 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 		return err
 	}
 
-	// works that should be done to make the tiflash cluster current state match the desired state:
-	//   - waiting for the tidb cluster available
-	//   - create or update tiflash headless service
-	//   - create the tiflash statefulset
-	//   - sync tiflash cluster status from pd to TidbCluster object
-	//   - set scheduler labels to tiflash stores
-	//   - upgrade the tiflash cluster
-	//   - scale out/in the tiflash cluster
-	//   - failover the tiflash cluster
-	if err := c.tiflashMemberManager.Sync(tc); err != nil {
-		return err
-	}
-
 	// works that should be done to make the pd cluster current state match the desired state:
 	//   - create or update the pd service
 	//   - create or update the pd headless service
@@ -193,6 +180,19 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 	//   - scale out/in the pd cluster
 	//   - failover the pd cluster
 	if err := c.pdMemberManager.Sync(tc); err != nil {
+		return err
+	}
+
+	// works that should be done to make the tiflash cluster current state match the desired state:
+	//   - waiting for the tidb cluster available
+	//   - create or update tiflash headless service
+	//   - create the tiflash statefulset
+	//   - sync tiflash cluster status from pd to TidbCluster object
+	//   - set scheduler labels to tiflash stores
+	//   - upgrade the tiflash cluster
+	//   - scale out/in the tiflash cluster
+	//   - failover the tiflash cluster
+	if err := c.tiflashMemberManager.Sync(tc); err != nil {
 		return err
 	}
 

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -45,7 +45,6 @@ func (u *pdUpgrader) gracefulUpgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Stat
 		return fmt.Errorf("tidbcluster: [%s/%s]'s pd status sync failed, can not to be upgraded", ns, tcName)
 	}
 	if tc.Status.TiCDC.Phase == v1alpha1.UpgradePhase ||
-		tc.Status.TiFlash.Phase == v1alpha1.UpgradePhase ||
 		tc.PDScaling() {
 		klog.Infof("TidbCluster: [%s/%s]'s ticdc status is %v, "+
 			"tiflash status is %v, pd status is %v, can not upgrade pd",

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -47,9 +47,9 @@ func (u *pdUpgrader) gracefulUpgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Stat
 	if tc.Status.TiCDC.Phase == v1alpha1.UpgradePhase ||
 		tc.PDScaling() {
 		klog.Infof("TidbCluster: [%s/%s]'s ticdc status is %v, "+
-			"tiflash status is %v, pd status is %v, can not upgrade pd",
+			"pd status is %v, can not upgrade pd",
 			ns, tcName, tc.Status.TiCDC.Phase,
-			tc.Status.TiFlash.Phase, tc.Status.PD.Phase)
+			tc.Status.PD.Phase)
 		_, podSpec, err := GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -273,21 +273,6 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
 			},
 		},
-		{
-			name: "pd can not upgrade when tiflash is upgrading",
-			changeFn: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiFlash.Phase = v1alpha1.UpgradePhase
-				tc.Status.PD.Synced = true
-			},
-			changePods: nil,
-			errExpectFn: func(g *GomegaWithT, err error) {
-				g.Expect(err).NotTo(HaveOccurred())
-			},
-			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
-				g.Expect(tc.Status.PD.Phase).To(Equal(v1alpha1.NormalPhase))
-				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
-			},
-		},
 	}
 
 	for _, test := range tests {

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -40,6 +40,7 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 	tcName := tc.GetName()
 
 	if tc.Status.TiCDC.Phase == v1alpha1.UpgradePhase ||
+		tc.Status.PD.Phase == v1alpha1.UpgradePhase ||
 		tc.TiFlashScaling() {
 		klog.Infof("TidbCluster: [%s/%s]'s ticdc status is %s, "+
 			"tiflash status is %s, can not upgrade tiflash", ns, tcName,

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -43,8 +43,8 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 		tc.Status.PD.Phase == v1alpha1.UpgradePhase ||
 		tc.TiFlashScaling() {
 		klog.Infof("TidbCluster: [%s/%s]'s ticdc status is %s, "+
-			"tiflash status is %s, can not upgrade tiflash", ns, tcName,
-			tc.Status.TiCDC.Phase, tc.Status.TiFlash.Phase)
+			"pd status is %s, tiflash status is %s, can not upgrade tiflash", ns, tcName,
+			tc.Status.TiCDC.Phase, tc.Status.PD.Phase, tc.Status.TiFlash.Phase)
 		_, podSpec, err := GetLastAppliedConfig(oldSet)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fix https://github.com/pingcap/tidb-operator/issues/4096
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Sync TiFlash after pd
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - Deploy TidbCluster with CDC, PD, TiKV, TiFlash, Pump, TiDB, waiting for Pods ready, upgrade the tc, check that the upgrade order is CDC, PD, TiFlash, TiKV, Pump, TiDB
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
