### PR TITLE
Add controller runtime related metrics

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -162,6 +162,10 @@ func main() {
 			WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 		}
 
+		initMetrics := func(c Controller) {
+			metrics.ActiveWorkers.WithLabelValues(c.Name()).Set(0)
+		}
+
 		// Initialize all controllers
 		controllers := []Controller{
 			tidbcluster.NewController(deps),
@@ -198,6 +202,7 @@ func main() {
 		// Start syncLoop for all controllers
 		for _, controller := range controllers {
 			c := controller
+			initMetrics(c)
 			go wait.Forever(func() { c.Run(cliCfg.Workers, ctx.Done()) }, cliCfg.WaitDuration)
 		}
 	}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -155,6 +155,7 @@ func main() {
 		// Define some nested types to simplify the codebase
 		type Controller interface {
 			Run(int, <-chan struct{})
+			Name() string
 		}
 		type InformerFactory interface {
 			Start(stopCh <-chan struct{})

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
@@ -20,6 +20,7 @@ import (
 	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/pkg/autoscaler/autoscaler"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -72,6 +73,9 @@ func (c *Controller) worker() {
 }
 
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
@@ -48,6 +48,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return t
 }
 
+// Name returns the name of the controller
+func (c *Controller) Name() string {
+	return "tidbclusterautoscaler"
+}
+
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
+++ b/pkg/controller/autoscaler/tidbcluster_autoscaler_controller.go
@@ -97,7 +97,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbClusterAutoScaler %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbClusterAutoScaler %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -128,7 +128,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing Backup %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing Backup %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/backup"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -99,6 +100,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -70,6 +70,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns backup controller name.
+func (c *Controller) Name() string {
+	return "backup"
+}
+
 // Run runs the backup controller.
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/backupschedule/backup_schedule_controller.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller.go
@@ -62,6 +62,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns backup controller name.
+func (c *Controller) Name() string {
+	return "backup"
+}
+
 // Run runs the backup schedule controller.
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/backupschedule/backup_schedule_controller.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller.go
@@ -120,7 +120,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing BackupSchedule %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing BackupSchedule %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/backupschedule/backup_schedule_controller.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/backupschedule"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -91,6 +92,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/dmcluster/dm_cluster_controller.go
+++ b/pkg/controller/dmcluster/dm_cluster_controller.go
@@ -23,6 +23,7 @@ import (
 	mm "github.com/pingcap/tidb-operator/pkg/manager/member"
 	"github.com/pingcap/tidb-operator/pkg/manager/meta"
 	"github.com/pingcap/tidb-operator/pkg/manager/suspender"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -115,6 +116,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/dmcluster/dm_cluster_controller.go
+++ b/pkg/controller/dmcluster/dm_cluster_controller.go
@@ -86,6 +86,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the dmcluster controller name
+func (c *Controller) Name() string {
+	return "dmcluster"
+}
+
 // Run runs the dmcluster controller.
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/dmcluster/dm_cluster_controller.go
+++ b/pkg/controller/dmcluster/dm_cluster_controller.go
@@ -141,7 +141,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing DMCluster %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing DMCluster %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/restore"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -92,6 +93,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -121,7 +121,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing Restore %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing Restore %q (%v)", key)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -123,7 +123,7 @@ func (c *Controller) sync(key string) error {
 	defer func() {
 		duration := time.Since(startTime)
 		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
-		klog.V(4).Infof("Finished syncing Restore %q (%v)", key)
+		klog.V(4).Infof("Finished syncing Restore %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -63,6 +63,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the restore controller
+func (c *Controller) Name() string {
+	return "restore"
+}
+
 // Run runs the restore controller.
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -105,6 +105,11 @@ func (c *PodController) enqueuePod(obj interface{}) {
 	c.queue.Add(key)
 }
 
+// Name returns the name of the PodController.
+func (c *PodController) Name() string {
+	return "tidbcluster-pod"
+}
+
 // Run the controller.
 func (c *PodController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -200,7 +200,9 @@ func (c *PodController) sync(key string) (reconcile.Result, error) {
 
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbCluster pod %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbCluster pod %q (%v)", key, duration)
 	}()
 
 	component := pod.Labels[label.ComponentLabelKey]

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager/member"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -134,6 +135,9 @@ func (c *PodController) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *PodController) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/manager/meta"
 	"github.com/pingcap/tidb-operator/pkg/manager/suspender"
 	"github.com/pingcap/tidb-operator/pkg/manager/volumes"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 )
 
 // Controller controls tidbclusters.
@@ -126,6 +127,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -97,6 +97,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the tidbcluster controller
+func (c *Controller) Name() string {
+	return "tidbcluster"
+}
+
 // Run runs the tidbcluster controller.
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/tidbcluster/tidb_cluster_controller.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller.go
@@ -152,7 +152,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbCluster %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbCluster %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
+++ b/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
@@ -126,7 +126,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbDashboard %s (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbDashboard %s (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
+++ b/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager/meta"
 	"github.com/pingcap/tidb-operator/pkg/manager/tidbdashboard"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -97,6 +98,9 @@ func (c *Controller) doWork() {
 }
 
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	keyIface, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
+++ b/pkg/controller/tidbdashboard/tidb_dashboard_controller.go
@@ -72,6 +72,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the controller.
+func (c *Controller) Name() string {
+	return "tidb-dashboard"
+}
+
 func (c *Controller) Run(numOfWorkers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/pkg/controller/tidbinitializer/tidb_initializer_controller.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_controller.go
@@ -115,7 +115,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TiDBInitializer %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TiDBInitializer %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/tidbinitializer/tidb_initializer_controller.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_controller.go
@@ -61,6 +61,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the tidbinitializer controller
+func (c *Controller) Name() string {
+	return "tidbinitializer"
+}
+
 // Run run workers
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/tidbinitializer/tidb_initializer_controller.go
+++ b/pkg/controller/tidbinitializer/tidb_initializer_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager/member"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 )
 
 // Controller syncs TidbInitializer
@@ -90,6 +91,9 @@ func (c *Controller) worker() {
 // It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -19,6 +19,7 @@ import (
 
 	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	"github.com/pingcap/tidb-operator/pkg/monitor/monitor"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,6 +86,9 @@ func (c *Controller) worker() {
 // processNextWorkItem dequeues items, processes them, and marks them done. It enforces that the syncHandler is never
 // invoked concurrently with the same key.
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	key, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -110,7 +110,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbMonitor %q (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbMonitor %q (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/tidbmonitor/tidb_monitor_controller.go
+++ b/pkg/controller/tidbmonitor/tidb_monitor_controller.go
@@ -58,6 +58,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the controller
+func (c *Controller) Name() string {
+	return "tidbmonitor"
+}
+
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
+++ b/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager/meta"
 	"github.com/pingcap/tidb-operator/pkg/manager/tidbngmonitoring"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 
 	perrors "github.com/pingcap/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +97,9 @@ func (c *Controller) worker() {
 }
 
 func (c *Controller) processNextWorkItem() bool {
+	metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(1)
+	defer metrics.ActiveWorkers.WithLabelValues(c.Name()).Add(-1)
+
 	keyIface, quit := c.queue.Get()
 	if quit {
 		return false

--- a/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
+++ b/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
@@ -125,7 +125,9 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) sync(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing TidbNGMonitoring %s (%v)", key, time.Since(startTime))
+		duration := time.Since(startTime)
+		metrics.ReconcileTime.WithLabelValues(c.Name()).Observe(duration.Seconds())
+		klog.V(4).Infof("Finished syncing TidbNGMonitoring %s (%v)", key, duration)
 	}()
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
+++ b/pkg/controller/tidbngmonitoring/tidb_ng_monitoring_controller.go
@@ -71,6 +71,11 @@ func NewController(deps *controller.Dependencies) *Controller {
 	return c
 }
 
+// Name returns the name of the controller
+func (c *Controller) Name() string {
+	return "tidb-ng-monitoring"
+}
+
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,6 +15,8 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // RegisterMetrics registers all metrics of tidb-operator.
@@ -28,3 +30,58 @@ const (
 	LabelName      = "name"
 	LabelComponent = "component"
 )
+
+var (
+	// ReconcileTotal is a prometheus counter metrics which holds the total
+	// number of reconciliations per controller. It has two labels. controller label refers
+	// to the controller name and result label refers to the reconcile result i.e
+	// success, error, requeue, requeue_after.
+	ReconcileTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_reconcile_total",
+		Help: "Total number of reconciliations per controller",
+	}, []string{"controller", "result"})
+
+	// ReconcileErrors is a prometheus counter metrics which holds the total
+	// number of errors from the Reconciler.
+	ReconcileErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_reconcile_errors_total",
+		Help: "Total number of reconciliation errors per controller",
+	}, []string{"controller"})
+
+	// ReconcileTime is a prometheus metric which keeps track of the duration
+	// of reconciliations.
+	ReconcileTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "controller_runtime_reconcile_time_seconds",
+		Help: "Length of time per reconciliation per controller",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+			1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
+	}, []string{"controller"})
+
+	// WorkerCount is a prometheus metric which holds the number of
+	// concurrent reconciles per controller.
+	WorkerCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "controller_runtime_max_concurrent_reconciles",
+		Help: "Maximum number of concurrent reconciles per controller",
+	}, []string{"controller"})
+
+	// ActiveWorkers is a prometheus metric which holds the number
+	// of active workers per controller.
+	ActiveWorkers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "controller_runtime_active_workers",
+		Help: "Number of currently used workers per controller",
+	}, []string{"controller"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		ReconcileTotal,
+		ReconcileErrors,
+		ReconcileTime,
+		WorkerCount,
+		ActiveWorkers,
+		// expose process metrics like CPU, Memory, file descriptor usage etc.
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		// expose Go runtime metrics like GC stats, memory stats etc.
+		collectors.NewGoCollector(),
+	)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,7 +15,6 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 // RegisterMetrics registers all metrics of tidb-operator.
@@ -78,9 +77,5 @@ func init() {
 		ReconcileTime,
 		WorkerCount,
 		ActiveWorkers,
-		// expose process metrics like CPU, Memory, file descriptor usage etc.
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		// expose Go runtime metrics like GC stats, memory stats etc.
-		collectors.NewGoCollector(),
 	)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,7 +16,6 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // RegisterMetrics registers all metrics of tidb-operator.
@@ -73,7 +72,7 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(
+	prometheus.MustRegister(
 		ReconcileTotal,
 		ReconcileErrors,
 		ReconcileTime,

--- a/pkg/metrics/workerqueue.go
+++ b/pkg/metrics/workerqueue.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// This file is copied and adapted from k8s.io/kubernetes/pkg/util/workqueue/prometheus
+// which registers metrics to the default prometheus Registry. We require very
+// similar functionality, but must register metrics to a different Registry.
+
+// Metrics subsystem and all keys used by the workqueue.
+const (
+	WorkQueueSubsystem         = "workqueue"
+	DepthKey                   = "depth"
+	AddsKey                    = "adds_total"
+	QueueLatencyKey            = "queue_duration_seconds"
+	WorkDurationKey            = "work_duration_seconds"
+	UnfinishedWorkKey          = "unfinished_work_seconds"
+	LongestRunningProcessorKey = "longest_running_processor_seconds"
+	RetriesKey                 = "retries_total"
+)
+
+var (
+	depth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      DepthKey,
+		Help:      "Current depth of workqueue",
+	}, []string{"name"})
+
+	adds = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      AddsKey,
+		Help:      "Total number of adds handled by workqueue",
+	}, []string{"name"})
+
+	latency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      QueueLatencyKey,
+		Help:      "How long in seconds an item stays in workqueue before being requested",
+		Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+	}, []string{"name"})
+
+	workDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      WorkDurationKey,
+		Help:      "How long in seconds processing an item from workqueue takes.",
+		Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+	}, []string{"name"})
+
+	unfinished = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      UnfinishedWorkKey,
+		Help: "How many seconds of work has been done that " +
+			"is in progress and hasn't been observed by work_duration. Large " +
+			"values indicate stuck threads. One can deduce the number of stuck " +
+			"threads by observing the rate at which this increases.",
+	}, []string{"name"})
+
+	longestRunningProcessor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      LongestRunningProcessorKey,
+		Help: "How many seconds has the longest running " +
+			"processor for workqueue been running.",
+	}, []string{"name"})
+
+	retries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      RetriesKey,
+		Help:      "Total number of retries handled by workqueue",
+	}, []string{"name"})
+)
+
+func init() {
+	prometheus.MustRegister(depth)
+	prometheus.MustRegister(adds)
+	prometheus.MustRegister(latency)
+	prometheus.MustRegister(workDuration)
+	prometheus.MustRegister(unfinished)
+	prometheus.MustRegister(longestRunningProcessor)
+	prometheus.MustRegister(retries)
+
+	workqueue.SetProvider(workqueueMetricsProvider{})
+}
+
+type workqueueMetricsProvider struct{}
+
+func (workqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return depth.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return adds.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return latency.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return workDuration.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return unfinished.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return longestRunningProcessor.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return retries.WithLabelValues(name)
+}

--- a/pkg/metrics/workerqueue.go
+++ b/pkg/metrics/workerqueue.go
@@ -1,3 +1,16 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 Copyright 2018 The Kubernetes Authors.
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Add workerqueue and reconcile related metrics.
Closes #4872

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Add the metrics for the reconciler and worker queue to improve observability
```

---

## Manual tests
Here're the metrics after introducing this change:
```console
➜  ~ curl localhost:6060/metrics
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="backup"} 10
controller_runtime_active_workers{controller="dmcluster"} 5
controller_runtime_active_workers{controller="restore"} 5
controller_runtime_active_workers{controller="tidb-dashboard"} 5
controller_runtime_active_workers{controller="tidb-ng-monitoring"} 5
controller_runtime_active_workers{controller="tidbcluster"} 5
controller_runtime_active_workers{controller="tidbcluster-pod"} 5
controller_runtime_active_workers{controller="tidbinitializer"} 5
controller_runtime_active_workers{controller="tidbmonitor"} 5
# HELP controller_runtime_reconcile_time_seconds Length of time per reconciliation per controller
# TYPE controller_runtime_reconcile_time_seconds histogram
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.01"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.025"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.05"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.15"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.2"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.25"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.3"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.35"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.4"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.45"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.5"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.6"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.7"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.8"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="0.9"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="1.25"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="1.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="1.75"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="2"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="2.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="3"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="3.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="4"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="4.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="6"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="7"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="8"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="9"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="10"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="15"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="20"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="25"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="30"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="40"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="50"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="60"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster",le="+Inf"} 1
controller_runtime_reconcile_time_seconds_sum{controller="tidbcluster"} 1.21825129
controller_runtime_reconcile_time_seconds_count{controller="tidbcluster"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.005"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.01"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.025"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.05"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.1"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.15"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.2"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.25"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.3"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.35"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.4"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.45"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.6"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.7"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.8"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="0.9"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="1"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="1.25"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="1.5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="1.75"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="2"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="2.5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="3"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="3.5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="4"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="4.5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="5"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="6"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="7"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="8"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="9"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="10"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="15"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="20"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="25"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="30"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="40"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="50"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="60"} 10
controller_runtime_reconcile_time_seconds_bucket{controller="tidbcluster-pod",le="+Inf"} 10
controller_runtime_reconcile_time_seconds_sum{controller="tidbcluster-pod"} 2.964e-06
controller_runtime_reconcile_time_seconds_count{controller="tidbcluster-pod"} 10
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.6153e-05
go_gc_duration_seconds{quantile="0.25"} 4.0808e-05
go_gc_duration_seconds{quantile="0.5"} 9.686e-05
go_gc_duration_seconds{quantile="0.75"} 0.000109721
go_gc_duration_seconds{quantile="1"} 0.000448633
go_gc_duration_seconds_sum 0.001160816
go_gc_duration_seconds_count 10
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 295
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.19.3"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.2733104e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 4.7086264e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.475697e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 472904
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 0.0008172941976989771
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 1.0071712e+07
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.2733104e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 3.489792e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.9972096e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 104392
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 696320
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 2.3461888e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.6765947598128574e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 577296
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 2400
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 297432
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 310080
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 2.350388e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 559559
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.703936e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.703936e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 3.7598472e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 8
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.31
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 11
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 6.909952e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.67659473769e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 8.0308224e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
# HELP tidb_operator_cluster_spec_replicas Desired replicas of each component in TidbCluster
# TYPE tidb_operator_cluster_spec_replicas gauge
tidb_operator_cluster_spec_replicas{component="pd",name="basic",namespace="demo"} 3
tidb_operator_cluster_spec_replicas{component="tidb",name="basic",namespace="demo"} 2
tidb_operator_cluster_spec_replicas{component="tikv",name="basic",namespace="demo"} 3
# HELP workqueue_adds_total Total number of adds handled by workqueue
# TYPE workqueue_adds_total counter
workqueue_adds_total{name="backup"} 0
workqueue_adds_total{name="backupSchedule"} 0
workqueue_adds_total{name="dmcluster"} 0
workqueue_adds_total{name="restore"} 0
workqueue_adds_total{name="tidb-dashboard"} 0
workqueue_adds_total{name="tidb-ng-monitoring"} 0
workqueue_adds_total{name="tidbcluster"} 2
workqueue_adds_total{name="tidbcluster pods"} 47
workqueue_adds_total{name="tidbinitializer"} 0
workqueue_adds_total{name="tidbmonitor"} 0
# HELP workqueue_depth Current depth of workqueue
# TYPE workqueue_depth gauge
workqueue_depth{name="backup"} 0
workqueue_depth{name="backupSchedule"} 0
workqueue_depth{name="dmcluster"} 0
workqueue_depth{name="restore"} 0
workqueue_depth{name="tidb-dashboard"} 0
workqueue_depth{name="tidb-ng-monitoring"} 0
workqueue_depth{name="tidbcluster"} 0
workqueue_depth{name="tidbcluster pods"} 0
workqueue_depth{name="tidbinitializer"} 0
workqueue_depth{name="tidbmonitor"} 0
# HELP workqueue_longest_running_processor_seconds How many seconds has the longest running processor for workqueue been running.
# TYPE workqueue_longest_running_processor_seconds gauge
workqueue_longest_running_processor_seconds{name="backup"} 0
workqueue_longest_running_processor_seconds{name="backupSchedule"} 0
workqueue_longest_running_processor_seconds{name="dmcluster"} 0
workqueue_longest_running_processor_seconds{name="restore"} 0
workqueue_longest_running_processor_seconds{name="tidb-dashboard"} 0
workqueue_longest_running_processor_seconds{name="tidb-ng-monitoring"} 0
workqueue_longest_running_processor_seconds{name="tidbcluster"} 0
workqueue_longest_running_processor_seconds{name="tidbcluster pods"} 0
workqueue_longest_running_processor_seconds{name="tidbinitializer"} 0
workqueue_longest_running_processor_seconds{name="tidbmonitor"} 0
# HELP workqueue_queue_duration_seconds How long in seconds an item stays in workqueue before being requested
# TYPE workqueue_queue_duration_seconds histogram
workqueue_queue_duration_seconds_bucket{name="backup",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="backup",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="backup"} 0
workqueue_queue_duration_seconds_count{name="backup"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="backupSchedule",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="backupSchedule"} 0
workqueue_queue_duration_seconds_count{name="backupSchedule"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="dmcluster",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="dmcluster"} 0
workqueue_queue_duration_seconds_count{name="dmcluster"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="restore",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="restore"} 0
workqueue_queue_duration_seconds_count{name="restore"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-dashboard",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="tidb-dashboard"} 0
workqueue_queue_duration_seconds_count{name="tidb-dashboard"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="tidb-ng-monitoring",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="tidb-ng-monitoring"} 0
workqueue_queue_duration_seconds_count{name="tidb-ng-monitoring"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="9.999999999999999e-05"} 1
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="0.001"} 1
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="0.01"} 1
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="0.1"} 1
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="1"} 2
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="10"} 2
workqueue_queue_duration_seconds_bucket{name="tidbcluster",le="+Inf"} 2
workqueue_queue_duration_seconds_sum{name="tidbcluster"} 0.284984075
workqueue_queue_duration_seconds_count{name="tidbcluster"} 2
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="9.999999999999999e-06"} 5
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="9.999999999999999e-05"} 6
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="0.001"} 6
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="0.01"} 6
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="0.1"} 6
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="1"} 47
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="10"} 47
workqueue_queue_duration_seconds_bucket{name="tidbcluster pods",le="+Inf"} 47
workqueue_queue_duration_seconds_sum{name="tidbcluster pods"} 6.069794323999998
workqueue_queue_duration_seconds_count{name="tidbcluster pods"} 47
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="tidbinitializer",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="tidbinitializer"} 0
workqueue_queue_duration_seconds_count{name="tidbinitializer"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="tidbmonitor",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="tidbmonitor"} 0
workqueue_queue_duration_seconds_count{name="tidbmonitor"} 0
# HELP workqueue_retries_total Total number of retries handled by workqueue
# TYPE workqueue_retries_total counter
workqueue_retries_total{name="backup"} 0
workqueue_retries_total{name="backupSchedule"} 0
workqueue_retries_total{name="dmcluster"} 0
workqueue_retries_total{name="restore"} 0
workqueue_retries_total{name="tidb-dashboard"} 0
workqueue_retries_total{name="tidb-ng-monitoring"} 0
workqueue_retries_total{name="tidbcluster"} 1
workqueue_retries_total{name="tidbcluster pods"} 0
workqueue_retries_total{name="tidbinitializer"} 0
workqueue_retries_total{name="tidbmonitor"} 0
# HELP workqueue_unfinished_work_seconds How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.
# TYPE workqueue_unfinished_work_seconds gauge
workqueue_unfinished_work_seconds{name="backup"} 0
workqueue_unfinished_work_seconds{name="backupSchedule"} 0
workqueue_unfinished_work_seconds{name="dmcluster"} 0
workqueue_unfinished_work_seconds{name="restore"} 0
workqueue_unfinished_work_seconds{name="tidb-dashboard"} 0
workqueue_unfinished_work_seconds{name="tidb-ng-monitoring"} 0
workqueue_unfinished_work_seconds{name="tidbcluster"} 0
workqueue_unfinished_work_seconds{name="tidbcluster pods"} 0
workqueue_unfinished_work_seconds{name="tidbinitializer"} 0
workqueue_unfinished_work_seconds{name="tidbmonitor"} 0
# HELP workqueue_work_duration_seconds How long in seconds processing an item from workqueue takes.
# TYPE workqueue_work_duration_seconds histogram
workqueue_work_duration_seconds_bucket{name="backup",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="1"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="10"} 0
workqueue_work_duration_seconds_bucket{name="backup",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="backup"} 0
workqueue_work_duration_seconds_count{name="backup"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="1"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="10"} 0
workqueue_work_duration_seconds_bucket{name="backupSchedule",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="backupSchedule"} 0
workqueue_work_duration_seconds_count{name="backupSchedule"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="1"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="10"} 0
workqueue_work_duration_seconds_bucket{name="dmcluster",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="dmcluster"} 0
workqueue_work_duration_seconds_count{name="dmcluster"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="1"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="10"} 0
workqueue_work_duration_seconds_bucket{name="restore",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="restore"} 0
workqueue_work_duration_seconds_count{name="restore"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="1"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="10"} 0
workqueue_work_duration_seconds_bucket{name="tidb-dashboard",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="tidb-dashboard"} 0
workqueue_work_duration_seconds_count{name="tidb-dashboard"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="1"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="10"} 0
workqueue_work_duration_seconds_bucket{name="tidb-ng-monitoring",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="tidb-ng-monitoring"} 0
workqueue_work_duration_seconds_count{name="tidb-ng-monitoring"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="1"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="10"} 1
workqueue_work_duration_seconds_bucket{name="tidbcluster",le="+Inf"} 1
workqueue_work_duration_seconds_sum{name="tidbcluster"} 1.2183066280000001
workqueue_work_duration_seconds_count{name="tidbcluster"} 1
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="9.999999999999999e-05"} 43
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="0.001"} 47
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="0.01"} 47
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="0.1"} 47
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="1"} 47
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="10"} 47
workqueue_work_duration_seconds_bucket{name="tidbcluster pods",le="+Inf"} 47
workqueue_work_duration_seconds_sum{name="tidbcluster pods"} 0.002343845
workqueue_work_duration_seconds_count{name="tidbcluster pods"} 47
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="1"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="10"} 0
workqueue_work_duration_seconds_bucket{name="tidbinitializer",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="tidbinitializer"} 0
workqueue_work_duration_seconds_count{name="tidbinitializer"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="1"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="10"} 0
workqueue_work_duration_seconds_bucket{name="tidbmonitor",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="tidbmonitor"} 0
workqueue_work_duration_seconds_count{name="tidbmonitor"} 0
```
We can see that there're some new metrics regarding reconcile time and work queue introduced.