### PR TITLE
refine e2e check cluster domain status

### DIFF
--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -503,12 +503,7 @@ func createXK8sTidbClusterWithComponentsReady(f *e2eframework.Framework, namespa
 	}
 
 	ginkgo.By("Check deploy status")
-	return wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
-		if err := e2etc.CheckClusterDomainEffect(f.ExtClient, []*v1alpha1.TidbCluster{tc1, tc2, tc3}); err != nil {
-			return false, nil
-		}
-		return true, nil
-	})
+	return e2etc.CheckClusterDomainEffectWithTimeout(f.ExtClient, []*v1alpha1.TidbCluster{tc1, tc2, tc3}, 5*time.Second, 3*time.Minute)
 }
 
 func GetTCForXK8s(ns, name, version, clusterDomain string, joinTC *v1alpha1.TidbCluster) *v1alpha1.TidbCluster {

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc3, 5*time.Minute, 10*time.Second)
 
 			ginkgo.By("Deploy status of all clusters")
-			err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			err := CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "failed to check status")
 		})
 
@@ -237,12 +237,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc3, 10*time.Minute, 10*time.Second)
 
 			ginkgo.By("Check status over all clusters")
-			err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
-				if err := CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3}); err != nil {
-					return false, nil
-				}
-				return true, nil
-			})
+			err := CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "failed to check status")
 		})
 
@@ -295,7 +290,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc3, 5*time.Minute, 10*time.Second)
 
 			ginkgo.By("Deploy status of all clusters")
-			err = CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3})
+			err = CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc2, tc3}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "failed to check status")
 		})
 
@@ -375,7 +370,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			framework.ExpectEqual(foundSecretName, true)
 
 			ginkgo.By("Check deploy status over all clusters")
-			err = CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2})
+			err = CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc2}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "failed to check status")
 
 			ginkgo.By("Connecting to tidb server to verify the connection is TLS enabled")
@@ -622,7 +617,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			framework.ExpectNoError(err, "%q cluster not healthy after cluster %q fail", tcName1, tcName2)
 			err = oa.WaitForTidbClusterReady(tc3, 10*time.Minute, 30*time.Second)
 			framework.ExpectNoError(err, "%q cluster not healthy after cluster %q fail", tcName3, tcName2)
-			err = CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc3})
+			err = CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc3}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "failed to check status after cluster %q fail", tcName2)
 
 			ginkgo.By("Check functionality of other clusters by querying tidb")
@@ -718,7 +713,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			ginkgo.By("Join cluster-2 into cluster-1 when pd running normally")
 			err = oa.WaitForTidbClusterReady(tc2, 10*time.Minute, 30*time.Second)
 			framework.ExpectNoError(err, "waiting for %q ready", tcName2)
-			err = CheckClusterDomainEffect(cli, []*v1alpha1.TidbCluster{tc1, tc2})
+			err = CheckClusterDomainEffectWithTimeout(cli, []*v1alpha1.TidbCluster{tc1, tc2}, 5*time.Second, 3*time.Minute)
 			framework.ExpectNoError(err, "%q failed to join into %q", tcName2, tcName1)
 		})
 	})
@@ -775,6 +770,15 @@ func GetTCForAcrossKubernetes(ns, name, version, clusterDomain string, joinTC *v
 	}
 
 	return tc
+}
+
+func CheckClusterDomainEffectWithTimeout(cli versioned.Interface, tidbclusters []*v1alpha1.TidbCluster, interval time.Duration, timeout time.Duration) error {
+	return wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+		if err := CheckClusterDomainEffect(cli, tidbclusters); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 func CheckClusterDomainEffect(cli versioned.Interface, tidbclusters []*v1alpha1.TidbCluster) error {

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -267,7 +267,11 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 
 			ginkgo.By("Update pd's peerURL of cluster-1")
 			pdAddr := fmt.Sprintf("%s:%d", localHost, localPort)
-			resp, err := pdutil.GetMembersV2(pdAddr)
+			var resp *pdutil.GetMembersResponse
+			err = retry.OnError(retry.DefaultRetry, func(e error) bool { return e != nil }, func() error {
+				resp, err = pdutil.GetMembersV2(pdAddr)
+				return err
+			})
 			framework.ExpectNoError(err, " failed to get pd members of cluster-1 %s/%s", tc1.Namespace, tc1.Name)
 			for _, member := range resp.Members {
 				peerURLs := []string{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

Address e2e problem in #4368 by adding timeout for checkClusterDomainstatus
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
