### PR TITLE
Resize PVCs pod by pod

### DIFF
--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -529,7 +529,6 @@ func (p *pvcResizer) collectAcutalStatus(ns string, selector labels.Selector) ([
 	}
 
 	for _, pod := range pods {
-		pods := pod.DeepCopy()
 		volToPVCs := map[v1alpha1.StorageVolumeName]*corev1.PersistentVolumeClaim{}
 
 		for _, vol := range pod.Spec.Volumes {

--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -87,7 +88,10 @@ type podVolumeContext struct {
 }
 
 type componentVolumeContext struct {
-	comp v1alpha1.MemberType
+	comp      v1alpha1.MemberType
+	namespace string
+	name      string
+
 	// label selector for pvc and pod
 	selector labels.Selector
 	// desiredVolumeSpec is the volume request in tc spec
@@ -395,37 +399,48 @@ func (p *pvcResizer) resizeVolumes(ctx *componentVolumeContext) error {
 	desiredVolumeQuantity := ctx.desiredVolumeQuantity
 	podVolumes := ctx.actualPodVolumes
 
+	tcID := fmt.Sprintf("%s/%s", ctx.namespace, ctx.name)
+
 	for _, podVolume := range podVolumes {
+
+		allResized := true
+
 		for volName, pvc := range podVolume.volToPVCs {
+			pvcID := fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name)
+
+			// check whether the PVC is resized
 			quantityInSpec, exist := desiredVolumeQuantity[volName]
 			if !exist {
-				klog.Warningf("PVC %s/%s does not exist in desired volumes", pvc.Namespace, pvc.Name)
+				klog.Errorf("Check PVC %q of TC %q resized failed: not exist in desired volumes", pvcID, tcID)
 				continue
 			}
-
-			// not support default storage class
-			if pvc.Spec.StorageClassName == nil {
-				klog.Warningf("PVC %s/%s has no storage class, skipped", pvc.Namespace, pvc.Name)
-				continue
-			}
-
-			// check whether the volume needs to be expanded
 			currentRequest, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 			if !ok {
-				klog.Warningf("PVC %s/%s storage request is empty, skipped", pvc.Namespace, pvc.Name)
+				klog.Errorf("Check PVC %q of TC %q resized failed: storage request is empty", pvcID, tcID)
 				continue
 			}
 			cmpVal := quantityInSpec.Cmp(currentRequest)
 			if cmpVal == 0 {
-				klog.V(4).Infof("PVC %s/%s storage request is already %s, skipped", pvc.Namespace, pvc.Name, quantityInSpec.String())
-				continue
-			}
-			if cmpVal < 0 {
-				klog.Warningf("PVC %s/%s/ storage request cannot be shrunk (%s to %s), skipped",
-					pvc.Namespace, pvc.Name, currentRequest.String(), quantityInSpec.String())
+				klog.V(4).Infof("PVC %q of TC %q storage request is already %s, skip resize",
+					pvcID, tcID, quantityInSpec.String())
 				continue
 			}
 
+			allResized = false
+
+			// check whether the PVC can be resized
+
+			// not support shrink
+			if cmpVal < 0 {
+				klog.Warningf("Skip to resize PVC %q of TC %q: storage request cannot be shrunk (%s to %s)",
+					pvcID, tcID, currentRequest.String(), quantityInSpec.String())
+				continue
+			}
+			// not support default storage class
+			if pvc.Spec.StorageClassName == nil {
+				klog.Warningf("Skip to resize PVC %q of TC %q: PVC have no storage class", pvcID, tcID)
+				continue
+			}
 			// check whether the storage class support
 			if p.deps.StorageClassLister != nil {
 				volumeExpansionSupported, err := p.isVolumeExpansionSupported(*pvc.Spec.StorageClassName)
@@ -433,13 +448,13 @@ func (p *pvcResizer) resizeVolumes(ctx *componentVolumeContext) error {
 					return err
 				}
 				if !volumeExpansionSupported {
-					klog.Warningf("Storage Class %q used by PVC %s/%s does not support volume expansion, skipped",
-						*pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
+					klog.Warningf("Skip to resize PVC %q of TC %q: storage class %q does not support volume expansion",
+						*pvc.Spec.StorageClassName, pvcID, tcID)
 					continue
 				}
 			} else {
-				klog.V(4).Infof("Storage classes lister is unavailable, skip checking volume expansion support for PVC %s/%s with storage class %s. This may be caused by no relevant permissions",
-					pvc.Namespace, pvc.Name, *pvc.Spec.StorageClassName)
+				klog.V(4).Infof("Storage classes lister is unavailable, skip checking volume expansion support for PVC %q of TC %q with storage class %s. This may be caused by no relevant permissions",
+					pvcID, tcID, *pvc.Spec.StorageClassName)
 			}
 
 			// patch PVC to expand the storage
@@ -460,8 +475,14 @@ func (p *pvcResizer) resizeVolumes(ctx *componentVolumeContext) error {
 				return err
 			}
 
-			klog.V(2).Infof("PVC %s/%s storage request is updated from %s to %s",
-				pvc.Namespace, pvc.Name, currentRequest.String(), quantityInSpec.String())
+			klog.V(2).Infof("PVC %q of TC %q storage request is updated from %s to %s",
+				pvcID, tcID, currentRequest.String(), quantityInSpec.String())
+		}
+
+		if !allResized {
+			klog.Infof("Skip to resize other PVCs of TC %q: wait all PVCs in Pod %s/%s to be resized",
+				tcID, podVolume.pod.Namespace, podVolume.pod.Name)
+			break
 		}
 	}
 
@@ -509,6 +530,11 @@ func (p *pvcResizer) collectAcutalStatus(ns string, selector labels.Selector) ([
 			volToPVCs: volToPVCs,
 		})
 	}
+
+	// sort by pod name to ensure the order is stable
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].pod.Name < result[j].pod.Name
+	})
 
 	return result, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

1. Deploy tc and tikv have three volumes
2. Scale up three volumes
3. Check the resize is pod by pod


- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Resize PVCs pod by pod 
```
