### PR TITLE
optimize clean pod log

### DIFF
--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -69,17 +69,16 @@ func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1
 			klog.Infof("For backup %s, delete %d objects successfully", bo, len(result.Deleted))
 			klog.V(4).Infof("For backup %s, all objects deleted: %s", bo, strings.Join(result.Deleted, ","))
 		}
-		if len(result.Deleted) < len(objs) {
-			if len(result.Errors) != 0 {
-				klog.Errorf("For backup %s, delete %d objects failed", bo, len(result.Errors))
-				for _, oerr := range result.Errors {
-					klog.V(4).Infof("For backup %s, delete object %s failed: %s", bo, oerr.Key, oerr.Err)
-				}
-			} else {
-				klog.Errorf("For backup %s, deleted objects are less than expected but failed is 0, deleted: %d, expected: %d", bo, len(result.Deleted), len(objs))
+		if len(result.Errors) != 0 {
+			klog.Errorf("For backup %s, delete %d objects failed", bo, len(result.Errors))
+			for _, oerr := range result.Errors {
+				klog.V(4).Infof("For backup %s, delete object %s failed: %s", bo, oerr.Key, oerr.Err)
 			}
-
-			return fmt.Errorf("objects remain to delete")
+			return fmt.Errorf("some objects failed to delete")
+		}
+		if len(result.Deleted) < len(objs) {
+			klog.Errorf("For backup %s, deleted objects are less than expected, deleted: %d, expected: %d", bo, len(result.Deleted), len(objs))
+			return fmt.Errorf("some objects remain to delete")
 		}
 	}
 

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -60,23 +60,23 @@ func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1
 			return err
 		}
 
-		klog.Infof("For backup %s, try to delete %s objects", bo, len(objs))
+		klog.Infof("For backup %s, try to delete %d objects", bo, len(objs))
 
 		// batch delete objects
 		result := s.BatchDeleteObjects(ctx, objs, opt.BatchDeleteOption)
 
 		if len(result.Deleted) != 0 {
-			klog.Infof("For backup %s, delete %s objects successfully", bo, len(result.Deleted))
+			klog.Infof("For backup %s, delete %d objects successfully", bo, len(result.Deleted))
 			klog.V(4).Infof("For backup %s, all objects deleted: %s", bo, strings.Join(result.Deleted, ","))
 		}
 		if len(result.Deleted) < len(objs) {
 			if len(result.Errors) != 0 {
-				klog.Errorf("For backup %s, delete %s objects failed", bo, len(result.Errors))
+				klog.Errorf("For backup %s, delete %d objects failed", bo, len(result.Errors))
 				for _, oerr := range result.Errors {
 					klog.V(4).Infof("For backup %s, delete object %s failed: %s", bo, oerr.Key, oerr.Err)
 				}
 			} else {
-				klog.Errorf("For backup %s, deleted objects are less than expected but failed is 0, deleted: %s, expected: %s", bo, len(result.Deleted), len(objs))
+				klog.Errorf("For backup %s, deleted objects are less than expected but failed is 0, deleted: %d, expected: %d", bo, len(result.Deleted), len(objs))
 			}
 
 			return fmt.Errorf("objects remain to delete")

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -60,16 +60,25 @@ func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1
 			return err
 		}
 
+		klog.Infof("For backup %s, try to delete %s objects", bo, len(objs))
+
 		// batch delete objects
 		result := s.BatchDeleteObjects(ctx, objs, opt.BatchDeleteOption)
 
 		if len(result.Deleted) != 0 {
-			klog.Infof("delete %d objects for cluster %s successfully: %s", len(result.Deleted), bo, strings.Join(result.Deleted, ","))
+			klog.Infof("For backup %s, delete %s objects successfully", bo, len(result.Deleted))
+			klog.V(4).Infof("For backup %s, all objects deleted: %s", bo, strings.Join(result.Deleted, ","))
 		}
-		if len(result.Errors) != 0 {
-			for _, oerr := range result.Errors {
-				klog.Errorf("delete object %s for cluster %s failed: %s", oerr.Key, bo, oerr.Err)
+		if len(result.Deleted) < len(objs) {
+			if len(result.Errors) != 0 {
+				klog.Errorf("For backup %s, delete %s objects failed", bo, len(result.Errors))
+				for _, oerr := range result.Errors {
+					klog.V(4).Infof("For backup %s, delete object %s failed: %s", bo, oerr.Key, oerr.Err)
+				}
+			} else {
+				klog.Errorf("For backup %s, deleted object is less than expected but failed is 0, deleted: %s, expected: %s", bo, len(result.Deleted), len(objs))
 			}
+
 			return fmt.Errorf("objects remain to delete")
 		}
 	}

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -76,7 +76,7 @@ func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1
 					klog.V(4).Infof("For backup %s, delete object %s failed: %s", bo, oerr.Key, oerr.Err)
 				}
 			} else {
-				klog.Errorf("For backup %s, deleted object is less than expected but failed is 0, deleted: %s, expected: %s", bo, len(result.Deleted), len(objs))
+				klog.Errorf("For backup %s, deleted objects are less than expected but failed is 0, deleted: %s, expected: %s", bo, len(result.Deleted), len(objs))
 			}
 
 			return fmt.Errorf("objects remain to delete")

--- a/pkg/controller/backup/backup_control.go
+++ b/pkg/controller/backup/backup_control.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
@@ -102,6 +103,7 @@ func (c *defaultBackupControl) removeProtectionFinalizer(backup *v1alpha1.Backup
 		if err != nil {
 			return fmt.Errorf("remove backup %s/%s protection finalizers failed, err: %v", ns, name, err)
 		}
+		klog.Infof("remove backup %s/%s protection finalizers success", ns, name)
 		return controller.RequeueErrorf(fmt.Sprintf("backup %s/%s has been cleaned up", ns, name))
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
* Return error when deleted objects are less than input.
* Only log count for deleted objects and failed objects.
* Add log when removing backup's finalizer.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
