### PR TITLE
Add http route for pprof

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -257,6 +257,8 @@ func main() {
 
 func createHTTPServer() *http.Server {
 	serverMux := http.NewServeMux()
+	// HTTP path for pprof
+	serverMux.Handle("/", http.DefaultServeMux)
 	// HTTP path for prometheus.
 	serverMux.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Originally the pprof routes are not working.
Closes #4873

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Added default http route back.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that pprof endpoint is not reachable because the route conflicts with the metrics endpoint
```

---
## Manual tests
Here's the manual test, you can see that now both `/metrics` and `/debug/pprof` endpoints are working:
```console
➜  tidb-operator git:(fix/pprof-route-conflict) curl -s localhost:6060/metrics | head -n 5                                 
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.4544e-05
go_gc_duration_seconds{quantile="0.25"} 7.0549e-05
go_gc_duration_seconds{quantile="0.5"} 9.0915e-05
➜  tidb-operator git:(fix/pprof-route-conflict) go tool pprof localhost:6060/debug/pprof/heap
Fetching profile over HTTP from http://localhost:6060/debug/pprof/heap
Saved profile in /Users/hanlins/pprof/pprof.tidb-controller-manager.alloc_objects.alloc_space.inuse_objects.inuse_space.001.pb.gz
File: tidb-controller-manager
Type: inuse_space
Time: Feb 14, 2023 at 8:43pm (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 44.83MB, 77.35% of 57.96MB total
Showing top 10 nodes out of 232
      flat  flat%   sum%        cum   cum%
   11.95MB 20.62% 20.62%    11.95MB 20.62%  reflect.unsafe_NewArray
    9.01MB 15.54% 36.16%     9.01MB 15.54%  reflect.mapassign
       8MB 13.80% 49.96%        8MB 13.80%  github.com/json-iterator/go.(*Iterator).ReadString
    4.51MB  7.78% 57.74%     4.51MB  7.78%  encoding/base64.(*Encoding).DecodeString
       3MB  5.18% 62.91%        3MB  5.18%  github.com/modern-go/reflect2.(*unsafeType).UnsafeNew
    2.51MB  4.33% 67.24%     2.51MB  4.33%  k8s.io/apimachinery/pkg/apis/meta/v1.(*FieldsV1).UnmarshalJSON
    1.86MB  3.20% 70.45%     2.37MB  4.09%  gopkg.in/yaml%2ev2.yaml_emitter_emit
    1.50MB  2.59% 73.04%     1.50MB  2.59%  github.com/aws/aws-sdk-go/aws/endpoints.init
    1.50MB  2.59% 75.62%     1.50MB  2.59%  github.com/modern-go/reflect2.newUnsafeStructField
       1MB  1.73% 77.35%        1MB  1.73%  runtime.allocm
(pprof) 
```