### PR TITLE
Check startup script when check if configmap has beed updated

### DIFF
--- a/pkg/manager/member/config.go
+++ b/pkg/manager/member/config.go
@@ -24,10 +24,12 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
+// updateConfigMap check if ConfigMap is has actually been updated
 func updateConfigMap(old, new *corev1.ConfigMap) (bool, error) {
-	tomlField := []string{"config-file" /*pd,tikv,tidb */, "pump-config", "config_templ.toml" /*tiflash*/, "proxy_templ.toml" /*tiflash*/}
 	dataEqual := true
 
+	// check config
+	tomlField := []string{"config-file" /*pd,tikv,tidb */, "pump-config", "config_templ.toml" /*tiflash*/, "proxy_templ.toml" /*tiflash*/}
 	for _, k := range tomlField {
 		oldData, oldOK := old.Data[k]
 		newData, newOK := new.Data[k]
@@ -48,6 +50,18 @@ func updateConfigMap(old, new *corev1.ConfigMap) (bool, error) {
 		if equal {
 			new.Data[k] = oldData
 		} else {
+			dataEqual = false
+		}
+	}
+
+	// check startup script
+	field := "startup-script"
+	oldScript, oldExist := old.Data[field]
+	newScript, newExist := new.Data[field]
+	if oldExist != newExist {
+		dataEqual = false
+	} else if oldExist && newExist {
+		if oldScript != newScript {
 			dataEqual = false
 		}
 	}

--- a/pkg/manager/member/config.go
+++ b/pkg/manager/member/config.go
@@ -24,7 +24,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
-// updateConfigMap check if ConfigMap is has actually been updated
 func updateConfigMap(old, new *corev1.ConfigMap) (bool, error) {
 	dataEqual := true
 

--- a/pkg/manager/member/config_test.go
+++ b/pkg/manager/member/config_test.go
@@ -210,7 +210,7 @@ func TestUpdateConfigMap(t *testing.T) {
 					"startup-script": "script-new",
 				},
 			},
-			equal: true,
+			equal: false,
 		},
 	}
 

--- a/pkg/manager/member/config_test.go
+++ b/pkg/manager/member/config_test.go
@@ -154,6 +154,64 @@ func TestUpdateConfigMap(t *testing.T) {
 			},
 			equal: true,
 		},
+		{
+			name: "the startup script of old is empty, and new is setted",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "old",
+				},
+				Data: map[string]string{},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new",
+				},
+				Data: map[string]string{
+					"startup-script": "script",
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "the startup script of old is empty, and new is setted",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "old",
+				},
+				Data: map[string]string{
+					"startup-script": "script",
+				},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new",
+				},
+				Data: map[string]string{
+					"startup-script": "script",
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "the data of old and new configmaps are different",
+			old: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "old",
+				},
+				Data: map[string]string{
+					"startup-script": "script-old",
+				},
+			},
+			new: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new",
+				},
+				Data: map[string]string{
+					"startup-script": "script-new",
+				},
+			},
+			equal: true,
+		},
 	}
 
 	for i := range tests {

--- a/pkg/manager/member/config_test.go
+++ b/pkg/manager/member/config_test.go
@@ -173,7 +173,7 @@ func TestUpdateConfigMap(t *testing.T) {
 			equal: false,
 		},
 		{
-			name: "the startup script of old is empty, and new is setted",
+			name: "the startup script of old is same",
 			old: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "old",
@@ -190,10 +190,10 @@ func TestUpdateConfigMap(t *testing.T) {
 					"startup-script": "script",
 				},
 			},
-			equal: false,
+			equal: true,
 		},
 		{
-			name: "the data of old and new configmaps are different",
+			name: "the startup script of old and new configmaps are different",
 			old: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "old",

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -38,9 +38,9 @@ import (
 )
 
 var (
-	tidbReadyTimeout       = time.Minute * 5
-	backupCompleteTimeout  = time.Minute * 5
-	restoreCompleteTimeout = time.Minute * 5
+	tidbReadyTimeout       = time.Minute * 7
+	backupCompleteTimeout  = time.Minute * 7
+	restoreCompleteTimeout = time.Minute * 7
 )
 
 const (

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -382,7 +382,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			return nil
 		})
 		framework.ExpectNoError(err, "failed to upgrade TidbCluster: %q", tc.Name)
-		err = oa.WaitForTidbClusterReady(tc, 5*time.Minute, 5*time.Second)
+		err = oa.WaitForTidbClusterReady(tc, 7*time.Minute, 5*time.Second)
 
 		framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
 		pdClient, cancel, err := proxiedpdclient.NewProxiedPDClient(secretLister, fw, ns, tc.Name, false)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Check startup script when check if configmap has beed updated

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
Upgrade operator v1.1.7 to v1.2.4:
* If set `clusterDomain` in TidbCluster, `PD`,`TiKV` and `TiDB` roll update. Because of PR #4123
* If don't set `clusterDomain` in TidbCluster, `PD`,`TiKV` and `TiDB` don't roll update.
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Roll update `PD`, `TiKV`, `TiDB` if set `clusterDomain`.
```
