### PR TITLE
fix backup failure on tidb cluster has massive tikv nodes (40+)

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -69,16 +69,16 @@ func (bo *Options) backupData(
 			progressStep = "Full Backup"
 			successTag   = "EBS backup success"
 		)
-		csbPath := path.Join(util.BRBinPath, "csb_backup.json")
+		localCSBFile := path.Join(util.BRBinPath, "csb_backup.json")
 		opts := bkUtil.GetOptions(backup.Spec.StorageProvider)
-		backupFullPath, _ := bkUtil.GetStoragePath(backup)
-		if err := bo.copyRemoteClusterMetaToLocal(ctx, backupFullPath, opts, csbPath); err != nil {
+		remoteStoragePath, _ := bkUtil.GetStoragePath(backup)
+		if err := bo.copyRemoteClusterMetaToLocal(ctx, remoteStoragePath, opts, localCSBFile); err != nil {
 			klog.Errorf("rclone copy remote cluster info to local failure.")
 			return err
 		}
 		// Currently, we only support aws ebs volume snapshot.
 		specificArgs = append(specificArgs, "--type=aws-ebs")
-		specificArgs = append(specificArgs, fmt.Sprintf("--volume-file=%s", csbPath))
+		specificArgs = append(specificArgs, fmt.Sprintf("--volume-file=%s", localCSBFile))
 		logCallback = func(line string) {
 			if strings.Contains(line, successTag) {
 				extract := strings.Split(line, successTag)[1]

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -31,7 +31,6 @@ import (
 	backupUtil "github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/constants"
-	backupConst "github.com/pingcap/tidb-operator/pkg/backup/constants"
 	pkgutil "github.com/pingcap/tidb-operator/pkg/backup/util"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/util"
@@ -331,16 +330,4 @@ func (bo *Options) updateProgressFromFile(
 			return
 		}
 	}
-}
-
-// copy remote clustermeta file to local csb_backup.json
-func (bo *Options) copyRemoteClusterMetaToLocal(ctx context.Context, bucket string, opts []string, csbPath string) error {
-	destBucket := backupUtil.NormalizeBucketURI(bucket)
-	args := backupUtil.ConstructRcloneArgs(backupConst.RcloneConfigArg, opts, "copyto", fmt.Sprintf("%s/%s", destBucket, backupConst.ClusterBackupMeta), csbPath, true)
-	output, err := exec.CommandContext(ctx, "rclone", args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("cluster %s, execute rclone copyto command failed, output: %s, err: %v", bo, string(output), err)
-	}
-	klog.Infof("cluster %s cluster meta from %s copy to local successfully", bo, bucket)
-	return nil
 }

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	bkutil "github.com/pingcap/tidb-operator/pkg/backup/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -56,7 +57,7 @@ func (bo *Options) String() string {
 
 // cleanBackupMetaWithVolSnapshots clean snapshot and the backup meta
 func (bo *Options) cleanBackupMetaWithVolSnapshots(ctx context.Context, backup *v1alpha1.Backup) error {
-	backend, err := util.NewStorageBackend(backup.Spec.StorageProvider)
+	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, nil)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,7 @@ func (bo *Options) deleteVolumeSnapshots(meta *util.EBSBasedBRMeta) error {
 func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1.Backup) error {
 	opt := backup.GetCleanOption()
 
-	backend, err := util.NewStorageBackend(backup.Spec.StorageProvider)
+	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, nil)
 	if err != nil {
 		return err
 	}
@@ -150,7 +151,7 @@ func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1
 	})
 }
 
-func (bo *Options) cleanBRRemoteBackupDataOnce(ctx context.Context, backend *util.StorageBackend, opt v1alpha1.CleanOption, round int) error {
+func (bo *Options) cleanBRRemoteBackupDataOnce(ctx context.Context, backend *bkutil.StorageBackend, opt v1alpha1.CleanOption, round int) error {
 	klog.Infof("For backup %s clean %d, start to clean backup with opt: %+v", bo, round, opt)
 
 	iter := backend.ListPage(nil)

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -57,7 +57,7 @@ func (bo *Options) String() string {
 
 // cleanBackupMetaWithVolSnapshots clean snapshot and the backup meta
 func (bo *Options) cleanBackupMetaWithVolSnapshots(ctx context.Context, backup *v1alpha1.Backup) error {
-	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, nil)
+	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, &bkutil.StorageCredential{})
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (bo *Options) deleteVolumeSnapshots(meta *util.EBSBasedBRMeta) error {
 func (bo *Options) cleanBRRemoteBackupData(ctx context.Context, backup *v1alpha1.Backup) error {
 	opt := backup.GetCleanOption()
 
-	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, nil)
+	backend, err := bkutil.NewStorageBackend(backup.Spec.StorageProvider, &bkutil.StorageCredential{})
 	if err != nil {
 		return err
 	}

--- a/cmd/backup-manager/app/clean/clean_test.go
+++ b/cmd/backup-manager/app/clean/clean_test.go
@@ -26,8 +26,8 @@ import (
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/driver"
 
-	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/backup/util"
 )
 
 func TestCleanBRRemoteBackupDataOnce(t *testing.T) {

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -205,6 +205,7 @@ func (ro *Options) restoreData(
 	return nil
 }
 
+// copy the restore meta to remote storage since k8s has limit to handle massive data pass between pods
 func (ro *Options) processCloudSnapBackup(
 	ctx context.Context,
 	restore *v1alpha1.Restore,

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -91,7 +91,7 @@ func (ro *Options) restoreData(
 		// init pitr restore args
 		args = append(args, fmt.Sprintf("--restored-ts=%s", ro.PitrRestoredTs))
 
-		if fullBackupArgs, err := backupUtil.GenStorageArgsForFlag(restore.Spec.PitrFullBackupStorageProvider, "full-backup-storage"); err != nil {
+		if fullBackupArgs, err := bkUtil.GenStorageArgsForFlag(restore.Spec.PitrFullBackupStorageProvider, "full-backup-storage"); err != nil {
 			return err
 		} else {
 			// parse full backup path

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -213,8 +213,8 @@ func (ro *Options) processCloudSnapBackup(
 ) error {
 	klog.Infof("Get restore meta file %s for cluster %s", csbPath, ro)
 	opts := bkUtil.GetOptions(restore.Spec.StorageProvider)
-	backupFullPath, _ := bkUtil.GetStorageRestorePath(restore)
-	if err := ro.copyRestoreMetaToRemote(ctx, backupFullPath, opts, csbPath); err != nil {
+	remoteStoragePath, _ := bkUtil.GetStorageRestorePath(restore)
+	if err := ro.copyRestoreMetaToRemote(ctx, remoteStoragePath, opts, csbPath); err != nil {
 		klog.Errorf("rclone copy remote cluster info to local failure.")
 		return err
 	}

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -351,7 +351,7 @@ func GetBRArchiveSize(meta *kvbackup.BackupMeta) uint64 {
 
 // GetBRMetaData get backup metadata from cloud storage
 func GetBRMetaData(ctx context.Context, provider v1alpha1.StorageProvider) (*kvbackup.BackupMeta, error) {
-	s, err := util.NewStorageBackend(provider, nil)
+	s, err := util.NewStorageBackend(provider, &util.StorageCredential{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -159,7 +159,7 @@ func ConstructBRGlobalOptionsForBackup(backup *v1alpha1.Backup) ([]string, error
 		return nil, fmt.Errorf("no config for br in Backup %s/%s", backup.Namespace, backup.Name)
 	}
 	args = append(args, constructBRGlobalOptions(spec.BR)...)
-	storageArgs, err := GenStorageArgsForFlag(backup.Spec.StorageProvider, "")
+	storageArgs, err := util.GenStorageArgsForFlag(backup.Spec.StorageProvider, "")
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func ConstructBRGlobalOptionsForRestore(restore *v1alpha1.Restore) ([]string, er
 		return nil, fmt.Errorf("no config for br in restore %s/%s", restore.Namespace, restore.Name)
 	}
 	args = append(args, constructBRGlobalOptions(config.BR)...)
-	storageArgs, err := GenStorageArgsForFlag(restore.Spec.StorageProvider, "")
+	storageArgs, err := util.GenStorageArgsForFlag(restore.Spec.StorageProvider, "")
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func GetBRArchiveSize(meta *kvbackup.BackupMeta) uint64 {
 
 // GetBRMetaData get backup metadata from cloud storage
 func GetBRMetaData(ctx context.Context, provider v1alpha1.StorageProvider) (*kvbackup.BackupMeta, error) {
-	s, err := NewStorageBackend(provider)
+	s, err := util.NewStorageBackend(provider, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.14
 
 ARG TARGETARCH
-ARG RCLONE_VERSION=v1.51.0
 RUN apk add tzdata bind-tools --no-cache
 ADD bin/${TARGETARCH}/tidb-scheduler /usr/local/bin/tidb-scheduler
 ADD bin/${TARGETARCH}/tidb-discovery /usr/local/bin/tidb-discovery

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -1,8 +1,15 @@
 FROM alpine:3.14
 
 ARG TARGETARCH
+ARG RCLONE_VERSION=v1.51.0
 RUN apk add tzdata bind-tools --no-cache
 ADD bin/${TARGETARCH}/tidb-scheduler /usr/local/bin/tidb-scheduler
 ADD bin/${TARGETARCH}/tidb-discovery /usr/local/bin/tidb-discovery
 ADD bin/${TARGETARCH}/tidb-controller-manager /usr/local/bin/tidb-controller-manager
 ADD bin/${TARGETARCH}/tidb-admission-webhook /usr/local/bin/tidb-admission-webhook
+
+RUN wget -nv https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
+  && unzip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
+  && mv rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone /usr/local/bin \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm -rf rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -7,9 +7,3 @@ ADD bin/${TARGETARCH}/tidb-scheduler /usr/local/bin/tidb-scheduler
 ADD bin/${TARGETARCH}/tidb-discovery /usr/local/bin/tidb-discovery
 ADD bin/${TARGETARCH}/tidb-controller-manager /usr/local/bin/tidb-controller-manager
 ADD bin/${TARGETARCH}/tidb-admission-webhook /usr/local/bin/tidb-admission-webhook
-
-RUN wget -nv https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
-  && unzip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
-  && mv rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone /usr/local/bin \
-  && chmod 755 /usr/local/bin/rclone \
-  && rm -rf rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -476,6 +476,14 @@ func (bm *backupManager) makeBRBackupJob(backup *v1alpha1.Backup) (*batchv1.Job,
 		Value: string(rune(1)),
 	})
 
+	// generate the rclone config for controller
+	if backup.Spec.Mode == v1alpha1.BackupModeVolumeSnapshot {
+		reason, err = backuputil.GenerateRemoteConfig(ns, backup.Spec.StorageProvider, bm.deps.SecretLister)
+		if err != nil {
+			return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
+		}
+	}
+
 	// set env vars specified in backup.Spec.Env
 	envVars = util.AppendOverwriteEnv(envVars, backup.Spec.Env)
 

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -697,7 +697,7 @@ func (bm *backupManager) saveClusterMetaToExternalStorage(b *v1alpha1.Backup, cs
 func (bm *backupManager) tryBackupIfCanSnapshot(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error) {
 	if s, reason, err := snapshotter.NewSnapshotterForBackup(b.Spec.Mode, bm.deps); err != nil {
 		return reason, err
-	} else if s != nil {
+	} else if s != (&snapshotter.NoneSnapshotter{}) {
 		csb, reason, err := s.GenerateBackupMetadata(b, tc)
 		if err != nil {
 			return reason, err

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -14,6 +14,7 @@
 package backup
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -666,7 +667,8 @@ func (bm *backupManager) saveClusterMetaToExternalStorage(b *v1alpha1.Backup, cs
 	if err != nil {
 		return "ParseCloudSnapshotBackupFailed", err
 	}
-	ctx, cancel := backuputil.GetContextForTerminationSignals(b.ClusterName)
+	// since the cluster meta is small (~5M), assume 1 minutes is enough
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Minute*1))
 	defer cancel()
 
 	// write a file into external storage

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -660,7 +660,7 @@ func (bm *backupManager) makeBRBackupJob(backup *v1alpha1.Backup) (*batchv1.Job,
 	return job, "", nil
 }
 
-// copy cluster info to external storage since k8s size limitation on annotation/configMap
+// save cluster meta to external storage since k8s size limitation on annotation/configMap
 func (bm *backupManager) saveClusterMetaToExternalStorage(b *v1alpha1.Backup, csb *snapshotter.CloudSnapBackup) (string, error) {
 
 	data, err := json.Marshal(csb)

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -696,7 +696,7 @@ func (bm *backupManager) saveClusterMetaToExternalStorage(b *v1alpha1.Backup, cs
 func (bm *backupManager) volSnapshotBackup(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error) {
 	if s, reason, err := snapshotter.NewSnapshotterForBackup(b.Spec.Mode, bm.deps); err != nil {
 		return reason, err
-	} else if s != (&snapshotter.NoneSnapshotter{}) {
+	} else if s != nil {
 		csb, reason, err := s.GenerateBackupMetadata(b, tc)
 		if err != nil {
 			return reason, err

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -476,12 +476,6 @@ func (bm *backupManager) makeBRBackupJob(backup *v1alpha1.Backup) (*batchv1.Job,
 		Value: string(rune(1)),
 	})
 
-	dwAPIEnvs, reason, err := backuputil.GenerateDownwardAPIEnvs()
-	if err != nil {
-		return nil, reason, fmt.Errorf("backup %s/%s, %v", ns, name, err)
-	}
-	envVars = append(envVars, dwAPIEnvs...)
-
 	// set env vars specified in backup.Spec.Env
 	envVars = util.AppendOverwriteEnv(envVars, backup.Spec.Env)
 

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -93,4 +93,15 @@ const (
 	KubeAnnBindCompleted          = "pv.kubernetes.io/bind-completed"
 	KubeAnnBoundByController      = "pv.kubernetes.io/bound-by-controller"
 	KubeAnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
+
+	LocalTmp           = "/tmp"
+	ClusterBackupMeta  = "clustermeta"
+	ClusterRestoreMeta = "restoremeta"
+	// RcloneConfigFile represents the path to the file that contains rclone
+	// configs. This path should be the same as defined in docker entrypoint
+	// script from backup-manager/entrypoint.sh. /tmp/rclone.conf
+	RcloneConfigFile = "/tmp/rclone.conf"
+
+	// RcloneConfigArg represents the config argument to rclone cmd
+	RcloneConfigArg = "--config=" + RcloneConfigFile
 )

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -97,11 +97,4 @@ const (
 	LocalTmp           = "/tmp"
 	ClusterBackupMeta  = "clustermeta"
 	ClusterRestoreMeta = "restoremeta"
-	// RcloneConfigFile represents the path to the file that contains rclone
-	// configs. This path should be the same as defined in docker entrypoint
-	// script from backup-manager/entrypoint.sh. /tmp/rclone.conf
-	RcloneConfigFile = "/tmp/rclone.conf"
-
-	// RcloneConfigArg represents the config argument to rclone cmd
-	RcloneConfigArg = "--config=" + RcloneConfigFile
 )

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -217,7 +217,7 @@ func (rm *restoreManager) readRestoreMetaFromExternalStorage(r *v1alpha1.Restore
 		return nil, "FileExistedInExternalStorageFailed", err
 	}
 	if !exist {
-		return nil, "FileExistedInExternalStorage", fmt.Errorf("%s does not exist", constants.ClusterRestoreMeta)
+		return nil, "FileNotExists", fmt.Errorf("%s does not exist", constants.ClusterRestoreMeta)
 	}
 
 	restoreMeta, err := externalStorage.ReadAll(ctx, constants.ClusterRestoreMeta)

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -101,6 +101,13 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 	}
 
 	if restore.Spec.BR != nil && restore.Spec.Mode == v1alpha1.RestoreModeVolumeSnapshot {
+		// generate the rclone config before volume restore complete
+		if !v1alpha1.IsRestoreVolumeComplete(restore) {
+			_, err = backuputil.GenerateRemoteConfig(ns, restore.Spec.StorageProvider, rm.deps.SecretLister)
+			if err != nil {
+				return fmt.Errorf("restore %s/%s, %v", ns, name, err)
+			}
+		}
 		// restore based snapshot for cloud provider
 		reason, err := rm.tryRestoreIfCanSnapshot(restore, tc)
 		if err != nil {

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -14,9 +14,11 @@
 package restore
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -200,7 +202,8 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 // after volume retore job complete, br output a meta file for controller to reconfig the tikvs
 // since the meta file may big, so we use remote storage as bridge to pass it from restore manager to controller
 func (rm *restoreManager) readRestoreMetaFromExternalStorage(r *v1alpha1.Restore) (*snapshotter.CloudSnapBackup, string, error) {
-	ctx, cancel := backuputil.GetContextForTerminationSignals(r.ClusterName)
+	// since the restore meta is small (~5M), assume 1 minutes is enough
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Minute*1))
 	defer cancel()
 
 	// write a file into external storage

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -196,7 +196,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 	return nil
 }
 
-// read cluster info from external storage since k8s size limitation on annotation/configMap
+// read cluster meta from external storage since k8s size limitation on annotation/configMap
 // after volume retore job complete, br output a meta file for controller to reconfig the tikvs
 // since the meta file may big, so we use remote storage as bridge to pass it from restore manager to controller
 func (rm *restoreManager) readRestoreMetaFromExternalStorage(r *v1alpha1.Restore) (*snapshotter.CloudSnapBackup, string, error) {
@@ -211,7 +211,7 @@ func (rm *restoreManager) readRestoreMetaFromExternalStorage(r *v1alpha1.Restore
 		return nil, "NewStorageBackendFailed", err
 	}
 
-	// if file existed, it looks backup write into a storage has backup already
+	// if file doesn't exist, br create volume has problem
 	exist, err := externalStorage.Exists(ctx, constants.ClusterRestoreMeta)
 	if err != nil {
 		return nil, "FileExistedInExternalStorageFailed", err

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -430,9 +430,6 @@ func TestBRRestoreByEBS(t *testing.T) {
 
 			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster)
 			helper.CreateRestore(tt.restore)
-			// tt.restore.Annotations = map[string]string{
-			// 	label.AnnBackupCloudSnapKey: testutils.ConstructRestoreMetaStr(),
-			// }
 			m := NewRestoreManager(deps)
 			err := m.Sync(tt.restore)
 			g.Expect(err).Should(BeNil())

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -16,13 +16,13 @@ package restore
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
-	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/testutils"
 	corev1 "k8s.io/api/core/v1"
@@ -259,10 +259,22 @@ func TestBRRestoreByEBS(t *testing.T) {
 						Cluster:          "cluster-1",
 					},
 					StorageProvider: v1alpha1.StorageProvider{
-						S3: &v1alpha1.S3StorageProvider{
-							Bucket:   "s3",
-							Prefix:   "prefix-",
-							Endpoint: "s3://localhost:80",
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
 						},
 					},
 				},
@@ -284,10 +296,22 @@ func TestBRRestoreByEBS(t *testing.T) {
 						Cluster:          "cluster-2",
 					},
 					StorageProvider: v1alpha1.StorageProvider{
-						S3: &v1alpha1.S3StorageProvider{
-							Bucket:   "s3",
-							Prefix:   "prefix-",
-							Endpoint: "s3://localhost:80",
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix1",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
 						},
 					},
 				},
@@ -317,10 +341,22 @@ func TestBRRestoreByEBS(t *testing.T) {
 						Cluster:          "cluster-3",
 					},
 					StorageProvider: v1alpha1.StorageProvider{
-						S3: &v1alpha1.S3StorageProvider{
-							Bucket:   "s3",
-							Prefix:   "prefix-",
-							Endpoint: "s3://localhost:80",
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
 						},
 					},
 				},
@@ -350,10 +386,22 @@ func TestBRRestoreByEBS(t *testing.T) {
 						Cluster:          "cluster-4",
 					},
 					StorageProvider: v1alpha1.StorageProvider{
-						S3: &v1alpha1.S3StorageProvider{
-							Bucket:   "s3",
-							Prefix:   "prefix-",
-							Endpoint: "s3://localhost:80",
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
 						},
 					},
 				},
@@ -373,17 +421,25 @@ func TestBRRestoreByEBS(t *testing.T) {
 			},
 		},
 	}
+	//generate the restore meta in local nfs
+	err := os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestoreMetaStr()), 0644)
+	g.Expect(err).To(Succeed())
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+
 			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster)
 			helper.CreateRestore(tt.restore)
-			tt.restore.Annotations = map[string]string{
-				label.AnnBackupCloudSnapKey: testutils.ConstructRestoreMetaStr(),
-			}
+			// tt.restore.Annotations = map[string]string{
+			// 	label.AnnBackupCloudSnapKey: testutils.ConstructRestoreMetaStr(),
+			// }
 			m := NewRestoreManager(deps)
 			err := m.Sync(tt.restore)
 			g.Expect(err).Should(BeNil())
 		})
 	}
+
+	//generate the restore meta in local nfs
+	err = os.Remove("/tmp/restoremeta")
+	g.Expect(err).To(Succeed())
 }

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -209,28 +209,28 @@ func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, execr Snap
 }
 
 func extractCloudSnapBackup(r *v1alpha1.Restore) (*CloudSnapBackup, string, error) {
-	// must init rclone config before download tc_meta to local
-	// 1. write a file into local
+
 	klog.Infof("download the remote cluster meta to local")
 
-	// 2. upload to remote
+	// 1. download remote meta to local
 	rclone := util.NewRclone(r.Namespace, r.ClusterName)
 
-	backupFullPath, _ := util.GetStorageRestorePath(r)
+	restoreFullPath, _ := util.GetStorageRestorePath(r)
 	opts := util.GetOptions(r.Spec.StorageProvider)
-	// 4. copy to s3
-	if err := rclone.CopyRemoteClusterMetaToLocal(backupFullPath, opts); err != nil {
+	// 2. copy to local
+	if err := rclone.CopyRemoteClusterMetaToLocal(restoreFullPath, opts); err != nil {
 		return nil, "CopyLocalClusterMetaToRemoteFailed", err
 	}
 
-	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta)
-	clusterMeta, err := ioutil.ReadFile(localMetaFile)
+	// 3. read the local file
+	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterRestoreMeta)
+	restoreMeta, err := ioutil.ReadFile(localMetaFile)
 	if err != nil {
 		return nil, "ReadFileFailed", err
 	}
 
 	csb := &CloudSnapBackup{}
-	err = json.Unmarshal(clusterMeta, csb)
+	err = json.Unmarshal(restoreMeta, csb)
 	if err != nil {
 		return nil, "ParseCloudSnapBackupFailed", err
 	}

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -213,7 +213,7 @@ func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, execr Snap
 func extractCloudSnapBackup(r *v1alpha1.Restore) (*CloudSnapBackup, string, error) {
 	// must init rclone config before download tc_meta to local
 	// 1. write a file into local
-	klog.Infof("upload the cluster meta to remote storage")
+	klog.Infof("download the remote cluster meta to local")
 
 	// 2. upload to remote
 	rclone := util.NewRclone(r.Namespace, r.ClusterName)

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -14,10 +14,8 @@
 package snapshotter
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,7 +23,6 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/constants"
-	"github.com/pingcap/tidb-operator/pkg/backup/util"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,13 +41,13 @@ type Snapshotter interface {
 	// for the PersistentVolume-PV.
 	GetVolumeID(pv *corev1.PersistentVolume) (string, error)
 
-	// PrepareBackupMetadata performs the preparations for creating
+	// GenerateBackupMetadata performs the preparations for creating
 	// a snapshot from the used volume for PV/PVC.
-	PrepareBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error)
+	GenerateBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (*CloudSnapBackup, string, error)
 
 	// PrepareRestoreMetadata performs the preparations for creating
 	// a volume from the snapshot that has been backed up.
-	PrepareRestoreMetadata(r *v1alpha1.Restore) (string, error)
+	PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error)
 
 	// SetVolumeID sets the cloud provider specific identifier
 	// for the PersistentVolume-PV.
@@ -139,62 +136,23 @@ func (s *BaseSnapshotter) PrepareCSBK8SMeta(csb *CloudSnapBackup, tc *v1alpha1.T
 	return pods, "", nil
 }
 
-func (s *BaseSnapshotter) prepareBackupMetadata(
-	b *v1alpha1.Backup, tc *v1alpha1.TidbCluster, execr Snapshotter) (string, error) {
+func (s *BaseSnapshotter) generateBackupMetadata(
+	b *v1alpha1.Backup, tc *v1alpha1.TidbCluster, execr Snapshotter) (*CloudSnapBackup, string, error) {
 	csb := NewCloudSnapshotBackup(tc)
 	pods, reason, err := s.PrepareCSBK8SMeta(csb, tc)
 	if err != nil {
-		return reason, err
+		return nil, reason, err
 	}
 
 	m := NewBackupStoresMixture(tc, csb.Kubernetes.PVCs, csb.Kubernetes.PVs, execr)
 	if reason, err := m.PrepareCSBStoresMeta(csb, pods); err != nil {
-		return reason, err
+		return nil, reason, err
 	}
 
-	if reason, err := uploadClusterMetaToRemote(b, csb); err != nil {
-		return reason, err
-	}
-
-	return "", nil
+	return csb, "", nil
 }
 
-// copy cluster info to remote storage since k8s size limitation on annotation/configMap
-func uploadClusterMetaToRemote(b *v1alpha1.Backup, csb *CloudSnapBackup) (string, error) {
-	out, err := json.Marshal(csb)
-	if err != nil {
-		return "ParseCloudSnapshotBackupFailed", err
-	}
-	// 1. write a file into local
-	klog.Infof("upload the cluster meta to remote storage")
-	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta)
-	err = ioutil.WriteFile(localMetaFile, []byte(out), 0644)
-	if err != nil {
-		return "WriteClusterMetaToLocalFailed", err
-	}
-	// 2. upload local file to remote
-	rclone := util.NewRclone(b.Namespace, b.ClusterName)
-
-	backupFullPath, err := util.GetStorageBackupPath(b)
-	if err != nil {
-		klog.Errorf("Get backup full path of cluster %s failed, err: %s", b.ClusterName, err)
-		return "GetStorageBackupPathFailed", err
-	}
-	opts := util.GetOptions(b.Spec.StorageProvider)
-	// copy to remote storage
-	if err = rclone.CopyLocalClusterMetaToRemote(backupFullPath, opts); err != nil {
-		return "CopyLocalClusterMetaToRemoteFailed", err
-	}
-
-	return "", nil
-}
-
-func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, execr Snapshotter) (string, error) {
-	csb, reason, err := extractCloudSnapBackup(r)
-	if err != nil {
-		return reason, err
-	}
-
+func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup, execr Snapshotter) (string, error) {
 	if reason, err := checkCloudSnapBackup(csb); err != nil {
 		return reason, err
 	}
@@ -210,41 +168,6 @@ func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, execr Snap
 	}
 
 	return "", nil
-}
-
-// after volume retore job complete, br output a meta file for controller to reconfig the tikvs
-// since the meta file may big, so we use remote storage as bridge to pass it from restore manager to controller
-func extractCloudSnapBackup(r *v1alpha1.Restore) (*CloudSnapBackup, string, error) {
-
-	klog.Infof("download the remote restore meta to local")
-
-	// 1. download remote meta to local
-	rclone := util.NewRclone(r.Namespace, r.ClusterName)
-
-	restoreFullPath, err := util.GetStorageRestorePath(r)
-	if err != nil {
-		klog.Errorf("Get restore full path of cluster %s failed, err: %s", r.Name, err)
-		return nil, "GetStorageRestorePathFailed", err
-	}
-	opts := util.GetOptions(r.Spec.StorageProvider)
-	// 2. copy to local
-	if err := rclone.CopyRemoteClusterMetaToLocal(restoreFullPath, opts); err != nil {
-		return nil, "CopyLocalClusterMetaToRemoteFailed", err
-	}
-
-	// 3. read the local file
-	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterRestoreMeta)
-	restoreMeta, err := ioutil.ReadFile(localMetaFile)
-	if err != nil {
-		return nil, "ReadFileFailed", err
-	}
-
-	csb := &CloudSnapBackup{}
-	err = json.Unmarshal(restoreMeta, csb)
-	if err != nil {
-		return nil, "ParseCloudSnapBackupFailed", err
-	}
-	return csb, "", nil
 }
 
 func checkCloudSnapBackup(b *CloudSnapBackup) (string, error) {

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -175,9 +175,6 @@ func uploadClusterMetaToRemote(b *v1alpha1.Backup, csb *CloudSnapBackup) (string
 	// 2. upload to remote
 	rclone := util.NewRclone(b.Namespace, b.ClusterName)
 
-	// 3. config rclone
-	rclone.Config(b.Spec.StorageProvider)
-
 	backupFullPath, _ := util.GetStoragePath(b)
 	opts := util.GetOptions(b.Spec.StorageProvider)
 	// 4. copy to s3
@@ -218,9 +215,6 @@ func extractCloudSnapBackup(r *v1alpha1.Restore) (*CloudSnapBackup, string, erro
 
 	// 2. upload to remote
 	rclone := util.NewRclone(r.Namespace, r.ClusterName)
-
-	// 3. config rclone
-	rclone.Config(r.Spec.StorageProvider)
 
 	backupFullPath, _ := util.GetStorageRestorePath(r)
 	opts := util.GetOptions(r.Spec.StorageProvider)

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -167,7 +167,8 @@ func uploadClusterMetaToRemote(b *v1alpha1.Backup, csb *CloudSnapBackup) (string
 	// must init rclone config before upload tc_meta to remote
 	// 1. write a file into local
 	klog.Infof("upload the cluster meta to remote storage")
-	err = os.WriteFile(constants.ClusterBackupMeta, []byte(out), 0644)
+	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta)
+	err = ioutil.WriteFile(localMetaFile, []byte(out), 0644)
 	if err != nil {
 		return "WriteClusterMetaToLocalFailed", err
 	}
@@ -228,7 +229,8 @@ func extractCloudSnapBackup(r *v1alpha1.Restore) (*CloudSnapBackup, string, erro
 		return nil, "CopyLocalClusterMetaToRemoteFailed", err
 	}
 
-	clusterMeta, err := os.ReadFile(constants.ClusterBackupMeta)
+	localMetaFile := fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta)
+	clusterMeta, err := ioutil.ReadFile(localMetaFile)
 	if err != nil {
 		return nil, "ReadFileFailed", err
 	}

--- a/pkg/backup/snapshotter/snapshotter_aws.go
+++ b/pkg/backup/snapshotter/snapshotter_aws.go
@@ -58,8 +58,8 @@ func (s *AWSSnapshotter) GetVolumeID(pv *corev1.PersistentVolume) (string, error
 	return "", nil
 }
 
-func (s *AWSSnapshotter) PrepareBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error) {
-	return s.BaseSnapshotter.prepareBackupMetadata(b, tc, s)
+func (s *AWSSnapshotter) GenerateBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (*CloudSnapBackup, string, error) {
+	return s.BaseSnapshotter.generateBackupMetadata(b, tc, s)
 }
 
 func (s *AWSSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID string) error {
@@ -86,6 +86,6 @@ func (s *AWSSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID strin
 	return nil
 }
 
-func (s *AWSSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore) (string, error) {
-	return s.BaseSnapshotter.prepareRestoreMetadata(r, s)
+func (s *AWSSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
+	return s.BaseSnapshotter.prepareRestoreMetadata(r, csb, s)
 }

--- a/pkg/backup/snapshotter/snapshotter_gcp.go
+++ b/pkg/backup/snapshotter/snapshotter_gcp.go
@@ -66,8 +66,8 @@ func (s *GCPSnapshotter) GetVolumeID(pv *corev1.PersistentVolume) (string, error
 	return "", nil
 }
 
-func (s *GCPSnapshotter) PrepareBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error) {
-	return s.BaseSnapshotter.prepareBackupMetadata(b, tc, s)
+func (s *GCPSnapshotter) GenerateBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (*CloudSnapBackup, string, error) {
+	return s.BaseSnapshotter.generateBackupMetadata(b, tc, s)
 }
 
 func (s *GCPSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID string) error {
@@ -95,6 +95,6 @@ func (s *GCPSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID strin
 	return nil
 }
 
-func (s *GCPSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore) (string, error) {
-	return s.BaseSnapshotter.prepareRestoreMetadata(r, s)
+func (s *GCPSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
+	return s.BaseSnapshotter.prepareRestoreMetadata(r, csb, s)
 }

--- a/pkg/backup/snapshotter/snapshotter_none.go
+++ b/pkg/backup/snapshotter/snapshotter_none.go
@@ -30,14 +30,14 @@ func (s *NoneSnapshotter) GetVolumeID(pv *corev1.PersistentVolume) (string, erro
 	return "", nil
 }
 
-func (s *NoneSnapshotter) PrepareBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (string, error) {
-	return "", nil
+func (s *NoneSnapshotter) GenerateBackupMetadata(b *v1alpha1.Backup, tc *v1alpha1.TidbCluster) (*CloudSnapBackup, string, error) {
+	return nil, "", nil
 }
 
 func (s *NoneSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID string) error {
 	return nil
 }
 
-func (s *NoneSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore) (string, error) {
+func (s *NoneSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
 	return "", nil
 }

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -14,6 +14,7 @@
 package snapshotter
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -860,15 +861,15 @@ func TestPrepareRestoreMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	// missing .annotation["tidb.pingcap.com/backup-cloud-snapshot"] as metadata
-	reason, err := s.PrepareRestoreMetadata(restore)
+	reason, err := s.PrepareRestoreMetadata(restore, &CloudSnapBackup{})
 	require.NotEmpty(t, reason)
 	require.Error(t, err)
 
 	meta := testutils.ConstructRestoreMetaStr()
-	restore.Annotations[label.AnnBackupCloudSnapKey] = meta
-
+	csb := &CloudSnapBackup{}
+	err = json.Unmarshal([]byte(meta), csb)
 	// happy path
-	reason, err = s.PrepareRestoreMetadata(restore)
+	reason, err = s.PrepareRestoreMetadata(restore, csb)
 	require.Empty(t, reason)
 	require.NoError(t, err)
 }

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -395,7 +395,7 @@ func TestPrepareCSBStoresMeta(t *testing.T) {
 	}
 }
 
-func TestPrepareBackupMetadata(t *testing.T) {
+func TestGenerateBackupMetadata(t *testing.T) {
 	helper := newHelper(t)
 	defer helper.Close()
 	deps := helper.Deps
@@ -454,7 +454,7 @@ func TestPrepareBackupMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _, err := NewSnapshotterForBackup(tt.backup.Spec.Mode, deps)
 			require.NoError(t, err)
-			_, err = s.PrepareBackupMetadata(tt.backup, tc)
+			_, _, err = s.GenerateBackupMetadata(tt.backup, tc)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -867,7 +867,7 @@ func TestPrepareRestoreMetadata(t *testing.T) {
 
 	meta := testutils.ConstructRestoreMetaStr()
 	csb := &CloudSnapBackup{}
-	err = json.Unmarshal([]byte(meta), csb)
+	_ = json.Unmarshal([]byte(meta), csb)
 	// happy path
 	reason, err = s.PrepareRestoreMetadata(restore, csb)
 	require.Empty(t, reason)

--- a/pkg/backup/util/remote.go
+++ b/pkg/backup/util/remote.go
@@ -43,6 +43,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/constants"
@@ -335,6 +336,7 @@ func GetStorageCredential(ns string, provider v1alpha1.StorageProvider, secretLi
 		if s3SecretName != "" {
 			secret, err = secretLister.Secrets(ns).Get(s3SecretName)
 			if err != nil {
+				klog.Errorf("Get the secret key failed.")
 				return &StorageCredential{}
 			}
 

--- a/pkg/backup/util/remote.go
+++ b/pkg/backup/util/remote.go
@@ -101,7 +101,6 @@ type StorageBackend struct {
 	gcs    *gcsConfig
 	azblob *azblobConfig
 	local  *localConfig
-	cred   *StorageCredential
 }
 
 // NewStorageBackend creates new storage backend, now supports S3/GCS/Azblob/Local

--- a/pkg/backup/util/remote.go
+++ b/pkg/backup/util/remote.go
@@ -215,26 +215,6 @@ type BatchDeleteObjectsResult struct {
 	Errors  []ObjectError
 }
 
-// WriteFile writes a complete file to storage, similar to os.WriteFile,
-func (b *StorageBackend) WriteFile(ctx context.Context, name string, data []byte) error {
-	return nil
-}
-
-// ReadFile reads a complete file from storage, similar to os.ReadFile
-func (b *StorageBackend) ReadFile(ctx context.Context, name string) ([]byte, error) {
-	return []byte(""), nil
-}
-
-// FileExists return true if file exists
-func (b *StorageBackend) FileExists(ctx context.Context, name string) (bool, error) {
-	return false, nil
-}
-
-// DeleteFile delete the file in storage
-func (b *StorageBackend) DeleteFile(ctx context.Context, name string) error {
-	return nil
-}
-
 // BatchDeleteObjects delete mutli objects
 //
 // Depending on storage type, it use function 'BatchDeleteObjectsOfS3' or 'BatchDeleteObjectsConcurrently'

--- a/pkg/backup/util/remote_test.go
+++ b/pkg/backup/util/remote_test.go
@@ -256,7 +256,7 @@ func TestStorageBackendBasic(t *testing.T) {
 		provider := tcases.provider
 
 		// mock function
-		s3patches := gomonkey.ApplyFunc(newS3Storage, func(conf *s3Config) (*blob.Bucket, error) {
+		s3patches := gomonkey.ApplyFunc(newS3Storage, func(conf *s3Config, cred *StorageCredential) (*blob.Bucket, error) {
 			return nil, nil
 		})
 		defer s3patches.Reset()

--- a/pkg/backup/util/remote_test.go
+++ b/pkg/backup/util/remote_test.go
@@ -273,7 +273,7 @@ func TestStorageBackendBasic(t *testing.T) {
 		})
 		defer localPatches.Reset()
 
-		backend, err := NewStorageBackend(provider, nil)
+		backend, err := NewStorageBackend(provider, &StorageCredential{})
 		g.Expect(err).Should(gomega.Succeed())
 
 		g.Expect(backend.StorageType()).Should(gomega.Equal(tcases.expectStorageType))

--- a/pkg/backup/util/remote_test.go
+++ b/pkg/backup/util/remote_test.go
@@ -273,7 +273,7 @@ func TestStorageBackendBasic(t *testing.T) {
 		})
 		defer localPatches.Reset()
 
-		backend, err := NewStorageBackend(provider)
+		backend, err := NewStorageBackend(provider, nil)
 		g.Expect(err).Should(gomega.Succeed())
 
 		g.Expect(backend.StorageType()).Should(gomega.Equal(tcases.expectStorageType))

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -856,14 +856,18 @@ func generateS3Confg(s3 *v1alpha1.S3StorageProvider, secret *corev1.Secret) (str
 	if s3.SecretName != "" {
 
 		s3AccessKey := secret.Data[constants.S3AccessKey]
+		klog.Infof("access key is %s before decode", string(s3AccessKey))
 		accessKey, err := base64DecodeToString(s3AccessKey)
+		klog.Infof("access key is %s after decode", s3AccessKey)
 		if err != nil {
 			return "DecodeAccessKeyFailed", err
 		}
 		accessKeyId = accessKeyId + accessKey
 
 		s3SecretKey := secret.Data[constants.S3SecretKey]
+		klog.Infof("secret is %s before decode", string(s3SecretKey))
 		secretKey, err := base64DecodeToString(s3SecretKey)
+		klog.Infof("secret is %s after decode", s3SecretKey)
 		if err != nil {
 			return "DecodeSecretKeyFailed", err
 		}
@@ -961,8 +965,7 @@ func GenerateRemoteConfig(ns string, provider v1alpha1.StorageProvider, secretLi
 	return reason, nil
 }
 
-// RClone for backup and restore controller, since volume snapshot backup and restore generate huge cluster info, the k8s related techinical
-// can not handle it
+// Rclone for backup and restore controller, since volume snapshot backup and restore generate huge cluster info, and hit the k8s limitation
 // annotation limit: 256K
 // configMap limit: 1MB
 // envVar limt: 1MB

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -715,58 +715,28 @@ func GetContextForTerminationSignals(op string) (context.Context, context.Cancel
 }
 
 // GetStorageRestorePath generate the path of a specific storage from Restore
-func GetStorageRestorePath(restore *v1alpha1.Restore) (string, error) {
+func GetStoragePath(privoder v1alpha1.StorageProvider) (string, error) {
 	var url, bucket, prefix string
-	st := GetStorageType(restore.Spec.StorageProvider)
+	st := GetStorageType(privoder)
 	switch st {
 	case v1alpha1.BackupStorageTypeS3:
-		prefix = restore.Spec.StorageProvider.S3.Prefix
-		bucket = restore.Spec.StorageProvider.S3.Bucket
+		prefix = privoder.S3.Prefix
+		bucket = privoder.S3.Bucket
 		url = fmt.Sprintf("s3://%s", path.Join(bucket, prefix))
 		return url, nil
 	case v1alpha1.BackupStorageTypeGcs:
-		prefix = restore.Spec.StorageProvider.Gcs.Prefix
-		bucket = restore.Spec.StorageProvider.Gcs.Bucket
+		prefix = privoder.Gcs.Prefix
+		bucket = privoder.Gcs.Bucket
 		url = fmt.Sprintf("gcs://%s/", path.Join(bucket, prefix))
 		return url, nil
 	case v1alpha1.BackupStorageTypeAzblob:
-		prefix = restore.Spec.StorageProvider.Azblob.Prefix
-		bucket = restore.Spec.StorageProvider.Azblob.Container
+		prefix = privoder.Azblob.Prefix
+		bucket = privoder.Azblob.Container
 		url = fmt.Sprintf("azure://%s/", path.Join(bucket, prefix))
 		return url, nil
 	case v1alpha1.BackupStorageTypeLocal:
-		prefix = restore.Spec.StorageProvider.Local.Prefix
-		mountPath := restore.Spec.StorageProvider.Local.VolumeMount.MountPath
-		url = fmt.Sprintf("local://%s", path.Join(mountPath, prefix))
-		return url, nil
-	default:
-		return "", fmt.Errorf("storage %s not supported yet", st)
-	}
-}
-
-// GetStorageBackupPath generate the path of a specific storage from Backup
-func GetStorageBackupPath(backup *v1alpha1.Backup) (string, error) {
-	var url, bucket, prefix string
-	st := GetStorageType(backup.Spec.StorageProvider)
-	switch st {
-	case v1alpha1.BackupStorageTypeS3:
-		prefix = backup.Spec.StorageProvider.S3.Prefix
-		bucket = backup.Spec.StorageProvider.S3.Bucket
-		url = fmt.Sprintf("s3://%s", path.Join(bucket, prefix))
-		return url, nil
-	case v1alpha1.BackupStorageTypeGcs:
-		prefix = backup.Spec.StorageProvider.Gcs.Prefix
-		bucket = backup.Spec.StorageProvider.Gcs.Bucket
-		url = fmt.Sprintf("gcs://%s/", path.Join(bucket, prefix))
-		return url, nil
-	case v1alpha1.BackupStorageTypeAzblob:
-		prefix = backup.Spec.StorageProvider.Azblob.Prefix
-		bucket = backup.Spec.StorageProvider.Azblob.Container
-		url = fmt.Sprintf("azure://%s/", path.Join(bucket, prefix))
-		return url, nil
-	case v1alpha1.BackupStorageTypeLocal:
-		prefix = backup.Spec.StorageProvider.Local.Prefix
-		mountPath := backup.Spec.StorageProvider.Local.VolumeMount.MountPath
+		prefix = privoder.Local.Prefix
+		mountPath := privoder.Local.VolumeMount.MountPath
 		url = fmt.Sprintf("local://%s", path.Join(mountPath, prefix))
 		return url, nil
 	default:

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -848,7 +848,7 @@ func generateS3Confg(s3 *v1alpha1.S3StorageProvider, secret *corev1.Secret) (str
 	fmt.Fprintln(f, "type = s3")
 	fmt.Fprintln(f, "env_auth = true")
 
-	provider := "provider =  " + string(s3.Provider)
+	provider := "provider = " + string(s3.Provider)
 	fmt.Fprintln(f, provider)
 
 	accessKeyId := "access_key_id = "
@@ -957,6 +957,7 @@ func GenerateRemoteConfig(ns string, provider v1alpha1.StorageProvider, secretLi
 		err := fmt.Errorf("volume-snapshot unsupported storage type %s", storageType)
 		return "UnsupportedStorageType", err
 	}
+	klog.Infof("volume-snapshot created rclone file done")
 	return reason, nil
 }
 
@@ -1012,6 +1013,8 @@ func (rc *Rclone) CopyLocalClusterMetaToRemote(bucket string, opts []string) err
 	destBucket := NormalizeBucketURI(bucket)
 	args := ConstructRcloneArgs(constants.RcloneConfigArg, opts, "copyto", fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta), fmt.Sprintf("%s/%s", destBucket, constants.ClusterBackupMeta), true)
 	cmdString := fmt.Sprintf("rclone %s", args)
+
+	klog.Infof("cmd %s was copy to %s start", cmdString, bucket)
 
 	cmd := exec.Command(cmdString)
 	if err := cmd.Run(); err != nil {

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -991,16 +991,17 @@ func (rc *Rclone) CopyRemoteClusterMetaToLocal(bucket string, opts []string) err
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
 	}
-	klog.Infof("backup %s was copy from %s successfully", rc.BackupName, bucket)
+	klog.Infof("restore meta for %s was copy from %s to local successfully", rc.BackupName, bucket)
 
 	// delete remote restore meta to local
 	argsDelete := ConstructRcloneArgs(constants.RcloneConfigArg, opts, "deletefile", fmt.Sprintf("%s/%s", destBucket, constants.ClusterRestoreMeta), "", true)
 
 	cmdDel := exec.Command("rclone", argsDelete...)
 	if err := cmdDel.Run(); err != nil {
-		return fmt.Errorf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
+		klog.Warningf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
+		return nil
 	}
-	klog.Infof("backup %s was copy from %s successfully", rc.BackupName, bucket)
+	klog.Infof("restore meta %s was deleted from %s successfully", rc.BackupName, bucket)
 
 	return nil
 }

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -987,9 +987,7 @@ func (rc *Rclone) String() string {
 func (rc *Rclone) CopyRemoteClusterMetaToLocal(bucket string, opts []string) error {
 	destBucket := NormalizeBucketURI(bucket)
 	args := ConstructRcloneArgs(constants.RcloneConfigArg, opts, "copyto", fmt.Sprintf("%s/%s", destBucket, constants.ClusterRestoreMeta), fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterRestoreMeta), true)
-	cmdString := fmt.Sprintf("rclone %s", args)
-
-	cmd := exec.Command(cmdString)
+	cmd := exec.Command("rclone", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
 	}
@@ -997,9 +995,8 @@ func (rc *Rclone) CopyRemoteClusterMetaToLocal(bucket string, opts []string) err
 
 	// delete remote restore meta to local
 	argsDelete := ConstructRcloneArgs(constants.RcloneConfigArg, opts, "deletefile", fmt.Sprintf("%s/%s", destBucket, constants.ClusterRestoreMeta), "", true)
-	cmdDelString := fmt.Sprintf("rclone %s", argsDelete)
 
-	cmdDel := exec.Command(cmdDelString)
+	cmdDel := exec.Command("rclone", argsDelete...)
 	if err := cmdDel.Run(); err != nil {
 		return fmt.Errorf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
 	}
@@ -1012,11 +1009,9 @@ func (rc *Rclone) CopyRemoteClusterMetaToLocal(bucket string, opts []string) err
 func (rc *Rclone) CopyLocalClusterMetaToRemote(bucket string, opts []string) error {
 	destBucket := NormalizeBucketURI(bucket)
 	args := ConstructRcloneArgs(constants.RcloneConfigArg, opts, "copyto", fmt.Sprintf("%s/%s", constants.LocalTmp, constants.ClusterBackupMeta), fmt.Sprintf("%s/%s", destBucket, constants.ClusterBackupMeta), true)
-	cmdString := fmt.Sprintf("rclone %s", args)
+	klog.Infof("cmd %s was copy to %s start", args, bucket)
 
-	klog.Infof("cmd %s was copy to %s start", cmdString, bucket)
-
-	cmd := exec.Command(cmdString)
+	cmd := exec.Command("rclone", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("backup %s, execute rclone copy command failed, err: %v", rc.BackupName, err)
 	}

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -14,14 +14,10 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"net/url"
-	"os"
-	"os/signal"
 	"path"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"github.com/Masterminds/semver"
@@ -694,24 +690,6 @@ func isLogBackSupport(tikvImage string) bool {
 		return false
 	}
 	return true
-}
-
-// GetContextForTerminationSignals get a context for some termination signals, and the context will become done after any of these signals triggered.
-func GetContextForTerminationSignals(op string) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-	go func() {
-		sig := <-sc
-		klog.Errorf("got signal %s to exit, %s will be canceled", sig, op)
-		cancel() // NOTE: the `Message` in `Status.Conditions` will contain `context canceled`.
-	}()
-	return ctx, cancel
 }
 
 // GetStorageRestorePath generate the path of a specific storage from Restore


### PR DESCRIPTION
### What problem does this PR solve?
Closes #4781

### What is changed and how does it work?
using the remote storage to pass info between backup manager and controller

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test 
 50+ EKS node with tidb cluster has 50 tikv nodes, backup works and completed

![AeNHSlVS1e](https://user-images.githubusercontent.com/85682690/202402445-80f3780e-4898-46d0-b38a-5a874e9b208b.jpg)

restore
![LVKf2V3nWh](https://user-images.githubusercontent.com/85682690/202414524-b2372290-9955-4f55-a882-d83a5a22293d.jpg)

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
