### PR TITLE
Add startUpScriptVersion for pd spec

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -10224,6 +10224,18 @@ bool
 <p>MountClusterClientSecret indicates whether to mount <code>cluster-client-secret</code> to the Pod</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>startUpScriptVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Start up script version</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="pdstatus">PDStatus</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -16863,6 +16863,11 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  startUpScriptVersion:
+                    enum:
+                    - ""
+                    - v1
+                    type: string
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -4917,6 +4917,11 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  startUpScriptVersion:
+                    enum:
+                    - ""
+                    - v1
+                    type: string
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:

--- a/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
@@ -4911,6 +4911,11 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
+                startUpScriptVersion:
+                  enum:
+                  - ""
+                  - v1
+                  type: string
                 statefulSetUpdateStrategy:
                   type: string
                 storageClassName:

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -16857,6 +16857,11 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
+                startUpScriptVersion:
+                  enum:
+                  - ""
+                  - v1
+                  type: string
                 statefulSetUpdateStrategy:
                   type: string
                 storageClassName:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -5138,6 +5138,13 @@ func schema_pkg_apis_pingcap_v1alpha1_PDSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"startUpScriptVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Start up script version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"replicas"},
 			},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -438,6 +438,10 @@ type PDSpec struct {
 	// MountClusterClientSecret indicates whether to mount `cluster-client-secret` to the Pod
 	// +optional
 	MountClusterClientSecret *bool `json:"mountClusterClientSecret,omitempty"`
+	// Start up script version
+	// +optional
+	// +kubebuilder:validation:Enum:="";"v1"
+	StartUpScriptVersion string `json:"startUpScriptVersion,omitempty"`
 }
 
 // TiKVSpec contains details of TiKV members

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -842,11 +842,17 @@ func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	if err != nil {
 		return nil, err
 	}
-	startScript, err := RenderPDStartScript(&PDStartScriptModel{
+
+	sm := &PDStartScriptModel{
 		Scheme:        tc.Scheme(),
 		DataDir:       filepath.Join(pdDataVolumeMountPath, tc.Spec.PD.DataSubDir),
 		ClusterDomain: tc.Spec.ClusterDomain,
-	})
+	}
+	if tc.Spec.PD.StartUpScriptVersion == "v1" {
+		sm.CheckDomainScript = checkDNSV1
+	}
+
+	startScript, err := RenderPDStartScript(sm)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
for version >= v.5.0.5, the nslookup version is changed in the image.

if nameserver in `/etc/resolv.conf` contains not only coredns cluster ip, PD pod will fail to start since the startup script use nslookup and the behavior of nslookup is different from general resolver.

ref: https://serverfault.com/a/398854
https://github.com/coredns/coredns/issues/3835#issuecomment-616715938

https://github.com/isc-projects/bind9/blob/808d0b07b00244de735be68ce85b2652e4e0efec/bin/dig/dighost.c#L4128-L4162
```
  if ((msg->rcode == dns_rcode_servfail && !l->servfail_stops) ||
(check_ra && (msg->flags & DNS_MESSAGEFLAG_RA) == 0 && l->recurse))
```
we will hit the `check_ra&&。。` condition here, and nslookup will try the next nameserver, and the next nameserver will return NXDOMAIN(since it is not the coredns)

### What is changed and how does it work?

support add startUpScriptVersion as v1 to use dig to wait dns can be
resolved:
...
pd:
  startUpScriptVersion: "v1"
...

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- deploy cluster using master version
- upgrade operator as version of the PR
- check will not trigger update of PD

---
- set `startUpScriptVersion` as v1
- check PD start success and startup script is using the v1

---
apply some invalid value
```
The TidbCluster "basic" is invalid: spec.pd.startUpScriptVersion: Unsupported value: "v11": supported values: "", "v1"
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
