### PR TITLE
tc: delete tiflash sts before scale from 0

### DIFF
--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -212,6 +212,15 @@ func (m *tiflashMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
 	}
 	setNotExist := errors.IsNotFound(err)
 
+	// if TiFlash is scale from 0 and with previous StatefulSet, we delete the previous StatefulSet first
+	// to avoid some fileds (e.g storage request) reused and cause unexpected behavior (e.g scale down).
+	if oldSetTmp != nil && *oldSetTmp.Spec.Replicas == 0 && tc.Spec.TiFlash.Replicas > 0 {
+		if err := m.deps.StatefulSetControl.DeleteStatefulSet(tc, oldSetTmp); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("syncStatefulSet: fail to delete sts %s for cluster %s/%s, error: %s", controller.TiFlashMemberName(tcName), ns, tcName, err)
+		}
+		return controller.RequeueErrorf("wait for previous sts %s for cluster %s/%s to be deleted", controller.TiFlashMemberName(tcName), ns, tcName)
+	}
+
 	oldSet := oldSetTmp.DeepCopy()
 
 	if err := m.syncTidbClusterStatus(tc, oldSet); err != nil {

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -214,10 +214,7 @@ func (m *tiflashMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
 
 	// if TiFlash is scale from 0 and with previous StatefulSet, we delete the previous StatefulSet first
 	// to avoid some fileds (e.g storage request) reused and cause unexpected behavior (e.g scale down).
-	if oldSetTmp != nil && *oldSetTmp.Spec.Replicas == 0 && tc.Spec.TiFlash.Replicas > 0 {
-		if oldSetTmp.Status.UpdatedReplicas != 0 {
-			return controller.RequeueErrorf("wait for previous sts %s for cluster %s/%s to be scaled to 0", controller.TiFlashMemberName(tcName), ns, tcName)
-		}
+	if oldSetTmp != nil && *oldSetTmp.Spec.Replicas == 0 && oldSetTmp.Status.UpdatedReplicas == 0 && tc.Spec.TiFlash.Replicas > 0 {
 		if err := m.deps.StatefulSetControl.DeleteStatefulSet(tc, oldSetTmp); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("syncStatefulSet: fail to delete sts %s for cluster %s/%s, error: %s", controller.TiFlashMemberName(tcName), ns, tcName, err)
 		}

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -215,6 +215,9 @@ func (m *tiflashMemberManager) syncStatefulSet(tc *v1alpha1.TidbCluster) error {
 	// if TiFlash is scale from 0 and with previous StatefulSet, we delete the previous StatefulSet first
 	// to avoid some fileds (e.g storage request) reused and cause unexpected behavior (e.g scale down).
 	if oldSetTmp != nil && *oldSetTmp.Spec.Replicas == 0 && tc.Spec.TiFlash.Replicas > 0 {
+		if oldSetTmp.Status.UpdatedReplicas != 0 {
+			return controller.RequeueErrorf("wait for previous sts %s for cluster %s/%s to be scaled to 0", controller.TiFlashMemberName(tcName), ns, tcName)
+		}
 		if err := m.deps.StatefulSetControl.DeleteStatefulSet(tc, oldSetTmp); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("syncStatefulSet: fail to delete sts %s for cluster %s/%s, error: %s", controller.TiFlashMemberName(tcName), ns, tcName, err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

fix #4843 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    1. create a TiFlash with 1 replica and 110G storage and `m6g.xlarge` instance in AWS EKS
    2. scale TiFlash to 0
    3. scale TiFlash to 1 with 100G storage
    4. TiFlash becomes ready and tc synced, TiFlash volume status with `modifiedCapacity: 100Gi` and `modifiedCount: 1`
    5. scale TiFlash to 0
    6. scale TiFlash to 1 with `t4g.medium` instance
    7. TiFlash becomes ready and tc synced
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
