### PR TITLE
Add config to increase kube-client qps limit

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -106,6 +106,12 @@ spec:
          {{- if .Values.controllerManager.leaderRetryPeriod }}
           - -leader-retry-period={{ .Values.controllerManager.leaderRetryPeriod }}
          {{- end }}
+         {{- if .Values.controllerManager.kubeClientQPS }}
+          - -kube-client-qps={{ .Values.controllerManager.kubeClientQPS }}
+         {{- end }}
+         {{- if .Values.controllerManager.kubeClientBurst }}
+          - -kube-client-burst={{ .Values.controllerManager.kubeClientBurst }}
+         {{- end }}
         env:
           - name: NAMESPACE
             valueFrom:

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -133,6 +133,10 @@ controllerManager:
   # PodAnnotations will set template.metadata.annotations
   # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
+  ## KubeClientQPS indicates the maximum QPS to the kubenetes api from client.
+  # kubeClientQPS: 5
+  ## Maximum burst for throttle.
+  # kubeClientBurst: 10
 
 scheduler:
   create: true

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -133,7 +133,7 @@ controllerManager:
   # PodAnnotations will set template.metadata.annotations
   # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
-  ## KubeClientQPS indicates the maximum QPS to the kubenetes api from client.
+  ## KubeClientQPS indicates the maximum QPS to the kubenetes API server from client.
   # kubeClientQPS: 5
   ## Maximum burst for throttle.
   # kubeClientBurst: 10

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -103,6 +103,10 @@ func main() {
 		klog.Fatalf("failed to get config: %v", err)
 	}
 
+	// If they are zero, the created client will use the default values: 5, 10.
+	cfg.QPS = float32(cliCfg.KubeClientQPS)
+	cfg.Burst = cliCfg.KubeClientBurst
+
 	cli, err := versioned.NewForConfig(cfg)
 	if err != nil {
 		klog.Fatalf("failed to create Clientset: %v", err)

--- a/pkg/controller/dependences.go
+++ b/pkg/controller/dependences.go
@@ -91,6 +91,10 @@ type CLIConfig struct {
 	// Selector is used to filter CR labels to decide
 	// what resources should be watched and synced by controller
 	Selector string
+
+	// KubeClientQPS indicates the maximum QPS to the kubenetes api from client.
+	KubeClientQPS   float64
+	KubeClientBurst int
 }
 
 // DefaultCLIConfig returns the default command line configuration
@@ -147,6 +151,8 @@ func (c *CLIConfig) AddFlag(_ *flag.FlagSet) {
 	flag.DurationVar(&c.LeaseDuration, "leader-lease-duration", c.LeaseDuration, "leader-lease-duration is the duration that non-leader candidates will wait to force acquire leadership")
 	flag.DurationVar(&c.RenewDeadline, "leader-renew-deadline", c.RenewDeadline, "leader-renew-deadline is the duration that the acting master will retry refreshing leadership before giving up")
 	flag.DurationVar(&c.RetryPeriod, "leader-retry-period", c.RetryPeriod, "leader-retry-period is the duration the LeaderElector clients should wait between tries of actions")
+	flag.Float64Var(&c.KubeClientQPS, "kube-client-qps", c.KubeClientQPS, "The maximum QPS to the kubenetes api from client")
+	flag.IntVar(&c.KubeClientBurst, "kube-client-burst", c.KubeClientBurst, "The maximum burst for throttle to the kubenetes api from client")
 }
 
 // HasNodePermission returns whether the user has permission for node operations.

--- a/pkg/controller/dependences.go
+++ b/pkg/controller/dependences.go
@@ -92,7 +92,7 @@ type CLIConfig struct {
 	// what resources should be watched and synced by controller
 	Selector string
 
-	// KubeClientQPS indicates the maximum QPS to the kubenetes api from client.
+	// KubeClientQPS indicates the maximum QPS to the kubenetes API server from client.
 	KubeClientQPS   float64
 	KubeClientBurst int
 }
@@ -151,8 +151,8 @@ func (c *CLIConfig) AddFlag(_ *flag.FlagSet) {
 	flag.DurationVar(&c.LeaseDuration, "leader-lease-duration", c.LeaseDuration, "leader-lease-duration is the duration that non-leader candidates will wait to force acquire leadership")
 	flag.DurationVar(&c.RenewDeadline, "leader-renew-deadline", c.RenewDeadline, "leader-renew-deadline is the duration that the acting master will retry refreshing leadership before giving up")
 	flag.DurationVar(&c.RetryPeriod, "leader-retry-period", c.RetryPeriod, "leader-retry-period is the duration the LeaderElector clients should wait between tries of actions")
-	flag.Float64Var(&c.KubeClientQPS, "kube-client-qps", c.KubeClientQPS, "The maximum QPS to the kubenetes api from client")
-	flag.IntVar(&c.KubeClientBurst, "kube-client-burst", c.KubeClientBurst, "The maximum burst for throttle to the kubenetes api from client")
+	flag.Float64Var(&c.KubeClientQPS, "kube-client-qps", c.KubeClientQPS, "The maximum QPS to the kubenetes API server from client")
+	flag.IntVar(&c.KubeClientBurst, "kube-client-burst", c.KubeClientBurst, "The maximum burst for throttle to the kubenetes API server from client")
 }
 
 // HasNodePermission returns whether the user has permission for node operations.


### PR DESCRIPTION
### What problem does this PR solve?

Close #4829.

### What is changed and how does it work?

Add two config `kubeClientQPS` and `kubeClientBurst`, they will be passed to kube `client-go` config.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support for configuring kube-client QPS and Burst: `kubeClientQPS`/`kubeClientBurst`
```
