### PR TITLE
remove: SyncAutoScalerAnn

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -116,11 +116,6 @@ const (
 	// AnnDMWorkerDeleteSlots is annotation key of dm-worker delete slots.
 	AnnDMWorkerDeleteSlots = "dm-worker.tidb.pingcap.com/delete-slots"
 
-	// AnnTiKVAutoScalingOutOrdinals describe the tikv pods' ordinal list which is created by auto-scaling out
-	AnnTiKVAutoScalingOutOrdinals = "tikv.tidb.pingcap.com/scale-out-ordinals"
-	// AnnTiDBAutoScalingOutOrdinals describe the tidb pods' ordinal list which is created by auto-scaling out
-	AnnTiDBAutoScalingOutOrdinals = "tidb.tidb.pingcap.com/scale-out-ordinals"
-
 	// AnnSkipTLSWhenConnectTiDB describes whether skip TLS when connecting to TiDB Server
 	AnnSkipTLSWhenConnectTiDB = "tidb.tidb.pingcap.com/skip-tls-when-connect-tidb"
 

--- a/pkg/manager/member/dm_master_scaler.go
+++ b/pkg/manager/member/dm_master_scaler.go
@@ -46,7 +46,7 @@ func (s *masterScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 	} else if scaling < 0 {
 		return s.ScaleIn(meta, oldSet, newSet)
 	}
-	return s.SyncAutoScalerAnn(meta, oldSet)
+	return nil
 }
 
 func (s *masterScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
@@ -167,10 +167,6 @@ func (s *masterScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	return nil
 }
 
-func (s *masterScaler) SyncAutoScalerAnn(meta metav1.Object, oldSet *apps.StatefulSet) error {
-	return nil
-}
-
 type fakeMasterScaler struct{}
 
 // NewFakeMasterScaler returns a fake Scaler
@@ -194,9 +190,5 @@ func (s *fakeMasterScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, n
 
 func (s *fakeMasterScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
-	return nil
-}
-
-func (s *fakeMasterScaler) SyncAutoScalerAnn(dc metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/dm_worker_scaler.go
+++ b/pkg/manager/member/dm_worker_scaler.go
@@ -46,7 +46,7 @@ func (s *workerScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 	} else if scaling < 0 {
 		return s.ScaleIn(meta, oldSet, newSet)
 	}
-	return s.SyncAutoScalerAnn(meta, oldSet)
+	return nil
 }
 
 func (s *workerScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
@@ -126,10 +126,6 @@ func (s *workerScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, new
 	return nil
 }
 
-func (s *workerScaler) SyncAutoScalerAnn(meta metav1.Object, oldSet *apps.StatefulSet) error {
-	return nil
-}
-
 type fakeWorkerScaler struct{}
 
 // NewFakeWorkerScaler returns a fake Scaler
@@ -153,9 +149,5 @@ func (s *fakeWorkerScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, n
 
 func (s *fakeWorkerScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
-	return nil
-}
-
-func (s *fakeWorkerScaler) SyncAutoScalerAnn(dc metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/pd_scaler.go
+++ b/pkg/manager/member/pd_scaler.go
@@ -44,7 +44,7 @@ func (s *pdScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newSet *a
 	} else if scaling < 0 {
 		return s.ScaleIn(meta, oldSet, newSet)
 	}
-	return s.SyncAutoScalerAnn(meta, oldSet)
+	return nil
 }
 
 func (s *pdScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
@@ -167,10 +167,6 @@ func (s *pdScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSet 
 	return nil
 }
 
-func (s *pdScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
-	return nil
-}
-
 func (s *pdScaler) preCheckUpMembers(tc *v1alpha1.TidbCluster, podName string) bool {
 	upComponents := 0
 
@@ -217,9 +213,5 @@ func (s *fakePDScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, newSe
 
 func (s *fakePDScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
-	return nil
-}
-
-func (s *fakePDScaler) SyncAutoScalerAnn(tc metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/pump_scaler.go
+++ b/pkg/manager/member/pump_scaler.go
@@ -248,10 +248,6 @@ func (s *pumpScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 	return fmt.Errorf("Pump %s/%s not found in cluster", ns, podName)
 }
 
-func (s *pumpScaler) SyncAutoScalerAnn(_ metav1.Object, actual *apps.StatefulSet) error {
-	return nil
-}
-
 type fakePumpScaler struct{}
 
 // NewFakePumpScaler returns a fake pump Scaler
@@ -275,9 +271,5 @@ func (s *fakePumpScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, new
 
 func (s *fakePumpScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
-	return nil
-}
-
-func (s *fakePumpScaler) SyncAutoScalerAnn(_ metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/manager/member/scaler.go
+++ b/pkg/manager/member/scaler.go
@@ -43,8 +43,6 @@ type Scaler interface {
 	ScaleOut(meta metav1.Object, actual *apps.StatefulSet, desired *apps.StatefulSet) error
 	// ScaleIn scales in the cluster
 	ScaleIn(meta metav1.Object, actual *apps.StatefulSet, desired *apps.StatefulSet) error
-	// SyncAutoScalerAnn would sync Ann created by AutoScaler
-	SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error
 }
 
 type generalScaler struct {

--- a/pkg/manager/member/ticdc_scaler.go
+++ b/pkg/manager/member/ticdc_scaler.go
@@ -107,9 +107,3 @@ func (s *ticdcScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newS
 	setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
 	return nil
 }
-
-// SyncAutoScalerAnn would reclaim the auto-scaling out slots if the target pod is no longer existed
-// NOTE: this method should be removed later.
-func (s *ticdcScaler) SyncAutoScalerAnn(_ metav1.Object, _ *apps.StatefulSet) error {
-	return nil
-}

--- a/pkg/manager/member/tidb_scaler.go
+++ b/pkg/manager/member/tidb_scaler.go
@@ -105,9 +105,3 @@ func (s *tidbScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, newSe
 	setReplicasAndDeleteSlots(newSet, replicas, deleteSlots)
 	return nil
 }
-
-// SyncAutoScalerAnn would reclaim the auto-scaling out slots if the target pod is no longer existed
-// NOTE: this method should be removed later.
-func (s *tidbScaler) SyncAutoScalerAnn(_ metav1.Object, _ *apps.StatefulSet) error {
-	return nil
-}

--- a/pkg/manager/member/tiflash_scaler.go
+++ b/pkg/manager/member/tiflash_scaler.go
@@ -44,7 +44,7 @@ func (s *tiflashScaler) Scale(meta metav1.Object, oldSet *apps.StatefulSet, newS
 		return s.ScaleIn(meta, oldSet, newSet)
 	}
 	// we only sync auto scaler annotations when we are finishing syncing scaling
-	return s.SyncAutoScalerAnn(meta, oldSet)
+	return nil
 }
 
 func (s *tiflashScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
@@ -159,11 +159,6 @@ func (s *tiflashScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, ne
 	return fmt.Errorf("tiflash %s/%s no store found in cluster", ns, podName)
 }
 
-// SyncAutoScalerAnn reclaims the auto-scaling-out slots if the target pods no longer exist
-func (s *tiflashScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
-	return nil
-}
-
 type fakeTiFlashScaler struct{}
 
 // NewFakeTiFlashScaler returns a fake tiflash Scaler
@@ -187,9 +182,5 @@ func (s *fakeTiFlashScaler) ScaleOut(_ metav1.Object, oldSet *apps.StatefulSet, 
 
 func (s *fakeTiFlashScaler) ScaleIn(_ metav1.Object, oldSet *apps.StatefulSet, newSet *apps.StatefulSet) error {
 	setReplicasAndDeleteSlots(newSet, *oldSet.Spec.Replicas-1, nil)
-	return nil
-}
-
-func (s *fakeTiFlashScaler) SyncAutoScalerAnn(meta metav1.Object, actual *apps.StatefulSet) error {
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -170,32 +170,6 @@ func GetStatefulSetName(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType
 	return fmt.Sprintf("%s-%s", tc.Name, memberType.String())
 }
 
-func GetAutoScalingOutSlots(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType) sets.Int32 {
-	s := sets.Int32{}
-	l := ""
-	switch memberType {
-	case v1alpha1.PDMemberType:
-		return s
-	case v1alpha1.TiKVMemberType:
-		l = label.AnnTiKVAutoScalingOutOrdinals
-	case v1alpha1.TiDBMemberType:
-		l = label.AnnTiDBAutoScalingOutOrdinals
-	default:
-		return s
-	}
-	v, existed := tc.Annotations[l]
-	if !existed {
-		return s
-	}
-	var slice []int32
-	err := json.Unmarshal([]byte(v), &slice)
-	if err != nil {
-		return s
-	}
-	s.Insert(slice...)
-	return s
-}
-
 func Encode(obj interface{}) (string, error) {
 	b, err := json.Marshal(obj)
 	if err != nil {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -14,7 +14,6 @@
 package util
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -176,32 +175,6 @@ func TestGetPodOrdinals(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetAutoScalingOutSlots(t *testing.T) {
-	g := NewGomegaWithT(t)
-	slice := []int32{1, 2}
-	sliceData, err := json.Marshal(slice)
-	sliceString := string(sliceData)
-	g.Expect(err).Should(BeNil())
-	tc := &v1alpha1.TidbCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				label.AnnTiKVAutoScalingOutOrdinals: sliceString,
-				label.AnnTiDBAutoScalingOutOrdinals: sliceString,
-			},
-		},
-	}
-
-	var get sets.Int32
-	get = GetAutoScalingOutSlots(tc, v1alpha1.PDMemberType)
-	g.Expect(get).Should(Equal(sets.Int32{}))
-
-	get = GetAutoScalingOutSlots(tc, v1alpha1.TiKVMemberType)
-	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
-
-	get = GetAutoScalingOutSlots(tc, v1alpha1.TiDBMemberType)
-	g.Expect(get).Should(Equal(sets.NewInt32(slice...)))
 }
 
 func TestName(t *testing.T) {

--- a/pkg/webhook/pod/pod_mutater.go
+++ b/pkg/webhook/pod/pod_mutater.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/features"
-	operatorUtils "github.com/pingcap/tidb-operator/pkg/util"
 	"github.com/pingcap/tidb-operator/pkg/webhook/util"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -75,16 +74,6 @@ func (pc *PodAdmissionControl) mutatePod(ar *admissionv1beta1.AdmissionRequest) 
 }
 
 func (pc *PodAdmissionControl) tikvHotRegionSchedule(tc *v1alpha1.TidbCluster, pod *corev1.Pod) error {
-	podName := pod.Name
-	ordinal, err := operatorUtils.GetOrdinalFromPodName(podName)
-	if err != nil {
-		return err
-	}
-	sets := operatorUtils.GetAutoScalingOutSlots(tc, v1alpha1.TiKVMemberType)
-	if !sets.Has(ordinal) {
-		return nil
-	}
-
 	cm, err := pc.getTikvConfigMap(tc, pod)
 	if err != nil {
 		klog.Infof("tc[%s/%s]'s tikv %s configmap not found, error: %v", tc.Namespace, tc.Name, pod.Name, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Close #3736 
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
remove unused func SyncAutoScalerAnn
```
