### PR TITLE
Use scheduler configuration to run tidb-scheduler

### DIFF
--- a/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
+++ b/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
@@ -1,0 +1,21 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: true
+  resourceNamespace: {{ .Release.Namespace }}
+  {{- if eq .Values.appendReleaseSuffix true}}
+  resourceName: {{ .Values.scheduler.schedulerName }}-{{.Release.Name}}
+  {{- else }}
+  resourceName: {{ .Values.scheduler.schedulerName }}
+  {{- end }}
+healthzBindAddress: 0.0.0.0:10261
+metricsBindAddress: 0.0.0.0:10261
+profiles:
+  - schedulerName: tidb-scheduler
+extenders:
+  - urlPrefix: http://127.0.0.1:10262/scheduler
+    filterVerb: filter
+    preemptVerb: preempt
+    weight: 1
+    enableHTTPS: false
+    httpTimeout: 30s

--- a/charts/tidb-operator/templates/scheduler-config-configmap.yaml
+++ b/charts/tidb-operator/templates/scheduler-config-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare "<1.19.0-0" .Capabilities.KubeVersion.GitVersion)  }}
+{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,9 +8,9 @@ metadata:
 {{ toYaml $annotations | indent 4 }}
   {{- end }}
   {{- if eq .Values.appendReleaseSuffix true}}
-  name: {{ .Values.scheduler.schedulerName }}-policy-{{.Release.Name}}
+  name: {{ .Values.scheduler.schedulerName }}-config-{{.Release.Name}}
   {{- else }}
-  name: {{ .Values.scheduler.schedulerName }}-policy
+  name: {{ .Values.scheduler.schedulerName }}-config
   {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -20,6 +20,6 @@ metadata:
     app.kubernetes.io/component: scheduler
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
 data:
-  policy.cfg: |-
-{{ tuple "config/_scheduler-policy-json.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  scheduler-config.yaml: |-
+{{ tuple "config/_scheduler-config-yaml.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
 {{- end }}

--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) }}
+{{- $lgK8sV119 := (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,23 +70,32 @@ spec:
         command:
         - kube-scheduler
         - --port=10261
+        - --v={{ .Values.scheduler.logLevel }}
+        {{- if $lgK8sV119 }}
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        {{- else }}
         - --leader-elect=true
         - --lock-object-namespace={{ .Release.Namespace }}
-        {{- if eq .Values.appendReleaseSuffix true}}
+        - --policy-configmap-namespace={{ .Release.Namespace }}
+          {{- if eq .Values.appendReleaseSuffix true}}
         - --lock-object-name={{ .Values.scheduler.schedulerName }}-{{.Release.Name}}
         - --scheduler-name={{ .Values.scheduler.schedulerName }}-{{.Release.Name}}
         - --policy-configmap={{ .Values.scheduler.schedulerName }}-policy-{{.Release.Name}}
-        {{- else }}
+          {{- else }}
         - --lock-object-name={{ .Values.scheduler.schedulerName }}
         - --scheduler-name={{ .Values.scheduler.schedulerName }}
         - --policy-configmap={{ .Values.scheduler.schedulerName }}-policy
+          {{- end }}
         {{- end }}
-        - --v={{ .Values.scheduler.logLevel }}
-        - --policy-configmap-namespace={{ .Release.Namespace }}
       {{- if and (ne .Values.timezone "UTC") (ne .Values.timezone "") }}
         env:
         - name: TZ
           value: {{ .Values.timezone | default "UTC" }}
+      {{- end }}
+      {{- if $lgK8sV119 }}
+        volumeMounts:
+        - name: scheduler-config
+          mountPath: /etc/kubernetes
       {{- end }}
     {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
@@ -103,4 +113,14 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
     {{- end}}
+    {{- if $lgK8sV119 }}
+      volumes:
+      - name: scheduler-config
+        configMap:
+          {{- if eq .Values.appendReleaseSuffix true}}
+          name: {{ .Values.scheduler.schedulerName }}-config-{{.Release.Name}}
+          {{- else }}
+          name: {{ .Values.scheduler.schedulerName }}-config
+          {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #4155

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Use scheduler configuration to run tidb-scheduler, when Kubernetes is larger than  v1.19.

### Code changes

- [ ] Has Go code change
- [x] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

* Kubernetes v1.22.1
- [x] Deploy tidb-scheduler and check if use scheduler configuration
- [x] Deploy tidb-cluster

* Kubernetes v1.19.13
- [x] Deploy tidb-scheduler and check if use scheduler configuration
- [x] Deploy tidb-cluster

* Kubernetes v1.18.13
- [x] Deploy tidb-scheduler and check if use scheduler policy
- [x] Deploy tidb-cluster

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Use scheduler configuration to run tidb-scheduler, when Kubernetes is larger than  v1.19
```
