### PR TITLE
fix panic without PV permission

### DIFF
--- a/pkg/manager/volumes/delegation/aws/ebs_modifier.go
+++ b/pkg/manager/volumes/delegation/aws/ebs_modifier.go
@@ -88,6 +88,11 @@ func (m *EBSModifier) Validate(spvc, dpvc *corev1.PersistentVolumeClaim, ssc, ds
 }
 
 func (m *EBSModifier) ModifyVolume(ctx context.Context, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, sc *storagev1.StorageClass) ( /*wait*/ bool, error) {
+	if pv == nil {
+		klog.V(4).Infof("Persistent volume is nil, skip modifying PV for %s. This may be caused by no relevant permissions", pvc.Spec.VolumeName)
+		return false, nil
+	}
+
 	desired, err := m.getExpectedVolume(pvc, pv, sc)
 	if err != nil {
 		return false, err

--- a/pkg/manager/volumes/delegation/interface.go
+++ b/pkg/manager/volumes/delegation/interface.go
@@ -23,7 +23,8 @@ import (
 
 type VolumeModifier interface {
 	MinWaitDuration() time.Duration
-	// ModifyVolume modifies the underlay volume of pvc to match the args of storageclass
+	// ModifyVolume modifies the underlay volume of pvc to match the args of storageclass.
+	// If no PV permission (e.g `-cluster-permission-pv=false`), the `pv` may be nil and will return `false, nil`.
 	ModifyVolume(ctx context.Context, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, sc *storagev1.StorageClass) (bool, error)
 
 	Validate(spvc, dpvc *corev1.PersistentVolumeClaim, ssc, dsc *storagev1.StorageClass) error

--- a/pkg/manager/volumes/pod_vol_modifier.go
+++ b/pkg/manager/volumes/pod_vol_modifier.go
@@ -298,6 +298,11 @@ func getDesiredVolumeByName(vs []DesiredVolume, name v1alpha1.StorageVolumeName)
 }
 
 func (p *podVolModifier) getBoundPVFromPVC(pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolume, error) {
+	if p.deps.PVLister == nil {
+		klog.V(4).Infof("Persistent volumes lister is unavailable, skip getting PV for %s. This may be caused by no relevant permissions", pvc.Spec.VolumeName)
+		return nil, nil
+	}
+
 	name := pvc.Spec.VolumeName
 
 	return p.deps.PVLister.Get(name)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

fix #4797

NOTE, in this case, some volume statuses will not be updated

```
      volumes:
        tikv:
          boundCount: 1
          currentCapacity: 1Gi
          currentCount: 1
          currentStorageClass: standard
          modifiedCapacity: 1Gi
          modifiedCount: 0
          modifiedStorageClass: test
          name: tikv
          resizedCapacity: 1Gi
          resizedCount: 0
```

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that TiDB Operator panics if without PV permission
```
