### PR TITLE
Set a preferred nameserver during nslookup in pd-start-script

### DIFF
--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -151,6 +151,11 @@ encoded_domain_url=` + "`" + `echo ${domain}:2380 | base64 | tr "\n" " " | sed "
 elapseTime=0
 period=1
 threshold=30
+nslookup_args="${domain}"
+if [ -n "${NSLOOKUP_NAMESERVER}" ]; then
+    echo "Using name server: ${NSLOOKUP_NAMESERVER}"
+    nslookup_args="${nslookup_args} ${NSLOOKUP_NAMESERVER}"
+fi
 while true; do
 sleep ${period}
 elapseTime=$(( elapseTime+period ))
@@ -161,7 +166,7 @@ echo "waiting for pd cluster ready timeout" >&2
 exit 1
 fi
 
-if nslookup ${domain} 2>/dev/null
+if nslookup ${nslookup_args} 2>/dev/null
 then
 echo "nslookup domain ${domain}.svc success"
 break

--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -152,7 +152,8 @@ elapseTime=0
 period=1
 threshold=30
 nslookup_args="${domain}"
-if [ -n "${NSLOOKUP_NAMESERVER}" ]; then
+# Check if NSLOOKUP_NAMESERVER is defined
+if [ ${NSLOOKUP_NAMESERVER:-unset} != "unset" ]; then
     echo "Using name server: ${NSLOOKUP_NAMESERVER}"
     nslookup_args="${nslookup_args} ${NSLOOKUP_NAMESERVER}"
 fi


### PR DESCRIPTION
This address a certain issue of not being able to deploy v5.0.5 TiDB cluster in K8s which fails
during PD deployment with the following nslookup error -
---
;; Got recursion not available from 10.60.0.10, trying next server

** server can't find basic-ch-pd-0.basic-ch-pd-peer.rigel-dev.svc: NXDOMAIN
----

Problem Description:
There are two nameservers present in Pods(one of CoreDNS and one of private cloud's DNS). CoreDNS
deployed in K8s has the recursion available (ra) flag disabled and the nslookup command in v5.0.5
image by default uses the recursion flag because there are two nameservers defined in Pods.

Solution:
Use NSLOOKUP_NAMESERVER environment variable as the preferred nameserver to use for lookup in
nslookup.

The following may be added in the TidbCluster spec to use a preffered name server during nslookup -
spec:
  pd:
    env:
      - name: NSLOOKUP_NAMESERVER
        value: 10.43.0.10

Alternate solutions considered:
1. Remove one nameserver - not possible centrally as few cloud services run outside of K8s
which can be resolved by an external nameserver only.
2. Use -norecurse flag in the nslookup command - This works for v5.0.5 image as it has the nslookup
command installed from bind-utils package. But it does not work with the v5.0.1 image as the
nslookup command available in the image does not support this flag.