### PR TITLE
TiFlash add metrics port

### DIFF
--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -289,7 +289,7 @@ func getNewHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 				},
 
 				{
-					Name:       "tiflash-proxy",
+					Name:       "proxy-metrics",
 					Port:       20292,
 					TargetPort: intstr.FromInt(int(20292)),
 					Protocol:   corev1.ProtocolTCP,

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -281,6 +281,12 @@ func getNewHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 					TargetPort: intstr.FromInt(int(20170)),
 					Protocol:   corev1.ProtocolTCP,
 				},
+				{
+					Name:       "metrics",
+					Port:       8234,
+					TargetPort: intstr.FromInt(int(8234)),
+					Protocol:   corev1.ProtocolTCP,
+				},
 			},
 			Selector:                 svcLabel,
 			PublishNotReadyAddresses: true,

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -287,6 +287,13 @@ func getNewHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 					TargetPort: intstr.FromInt(int(8234)),
 					Protocol:   corev1.ProtocolTCP,
 				},
+
+				{
+					Name:       "tiflash-proxy",
+					Port:       20292,
+					TargetPort: intstr.FromInt(int(20292)),
+					Protocol:   corev1.ProtocolTCP,
+				},
 			},
 			Selector:                 svcLabel,
 			PublishNotReadyAddresses: true,


### PR DESCRIPTION
### What problem does this PR solve?
Reslove #3184
### What is changed and how does it work?
TiFlash add metrics port.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
