### PR TITLE
Auto generate account for tidb-cluster

### DIFF
--- a/charts/tidb-cluster/templates/NOTES.txt
+++ b/charts/tidb-cluster/templates/NOTES.txt
@@ -3,17 +3,17 @@ Cluster Startup
      watch kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
 2. List services in the tidb-cluster
      kubectl get services --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
-{{- if .Values.tidb.passwordSecretName }}
+{{- if (include "tidb-cluster.tidb.passwordSecretName" .) }}
 3. Wait until tidb-initializer pod becomes completed
      watch kubectl get po --namespace {{ .Release.Namespace }}  -l app.kubernetes.io/component=tidb-initializer
 4. Get the TiDB password
-     kubectl get secret -n {{ .Release.Namespace }} {{ .Values.tidb.passwordSecretName }} -ojsonpath='{.data.root}' | base64 --decode
+     kubectl get secret -n {{ .Release.Namespace }} {{ template "tidb-cluster.tidb.passwordSecretName" . }} -ojsonpath='{.data.root}' | base64 --decode
 {{- end }}
 
 Cluster access
 * Access tidb-cluster using the MySQL client
     kubectl port-forward -n {{ .Release.Namespace }} svc/{{ template "cluster.name" . }}-tidb 4000:4000 &
-{{- if .Values.tidb.passwordSecretName }}
+{{- if (include "tidb-cluster.tidb.passwordSecretName" .) }}
     mysql -h 127.0.0.1 -P 4000 -u root -D test -p
 {{- else }}
     mysql -h 127.0.0.1 -P 4000 -u root -D test

--- a/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
+++ b/charts/tidb-cluster/templates/scripts/_initialize_tidb_users.py.tpl
@@ -3,7 +3,7 @@ host = '{{ template "cluster.name" . }}-tidb'
 permit_host = {{ .Values.tidb.permitHost | default "%" | quote }}
 port = 4000
 conn = MySQLdb.connect(host=host, port=port, user='root', connect_timeout=5)
-{{- if .Values.tidb.passwordSecretName }}
+{{- if (include "tidb-cluster.tidb.passwordSecretName" .) }}
 password_dir = '/etc/tidb/password'
 for file in os.listdir(password_dir):
     if file.startswith('.'):

--- a/charts/tidb-cluster/templates/tidb-initializer-job.yaml
+++ b/charts/tidb-cluster/templates/tidb-initializer-job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.tidb.passwordSecretName .Values.tidb.permitHost .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
+{{- if or (include "tidb-cluster.tidb.passwordSecretName" .) .Values.tidb.permitHost .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -56,9 +56,9 @@ spec:
         - -c
         - |
 {{ tuple "scripts/_initialize_tidb_users.py.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
-        {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
+        {{- if or (include "tidb-cluster.tidb.passwordSecretName" .) .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
         volumeMounts:
-          {{- if .Values.tidb.passwordSecretName }}
+          {{- if (include "tidb-cluster.tidb.passwordSecretName" .) }}
           - name: password
             mountPath: /etc/tidb/password
             readOnly: true
@@ -80,12 +80,12 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.tidb.initializer.resources | indent 10 }}
-      {{- if or .Values.tidb.passwordSecretName .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
+      {{- if or (include "tidb-cluster.tidb.passwordSecretName" .) .Values.tidb.initSql .Values.tidb.initSqlConfigMapName }}
       volumes:
-        {{- if .Values.tidb.passwordSecretName }}
+        {{- if (include "tidb-cluster.tidb.passwordSecretName" .) }}
         - name: password
           secret:
-            secretName: {{ .Values.tidb.passwordSecretName }}
+            secretName: {{ template "tidb-cluster.tidb.passwordSecretName" . }}
         {{- end }}
         {{- if .Values.tidb.initSqlConfigMapName }}
         - name: init-sql

--- a/charts/tidb-cluster/templates/tidb-secret.yaml
+++ b/charts/tidb-cluster/templates/tidb-secret.yaml
@@ -1,0 +1,23 @@
+{{- if and (not .Values.passwordSecretName) .Values.tidb.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "cluster.name" . }}-tidb-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: tidb
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+  {{- if .Values.tidb.service.annotations }}
+  annotations:
+{{ toYaml .Values.tidb.service.annotations | indent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  root: {{ template "tidb-cluster.tidb.rootPassword" . }}
+{{- if .Values.tidb.auth.username }}
+  {{ .Values.tidb.auth.username }}: {{ template "tidb-cluster.tidb.password" . }}
+{{- end -}}
+{{- end }}

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -345,6 +345,11 @@ tidb:
   # kubectl create secret generic tidb-secret --from-literal=root=<root-password> --namespace=<namespace>
   # If unset, the root password will be empty and you can set it after connecting
   # passwordSecretName: tidb-secret
+  auth:
+    enabled: false
+    rootPassword: ""
+    username: ""
+    password: ""
   # permitHost is the host which will only be allowed to connect to the TiDB.
   # If unset, defaults to '%' which means allow any host to connect to the TiDB.
   # permitHost: 127.0.0.1


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Unable to set password (randomly) for TiDB during installation by helm
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
It will automatically create a root account with a random password
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
