### PR TITLE
add: validation for service in pd

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/validation/validation.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation.go
@@ -148,6 +148,9 @@ func validatePDSpec(spec *v1alpha1.PDSpec, fldPath *field.Path) field.ErrorList 
 	if len(spec.StorageVolumes) > 0 {
 		allErrs = append(allErrs, validateStorageVolumes(spec.StorageVolumes, fldPath.Child("storageVolumes"))...)
 	}
+	if spec.Service != nil {
+		allErrs = append(allErrs, validateService(spec.Service, fldPath)...)
+	}
 	return allErrs
 }
 

--- a/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
@@ -656,3 +656,50 @@ func TestValidatePDAddresses(t *testing.T) {
 		}
 	}
 }
+
+func TestValidatePDSpec(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []struct {
+		name                     string
+		LoadBalancerSourceRanges []string
+		resourceRequirements     corev1.ResourceRequirements
+		expectedErrors           int
+	}{
+		{
+			name: "has valid LoadBalancerSourceRanges",
+			LoadBalancerSourceRanges: []string{
+				"10.0.0.0/8",
+			},
+			resourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10G"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "has invalid LoadBalancerSourceRanges",
+			LoadBalancerSourceRanges: []string{
+				"invalidIP",
+			},
+			resourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10G"),
+				},
+			},
+			expectedErrors: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newTidbCluster()
+			tc.Spec.PD.ResourceRequirements = tt.resourceRequirements
+			tc.Spec.PD.Service = &v1alpha1.ServiceSpec{
+				LoadBalancerSourceRanges: tt.LoadBalancerSourceRanges,
+			}
+			err := validatePDSpec(tc.Spec.PD, field.NewPath("pd"))
+			r := len(err)
+			g.Expect(r).Should(Equal(tt.expectedErrors))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
This PR solves the problem that when validating PD spec, `Service` is not validated. This causes the invalid IP in `Spec.PD.Service.LoadBalancerSourceRanges` being silently rejected. However, according to the [source code](https://github.com/pingcap/tidb-operator/blob/346a330c71e2f50e98b0f5394660f9713821cf3a/pkg/apis/pingcap/v1alpha1/validation/validation.go#L632) of this operator, the function `validateService` is used to validate the field `LoadBalancerSourceRanges`, and the operator is supposed to throw an error message for the invalid IP in `LoadBalancerSourceRanges`  . 

Details of this problem can be found at https://github.com/pingcap/tidb-operator/issues/4637.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
We added a sanity check in the function `validatePDSpec` by calling the function `validateService`. This change ensures that when validating PD spec, `Spec.PD.Service` is also validated.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Add validation for `Spec.PD.Service`.
```
