### PR TITLE
enable prometheus reloader rule default

### DIFF
--- a/pkg/monitor/monitor/monitor_manager_test.go
+++ b/pkg/monitor/monitor/monitor_manager_test.go
@@ -284,7 +284,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 
 				sts, err := tmm.deps.StatefulSetLister.StatefulSets(tm.Namespace).Get(GetMonitorObjectName(tm))
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
+				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(4))
 			},
 			stsCreated:    true,
 			svcCreated:    true,
@@ -327,7 +327,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 
 				sts, err := tmm.deps.StatefulSetLister.StatefulSets(tm.Namespace).Get(GetMonitorObjectName(tm))
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
+				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(4))
 			},
 			stsCreated:    true,
 			svcCreated:    true,
@@ -364,7 +364,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				sts, err := tmm.deps.StatefulSetLister.StatefulSets(tm.Namespace).Get(GetMonitorObjectName(tm))
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
+				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(4))
 
 			},
 			stsCreated:    true,
@@ -393,7 +393,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 				errExpectRequeuefunc(g, err, tmm, tm)
 				sts, err := tmm.deps.StatefulSetLister.StatefulSets(tm.Namespace).Get(GetMonitorObjectName(tm))
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(2))
+				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
 				g.Expect(sts.Spec.Template.Spec.InitContainers).To(HaveLen(2))
 			},
 			stsCreated:    true,
@@ -589,7 +589,7 @@ func TestTidbMonitorSyncUpdate(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				sts, err := tmm.deps.StatefulSetLister.StatefulSets(tm.Namespace).Get(GetMonitorObjectName(tm))
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(3))
+				g.Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(4))
 			},
 			update: func(tmm *MonitorManager, monitor *v1alpha1.TidbMonitor) {
 				monitor.Spec.Grafana.Service.Type = v1.ServiceTypeLoadBalancer


### PR DESCRIPTION
### What problem does this PR solve?
#4467
### What is changed and how does it work?
Enable prometheus reloader image default.
### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Enable prometheus reloader image default.
```
