### PR TITLE
Resize pvc one by one

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -8683,6 +8683,18 @@ int
 </tr>
 <tr>
 <td>
+<code>resizingCount</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResizingCount is the count of volumes that are resizing.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>currentCount</code></br>
 <em>
 int

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -10453,6 +10453,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         resizedCount:
                           type: integer
+                        resizingCount:
+                          type: integer
                       required:
                       - currentCapacity
                       - name
@@ -10566,6 +10568,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -29613,6 +29617,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         resizedCount:
                           type: integer
+                        resizingCount:
+                          type: integer
                       required:
                       - currentCapacity
                       - name
@@ -29707,6 +29713,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -29804,6 +29812,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -29920,6 +29930,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -30097,6 +30109,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -30286,6 +30300,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity

--- a/manifests/crd/v1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_dmclusters.yaml
@@ -7659,6 +7659,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         resizedCount:
                           type: integer
+                        resizingCount:
+                          type: integer
                       required:
                       - currentCapacity
                       - name
@@ -7772,6 +7774,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -17414,6 +17414,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         resizedCount:
                           type: integer
+                        resizingCount:
+                          type: integer
                       required:
                       - currentCapacity
                       - name
@@ -17508,6 +17510,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -17605,6 +17609,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -17721,6 +17727,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -17898,6 +17906,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity
@@ -18087,6 +18097,8 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizedCount:
+                          type: integer
+                        resizingCount:
                           type: integer
                       required:
                       - currentCapacity

--- a/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
@@ -7649,6 +7649,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       resizedCount:
                         type: integer
+                      resizingCount:
+                        type: integer
                     required:
                     - currentCapacity
                     - name
@@ -7762,6 +7764,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity

--- a/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
@@ -17391,6 +17391,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       resizedCount:
                         type: integer
+                      resizingCount:
+                        type: integer
                     required:
                     - currentCapacity
                     - name
@@ -17485,6 +17487,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -17582,6 +17586,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -17698,6 +17704,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -17875,6 +17883,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -18064,6 +18074,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -10447,6 +10447,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       resizedCount:
                         type: integer
+                      resizingCount:
+                        type: integer
                     required:
                     - currentCapacity
                     - name
@@ -10560,6 +10562,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -29590,6 +29594,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       resizedCount:
                         type: integer
+                      resizingCount:
+                        type: integer
                     required:
                     - currentCapacity
                     - name
@@ -29684,6 +29690,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -29781,6 +29789,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -29897,6 +29907,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -30074,6 +30086,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity
@@ -30263,6 +30277,8 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       resizedCount:
+                        type: integer
+                      resizingCount:
                         type: integer
                     required:
                     - currentCapacity

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2435,6 +2435,9 @@ type ObservedStorageVolumeStatus struct {
 	// BoundCount is the count of bound volumes.
 	// +optional
 	BoundCount int `json:"boundCount"`
+	// ResizingCount is the count of volumes that are resizing.
+	// +optional
+	ResizingCount int `json:"resizingCount"`
 	// CurrentCount is the count of volumes whose capacity is equal to `currentCapacity`.
 	// +optional
 	CurrentCount int `json:"currentCount"`


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

* Add `resizingCount` field in volume status
* Before resize, check whether `resizingCount` is zero
* Resize only one PVC one time

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

Resize tikv volume and check whether resize PVC one by one.

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Resize pvc one by one
```
