### PR TITLE
Changes required to run TiDB on Istio enabled k8s cluster

### DIFF
--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -1,4 +1,4 @@
-# A Basic TiDB cluster with monitoring
+# A TiDB cluster with monitoring in an Istio enabled kubernetes cluster
 
 > **Note:**
 >

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -1,0 +1,83 @@
+# A Basic TiDB cluster with monitoring
+
+> **Note:**
+>
+> This setup is for test or demo purpose only and **IS NOT** applicable for critical environment. Refer to the [Documents](https://pingcap.com/docs/stable/tidb-in-kubernetes/deploy/prerequisites/) for production setup.
+
+The following steps will create a TiDB cluster with monitoring, the monitoring data is not persisted by default.
+
+**Prerequisites**: 
+- Has TiDB operator `v1.1.0-beta.1` or higher version installed. [Doc](https://pingcap.com/docs/stable/tidb-in-kubernetes/deploy/tidb-operator/)
+- Has default `StorageClass` configured, and there are enough PVs (by default, 6 PVs are required) of that storageClass:
+  
+  This could by verified by the following command:
+  
+  ```bash
+  > kubectl get storageclass
+  ```
+  
+  The output is similar to this:
+  
+  ```bash
+  NAME                 PROVISIONER               AGE
+  standard (default)   kubernetes.io/gce-pd      1d
+  gold                 kubernetes.io/gce-pd      1d
+  ```
+  
+  Alternatively, you could specify the storageClass explicitly by modifying `tidb-cluster.yaml`.
+
+## Disable MTLS
+
+```bash
+> kubectl -n <namespace> apply -f disable-mtls.yaml
+```
+
+## Install
+
+The following commands is assumed to be executed in this directory.
+
+Install the cluster:
+
+```bash
+> kubectl -n <namespace> apply -f tidb-cluster.yaml
+```
+
+```bash
+> kubectl -n <namespace> apply -f tidb-monitor.yaml
+```
+
+Wait for cluster Pods ready:
+
+```bash
+watch kubectl -n <namespace> get pod
+```
+
+## Explore
+
+Explore the TiDB sql interface:
+
+```bash
+> kubectl -n <namespace> port-forward svc/basic-tidb 4000:4000 &>/tmp/pf-tidb.log &
+> mysql -h 127.0.0.1 -P 4000 -u root --comments
+```
+
+Explore the monitoring dashboards:
+
+```bash
+> kubectl -n <namespace> port-forward svc/basic-grafana 3000:3000 &>/tmp/pf-grafana.log &
+```
+
+Browse [localhost:3000](http://localhost:3000).
+
+## Destroy
+
+```bash
+> kubectl -n <namespace> delete -f ./
+```
+
+The PVCs used by TiDB cluster will not be deleted in the above process, therefore, the PVs will be not be released neither. You can delete PVCs and release the PVs by the following command:
+
+```bash
+> kubectl -n <namespace> delete pvc -l app.kubernetes.io/instance=basic,app.kubernetes.io/managed-by=tidb-operator
+```
+

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -28,6 +28,8 @@ The following steps will create a TiDB cluster with monitoring, the monitoring d
 
 ## Disable MTLS
 
+Replace `<namespace>` with your namespace in `disable-mtls.yaml` and apply it.
+
 ```bash
 > kubectl -n <namespace> apply -f disable-mtls.yaml
 ```

--- a/examples/istio/disable-mtls.yaml
+++ b/examples/istio/disable-mtls.yaml
@@ -3,7 +3,6 @@ apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"
 metadata:
   name: "ns-disable-mtls-pa"
-  namespace: "<namespace>"
 spec:
   mtls:
     mode: DISABLE

--- a/examples/istio/disable-mtls.yaml
+++ b/examples/istio/disable-mtls.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "ns-disable-mtls-pa"
+  namespace: "<namespace>"
+spec:
+  mtls:
+    mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "ns-disable-mtls-dr"
+spec:
+  host: "*.<namespace>.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/examples/istio/tidb-cluster.yaml
+++ b/examples/istio/tidb-cluster.yaml
@@ -1,0 +1,54 @@
+# IT IS NOT SUITABLE FOR PRODUCTION USE.
+# This YAML describes a basic TiDB cluster with minimum resource requirements,
+# which should be able to run in any Kubernetes cluster with storage support.
+apiVersion: pingcap.com/v1alpha1
+kind: TidbCluster
+metadata:
+  name: basic
+spec:
+  version: v5.4.0
+  timezone: UTC
+  pvReclaimPolicy: Retain
+  enableDynamicConfiguration: true
+  configUpdateStrategy: RollingUpdate
+  discovery: {}
+  helper:
+    image: busybox:1.34.1
+  pd:
+    baseImage: pingcap/pd
+    maxFailoverCount: 0
+    replicas: 1
+    # if storageClassName is not set, the default Storage Class of the Kubernetes cluster will be used
+    # storageClassName: local-storage
+    requests:
+      storage: "1Gi"
+    config: {}
+  tikv:
+    baseImage: pingcap/tikv
+    maxFailoverCount: 0
+    # If only 1 TiKV is deployed, the TiKV region leader 
+    # cannot be transferred during upgrade, so we have
+    # to configure a short timeout
+    evictLeaderTimeout: 1m
+    replicas: 1
+    # if storageClassName is not set, the default Storage Class of the Kubernetes cluster will be used
+    # storageClassName: local-storage
+    requests:
+      storage: "1Gi"
+    config:
+      storage:
+        # In basic examples, we set this to avoid using too much storage.
+        reserve-space: "0MB"
+      rocksdb:
+        # In basic examples, we set this to avoid the following error in some Kubernetes clusters:
+        # "the maximum number of open file descriptors is too small, got 1024, expect greater or equal to 82920"
+        max-open-files: 256
+      raftdb:
+        max-open-files: 256
+  tidb:
+    baseImage: pingcap/tidb
+    maxFailoverCount: 0
+    replicas: 1
+    service:
+      type: ClusterIP
+    config: {}

--- a/examples/istio/tidb-monitor.yaml
+++ b/examples/istio/tidb-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: pingcap.com/v1alpha1
+kind: TidbMonitor
+metadata:
+  name: basic
+spec:
+  replicas: 1
+  clusters:
+  - name: basic
+  prometheus:
+    baseImage: prom/prometheus
+    version: v2.27.1
+  grafana:
+    baseImage: grafana/grafana
+    version: 7.5.11
+  initializer:
+    baseImage: pingcap/tidb-monitor-initializer
+    version: v5.4.0
+  reloader:
+    baseImage: pingcap/tidb-monitor-reloader
+    version: v1.0.1
+  imagePullPolicy: IfNotPresent

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -502,9 +502,15 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 			ClusterIP: "None",
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "peer",
+					Name:       "tcp-peer-2380",
 					Port:       2380,
 					TargetPort: intstr.FromInt(2380),
+					Protocol:   corev1.ProtocolTCP,
+				},
+				{
+					Name:       "tcp-peer-2379",
+					Port:       2379,
+					TargetPort: intstr.FromInt(2379),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -930,11 +930,17 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 					ClusterIP: "None",
 					Ports: []corev1.ServicePort{
 						{
-							Name:       "peer",
+							Name:       "tcp-peer-2380",
 							Port:       2380,
 							TargetPort: intstr.FromInt(2380),
 							Protocol:   corev1.ProtocolTCP,
 						},
+						{
+							Name:       "tcp-peer-2379",
+							Port:       2379,
+							TargetPort: intstr.FromInt(2379),
+							Protocol:   corev1.ProtocolTCP,
+				},
 					},
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -940,7 +940,7 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 							Port:       2379,
 							TargetPort: intstr.FromInt(2379),
 							Protocol:   corev1.ProtocolTCP,
-				},
+						},
 					},
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",


### PR DESCRIPTION
### What problem does this PR solve?

Run TiDB on istio enabled k8s cluster
Closes: https://github.com/pingcap/tidb-operator/issues/4150

### What is changed and how does it work?
For TiDB to work on Istio enabled k8s cluster below are the configuration changes needed

1. Disable MTLS
```
---
apiVersion: "security.istio.io/v1beta1"
kind: "PeerAuthentication"
metadata:
  name: "ns-disable-mtls-pa"
  namespace: "<namespace>"
spec:
  mtls:
    mode: DISABLE
---
apiVersion: "networking.istio.io/v1alpha3"
kind: "DestinationRule"
metadata:
  name: "ns-disable-mtls-dr"
spec:
  host: "*.<namespace>.svc.cluster.local"
  trafficPolicy:
    tls:
      mode: DISABLE
```

2. Prefix protocol name to peer port or in Kubernetes 1.18+ by the appProtocol 
3. Add port 2379 to PD peer service to create listeners for pod DNS with this port as we have noticed that other components of TiDB communicate to a particular replica of PD using pod DNS and on this port

This PR addresses 2nd and 3rd only, 1st one can be manually applied for now

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manually tested on Istio 1.11.4 <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->

```release-note
Support for TiDB to run on Istio enabled kubernetes cluster
```
