### PR TITLE
feat(controller): treat "master" as latest version

### DIFF
--- a/pkg/util/cmpver/cmpver.go
+++ b/pkg/util/cmpver/cmpver.go
@@ -15,6 +15,7 @@ package cmpver
 
 import (
 	"fmt"
+	"strings"
 
 	semver "github.com/Masterminds/semver"
 )
@@ -130,8 +131,13 @@ func validateOperation(op Operation) error {
 }
 
 func isLatest(version string) bool {
-	switch version {
-	case "latest", "nightly":
+	switch {
+	case version == "latest",
+		version == "nightly",
+		version == "master",
+		strings.HasPrefix(version, "latest-"),
+		strings.HasPrefix(version, "nightly-"),
+		strings.HasPrefix(version, "master-"):
 		return true
 	}
 

--- a/pkg/util/cmpver/cmpver.go
+++ b/pkg/util/cmpver/cmpver.go
@@ -38,7 +38,7 @@ const (
 // Dirty versions and pre versions are regarded as standard version.
 // For example: 'v5.1.2-dev' and 'v5.1.2-betav1' are regarded as 'v5.1.2'.
 //
-// Latest or nightly version is larger than any version
+// Latest, nightly or master version is larger than any version
 func Compare(ver1 string, op Operation, ver2 string) (bool, error) {
 	err := validateOperation(op)
 	if err != nil {
@@ -62,7 +62,7 @@ func Compare(ver1 string, op Operation, ver2 string) (bool, error) {
 // Dirty versions and pre versions are regarded as standard version.
 // For example: 'v5.1.2-dev' and 'v5.1.2-betav1' are regarded as 'v5.1.2'.
 //
-// Latest or nightly version is larger than any version
+// Latest, nightly or master version is larger than any version
 func CompareByStr(ver1, opstr, ver2 string) (bool, error) {
 	op := Operation(opstr)
 	return Compare(ver1, op, ver2)
@@ -98,7 +98,7 @@ func NewConstraint(op Operation, version string) (*Constraint, error) {
 // Dirty versions and pre versions are regarded as standard version.
 // For example: 'v5.1.2-dev' and 'v5.1.2-betav1' are regarded as 'v5.1.2'.
 //
-// Latest or nightly version is larger than any version
+// Latest, nightly or master version is larger than any version
 func (c *Constraint) Check(version string) (bool, error) {
 	if isLatest(version) {
 		return compareLatest(c.op), nil

--- a/pkg/util/cmpver/cmpver_test.go
+++ b/pkg/util/cmpver/cmpver_test.go
@@ -71,6 +71,10 @@ func genTestCases() []testcase {
 		{"v5.3.1-dev12", Greater, "v5.3.1", false},
 		{"latest", Greater, "v5.3.1", true},
 		{"nightly", Greater, "v5.3.1", true},
+		{"master", Greater, "v5.3.1", true},
+		{"latest-dev", Greater, "v5.3.1", true},
+		{"nightly-dev", Greater, "v5.3.1", true},
+		{"master-dev", Greater, "v5.3.1", true},
 		// GreaterOrEqual
 		{"v5.3.1", GreaterOrEqual, "v5.1.2", true},
 		{"5.3.1", GreaterOrEqual, "5.1.2", true},
@@ -82,6 +86,10 @@ func genTestCases() []testcase {
 		{"v5.3.1-dev12", GreaterOrEqual, "v5.3.1", true},
 		{"latest", GreaterOrEqual, "v5.3.1", true},
 		{"nightly", GreaterOrEqual, "v5.3.1", true},
+		{"master", GreaterOrEqual, "v5.3.1", true},
+		{"latest-dev", GreaterOrEqual, "v5.3.1", true},
+		{"nightly-dev", GreaterOrEqual, "v5.3.1", true},
+		{"master-dev", GreaterOrEqual, "v5.3.1", true},
 		// Less
 		{"v5.3.1", Less, "v5.1.2", false},
 		{"v5.1.2", Less, "v5.3.1", true},
@@ -92,6 +100,10 @@ func genTestCases() []testcase {
 		{"v5.3.1-dev12", Less, "v5.3.1", false},
 		{"latest", Less, "v5.3.1", false},
 		{"nightly", Less, "v5.3.1", false},
+		{"master", Less, "v5.3.1", false},
+		{"latest-dev", Less, "v5.3.1", false},
+		{"nightly-dev", Less, "v5.3.1", false},
+		{"master-dev", Less, "v5.3.1", false},
 		// LessOrEqual
 		{"v5.3.1", LessOrEqual, "v5.1.2", false},
 		{"5.3.1", LessOrEqual, "5.1.2", false},
@@ -102,5 +114,9 @@ func genTestCases() []testcase {
 		{"v5.3.1-dev12", LessOrEqual, "v5.3.1", true},
 		{"latest", LessOrEqual, "v5.3.1", false},
 		{"nightly", LessOrEqual, "v5.3.1", false},
+		{"master", LessOrEqual, "v5.3.1", false},
+		{"latest-dev", LessOrEqual, "v5.3.1", false},
+		{"nightly-dev", LessOrEqual, "v5.3.1", false},
+		{"master-dev", LessOrEqual, "v5.3.1", false},
 	}
 }


### PR DESCRIPTION
Signed-off-by: lobshunter <pengyu@pingcap.com>

### What problem does this PR solve?
This PR adds `master` to latest version list, so images with that tag can be used(mainly used in testing).

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Treat "master" as latest version of TiDB components too
```
