### PR TITLE
feat: Use secret as Grafana credentials

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -6238,6 +6238,20 @@ ServiceSpec
 </tr>
 <tr>
 <td>
+<code>passwordSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>if passwordSecret is omitted, Grafana will use <code>admin</code> as its password by default.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>username</code></br>
 <em>
 string
@@ -6254,6 +6268,8 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>Deprecated</p>
 </td>
 </tr>
 <tr>

--- a/examples/monitor-grafana-secret/grafana-secret.yaml
+++ b/examples/monitor-grafana-secret/grafana-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  password: YWRtaW4=
+kind: Secret
+metadata:
+  name: basic-grafana
+type: Opaque

--- a/examples/monitor-grafana-secret/tidb-monitor.yaml
+++ b/examples/monitor-grafana-secret/tidb-monitor.yaml
@@ -4,23 +4,20 @@ metadata:
   name: basic
 spec:
   clusters:
-  - name: basic
+    - name: basic
   prometheus:
-    config:
-      configMapRef:
-        name: external-config
-      commandOptions:
-        - --web.read-timeout=5m
-        - --web.max-connections=512
-        - --storage.remote.read-concurrent-limit=10
     baseImage: prom/prometheus
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 6.0.1
+    username: "admin"
+    passwordSecret:
+      name: basic-grafana
+      key: password
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
-    version: v5.1.0
+    version: v3.0.13
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     version: v1.0.1

--- a/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
@@ -178,8 +178,18 @@ type GrafanaSpec struct {
 
 	LogLevel string      `json:"logLevel,omitempty"`
 	Service  ServiceSpec `json:"service,omitempty"`
-	Username string      `json:"username,omitempty"`
-	Password string      `json:"password,omitempty"`
+
+	// +optional
+	// if passwordSecret is omitted, Grafana will use `admin` as its password by default.
+	PasswordSecret *corev1.SecretKeySelector `json:"passwordSecret,omitempty"`
+
+	Username string `json:"username,omitempty"`
+
+	// +optional
+	// Deprecated in v1.2.1 for security concerns, planned for removal in v1.3.0. Use `passwordSecret` instead.
+	// +k8s:openapi-gen=false
+	Password string `json:"password,omitempty"`
+
 	// +optional
 	Envs map[string]string `json:"envs,omitempty"`
 

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -1923,6 +1923,11 @@ func (in *GrafanaSpec) DeepCopyInto(out *GrafanaSpec) {
 	*out = *in
 	in.MonitorContainer.DeepCopyInto(&out.MonitorContainer)
 	in.Service.DeepCopyInto(&out.Service)
+	if in.PasswordSecret != nil {
+		in, out := &in.PasswordSecret, &out.PasswordSecret
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Envs != nil {
 		in, out := &in.Envs, &out.Envs
 		*out = make(map[string]string, len(*in))

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -1073,6 +1073,12 @@ func TestGetMonitorGrafanaContainer(t *testing.T) {
 				},
 				Spec: v1alpha1.TidbMonitorSpec{
 					Grafana: &v1alpha1.GrafanaSpec{
+						PasswordSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "basic-grafana",
+							},
+							Key: "password",
+						},
 						MonitorContainer: v1alpha1.MonitorContainer{
 							BaseImage: "hub.pingcap.net",
 							Version:   "latest",
@@ -1100,7 +1106,7 @@ func TestGetMonitorGrafanaContainer(t *testing.T) {
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "foo",
+									Name: "basic-grafana",
 								},
 								Key: "password",
 							},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

close #2637 
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
use secretRef for Grafana password in TidbMonitor
```
