### PR TITLE
Fix tiflash config after v5.4.0

### DIFF
--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -137,7 +137,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 	{
 		// storage
 		// check "path" to be compatible with old version
-		if common.Get("path") == nil && common.Get("storage") == nil {
+		if common.Get("path") == nil && common.Get("storage.main.dir") == nil {
 			paths := []string{}
 			for i := range tc.Spec.TiFlash.StorageClaims {
 				paths = append(paths, fmt.Sprintf("/data%d/db", i))

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -151,6 +151,8 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		if common.Get("raft.kvstore_path") == nil {
 			common.SetIfNil("storage.raft.dir", []string{"/data0/kvstore"})
 		}
+		// workaround for issue #4091 about v5.4.0 TiFlash
+		common.SetIfNil("tmp_path", "/data0/tmp")
 
 		// port
 		common.SetIfNil("tcp_port", int64(9000))

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -149,7 +149,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		}
 		// check "raft.kvstore_path" to be compatible with old version
 		if common.Get("raft.kvstore_path") == nil {
-			common.SetIfNil("storage.raft.dir", "/data0/kvstore")
+			common.SetIfNil("storage.raft.dir", []string{"/data0/kvstore"})
 		}
 
 		// port

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1512,6 +1512,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1549,6 +1550,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					https_port = 8123
 					tcp_port_secure = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1597,6 +1599,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					https_port = 8123
 					tcp_port_secure = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1651,6 +1654,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1690,6 +1694,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "cluster-1-tidb.default.svc:10080"
@@ -1727,6 +1732,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1767,6 +1773,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
@@ -1807,6 +1814,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					http_port = 8123
 					tcp_port = 9000
+					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "cluster-1-tidb-peer.default.svc:10080"

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1531,7 +1531,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 
@@ -1572,7 +1572,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 					[security]
@@ -1621,7 +1621,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 					[security]
@@ -1670,7 +1670,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db","/data1/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 
@@ -1709,7 +1709,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 
@@ -1746,7 +1746,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 
@@ -1786,7 +1786,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 
@@ -1826,7 +1826,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					  [storage.main]
 						dir = ["/data0/db"]
 					  [storage.raft]
-						dir = "/data0/kvstore"`,
+						dir = ["/data0/kvstore"]`,
 				expectProxyCfg: `
 					log-level = "info"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #4434 
Close #4435

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

    - [x] Deploy operator and v5.4.0 cluster, check the result of using TiFlash.
    - [x] Deploy v1.3.0 operator and v5.3.0 cluster, use TiFlash, then upgrade operator and cluster to v5.4.0 cluster, check the result of using TiFlash.
    - [x] Deploy v1.3.0 operator and v5.4.0 cluster, use TiFlash, then upgrade operator, check the result of using TiFlash.

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue about creating TiFlash replicas for tables
```
