### PR TITLE
Add `--comments` to READMEs

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -48,7 +48,7 @@ Explore the TiDB sql interface:
 
 ```bash
 > kubectl -n <namespace> port-forward svc/basic-tidb 4000:4000 &>/tmp/pf-tidb.log &
-> mysql -h 127.0.0.1 -P 4000 -u root
+> mysql -h 127.0.0.1 -P 4000 -u root --comments
 ```
 
 Explore the monitoring dashboards:

--- a/examples/tiflash/README.md
+++ b/examples/tiflash/README.md
@@ -50,7 +50,7 @@ Explore the TiDB SQL interface:
 
 ```bash
 > kubectl -n <namespace> port-forward svc/demo-tidb 4000:4000 &>/tmp/pf-tidb.log &
-> mysql -h 127.0.0.1 -P 4000 -u root
+> mysql -h 127.0.0.1 -P 4000 -u root --comments
 ```
 Refer to the [doc](https://pingcap.com/docs/stable/reference/tiflash/use-tiflash/) to try TiFlash.
 

--- a/marketplace/gcp/tidb-operator/README.md
+++ b/marketplace/gcp/tidb-operator/README.md
@@ -55,5 +55,5 @@ When the tidb containers are running, you can connect with a MySQL client.
 
 ``` bash
 kubectl -n $NAMESPACE port-forward db-tidb-0 4000:4000 &
-mysql -u root -P 4000 -h 127.0.0.1
+mysql -u root -P 4000 -h 127.0.0.1 --comments
 ```


### PR DESCRIPTION

### What problem does this PR solve?
To stop the MySQL client from stripping TiDB specific comments (`/*T! ... */`) we need to add `--comments`


### Tests
<!-- AT LEAST ONE test must be included. -->


- [x] No code <!-- If this PR contains no code changes, check this box -->

### Release Notes


```release-note
NONE
```
