### PR TITLE
[WIP] Add more e2e cases about deploying cluster across kubernetes

### DIFF
--- a/.github/workflows/e2e-temp.yaml
+++ b/.github/workflows/e2e-temp.yaml
@@ -1,0 +1,146 @@
+name: e2e
+
+on:
+  push:
+    branches:
+      - multicluster-e2e
+  workflow_dispatch:
+
+jobs:
+  image-build:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            go/src/github.com/${{ github.repository }}/go/pkg/mod
+            go/src/github.com/${{ github.repository }}/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Build binary
+        run: |
+          echo $GOCACHE
+          make build
+          make e2e-build
+          [ -d tests/images/e2e/tidb-operator ] && rm -r tests/images/e2e/tidb-operator || true
+          [ -d tests/images/e2e/tidb-cluster ] && rm -r tests/images/e2e/tidb-cluster || true
+          [ -d tests/images/e2e/tidb-backup ] && rm -r tests/images/e2e/tidb-backup || true
+          [ -d tests/images/e2e/manifests ] && rm -r tests/images/e2e/manifests || true
+          cp -r charts/tidb-operator tests/images/e2e
+          cp -r charts/tidb-cluster tests/images/e2e
+          cp -r charts/tidb-backup tests/images/e2e
+          cp -r charts/tidb-drainer tests/images/e2e
+          cp -r manifests tests/images/e2e
+        working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/images/tidb-backup-manager
+          file: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/images/tidb-backup-manager/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/handlerww/tidb-operator/tidb-backup-manager:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/images/tidb-operator
+          file: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/images/tidb-operator/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/handlerww/tidb-operator/tidb-operator:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/tests/images/e2e
+          file: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}/tests/images/e2e/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/handlerww/tidb-operator/tidb-operator-e2e:${{ github.sha }}
+      - name: Get matrix jobs
+        id: set-matrix
+        run: |
+          echo "::set-output name=matrix::{\"include\":[{\"job\":\"Multicluster\"}]}"
+  e2e-cases:
+    needs: ["image-build"]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.image-build.outputs.matrix)}}
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Creating kind cluster
+        run: |
+          SKIP_DOWN=y SKIP_BUILD=y SKIP_IMAGE_BUILD=y SKIP_TEST=y KUBE_WORKERS=0 ./hack/e2e.sh
+          echo "info: waiting for all nodes to be ready"
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+          echo "info: waiting for all pods in kube-system namespace to be ready"
+          kubectl -n kube-system wait --for=condition=Ready pods --all
+          echo "info: print cluster information"
+          kubectl get nodes
+          kubectl get pods -n kube-system
+          helm version
+          kubectl version
+          echo "info: create pingcap namespace for configurations"
+          kubectl create ns pingcap
+        working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+
+      - name: e2e(${{ matrix.job }})
+        run: |
+          SKIP_BUILD=y SKIP_IMAGE_BUILD=y SKIP_UP=y DOCKER_REPO=ghcr.io/handlerww/tidb-operator IMAGE_TAG=${{ github.sha }} ./hack/e2e.sh -- --ginkgo.focus='${{ matrix.job }}'
+        working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}

--- a/.github/workflows/e2e-temp.yaml
+++ b/.github/workflows/e2e-temp.yaml
@@ -1,9 +1,9 @@
 name: e2e
 
 on:
-  push:
-    branches:
-      - multicluster-e2e
+  # push:
+  #   branches:
+  #     - multicluster-e2e
   workflow_dispatch:
 
 jobs:
@@ -97,7 +97,7 @@ jobs:
       - name: Get matrix jobs
         id: set-matrix
         run: |
-          echo "::set-output name=matrix::{\"include\":[{\"job\":\"Multicluster\"}]}"
+          echo "::set-output name=matrix::{\"include\":[{\"job\":\"Across Kubernetes\"}]}"
   e2e-cases:
     needs: ["image-build"]
     runs-on: ubuntu-latest

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 		}
 	})
 
-	ginkgo.Describe("[Basic]", func() {
+	ginkgo.Describe("[Deploy and delete Cluster]", func() {
 
 		// create three namespace
 		ginkgo.BeforeEach(func() {
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 		cluster2Cli := genericCli
 		cluster3Cli := genericCli
 
-		ginkgo.It("Deploy and delete cluster across kubernetes", func() {
+		ginkgo.It("Deploy and delete cluster across kubernetes without TLS", func() {
 			ns1 := namespaces[0]
 			ns2 := namespaces[1]
 			ns3 := namespaces[2]
@@ -158,30 +158,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			ginkgo.By("Deploy the basic cluster-3")
 			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
 
-			ginkgo.By("Deploy status of all clusters")
-			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
-			framework.ExpectNoError(err, "failed to check status")
-		})
-
-		ginkgo.It("Deploy and delete cluster across kubernetes with TLS", func() {
-			ns1 := namespaces[0]
-			ns2 := namespaces[1]
-			ns3 := namespaces[2]
-
-			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
-			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
-			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
-
-			ginkgo.By("Deploy the basic cluster-1")
-			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
-
-			ginkgo.By("Deploy the basic cluster-2")
-			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
-
-			ginkgo.By("Deploy the basic cluster-3")
-			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
-
-			ginkgo.By("Deploy status of all clusters")
+			ginkgo.By("Check status of all clusters")
 			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
 			framework.ExpectNoError(err, "failed to check status")
 		})

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -132,31 +132,243 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 		})
 
 		version := utilimage.TiDBLatest
-		clusterDomain := defaultClusterDomain
+		cluster1Domain := defaultClusterDomain
+		cluster2Domain := defaultClusterDomain
+		cluster3Domain := defaultClusterDomain
 
-		ginkgo.It("Deploy cluster across kubernetes", func() {
+		cluster1Cli := genericCli
+		cluster2Cli := genericCli
+		cluster3Cli := genericCli
+
+		ginkgo.It("Deploy and delete cluster across kubernetes", func() {
 			ns1 := namespaces[0]
 			ns2 := namespaces[1]
 			ns3 := namespaces[2]
 
-			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, clusterDomain, nil)
-			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, clusterDomain, tc1)
-			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, clusterDomain, tc1)
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
 
 			ginkgo.By("Deploy the basic cluster-1")
-			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc1, 5*time.Minute, 10*time.Second)
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
 
 			ginkgo.By("Deploy the basic cluster-2")
-			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc2, 5*time.Minute, 10*time.Second)
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
 
 			ginkgo.By("Deploy the basic cluster-3")
-			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc3, 5*time.Minute, 10*time.Second)
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
 
 			ginkgo.By("Deploy status of all clusters")
 			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
 			framework.ExpectNoError(err, "failed to check status")
 		})
 
+		ginkgo.It("Deploy and delete cluster across kubernetes with TLS", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("Scale out and scale in the clusters", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("Upgrade the TiDB clusters", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("Backup and restore the TiDB clusters", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("TiDB Dashboard works as expected", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("DM works as expected", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("TiCDC works as expected", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("TiCDC works as expected", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
+
+		ginkgo.It("Failover", func() {
+			ns1 := namespaces[0]
+			ns2 := namespaces[1]
+			ns3 := namespaces[2]
+
+			tc1 := GetTCForAcrossKubernetes(ns1, "basic-1", version, cluster1Domain, nil)
+			tc2 := GetTCForAcrossKubernetes(ns2, "basic-2", version, cluster2Domain, tc1)
+			tc3 := GetTCForAcrossKubernetes(ns3, "basic-3", version, cluster3Domain, tc1)
+
+			ginkgo.By("Deploy the basic cluster-1")
+			utiltc.MustCreateTCWithComponentsReady(cluster1Cli, oa, tc1, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-2")
+			utiltc.MustCreateTCWithComponentsReady(cluster2Cli, oa, tc2, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy the basic cluster-3")
+			utiltc.MustCreateTCWithComponentsReady(cluster3Cli, oa, tc3, 5*time.Minute, 10*time.Second)
+
+			ginkgo.By("Deploy status of all clusters")
+			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			framework.ExpectNoError(err, "failed to check status")
+		})
 	})
 
 	ginkgo.Describe("[Advanced]", func() {
@@ -170,7 +382,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 		version := utilimage.TiDBLatest
 		clusterDomain := defaultClusterDomain
 
-		ginkgo.It("Deploy cluster with existing data across kubernetes", func() {
+		ginkgo.It("Upgrade a cluster with existing data to a cluster supporting across kubernetes", func() {
 			ns1 := namespaces[0]
 			ns2 := namespaces[1]
 			ns3 := namespaces[2]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Add more e2e cases about deploying clusters across Kubernetes, cover some common scenarios.
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
add e2e test for cluster across Kubernetes
```
