### PR TITLE
Fix version comparison don't support dirty version

### DIFF
--- a/cmd/backup-manager/app/util/util_test.go
+++ b/cmd/backup-manager/app/util/util_test.go
@@ -293,6 +293,11 @@ func TestSuffix(t *testing.T) {
 			version: "v4.0.x",
 			expect:  "40",
 		},
+		{
+			name:    "dirty version",
+			version: "v4.0.0-20200909",
+			expect:  "40",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -31,7 +31,7 @@ import (
 var (
 	// the first version which allows skipping setting tikv_gc_life_time
 	// https://github.com/pingcap/br/pull/553
-	tikvV408 = semver.MustParse("v4.0.8")
+	tikvV408Constraints, _ = semver.NewConstraint("<4.0.8-0")
 )
 
 // CheckAllKeysExistInSecret check if all keys are included in the specific secret
@@ -536,7 +536,7 @@ func canSkipSetGCLifeTime(image string) bool {
 		klog.Errorf("Parse version %s failure, error: %v", version, err)
 		return true
 	}
-	if v.LessThan(tikvV408) {
+	if tikvV408Constraints.Check(v) {
 		return false
 	}
 	return true

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -30,7 +30,7 @@ import (
 var (
 	// the first version that tiflash support `tiflash/store-status` api.
 	// https://github.com/pingcap/tidb-operator/issues/4159
-	tiflashV512                    = semver.MustParse("v5.1.2")
+	tiflashV512Constraints, _      = semver.NewConstraint(">=5.1.2-0")
 	tiflashVersionsNeedCheckStatus = map[string]struct{}{"lastest": {}, "nightly": {}}
 )
 
@@ -116,7 +116,7 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 			tiflashVersion := tc.TiFlashVersion()
 			if _, ok := tiflashVersionsNeedCheckStatus[tiflashVersion]; ok {
 				needCheckStatus = true
-			} else if ver, err := semver.NewVersion(tiflashVersion); err == nil && ver.Compare(tiflashV512) >= 0 { // NOTE: if parse image version failed, will skip this check
+			} else if ver, err := semver.NewVersion(tiflashVersion); err == nil && tiflashV512Constraints.Check(ver) { // NOTE: if parse image version failed, will skip this check
 				needCheckStatus = true
 			}
 			if needCheckStatus {

--- a/pkg/manager/member/tiflash_upgrader_test.go
+++ b/pkg/manager/member/tiflash_upgrader_test.go
@@ -257,7 +257,7 @@ func TestTiFlashUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: fmt.Sprintf("tiflash version less than %s", tiflashV512.String()),
+			name: fmt.Sprintf("tiflash version less than v5.1.2"),
 			changeFn: func(tc *v1alpha1.TidbCluster, tiflashControl *tiflashapi.FakeTiFlashControl) {
 				tc.Status.PD.Phase = v1alpha1.NormalPhase
 				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
@@ -319,7 +319,7 @@ func TestTiFlashUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: fmt.Sprintf("tiflash version greater than %s and tiflash is running", tiflashV512.String()),
+			name: fmt.Sprintf("tiflash version greater than v5.1.2 and tiflash is running"),
 			changeFn: func(tc *v1alpha1.TidbCluster, tiflashControl *tiflashapi.FakeTiFlashControl) {
 				tc.Status.PD.Phase = v1alpha1.NormalPhase
 				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
@@ -412,7 +412,7 @@ func TestTiFlashUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: fmt.Sprintf("tiflash version greater than %s and tiflash isn't running", tiflashV512.String()),
+			name: fmt.Sprintf("tiflash version greater than v5.1.2 and tiflash isn't running"),
 			changeFn: func(tc *v1alpha1.TidbCluster, tiflashControl *tiflashapi.FakeTiFlashControl) {
 				tc.Status.PD.Phase = v1alpha1.NormalPhase
 				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
@@ -444,7 +444,39 @@ func TestTiFlashUpgraderUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: fmt.Sprintf("tiflash version greater than %s and get store status failed", tiflashV512.String()),
+			name: fmt.Sprintf("tiflash version greater than v5.1.2, version is dirty-release and tiflash isn't running"),
+			changeFn: func(tc *v1alpha1.TidbCluster, tiflashControl *tiflashapi.FakeTiFlashControl) {
+				tc.Status.PD.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase
+				tc.Status.TiFlash.Synced = true
+				version := "v5.2.0-20200909"
+				tc.Spec.TiFlash.BaseImage = "base-image"
+				tc.Spec.TiFlash.Version = &version
+
+				fakeClient := NewFakeTiKVClient(tiflashControl, tc, "upgrader-tiflash-2")
+				fakeClient.AddReaction(tiflashapi.GetStoreStatusActionType, func(action *tiflashapi.Action) (interface{}, error) {
+					return tiflashapi.Stopping, nil
+				})
+			},
+			changeOldSet: func(oldSet *apps.StatefulSet) { // tigger upgrade
+				SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+				oldSet.Spec.Template.Spec.Containers[0].Image = "old-image"
+			},
+			changePods: func(pods []*corev1.Pod, tc *v1alpha1.TidbCluster, old, new *apps.StatefulSet) {
+				pod := pods[2]
+				pod.Labels[apps.ControllerRevisionHashLabelKey] = tc.Status.TiFlash.StatefulSet.UpdateRevision // pod is upgraded
+			},
+			updatePodErr: false,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("store status is Stopping instead of Running")) // compare error
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet, pods map[string]*corev1.Pod) {
+				g.Expect(*newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(int32(3)))
+			},
+		},
+		{
+			name: fmt.Sprintf("tiflash version greater than v5.1.2 and get store status failed"),
 			changeFn: func(tc *v1alpha1.TidbCluster, tiflashControl *tiflashapi.FakeTiFlashControl) {
 				tc.Status.PD.Phase = v1alpha1.NormalPhase
 				tc.Status.TiFlash.Phase = v1alpha1.NormalPhase


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Close #4206

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
