### PR TITLE
Fix the issue cluster sync stuck caused by suspending cluster when scaling

### DIFF
--- a/pkg/manager/suspender/suspender.go
+++ b/pkg/manager/suspender/suspender.go
@@ -102,7 +102,7 @@ func (s *suspender) SuspendComponent(cluster v1alpha1.Cluster, comp v1alpha1.Mem
 	if !suspending {
 		if can, reason := canSuspendComponent(ctx.cluster, ctx.component); !can {
 			klog.Warningf("component %s can not be suspended now because: %s", ctx.ComponentID(), reason)
-			return true, nil
+			return false, nil
 		}
 
 		err := s.begin(ctx)

--- a/pkg/manager/suspender/suspender.go
+++ b/pkg/manager/suspender/suspender.go
@@ -223,11 +223,6 @@ func needsSuspendComponent(cluster v1alpha1.Cluster, comp v1alpha1.MemberType) b
 
 // canSuspendComponent checks whether suspender can start to suspend the component
 func canSuspendComponent(cluster v1alpha1.Cluster, comp v1alpha1.MemberType) (bool, string) {
-	// only support to suspend Normal or Suspend cluster
-	if !cluster.ComponentIsNormal(comp) && !cluster.ComponentIsSuspending(comp) {
-		return false, "component phase is not Normal or Suspend"
-	}
-
 	// wait for other components to be suspended
 	var suspendOrder []v1alpha1.MemberType
 	switch cluster.(type) {

--- a/pkg/manager/suspender/suspender_test.go
+++ b/pkg/manager/suspender/suspender_test.go
@@ -63,7 +63,7 @@ func TestSuspendComponent(t *testing.T) {
 			component: v1alpha1.TiKVMemberType,
 			sts:       nil,
 			expect: func(suspeded bool, err error) {
-				g.Expect(suspeded).To(BeTrue())
+				g.Expect(suspeded).To(BeFalse())
 				g.Expect(err).To(BeNil())
 			},
 			expectResource: func(cluster v1alpha1.Cluster, s *suspender) {},

--- a/pkg/manager/suspender/suspender_test.go
+++ b/pkg/manager/suspender/suspender_test.go
@@ -58,7 +58,10 @@ func TestSuspendComponent(t *testing.T) {
 				tc.Spec.TiKV = &v1alpha1.TiKVSpec{}
 				tc.Status.TiKV = v1alpha1.TiKVStatus{}
 				tc.Spec.TiKV.SuspendAction = &v1alpha1.SuspendAction{SuspendStatefulSet: true}
-				tc.Status.TiKV.Phase = v1alpha1.UpgradePhase // can not suspend
+				// can not suspend
+				tc.Spec.TiDB = &v1alpha1.TiDBSpec{}
+				tc.Spec.TiDB.SuspendAction = &v1alpha1.SuspendAction{SuspendStatefulSet: true}
+				tc.Status.TiDB.Phase = v1alpha1.NormalPhase
 			},
 			component: v1alpha1.TiKVMemberType,
 			sts:       nil,
@@ -384,16 +387,6 @@ func TestCanSuspendComponent(t *testing.T) {
 			expect: func(can bool, reason string) {
 				g.Expect(can).To(BeTrue())
 				g.Expect(reason).To(BeEmpty())
-			},
-		},
-		"component's phase is not Normal and Suspend": {
-			setup: func(tc *v1alpha1.TidbCluster) {
-				tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
-			},
-			component: v1alpha1.TiKVMemberType,
-			expect: func(can bool, reason string) {
-				g.Expect(can).To(BeFalse())
-				g.Expect(reason).To(Equal("component phase is not Normal or Suspend"))
 			},
 		},
 		"wait for other components to be suspended": {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue cluster sync stuck caused by suspending cluster when scaling
```
