### PR TITLE
adjust KubeSchedulerConfiguration api changes in k8s v1.23

### DIFF
--- a/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
+++ b/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
@@ -1,3 +1,24 @@
+{{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: true
+  resourceNamespace: {{ .Release.Namespace }}
+  {{- if eq .Values.appendReleaseSuffix true}}
+  resourceName: {{ .Values.scheduler.schedulerName }}-{{.Release.Name}}
+  {{- else }}
+  resourceName: {{ .Values.scheduler.schedulerName }}
+  {{- end }}
+profiles:
+  - schedulerName: tidb-scheduler
+extenders:
+  - urlPrefix: http://127.0.0.1:10262/scheduler
+    filterVerb: filter
+    preemptVerb: preempt
+    weight: 1
+    enableHTTPS: false
+    httpTimeout: 30s
+{{- else }}
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 leaderElection:
@@ -19,3 +40,4 @@ extenders:
     weight: 1
     enableHTTPS: false
     httpTimeout: 30s
+{{- end }}

--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -69,11 +69,11 @@ spec:
 {{ toYaml .Values.scheduler.resources | indent 12 }}
         command:
         - kube-scheduler
-        - --port=10261
         - --v={{ .Values.scheduler.logLevel }}
         {{- if $lgK8sV119 }}
         - --config=/etc/kubernetes/scheduler-config.yaml
         {{- else }}
+        - --port=10261
         - --leader-elect=true
         - --lock-object-namespace={{ .Release.Namespace }}
         - --policy-configmap-namespace={{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: just1900 <legendj228@gmail.com>

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Closes #4383 
refer to [k8s v1.23 changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#deprecation)

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
adjust KubeSchedulerConfiguration api changes in k8s v1.23
```
