### PR TITLE
Fix the issue than can not upgrade tikv when using local storage

### DIFF
--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -480,12 +480,14 @@ func (p *pvcResizer) classifyVolumes(ctx *componentVolumeContext, volumes []*vol
 			continue
 		}
 
-		if cmpVal < 0 { // not support shrink
+		// check whether the PVC can be resized
+
+		// not support shrink
+		if cmpVal < 0 {
 			klog.Warningf("Skip to resize PVC %q of %q: storage request cannot be shrunk (%s to %s)",
 				pvcID, cid, currentRequest.String(), quantityInSpec.String())
 			continue
 		}
-
 		// not support default storage class
 		if pvc.Spec.StorageClassName == nil {
 			klog.Warningf("Skip to resize PVC %q of %q: PVC have no storage class", pvcID, cid)

--- a/pkg/manager/member/pvc_resizer.go
+++ b/pkg/manager/member/pvc_resizer.go
@@ -480,6 +480,12 @@ func (p *pvcResizer) classifyVolumes(ctx *componentVolumeContext, volumes []*vol
 			continue
 		}
 
+		if cmpVal < 0 { // not support shrink
+			klog.Warningf("Skip to resize PVC %q of %q: storage request cannot be shrunk (%s to %s)",
+				pvcID, cid, currentRequest.String(), quantityInSpec.String())
+			continue
+		}
+
 		// not support default storage class
 		if pvc.Spec.StorageClassName == nil {
 			klog.Warningf("Skip to resize PVC %q of %q: PVC have no storage class", pvcID, cid)
@@ -499,12 +505,6 @@ func (p *pvcResizer) classifyVolumes(ctx *componentVolumeContext, volumes []*vol
 		} else {
 			klog.V(4).Infof("Storage classes lister is unavailable, skip checking volume expansion support for PVC %q of %q with storage class %s. This may be caused by no relevant permissions",
 				pvcID, cid, *pvc.Spec.StorageClassName)
-		}
-
-		if cmpVal < 0 { // not support shrink
-			klog.Warningf("Skip to resize PVC %q of %q: storage request cannot be shrunk (%s to %s)",
-				pvcID, cid, currentRequest.String(), quantityInSpec.String())
-			continue
 		}
 
 		needResizeVolumes = append(needResizeVolumes, volume)

--- a/pkg/manager/member/pvc_resizer_test.go
+++ b/pkg/manager/member/pvc_resizer_test.go
@@ -853,37 +853,6 @@ func TestClassifyVolumes(t *testing.T) {
 				diffVolumes(g, volumes, expectVolumes)
 			},
 		},
-		"skip resize when resize pv manually": {
-			setup: func(ctx *componentVolumeContext) []*volume {
-				ctx.desiredVolumeQuantity = map[v1alpha1.StorageVolumeName]resource.Quantity{
-					"volume-1": resource.MustParse("2Gi"),
-					"volume-2": resource.MustParse("2Gi"),
-					"volume-3": resource.MustParse("2Gi"),
-				}
-				volumes := []*volume{
-					newVolume("volume-1", newMockPVC("volume-1-pvc-1", scName, "2Gi", "3Gi")),
-					newVolume("volume-2", newMockPVC("volume-2-pvc-1", scName, "2Gi", "3Gi")),
-					newVolume("volume-3", newMockPVC("volume-3-pvc-1", scName, "2Gi", "3Gi")),
-				}
-
-				return volumes
-			},
-			sc: newStorageClass(scName, true),
-			expect: func(g *GomegaWithT, volumes map[volumePhase][]*volume, err error) {
-				expectVolumes := map[volumePhase][]*volume{
-					needResize: {},
-					resized: {
-						newVolume("volume-1", newMockPVC("volume-1-pvc-1", scName, "2Gi", "3Gi")),
-						newVolume("volume-2", newMockPVC("volume-2-pvc-1", scName, "2Gi", "3Gi")),
-						newVolume("volume-3", newMockPVC("volume-3-pvc-1", scName, "2Gi", "3Gi")),
-					},
-					resizing: {},
-				}
-
-				g.Expect(err).To(Succeed())
-				diffVolumes(g, volumes, expectVolumes)
-			},
-		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Close #4616
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that can not upgrade tikv when using local storage
```
