### PR TITLE
Fixed the problem where pump would get stuck when local pds are down

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gomodules.xyz/jsonpatch/v2 v2.1.0
+	google.golang.org/grpc v1.27.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.16

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"go.etcd.io/etcd/clientv3"
+	"google.golang.org/grpc"
 )
 
 // Client is the client of binlog.
@@ -46,11 +47,12 @@ func (c *Client) hookAddr(addr string) string {
 	return addr
 }
 
-// NewBinlogClient create a Client.
+// NewBinlogClient create a Client and return an error if the underlying conn is not up within 5 seconds.
 func NewBinlogClient(pdEndpoint []string, tlsConfig *tls.Config) (*Client, error) {
 	etcdClient, err := clientv3.New(clientv3.Config{
 		Endpoints:   pdEndpoint,
 		DialTimeout: time.Second * 5,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tlsConfig,
 	})
 	if err != nil {

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -33,6 +33,7 @@ type Client struct {
 	tls        *tls.Config
 	httpClient *http.Client
 	etcdClient *clientv3.Client
+	timeout    time.Duration
 
 	// if setted, will call HookAddr to change the address of pump/drainer
 	// before accessing pump/drainer.
@@ -47,11 +48,11 @@ func (c *Client) hookAddr(addr string) string {
 	return addr
 }
 
-// NewBinlogClient create a Client and return an error if the underlying conn is not up within 5 seconds.
-func NewBinlogClient(pdEndpoint []string, tlsConfig *tls.Config) (*Client, error) {
+// NewBinlogClient create a Client and return an error if the underlying conn is not up within timeout duration.
+func NewBinlogClient(pdEndpoint []string, tlsConfig *tls.Config, timeout time.Duration) (*Client, error) {
 	etcdClient, err := clientv3.New(clientv3.Config{
 		Endpoints:   pdEndpoint,
-		DialTimeout: time.Second * 5,
+		DialTimeout: timeout,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tlsConfig,
 	})
@@ -62,12 +63,14 @@ func NewBinlogClient(pdEndpoint []string, tlsConfig *tls.Config) (*Client, error
 	return &Client{
 		tls: tlsConfig,
 		httpClient: &http.Client{
+			Timeout: timeout,
 			Transport: &http.Transport{
 				TLSClientConfig:   tlsConfig,
 				DisableKeepAlives: true,
 			},
 		},
 		etcdClient: etcdClient,
+		timeout:    timeout,
 	}, nil
 }
 
@@ -180,6 +183,8 @@ func (c *Client) UpdatePumpState(ctx context.Context, addr string, state string)
 func (c *Client) updateStatus(ctx context.Context, ty string, nodeID string, state string) error {
 	key := fmt.Sprintf("/tidb-binlog/v1/%s/%s", ty, nodeID)
 
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 	resp, err := c.etcdClient.KV.Get(ctx, key)
 	if err != nil {
 		return errors.AddStack(err)
@@ -217,6 +222,8 @@ func (c *Client) updateStatus(ctx context.Context, ty string, nodeID string, sta
 func (c *Client) nodeStatus(ctx context.Context, ty string) (status []*v1alpha1.PumpNodeStatus, err error) {
 	key := fmt.Sprintf("/tidb-binlog/v1/%s", ty)
 
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 	resp, err := c.etcdClient.KV.Get(ctx, key, clientv3.WithPrefix())
 	if err != nil {
 		return nil, errors.AddStack(err)

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -150,17 +150,13 @@ func buildBinlogClient(tc *v1alpha1.TidbCluster, control pdapi.PDControlInterfac
 	}
 
 	// support x-k8s tidbcluster without local pd
-	client, err = binlog.NewBinlogClient(endpoints, tlsConfig)
-	if err == nil {
-		return client, nil
+	for _, pdMember := range tc.Status.PD.PeerMembers {
+		endpoints = append(endpoints, pdMember.ClientURL)
 	}
 
-	for _, pdMember := range tc.Status.PD.PeerMembers {
-		endpoints = []string{pdMember.ClientURL}
-		client, err = binlog.NewBinlogClient(endpoints, tlsConfig)
-		if err == nil {
-			return client, nil
-		}
+	client, err = binlog.NewBinlogClient(endpoints, tlsConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	return

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -154,7 +155,7 @@ func buildBinlogClient(tc *v1alpha1.TidbCluster, control pdapi.PDControlInterfac
 		endpoints = append(endpoints, pdMember.ClientURL)
 	}
 
-	client, err = binlog.NewBinlogClient(endpoints, tlsConfig)
+	client, err = binlog.NewBinlogClient(endpoints, tlsConfig, 5*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -401,8 +401,6 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			tc1 := GetTCForAcrossKubernetes(ns1, tcName1, version, clusterDomain, nil)
 			tc2 := GetTCForAcrossKubernetes(ns2, tcName2, version, clusterDomain, tc1)
 			tc3 := GetTCForAcrossKubernetes(ns3, tcName3, version, clusterDomain, tc1)
-			// FIXME(jsut1900): remove this after #4361 get fixed.
-			tc1.Spec.Pump, tc2.Spec.Pump, tc3.Spec.Pump = nil, nil, nil
 
 			ginkgo.By("Installing initial tidb CA certificate")
 			err := InstallTiDBIssuer(ns1, tcName1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Closes #4361 

### What is changed and how does it work?

For the 2 problems mentioned in #4361 :

1. add all peermembers to endpoints when initializing etcd client. 

2. Instead of timedout every context in pumpclient, I just making the clientv3.New() to return error when underlying endpoints are not available(see https://github.com/etcd-io/etcd/issues/9877), thus to avoid the following client call get stucked indefinitely.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fixed the problem where sync pump would get stuck when the PDs of one Kubernetes cluster are all down in across Kubernetes deployment.
```
