### PR TITLE
Fix tikv ugprade process when local pd are down

### DIFF
--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -18,8 +18,8 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 )
 
-// GetPDClientFromService gets the pd client from the TidbCluster
-func GetPDClientFromService(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) pdapi.PDClient {
+// getPDClientFromService gets the pd client from the TidbCluster
+func getPDClientFromService(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) pdapi.PDClient {
 	if tc.Heterogeneous() && tc.WithoutLocalPD() {
 		return pdControl.GetPDClient(pdapi.Namespace(tc.Spec.Cluster.Namespace), tc.Spec.Cluster.Name, tc.IsTLSClusterEnabled(),
 			pdapi.TLSCertFromTC(pdapi.Namespace(tc.GetNamespace()), tc.GetName()),
@@ -36,7 +36,7 @@ func GetPDClientFromService(pdControl pdapi.PDControlInterface, tc *v1alpha1.Tid
 // ClientURL example:
 // ClientURL: https://cluster2-pd-0.cluster2-pd-peer.pingcap.svc.cluster2.local
 func GetPDClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) pdapi.PDClient {
-	pdClient := GetPDClientFromService(pdControl, tc)
+	pdClient := getPDClientFromService(pdControl, tc)
 
 	if len(tc.Status.PD.PeerMembers) == 0 {
 		return pdClient

--- a/pkg/controller/pod_control.go
+++ b/pkg/controller/pod_control.go
@@ -119,7 +119,7 @@ func (c *realPodControl) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.Po
 	memberID := labels[label.MemberIDLabelKey]
 	storeID := labels[label.StoreIDLabelKey]
 
-	pdClient := GetPDClientFromService(c.pdControl, tc)
+	pdClient := GetPDClient(c.pdControl, tc)
 
 	if labels[label.ClusterIDLabelKey] == "" {
 		cluster, err := pdClient.GetCluster()

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -263,7 +263,7 @@ func endEvictLeaderbyStoreID(deps *controller.Dependencies, tc *v1alpha1.TidbClu
 		time.Sleep(5 * time.Second)
 	}
 
-	err := controller.GetPDClientFromService(deps.PDControl, tc).EndEvictLeader(storeID)
+	err := controller.GetPDClient(deps.PDControl, tc).EndEvictLeader(storeID)
 	if err != nil {
 		klog.Errorf("tikv: failed to end evict leader for store: %d of %s/%s, error: %v", storeID, tc.Namespace, tc.Name, err)
 		return err

--- a/tests/failover.go
+++ b/tests/failover.go
@@ -165,7 +165,7 @@ func (oa *OperatorActions) TruncateSSTFileThenCheckFailover(info *TidbClusterCon
 	}
 
 	// checkout pd config
-	pdCfg, err := controller.GetPDClientFromService(oa.pdControl, tc).GetConfig()
+	pdCfg, err := controller.GetPDClient(oa.pdControl, tc).GetConfig()
 	if err != nil {
 		log.Logf("ERROR: failed to get the pd config: tc=%s err=%s", info.ClusterName, err.Error())
 		return err
@@ -518,7 +518,7 @@ func (oa *OperatorActions) CheckRecover(cluster *TidbClusterConfig) (bool, error
 	// delete failover member store manually
 	if int32(len(tc.Status.TiKV.Stores)) > tc.Spec.TiKV.Replicas {
 
-		pdclient := controller.GetPDClientFromService(oa.pdControl, tc)
+		pdclient := controller.GetPDClient(oa.pdControl, tc)
 		for _, v := range tc.Status.TiKV.Stores {
 			ordinal, err := util.GetOrdinalFromPodName(v.PodName)
 			if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

- fixes #4412
- Using `GetPDClient` to get pd client, and make `getPDClientFromService` private

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix tikv ugprade process when local pd are down
```
