### PR TITLE
feat(restore): retry updating restore status when restore job succeeded

### DIFF
--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -76,7 +76,8 @@ func (u *realBackupConditionUpdater) Update(backup *v1alpha1.Backup, condition *
 	ns := backup.GetNamespace()
 	backupName := backup.GetName()
 	var isUpdate bool
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	// try best effort to guarantee backup is updated.
+	err := retry.OnError(retry.DefaultRetry, func(e error) bool { return e != nil }, func() error {
 		updateBackupStatus(&backup.Status, newStatus)
 		isUpdate = v1alpha1.UpdateBackupCondition(&backup.Status, condition)
 		if isUpdate {

--- a/pkg/controller/restore_status_updater.go
+++ b/pkg/controller/restore_status_updater.go
@@ -68,7 +68,8 @@ func (u *realRestoreConditionUpdater) Update(restore *v1alpha1.Restore, conditio
 	ns := restore.GetNamespace()
 	restoreName := restore.GetName()
 	var isUpdate bool
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	// try best effort to guarantee restore is updated.
+	err := retry.OnError(retry.DefaultRetry, func(e error) bool { return e != nil }, func() error {
 		updateRestoreStatus(&restore.Status, newStatus)
 		isUpdate = v1alpha1.UpdateRestoreCondition(&restore.Status, condition)
 		if isUpdate {


### PR DESCRIPTION
Signed-off-by: just1900 <legendj228@gmail.com>

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

fix #4334 
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
FYI, I've test it with creating a backup and then add firewall that simply drop the packets to the apiserver after br succeed, here are the retry logs( focus on "Failed to update backup ..."). After retrying 3 times, I remove the firewall and it succeeds.

  ```
  I1231 05:29:43.876251       8 manager.go:321] Get cluster tidb-operator-test/basic2-backup-s3 commitTs 430159582415028225 success
  E1231 05:30:27.684019       8 backup_status_updater.go:89] Failed to update backup [tidb-operator-test/basic2-backup-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/backups/basic2-backup-s3": http2: client connection lost
  W1231 05:30:27.684049       8 reflector.go:424] k8s.io/client-go@v0.19.16/tools/cache/reflector.go:156: watch of *v1alpha1.Backup ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding
  E1231 05:30:57.696650       8 backup_status_updater.go:89] Failed to update backup [tidb-operator-test/basic2-backup-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/backups/basic2-backup-s3": dial tcp 10.0.0.1:443: i/o timeout
  I1231 05:30:58.836848       8 trace.go:205] Trace[1474941318]: "Reflector ListAndWatch" name:k8s.io/client-go@v0.19.16/tools/cache/reflector.go:156 (31-Dec-2021 05:30:28.834) (total time: 30001ms):
  Trace[1474941318]: [30.001983021s] [30.001983021s] END
  E1231 05:30:58.836960       8 reflector.go:127] k8s.io/client-go@v0.19.16/tools/cache/reflector.go:156: Failed to watch *v1alpha1.Backup: failed to list *v1alpha1.Backup: Get "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/backups?resourceVersion=79880584": dial tcp 10.0.0.1:443: i/o timeout
  I1231 05:31:12.751950       8 trace.go:205] Trace[336122540]: "Reflector ListAndWatch" name:k8s.io/client-go@v0.19.16/tools/cache/reflector.go:156 (31-Dec-2021 05:31:00.542) (total time: 12209ms):
  Trace[336122540]: ---"Objects listed" 12209ms (05:31:00.751)
  Trace[336122540]: [12.209709474s] [12.209709474s] END
  I1231 05:31:12.756815       8 backup_status_updater.go:86] Backup: [tidb-operator-test/basic2-backup-s3] updated successfully
  ```
  Check status of `Backup` by kubeclt get backup basic2-backup-s3 :

  ```
  NAME               STATUS     BACKUPPATH                      BACKUPSIZE   COMMITTS             AGE
  basic2-backup-s3   Complete   s3://basic-tidb-bucket/basic2   161 kB       430159582415028225   3m25s
  ```

  And here are the 5 times retry logs for restore job that I fail apiserver directly.
  
  ```
  restore-basic-restore-s3-2djks restore I1231 05:36:47.999681       8 restore.go:105] Restore data for cluster tidb-operator-test/basic-restore-s3 successfully
  restore-basic-restore-s3-2djks restore I1231 05:36:47.999734       8 manager.go:289] restore cluster tidb-operator-test/basic-restore-s3 from  succeed
  restore-basic-restore-s3-2djks restore E1231 05:37:18.001843       8 restore_status_updater.go:81] Failed to update resotre [tidb-operator-test/basic-restore-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/restores/basic-restore-s3": dial tcp 10.0.0.1:443: connect: connection refused
  restore-basic-restore-s3-2djks restore E1231 05:37:18.013810       8 restore_status_updater.go:81] Failed to update resotre [tidb-operator-test/basic-restore-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/restores/basic-restore-s3": dial tcp 10.0.0.1:443: connect: connection refused
  restore-basic-restore-s3-2djks restore E1231 05:37:18.025884       8 restore_status_updater.go:81] Failed to update resotre [tidb-operator-test/basic-restore-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/restores/basic-restore-s3": dial tcp 10.0.0.1:443: connect: connection refused
  restore-basic-restore-s3-2djks restore E1231 05:37:18.037810       8 restore_status_updater.go:81] Failed to update resotre [tidb-operator-test/basic-restore-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/restores/basic-restore-s3": dial tcp 10.0.0.1:443: connect: connection refused
  restore-basic-restore-s3-2djks restore E1231 05:37:18.049867       8 restore_status_updater.go:81] Failed to update resotre [tidb-operator-test/basic-restore-s3], error: Put "https://10.0.0.1:443/apis/pingcap.com/v1alpha1/namespaces/tidb-operator-test/restores/basic-restore-s3": dial tcp 10.0.0.1:443: connect: connection refused
  restore-basic-restore-s3-2djks restore The connection to the server 10.0.0.1:443 was refused - did you specify the right host or port?
  ```

  Check status of `Restore` :
  
  ```
  NAME               STATUS    COMMITTS   AGE
  basic-restore-s3   Running              77s
  ```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Add retry for the status update for the Backup and Restore CR
```
