### PR TITLE
ticdc: wait TiCDC cluster becomes healthy after resigning owner

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -230,6 +230,23 @@ func (tc *TidbCluster) TiCDCImage() string {
 	return image
 }
 
+// TiCDCVersion returns the image version used by TiCDC.
+//
+// If TiCDC isn't specified, return empty string.
+func (tc *TidbCluster) TiCDCVersion() string {
+	if tc.Spec.TiCDC == nil {
+		return ""
+	}
+
+	image := tc.TiCDCImage()
+	colonIdx := strings.LastIndexByte(image, ':')
+	if colonIdx >= 0 {
+		return image[colonIdx+1:]
+	}
+
+	return "latest"
+}
+
 // TiCDCGracefulShutdownTimeout returns the timeout of gracefully shutdown
 // a TiCDC pod.
 func (tc *TidbCluster) TiCDCGracefulShutdownTimeout() time.Duration {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
@@ -673,6 +673,56 @@ func TestPDVersion(t *testing.T) {
 	}
 }
 
+func TestTiCDCVersion(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name     string
+		update   func(*TidbCluster)
+		expectFn func(*GomegaWithT, *TidbCluster)
+	}
+	testFn := func(test *testcase, t *testing.T) {
+		t.Log(test.name)
+
+		tc := newTidbCluster()
+		test.update(tc)
+		test.expectFn(g, tc)
+	}
+	tests := []testcase{
+		{
+			name: "has tag",
+			update: func(tc *TidbCluster) {
+				tc.Spec.TiCDC.Image = "pingcap/ticdc:v3.1.0"
+			},
+			expectFn: func(g *GomegaWithT, tc *TidbCluster) {
+				g.Expect(tc.TiCDCVersion()).To(Equal("v3.1.0"))
+			},
+		},
+		{
+			name: "don't have tag",
+			update: func(tc *TidbCluster) {
+				tc.Spec.TiCDC.Image = "pingcap/ticdc"
+			},
+			expectFn: func(g *GomegaWithT, tc *TidbCluster) {
+				g.Expect(tc.TiCDCVersion()).To(Equal("latest"))
+			},
+		},
+		{
+			name: "don't have ticdc",
+			update: func(tc *TidbCluster) {
+				tc.Spec.TiCDC = nil
+			},
+			expectFn: func(g *GomegaWithT, tc *TidbCluster) {
+				g.Expect(tc.TiCDCVersion()).To(Equal(""))
+			},
+		},
+	}
+
+	for i := range tests {
+		testFn(&tests[i], t)
+	}
+}
+
 func TestTiCDCGracefulShutdownTimeout(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -62,6 +62,9 @@ type TiCDCControlInterface interface {
 	// otherwise caller should retry resign owner.
 	// If there is only one capture, it always return true.
 	ResignOwner(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error)
+	// IsHealthy gets the healthy status of TiCDC cluster.
+	// Returns true if the TiCDC cluster is heathy.
+	IsHealthy(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error)
 }
 
 // defaultTiCDCControl is default implementation of TiCDCControlInterface.
@@ -218,6 +221,48 @@ func (c *defaultTiCDCControl) ResignOwner(tc *v1alpha1.TidbCluster, ordinal int3
 	return false, nil
 }
 
+func (c *defaultTiCDCControl) IsHealthy(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
+	httpClient, err := c.getHTTPClient(tc)
+	if err != nil {
+		klog.Warningf("ticdc control: get http client failed, error: %v", err)
+		return false, err
+	}
+
+	captures, retry, err := getCaptures(httpClient, c.getBaseURL(tc, ordinal))
+	if err != nil {
+		klog.Warningf("ticdc control: get capture failed, error: %v", err)
+		return false, err
+	}
+	if retry {
+		// Let caller retry.
+		return false, nil
+	}
+
+	_, owner := getOrdinalAndOwnerCaptureInfo(tc, ordinal, captures)
+	if owner == nil {
+		// Unhealthy, owner is not found.
+		return false, nil
+	}
+
+	healthURL := fmt.Sprintf("%s://%s/api/v1/health", tc.Scheme(), owner.AdvertiseAddr)
+	res, err := httpClient.Get(healthURL)
+	if err != nil {
+		return false, fmt.Errorf("ticdc get health failed, request error: %v", err)
+	}
+	httputil.DeferClose(res.Body)
+	if res.StatusCode == http.StatusNotFound {
+		// It is likely the TiCDC does not support the API, ignore.
+		klog.Infof("ticdc control: %s does not support health API, skip", owner.AdvertiseAddr)
+		return true, nil
+	}
+	if res.StatusCode == http.StatusInternalServerError {
+		// Let caller retry get health.
+		klog.Infof("ticdc control: %s report unhealthy, retry", owner.AdvertiseAddr)
+		return false, nil
+	}
+	return true, nil
+}
+
 func (c *defaultTiCDCControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32) string {
 	if c.testURL != "" {
 		return c.testURL
@@ -310,5 +355,9 @@ func (c *FakeTiCDCControl) DrainCapture(tc *v1alpha1.TidbCluster, ordinal int32)
 }
 
 func (c *FakeTiCDCControl) ResignOwner(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error) {
+	return true, nil
+}
+
+func (c *FakeTiCDCControl) IsHealthy(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
 	return true, nil
 }

--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -330,7 +330,10 @@ func getOrdinalAndOwnerCaptureInfo(
 
 // FakeTiCDCControl is a fake implementation of TiCDCControlInterface.
 type FakeTiCDCControl struct {
-	getStatus func(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error)
+	GetStatusFn    func(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error)
+	DrainCaptureFn func(tc *v1alpha1.TidbCluster, ordinal int32) (tableCount int, retry bool, err error)
+	ResignOwnerFn  func(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error)
+	IsHealthyFn    func(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error)
 }
 
 // NewFakeTiCDCControl returns a FakeTiCDCControl instance
@@ -338,26 +341,30 @@ func NewFakeTiCDCControl() *FakeTiCDCControl {
 	return &FakeTiCDCControl{}
 }
 
-// SetHealth set health info for FakeTiCDCControl
-func (c *FakeTiCDCControl) MockGetStatus(mockfunc func(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error)) {
-	c.getStatus = mockfunc
-}
-
 func (c *FakeTiCDCControl) GetStatus(tc *v1alpha1.TidbCluster, ordinal int32) (*CaptureStatus, error) {
-	if c.getStatus == nil {
-		return nil, fmt.Errorf("undefined")
+	if c.GetStatusFn == nil {
+		return nil, fmt.Errorf("undefined GetStatus")
 	}
-	return c.getStatus(tc, ordinal)
+	return c.GetStatusFn(tc, ordinal)
 }
 
 func (c *FakeTiCDCControl) DrainCapture(tc *v1alpha1.TidbCluster, ordinal int32) (tableCount int, retry bool, err error) {
-	return 0, false, nil
+	if c.DrainCaptureFn == nil {
+		return 0, false, fmt.Errorf("undefined DrainCapture")
+	}
+	return c.DrainCaptureFn(tc, ordinal)
 }
 
 func (c *FakeTiCDCControl) ResignOwner(tc *v1alpha1.TidbCluster, ordinal int32) (ok bool, err error) {
-	return true, nil
+	if c.ResignOwnerFn == nil {
+		return true, fmt.Errorf("undefined ResignOwner")
+	}
+	return c.ResignOwnerFn(tc, ordinal)
 }
 
 func (c *FakeTiCDCControl) IsHealthy(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error) {
-	return true, nil
+	if c.IsHealthyFn == nil {
+		return true, fmt.Errorf("undefined IsHealthy")
+	}
+	return c.IsHealthyFn(tc, ordinal)
 }

--- a/pkg/manager/member/ticdc_member_manager_test.go
+++ b/pkg/manager/member/ticdc_member_manager_test.go
@@ -441,9 +441,9 @@ func TestTiCDCMemberManagerSyncTidbClusterStatus(t *testing.T) {
 
 				// mock status of captures
 				cdcControl := m.deps.CDCControl.(*controller.FakeTiCDCControl)
-				cdcControl.MockGetStatus(func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
+				cdcControl.GetStatusFn = func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					return &controller.CaptureStatus{}, nil
-				})
+				}
 			},
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				// check status of statefulset
@@ -480,13 +480,13 @@ func TestTiCDCMemberManagerSyncTidbClusterStatus(t *testing.T) {
 
 				// mock status of captures
 				cdcControl := m.deps.CDCControl.(*controller.FakeTiCDCControl)
-				cdcControl.MockGetStatus(func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
+				cdcControl.GetStatusFn = func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					if ordinal == 1 {
 						return nil, fmt.Errorf("mock err")
 					}
 
 					return &controller.CaptureStatus{}, nil
-				})
+				}
 			},
 			errExpectFn: errExpectNil,
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {

--- a/pkg/manager/member/ticdc_scaler.go
+++ b/pkg/manager/member/ticdc_scaler.go
@@ -232,21 +232,17 @@ func isTiCDCPodSupportGracefulUpgrade(
 			action, tc.GetNamespace(), tc.GetName(), err)
 	}
 	podVersion := status.Version
-	currentVersion := tc.Spec.TiCDC.Version
-	if currentVersion == nil {
-		currentVersion = &tc.Spec.Version
-	}
-
-	ge, err := cmpver.Compare(podVersion, cmpver.GreaterOrEqual, *currentVersion)
+	currentVersion := tc.TiCDCVersion()
+	ge, err := cmpver.Compare(podVersion, cmpver.GreaterOrEqual, currentVersion)
 	if err != nil {
 		klog.Errorf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, skip graceful shutdown",
-			action, podVersion, *currentVersion, err)
+			action, podVersion, currentVersion, err)
 		return false, nil
 	}
-	le, err := cmpver.Compare(podVersion, cmpver.LessOrEqual, *currentVersion)
+	le, err := cmpver.Compare(podVersion, cmpver.LessOrEqual, currentVersion)
 	if err != nil {
 		klog.Errorf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, skip graceful shutdown",
-			action, podVersion, *currentVersion, err)
+			action, podVersion, currentVersion, err)
 		return false, nil
 	}
 	// Reload TiCDC if the current version matches pod version.
@@ -273,10 +269,10 @@ func isTiCDCPodSupportGracefulUpgrade(
 		return false, nil
 	}
 	podVersionPlus2 := podVer.IncMajor().IncMajor()
-	withInTwoMajorVersion, err := cmpver.Compare(*currentVersion, cmpver.Less, podVersionPlus2.String())
+	withInTwoMajorVersion, err := cmpver.Compare(currentVersion, cmpver.Less, podVersionPlus2.String())
 	if err != nil {
 		klog.Errorf("ticdc.%s: fail to compare version \"%s\", version \"%s\", error: %v, skip graceful shutdown",
-			action, *currentVersion, ticdcCrossUpgradeVersion, err)
+			action, currentVersion, ticdcCrossUpgradeVersion, err)
 		return false, nil
 	}
 	return withInTwoMajorVersion, nil

--- a/pkg/manager/member/ticdc_scaler_test.go
+++ b/pkg/manager/member/ticdc_scaler_test.go
@@ -710,6 +710,22 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			caseName: "v6.3.0 -> latest, skip graceful upgrade",
+			cdcCtl: &cdcCtlMock{
+				getStatus: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
+					return &controller.CaptureStatus{
+						Version: "7.0.0",
+					}, nil
+				},
+			},
+			changeTc: func(tc *v1alpha1.TidbCluster) {
+				v := "latest"
+				tc.Spec.TiCDC.Version = &v
+			},
+			expectedOk:  false,
+			expectedErr: false,
+		},
+		{
 			caseName: "get status failed",
 			cdcCtl: &cdcCtlMock{
 				getStatus: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {

--- a/pkg/manager/member/ticdc_scaler_test.go
+++ b/pkg/manager/member/ticdc_scaler_test.go
@@ -636,7 +636,9 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tc := newTidbClusterForPD()
-	tc.Spec.TiCDC = &v1alpha1.TiCDCSpec{}
+	tc.Spec.TiCDC = &v1alpha1.TiCDCSpec{
+		BaseImage: "pingcap/ticdc",
+	}
 
 	cases := []struct {
 		caseName    string

--- a/pkg/manager/member/ticdc_scaler_test.go
+++ b/pkg/manager/member/ticdc_scaler_test.go
@@ -678,6 +678,22 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			caseName: "cross two major versions, skip graceful upgrade",
+			cdcCtl: &cdcCtlMock{
+				getStatus: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
+					return &controller.CaptureStatus{
+						Version: "6.3.0",
+					}, nil
+				},
+			},
+			changeTc: func(tc *v1alpha1.TidbCluster) {
+				v := "v8.0.0"
+				tc.Spec.TiCDC.Version = &v
+			},
+			expectedOk:  false,
+			expectedErr: false,
+		},
+		{
 			caseName: "support graceful reload",
 			cdcCtl: &cdcCtlMock{
 				getStatus: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {

--- a/pkg/manager/member/ticdc_upgrader.go
+++ b/pkg/manager/member/ticdc_upgrader.go
@@ -109,7 +109,7 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 			continue
 		}
 
-		support, err := isTiCDCPodSupportGracefulUpgrade(tc, u.deps.CDCControl, ordinal, "Upgrade")
+		support, err := isTiCDCPodSupportGracefulUpgrade(tc, u.deps.CDCControl, u.deps.PodControl, pod, ordinal, "Upgrade")
 		if err != nil {
 			return err
 		}

--- a/pkg/manager/member/ticdc_upgrader.go
+++ b/pkg/manager/member/ticdc_upgrader.go
@@ -85,11 +85,6 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 		return nil
 	}
 
-	// nextOrdinal returns the next upgrade ordinal.
-	// returns false when the upgrade is completed.
-	nextOrdinal := func(ord int32) (int32, bool) {
-		return ord - 1, ord-1 >= 0
-	}
 	mngerutils.SetUpgradePartition(newSet, *oldSet.Spec.UpdateStrategy.RollingUpdate.Partition)
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
 	for i := len(podOrdinals) - 1; i >= 0; i-- {
@@ -114,22 +109,32 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 			continue
 		}
 
-		err = gracefulDrainTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, ordinal, "Upgrade")
+		support, err := isTiCDCPodSupportGracefulUpgrade(tc, u.deps.CDCControl, ordinal, "Upgrade")
 		if err != nil {
 			return err
 		}
-		klog.Infof("ticdcUpgrade.Upgrade: %s graceful drain TiCDC complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
-		nextOrd, hasNext := nextOrdinal(ordinal)
-		if hasNext {
-			nextPodName := ticdcPodName(tcName, nextOrd)
-			klog.Infof("ticdcUpgrade.Upgrade: try to graceful resign owner from the next ticdc pod %s in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
-			err = gracefulResignOwnerTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, nextPodName, nextOrd, "Upgrade")
+		if support {
+			err = gracefulDrainTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, ordinal, "Upgrade")
 			if err != nil {
 				return err
 			}
-			klog.Infof("ticdcUpgrade.Upgrade: %s graceful resign owner complete in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
+			klog.Infof("ticdcUpgrade.Upgrade: %s graceful drain TiCDC complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
+			// To prevent TiCDC service disruption, we need to resign owner
+			// gracefully from the next pod that is going to be upgraded.
+			// If the current pod is the last one to upgrade, skip resign owner.
+			hasNext := i-1 >= 0
+			if hasNext {
+				nextOrd := podOrdinals[i-1]
+				nextPodName := ticdcPodName(tcName, nextOrd)
+				klog.Infof("ticdcUpgrade.Upgrade: try to graceful resign owner from the next ticdc pod %s in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
+				err = gracefulResignOwnerTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, nextPodName, nextOrd, "Upgrade")
+				if err != nil {
+					return err
+				}
+				klog.Infof("ticdcUpgrade.Upgrade: %s graceful resign owner complete in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
+			}
+			klog.Infof("ticdcUpgrade.Upgrade: %s graceful shutdown complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
 		}
-		klog.Infof("ticdcUpgrade.Upgrade: %s graceful shutdown complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
 
 		mngerutils.SetUpgradePartition(newSet, ordinal)
 		return nil

--- a/pkg/manager/member/ticdc_upgrader.go
+++ b/pkg/manager/member/ticdc_upgrader.go
@@ -85,6 +85,11 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 		return nil
 	}
 
+	// nextOrdinal returns the next upgrade ordinal.
+	// returns false when the upgrade is completed.
+	nextOrdinal := func(ord int32) (int32, bool) {
+		return ord - 1, ord-1 >= 0
+	}
 	mngerutils.SetUpgradePartition(newSet, *oldSet.Spec.UpdateStrategy.RollingUpdate.Partition)
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
 	for i := len(podOrdinals) - 1; i >= 0; i-- {
@@ -109,11 +114,22 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 			continue
 		}
 
-		err = gracefulShutdownTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, ordinal, "Upgrade")
+		err = gracefulDrainTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, ordinal, "Upgrade")
 		if err != nil {
 			return err
 		}
-		klog.Infof("ticdcUpgrade.Upgrade: %s has graceful shutdown in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
+		klog.Infof("ticdcUpgrade.Upgrade: %s graceful drain TiCDC complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
+		nextOrd, hasNext := nextOrdinal(ordinal)
+		if hasNext {
+			nextPodName := ticdcPodName(tcName, nextOrd)
+			klog.Infof("ticdcUpgrade.Upgrade: try to graceful resign owner from the next ticdc pod %s in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
+			err = gracefulResignOwnerTiCDC(tc, u.deps.CDCControl, u.deps.PodControl, pod, nextPodName, nextOrd, "Upgrade")
+			if err != nil {
+				return err
+			}
+			klog.Infof("ticdcUpgrade.Upgrade: %s graceful resign owner complete in cluster %s/%s", nextPodName, tc.GetNamespace(), tc.GetName())
+		}
+		klog.Infof("ticdcUpgrade.Upgrade: %s graceful shutdown complete in cluster %s/%s", podName, tc.GetNamespace(), tc.GetName())
 
 		mngerutils.SetUpgradePartition(newSet, ordinal)
 		return nil

--- a/pkg/util/cmpver/cmpver_test.go
+++ b/pkg/util/cmpver/cmpver_test.go
@@ -62,6 +62,9 @@ func genTestCases() []testcase {
 	return []testcase{
 		// Greater
 		{"v5.3.1", Greater, "v5.1.2", true},
+		{"5.3.1", Greater, "5.1.2", true},
+		{"v5.3.1", Greater, "5.1.2", true},
+		{"v5.3.1-master-dirty", Greater, "5.1.2-alpha-308-gbd21a6ea5", true},
 		{"v5.1.2", Greater, "v5.3.1", false},
 		{"v5.3.1", Greater, "v5.3.1", false},
 		{"v5.3.1-dev12", Greater, "v5.1.2", true},
@@ -70,6 +73,9 @@ func genTestCases() []testcase {
 		{"nightly", Greater, "v5.3.1", true},
 		// GreaterOrEqual
 		{"v5.3.1", GreaterOrEqual, "v5.1.2", true},
+		{"5.3.1", GreaterOrEqual, "5.1.2", true},
+		{"5.3.1", GreaterOrEqual, "v5.1.2", true},
+		{"5.3.1-master-dirty", GreaterOrEqual, "v5.1.2-alpha-308-gbd21a6ea5", true},
 		{"v5.1.2", GreaterOrEqual, "v5.3.1", false},
 		{"v5.3.1", GreaterOrEqual, "v5.3.1", true},
 		{"v5.3.1-dev12", GreaterOrEqual, "v5.1.2", true},
@@ -79,6 +85,8 @@ func genTestCases() []testcase {
 		// Less
 		{"v5.3.1", Less, "v5.1.2", false},
 		{"v5.1.2", Less, "v5.3.1", true},
+		{"5.1.2", Less, "5.3.1", true},
+		{"5.1.2-alpha-308-gbd21a6ea5-dirty", Less, "v5.3.1", true},
 		{"v5.3.1", Less, "v5.3.1", false},
 		{"v5.3.1-dev12", Less, "v5.1.2", false},
 		{"v5.3.1-dev12", Less, "v5.3.1", false},
@@ -86,6 +94,8 @@ func genTestCases() []testcase {
 		{"nightly", Less, "v5.3.1", false},
 		// LessOrEqual
 		{"v5.3.1", LessOrEqual, "v5.1.2", false},
+		{"5.3.1", LessOrEqual, "5.1.2", false},
+		{"v5.3.1", LessOrEqual, "5.1.2-alpha-308-gbd21a6ea5-dirty", false},
 		{"v5.1.2", LessOrEqual, "v5.3.1", true},
 		{"v5.3.1", LessOrEqual, "v5.3.1", true},
 		{"v5.3.1-dev12", LessOrEqual, "v5.1.2", false},


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #4664

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Wait TiCDC cluster becomes healthy after resigning owner, otherwise there may be latency spike.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

| master branch | this PR |
| -- | -- |
| <img width="918" alt="image" src="https://user-images.githubusercontent.com/2150711/182792275-db702588-bbde-4a19-a867-7bb8376c45cb.png"> | <img width="919" alt="image" src="https://user-images.githubusercontent.com/2150711/182790823-e443da77-3849-45b1-9fd1-67c31cea261a.png"> |

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
