### PR TITLE
Use baseImage which is effective

### DIFF
--- a/charts/tidb-cluster/templates/tidb-cluster.yaml
+++ b/charts/tidb-cluster/templates/tidb-cluster.yaml
@@ -34,7 +34,7 @@ spec:
     image: {{ .Values.helper.image }}
   pd:
     replicas: {{ .Values.pd.replicas }}
-    image: {{ .Values.pd.image }}
+    baseImage: {{ .Values.pd.image }}
     imagePullPolicy: {{ .Values.pd.imagePullPolicy | default "IfNotPresent" }}
   {{- if .Values.pd.storageClassName }}
     storageClassName: {{ .Values.pd.storageClassName }}
@@ -69,7 +69,7 @@ spec:
   {{- end }}
   tikv:
     replicas: {{ .Values.tikv.replicas }}
-    image: {{ .Values.tikv.image }}
+    baseImage: {{ .Values.tikv.image }}
     imagePullPolicy: {{ .Values.tikv.imagePullPolicy | default "IfNotPresent" }}
   {{- if .Values.tikv.storageClassName }}
     storageClassName: {{ .Values.tikv.storageClassName }}
@@ -104,7 +104,7 @@ spec:
 {{ toYaml .Values.tidb.tlsClient | indent 6 }}
   {{- end }}
     replicas: {{ .Values.tidb.replicas }}
-    image: {{ .Values.tidb.image }}
+    baseImage: {{ .Values.tidb.image }}
     imagePullPolicy: {{ .Values.tidb.imagePullPolicy | default "IfNotPresent" }}
   {{- if .Values.tidb.resources }}
 {{ toYaml .Values.tidb.resources | indent 4 }}


### PR DESCRIPTION
### What problem does this PR solve?
It fixes a bug in helm chart.

### What is changed and how does it work?
When `baseImage` is not specified in YAML, controller populate baseImage to default value "pingcap/pd" and that takes precedence over image specified via spec.pd/tikv/tidb.image. (see https://github.com/pingcap/tidb-operator/blob/master/pkg/apis/pingcap/v1alpha1/tidbcluster.go#L104)

Below YAML is getting created with current chart which is wrong as the container gets created with `pingcap/pd` image.
```
pd:
    baseImage: pingcap/pd
    image: registry-personal.com/tidb/pd:v5.4.1
```

With this change, following yaml will be generated - 
```
pd:
    baseImage: registry-personal.com/tidb/pd:v5.4.1 
```

### Code changes

- [ ] Has helm chart changes

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
