### PR TITLE
Defaulting ns of target cluster to be same as TidbNGMonitoring

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -4040,7 +4040,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Namespace is the namespace that TidbCluster object locates,
-default to the same namespace with TidbMonitor</p>
+default to the same namespace as TidbMonitor/TidbCluster/TidbNGMonitoring</p>
 </td>
 </tr>
 <tr>
@@ -20645,7 +20645,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Namespace is the namespace that TidbCluster object locates,
-default to the same namespace with TidbMonitor</p>
+default to the same namespace as TidbMonitor/TidbCluster/TidbNGMonitoring</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring.go
@@ -15,10 +15,6 @@ package defaulting
 
 import "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 
-const (
-	defaultNGMonitoringImage = "pingcap/ng-monitoring"
-)
-
 func SetTidbNGMonitoringDefault(tngm *v1alpha1.TidbNGMonitoring) {
 	setTidbNGMonitoringSpecDefault(tngm)
 }

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring.go
@@ -1,0 +1,32 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaulting
+
+import "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+
+const (
+	defaultNGMonitoringImage = "pingcap/ng-monitoring"
+)
+
+func SetTidbNGMonitoringDefault(tngm *v1alpha1.TidbNGMonitoring) {
+	setTidbNGMonitoringSpecDefault(tngm)
+}
+
+func setTidbNGMonitoringSpecDefault(tngm *v1alpha1.TidbNGMonitoring) {
+	for id := range tngm.Spec.Clusters {
+		if tngm.Spec.Clusters[id].Namespace == "" {
+			tngm.Spec.Clusters[id].Namespace = tngm.Namespace
+		}
+	}
+}

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring_test.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidb_ng_monitoring_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaulting
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSetTidbNGMonitoringDefault(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name     string
+		setTNGM  func(*v1alpha1.TidbNGMonitoring)
+		expectFn func(*v1alpha1.TidbNGMonitoring)
+	}
+
+	cases := []testcase{
+		{
+			name: "should set ns if ns of tc isn't setted",
+			setTNGM: func(tngm *v1alpha1.TidbNGMonitoring) {
+				tngm.Spec.Clusters = []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc",
+					},
+					{
+						Name:      "tc-2",
+						Namespace: "tc-2-ns",
+					},
+				}
+			},
+			expectFn: func(tngm *v1alpha1.TidbNGMonitoring) {
+				g.Expect(tngm.Spec.Clusters[0].Namespace).Should(Equal(tngm.Namespace))
+				g.Expect(tngm.Spec.Clusters[1].Namespace).Should(Equal("tc-2-ns"))
+			},
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Logf("testcase: %s", testcase.name)
+
+		tngm := &v1alpha1.TidbNGMonitoring{}
+		tngm.Name = "tngm"
+		tngm.Namespace = "tngm-ns"
+		if testcase.setTNGM != nil {
+			testcase.setTNGM(tngm)
+		}
+
+		SetTidbNGMonitoringDefault(tngm)
+
+		testcase.expectFn(tngm)
+	}
+}

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1297,7 +1297,7 @@ func schema_pkg_apis_pingcap_v1alpha1_ClusterRef(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace is the namespace that TidbCluster object locates, default to the same namespace with TidbMonitor",
+							Description: "Namespace is the namespace that TidbCluster object locates, default to the same namespace as TidbMonitor/TidbCluster/TidbNGMonitoring",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11537,7 +11537,7 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbClusterRef(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace is the namespace that TidbCluster object locates, default to the same namespace with TidbMonitor",
+							Description: "Namespace is the namespace that TidbCluster object locates, default to the same namespace as TidbMonitor/TidbCluster/TidbNGMonitoring",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go
@@ -356,7 +356,7 @@ type MonitorContainer struct {
 // TidbClusterRef reference to a TidbCluster
 type TidbClusterRef struct {
 	// Namespace is the namespace that TidbCluster object locates,
-	// default to the same namespace with TidbMonitor
+	// default to the same namespace as TidbMonitor/TidbCluster/TidbNGMonitoring
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 

--- a/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_control.go
+++ b/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_control.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1/defaulting"
 	v1alpha1validation "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1/validation"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager"
@@ -72,6 +73,7 @@ type defaultTiDBNGMonitoringControl struct {
 }
 
 func (c *defaultTiDBNGMonitoringControl) Reconcile(tngm *v1alpha1.TidbNGMonitoring) error {
+	c.defaulting(tngm)
 	if !c.validate(tngm) {
 		return nil // fatal error, no need to retry on invalid object
 	}
@@ -168,6 +170,10 @@ func (c *defaultTiDBNGMonitoringControl) Update(tngm *v1alpha1.TidbNGMonitoring)
 		klog.Errorf("failed to update TidbMonTiDBNGMonitoringitor: [%s/%s], error: %v", ns, name, err)
 	}
 	return update, err
+}
+
+func (c *defaultTiDBNGMonitoringControl) defaulting(tngm *v1alpha1.TidbNGMonitoring) {
+	defaulting.SetTidbNGMonitoringDefault(tngm)
 }
 
 func (c *defaultTiDBNGMonitoringControl) validate(tngm *v1alpha1.TidbNGMonitoring) bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Default ns of target cluster to be same as TidbNGMonitoring
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
