### PR TITLE
support hostnetwork for all components

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_component.go
@@ -232,6 +232,7 @@ func (a *componentAccessorImpl) BuildPodSpec() corev1.PodSpec {
 		Tolerations:               a.Tolerations(),
 		SecurityContext:           a.PodSecurityContext(),
 		TopologySpreadConstraints: a.TopologySpreadConstraints(),
+		DNSPolicy:                 a.DnsPolicy(),
 	}
 	if a.PriorityClassName() != nil {
 		spec.PriorityClassName = *a.PriorityClassName()

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -899,6 +899,9 @@ func testHostNetwork(t *testing.T, hostNetwork bool, dnsPolicy v1.DNSPolicy) fun
 		if hostNetwork != sts.Spec.Template.Spec.HostNetwork {
 			t.Errorf("unexpected hostNetwork %v, want %v", sts.Spec.Template.Spec.HostNetwork, hostNetwork)
 		}
+		if len(dnsPolicy) == 0 {
+			dnsPolicy = v1.DNSClusterFirst
+		}
 		if dnsPolicy != sts.Spec.Template.Spec.DNSPolicy {
 			t.Errorf("unexpected dnsPolicy %v, want %v", sts.Spec.Template.Spec.DNSPolicy, dnsPolicy)
 		}

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -297,6 +297,10 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		ginkgo.By("Deploy initial tc")
 		clusterName := "host-network"
 		tc := fixture.GetTidbCluster(ns, clusterName, utilimage.TiDBLatest)
+		tc = fixture.AddTiFlashForTidbCluster(tc)
+		tc = fixture.AddTiCDCForTidbCluster(tc)
+		tc = fixture.AddPumpForTidbCluster(tc)
+
 		// Set some properties
 		tc.Spec.PD.Replicas = 1
 		tc.Spec.TiKV.Replicas = 1
@@ -306,6 +310,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		ginkgo.By("Switch to host network")
 		// TODO: Considering other components?
 		err := controller.GuaranteedUpdate(genericCli, tc, func() error {
+			tc.Spec.HostNetwork = pointer.BoolPtr(true)
 			tc.Spec.PD.HostNetwork = pointer.BoolPtr(true)
 			tc.Spec.TiKV.HostNetwork = pointer.BoolPtr(true)
 			tc.Spec.TiDB.HostNetwork = pointer.BoolPtr(true)
@@ -317,6 +322,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 		ginkgo.By("Switch back to pod network")
 		err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+			tc.Spec.HostNetwork = pointer.BoolPtr(false)
 			tc.Spec.PD.HostNetwork = pointer.BoolPtr(false)
 			tc.Spec.TiKV.HostNetwork = pointer.BoolPtr(false)
 			tc.Spec.TiDB.HostNetwork = pointer.BoolPtr(false)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
After https://github.com/pingcap/tidb-operator/pull/3909, hostNetwork is available for Discovery, however, the dnsPolicy is not updated accordingly.
After a further check, TiCDC has a similar issue.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Update dnsPolicy accordingly to match with the hostNetwork config.
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - Deploy a TidbCluster with PD/TiDB/TiKV/TiFlash/Pump/TiCDC and set `spec.hostNetwork: true`, check that the cluster is created successfully, and hostNetwork and dnsPolicy configurations are as below:
```
t6-discovery-78ccf7fb5f-chx8n   1/1     Running     0          103s
t6-pd-0                         1/1     Running     0          3h2m
t6-pump-0                       1/1     Running     0          3h2m
t6-ticdc-0                      1/1     Running     0          83s
t6-tidb-0                       2/2     Running     0          3h2m
t6-tiflash-0                    4/4     Running     0          3h2m
t6-tikv-0                       1/1     Running     0          3h2m

    name: t6-discovery-78ccf7fb5f-chx8n
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-pd-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-pump-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-ticdc-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-tidb-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-tiflash-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
    name: t6-tikv-0
    dnsPolicy: ClusterFirstWithHostNet
    hostNetwork: true
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support HostNetwork for all components
ACTION REQUIRED: If you have enabled hostNetwork for TiCDC, after upgrading the TiDB Operator, the TiCDC Pod will roll update
```
