### PR TITLE
bump grafana to 7.5.11

### DIFF
--- a/examples/aks/tidb-monitor.yaml
+++ b/examples/aks/tidb-monitor.yaml
@@ -24,7 +24,7 @@ spec:
     service:
       type: LoadBalancer
     username: admin
-    version: 7.5.7
+    version: 7.5.11
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/auto-scale/tidb-monitor.yaml
+++ b/examples/auto-scale/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/aws/tidb-monitor.yaml
+++ b/examples/aws/tidb-monitor.yaml
@@ -27,7 +27,7 @@ spec:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
       type: LoadBalancer
     username: admin
-    version: 7.5.7
+    version: 7.5.11
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: uhub.service.ucloud.cn/pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/basic-tls/tidb-monitor.yaml
+++ b/examples/basic-tls/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/dm/dm-monitor.yaml
+++ b/examples/dm/dm-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/gcp/tidb-monitor.yaml
+++ b/examples/gcp/tidb-monitor.yaml
@@ -25,7 +25,7 @@ spec:
       portName: http-grafana
       type: LoadBalancer
     username: admin
-    version: 7.5.7
+    version: 7.5.11
   imagePullPolicy: IfNotPresent
   initializer:
     baseImage: pingcap/tidb-monitor-initializer

--- a/examples/heterogeneous-tls/tidb-monitor.yaml
+++ b/examples/heterogeneous-tls/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/heterogeneous/tidb-monitor.yaml
+++ b/examples/heterogeneous/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-dynamic-configmap/tidb-monitor.yaml
+++ b/examples/monitor-dynamic-configmap/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-grafana-secret/tidb-monitor.yaml
+++ b/examples/monitor-grafana-secret/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
     UserSecret:
       name: basic-grafana
       key: username

--- a/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-prom-remotewrite/tidb-monitor.yaml
+++ b/examples/monitor-prom-remotewrite/tidb-monitor.yaml
@@ -19,7 +19,7 @@ spec:
             action: replace
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: registry.cn-beijing.aliyuncs.com/tidb/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
     additionalVolumeMounts:
       - name: customdashboard
         mountPath: /grafana-dashboard-definitions/tidb/dashboards/custom

--- a/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
@@ -17,7 +17,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-with-externalRules/tidb-monitor.yaml
+++ b/examples/monitor-with-externalRules/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
@@ -18,7 +18,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/monitor-with-thanos/tidb-monitor.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     version: v2.11.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/namespaced/tidb-monitor.yaml
+++ b/examples/namespaced/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v5.2.0

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     version: v2.18.1
   grafana:
     baseImage: grafana/grafana
-    version: 7.5.7
+    version: 7.5.11
     service:
       type: NodePort
   initializer:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Bump grafana image to 7.5.11

### What is changed and how does it work?
Grafana Labs [announced](https://grafana.com/blog/2021/10/05/grafana-7.5.11-and-8.1.6-released-with-critical-security-fix/) `CVE-2021-39226`.


### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Update grafana images in examples to 7.5.11 due to security issue. 
```
