### PR TITLE
crd: validate container resources when create tidbmonitor

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -21044,8 +21044,14 @@ spec:
                     properties:
                       limits:
                         type: object
+                        additionalProperties:
+                          type: string
+                          pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                       requests:
                         type: object
+                        additionalProperties:
+                          type: string
+                          pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
                     type: object
                   securityContext:
                     properties:
@@ -21957,7 +21963,19 @@ spec:
               type: boolean
             externalLabels:
               type: object
-            grafana: {}
+            grafana:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
             imagePullPolicy:
               type: string
             imagePullSecrets:
@@ -21967,7 +21985,19 @@ spec:
                     type: string
                 type: object
               type: array
-            initializer: {}
+            initializer:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
             kubePrometheusURL:
               type: string
             labels:
@@ -22038,11 +22068,47 @@ spec:
                       type: string
                   type: object
               type: object
-            prometheus: {}
-            prometheusReloader: {}
+            prometheus:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+            prometheusReloader:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
             pvReclaimPolicy:
               type: string
-            reloader: {}
+            reloader:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
             replicaExternalLabelName:
               type: string
             replicas:
@@ -22055,7 +22121,19 @@ spec:
               type: string
             storageClassName:
               type: string
-            thanos: {}
+            thanos:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                requests:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
             tolerations:
               items:
                 properties:


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:


-->

validate container resources when creating `tidbMonitor`, checked the following items:

- additionalContainers
- prometheus
- prometheusReloader
- grafana
- initializer
- thanos
- reloader

for example, error format like, notice the `spec.prometheus.limits.cpu`:

```yaml
apiVersion: pingcap.com/v1alpha1
kind: TidbMonitor
metadata:
  name: basic
spec:
  clusters:
    - name: advanced-tidba
  prometheus:
    baseImage: prom/prometheus
    version: v2.27.1
    limits:
      cpu: a
    requests:
      cpu: a
  initializer:
    baseImage: pingcap/tidb-monitor-initializer
    version: v5.2.1
    limits:
      cpu: 1m
    requests:
      cpu: 1m
  reloader:
    baseImage: pingcap/tidb-monitor-reloader
    version: v1.0.1
  imagePullPolicy: IfNotPresent

```

```console
# kubectl apply -f tidbmonitor.yaml
The TidbMonitor "basic" is invalid:
* spec.prometheus.limits.cpu: Invalid value: "a": spec.prometheus.limits.cpu in body should match '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
* spec.prometheus.requests.cpu: Invalid value: "a": spec.prometheus.requests.cpu in body should match '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

Closes #2534 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

add the `additionalProperties` in crd validation part, using the `pettern` used by kubernetes/kubernetes to check the pods.


### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

```yaml
apiVersion: pingcap.com/v1alpha1
kind: TidbMonitor
metadata:
  name: basic
spec:
  clusters:
    - name: advanced-tidba
  prometheus:
    baseImage: prom/prometheus
    version: v2.27.1
    limits:
      cpu: a
    requests:
      cpu: a
  initializer:
    baseImage: pingcap/tidb-monitor-initializer
    version: v5.2.1
    limits:
      cpu: 1m
    requests:
      cpu: 1m
  reloader:
    baseImage: pingcap/tidb-monitor-reloader
    version: v1.0.1
  imagePullPolicy: IfNotPresent
```

```console
# kubectl apply -f tidbmonitor.yaml
The TidbMonitor "basic" is invalid:
* spec.prometheus.limits.cpu: Invalid value: "a": spec.prometheus.limits.cpu in body should match '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
* spec.prometheus.requests.cpu: Invalid value: "a": spec.prometheus.requests.cpu in body should match '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
