### PR TITLE
Optimize IsAPIGroupVersionResourceSupported method comment

### DIFF
--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -56,9 +56,9 @@ func IsAPIGroupSupported(discoveryCli discovery.DiscoveryInterface, group string
 	return false, nil
 }
 
-// IsAPIGroupVersionSupported checks if given groupVersion and resource is supported by the cluster.
+// IsAPIGroupVersionResourceSupported checks if given groupVersion and resource is supported by the cluster.
 //
-// you can exec `kubectl api-resoures` to find groupVersion and resource.
+// you can exec `kubectl api-resources` to find groupVersion and resource.
 func IsAPIGroupVersionResourceSupported(discoveryCli discovery.DiscoveryInterface, groupversion string, resource string) (bool, error) {
 	apiResourceList, err := discoveryCli.ServerResourcesForGroupVersion(groupversion)
 	if err != nil {

--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -59,8 +59,8 @@ func IsAPIGroupSupported(discoveryCli discovery.DiscoveryInterface, group string
 // IsAPIGroupVersionResourceSupported checks if given groupVersion and resource is supported by the cluster.
 //
 // you can exec `kubectl api-resources` to find groupVersion and resource.
-func IsAPIGroupVersionResourceSupported(discoveryCli discovery.DiscoveryInterface, groupversion string, resource string) (bool, error) {
-	apiResourceList, err := discoveryCli.ServerResourcesForGroupVersion(groupversion)
+func IsAPIGroupVersionResourceSupported(discoveryCli discovery.DiscoveryInterface, groupVersion string, resource string) (bool, error) {
+	apiResourceList, err := discoveryCli.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil


### PR DESCRIPTION

### What problem does this PR solve?
Optimize IsAPIGroupVersionResourceSupported method comment.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
