### PR TITLE
Update tidb-controller-manager helm chart to add detectNodeFailure flag

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -79,6 +79,13 @@ spec:
           - -tidb-failover-period={{ .Values.controllerManager.tidbFailoverPeriod | default "5m" }}
           - -dm-master-failover-period={{ .Values.controllerManager.dmMasterFailoverPeriod | default "5m" }}
           - -dm-worker-failover-period={{ .Values.controllerManager.dmWorkerFailoverPeriod | default "5m" }}
+         {{- if eq .Values.controllerManager.detectNodeFailure true }}
+          - -detect-node-failure=true
+          - -pod-hard-recovery-period={{ .Values.controllerManager.podHardRecoveryPeriod | default "24h" }}
+         {{- end }}
+         {{- if eq .Values.controllerManager.detectNodeFailure false }}
+          - -detect-node-failure=false
+         {{- end }}
           - -v={{ .Values.controllerManager.logLevel }}
           {{- if .Values.testMode }}
           - -test-mode={{ .Values.testMode }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -92,7 +92,7 @@ controllerManager:
   dmMasterFailoverPeriod: 5m
   # dm-worker failover period default(5m)
   dmWorkerFailoverPeriod: 5m
-  # detectNodeFailure tells whether tidb-operator should auto detect k8s node failures for recovery for failure pods. Currently it is experimental
+  # detectNodeFailure tells whether tidb-operator should auto detect k8s node failures for recovery of failure pods. Currently it is experimental
   detectNodeFailure: false
   # podHardRecoveryPeriod is the period after which a failure pod is forcefully marked as k8s node failure. To be set if detectNodeFailure is true default (24h)
   # podHardRecoveryPeriod: 24h

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -92,6 +92,10 @@ controllerManager:
   dmMasterFailoverPeriod: 5m
   # dm-worker failover period default(5m)
   dmWorkerFailoverPeriod: 5m
+  # automatically detect k8s node failures for failure pods
+  detectNodeFailure: false
+  # podHardRecoveryPeriod is the period after which a failure pod is forcefully marked as k8s node failure. To be set if detectNodeFailure is true default (24h)
+  # podHardRecoveryPeriod: 24h
   ## affinity defines pod scheduling rules,affinity default settings is empty.
   ## please read the affinity document before set your scheduling rule:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -92,7 +92,7 @@ controllerManager:
   dmMasterFailoverPeriod: 5m
   # dm-worker failover period default(5m)
   dmWorkerFailoverPeriod: 5m
-  # automatically detect k8s node failures for failure pods
+  # detectNodeFailure tells whether tidb-operator should auto detect k8s node failures for recovery for failure pods. Currently it is experimental
   detectNodeFailure: false
   # podHardRecoveryPeriod is the period after which a failure pod is forcefully marked as k8s node failure. To be set if detectNodeFailure is true default (24h)
   # podHardRecoveryPeriod: 24h


### PR DESCRIPTION
### What problem does this PR solve?
Update tidb-controller-manager helm chart for the https://github.com/pingcap/tidb-operator/pull/4782 code changes where two new flags were added to the TiDB operator - `detectNodeFailure` and `podHardRecoveryPeriod`

### What is changed and how does it work?
Add `detectNodeFailure` and `podHardRecoveryPeriod` flag to tidb-controller-manager helm chart values. It is disabled by default.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test
  - Deploy the TiDB operator by generating the tidb-operator template using helm
  - Verify the deployed TiDB operator pod has the correct flag set as per the values.yaml
  - Test the auto failure recovery feature as described in https://github.com/pingcap/tidb-operator/pull/4782
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

ACTION REQUIRED: None
```
Add auto failure recovery feature that removes failed Pod and PVCs of PD, TIKV and TiFlash components to handle unplanned failures of Kubernetes nodes hosting any stateful Pod of a TiDB Cluster. This feature can be enabled by the `controllerManager.detectNodeFailure` configuration in the TiDB Operator and the `app.kubernetes.io/auto-failure-recovery: "true"` annotation in the TiDB Cluster
```
