### PR TITLE
update go version to 1.19.5 for e2e

### DIFF
--- a/ci/e2e_eks.groovy
+++ b/ci/e2e_eks.groovy
@@ -16,7 +16,7 @@ kind: Pod
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - sleep

--- a/ci/e2e_gke.groovy
+++ b/ci/e2e_gke.groovy
@@ -16,7 +16,7 @@ kind: Pod
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - sleep

--- a/ci/e2e_kind.groovy
+++ b/ci/e2e_kind.groovy
@@ -16,7 +16,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - exec

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -37,7 +37,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - exec
@@ -258,7 +258,7 @@ try {
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
         // increase version in pod label when we update pod template
-        def buildPodLabel = "tidb-operator-build-v4-pingcap-docker-mirror"
+        def buildPodLabel = "tidb-operator-build-v5-pingcap-docker-mirror"
         def resources = [
             requests: [
                 cpu: "4",

--- a/ci/pull_e2e_release.groovy
+++ b/ci/pull_e2e_release.groovy
@@ -37,7 +37,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - exec
@@ -221,7 +221,7 @@ try {
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
         // increase version in pod label when we update pod template
-        def buildPodLabel = "tidb-operator-build-v4-pingcap-docker-mirror"
+        def buildPodLabel = "tidb-operator-build-v5-pingcap-docker-mirror"
         def resources = [
             requests: [
                 cpu: "6",

--- a/ci/vm.groovy
+++ b/ci/vm.groovy
@@ -16,7 +16,7 @@ kind: Pod
 spec:
   containers:
   - name: main
-    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18
+    image: hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19
     command:
     - runner.sh
     - sleep

--- a/hack/run-in-container.sh
+++ b/hack/run-in-container.sh
@@ -144,5 +144,5 @@ docker run ${docker_args[@]} \
     -v $ROOT:/go/src/github.com/pingcap/tidb-operator \
     -w /go/src/github.com/pingcap/tidb-operator \
     --entrypoint /usr/local/bin/runner.sh \
-    "hub-new.pingcap.net/tidb-operator/kubekins-e2e:v4-go1.18" \
+    "hub-new.pingcap.net/tidb-operator/kubekins-e2e:v5-go1.19" \
     "${args[@]}"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
