### PR TITLE
br: ensure pvc names sequential for ebs restore

### DIFF
--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -460,10 +460,9 @@ func (m *StoresMixture) ProcessCSBPVCsAndPVs(r *v1alpha1.Restore, csb *CloudSnap
 	volID2PV := make(map[string]*corev1.PersistentVolume)
 	for _, pv := range csb.Kubernetes.PVs {
 		volID, ok := pv.Annotations[constants.AnnTemporaryVolumeID]
-		if !ok {
-			return "GetVolumeIDFailed", fmt.Errorf("%s pv.annotations[%s] not found", pv.GetName(), constants.AnnTemporaryVolumeID)
+		if ok {
+			volID2PV[volID] = pv
 		}
-		volID2PV[volID] = pv
 	}
 
 	pvs, pvcs := make([]*corev1.PersistentVolume, 0, len(m.rsVolIDMap)), make([]*corev1.PersistentVolumeClaim, 0, len(m.rsVolIDMap))

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -450,21 +450,30 @@ func (m *StoresMixture) PrepareCSBStoresMeta(csb *CloudSnapBackup, pods []*corev
 }
 
 func (m *StoresMixture) ProcessCSBPVCsAndPVs(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
-	pvcs := csb.Kubernetes.PVCs
-	pvs := csb.Kubernetes.PVs
-
 	m.generateRestoreVolumeIDMap(csb.TiKV.Stores)
 
 	backupClusterName := csb.Kubernetes.TiDBCluster.Name
-
 	pvcMap := make(map[string]*corev1.PersistentVolumeClaim)
-	for _, pvc := range pvcs {
+	for _, pvc := range csb.Kubernetes.PVCs {
 		pvcMap[pvc.Name] = pvc
 	}
+	volID2PV := make(map[string]*corev1.PersistentVolume)
+	for _, pv := range csb.Kubernetes.PVs {
+		volID, ok := pv.Annotations[constants.AnnTemporaryVolumeID]
+		if !ok {
+			return "GetVolumeIDFailed", fmt.Errorf("%s pv.annotations[%s] not found", pv.GetName(), constants.AnnTemporaryVolumeID)
+		}
+		volID2PV[volID] = pv
+	}
 
-	for _, pv := range pvs {
+	pvs, pvcs := make([]*corev1.PersistentVolume, 0, len(m.rsVolIDMap)), make([]*corev1.PersistentVolumeClaim, 0, len(m.rsVolIDMap))
+	for backupVolID, restoreVolID := range m.rsVolIDMap {
+		pv, ok := volID2PV[backupVolID]
+		if !ok {
+			return "GetPVFailed", fmt.Errorf("pv with volume id %s not found", backupVolID)
+		}
+
 		klog.Infof("snapshotter-pv: %v", pv)
-
 		if pv.Spec.ClaimRef == nil {
 			return "PVClaimRefNil", fmt.Errorf("pv %s claimRef is nil", pv.Name)
 		}
@@ -476,47 +485,49 @@ func (m *StoresMixture) ProcessCSBPVCsAndPVs(r *v1alpha1.Restore, csb *CloudSnap
 		// Reset the PV's binding status so that Kubernetes can properly
 		// associate it with the restored PVC.
 		resetVolumeBindingInfo(pvc, pv)
-
 		// Reset the PV's volumeID for restore from snapshot
-		// Note: This function has to precede the following `resetMetadataAndStatus`
-		if reason, err := m.resetRestoreVolumeID(pv); err != nil {
-			return reason, err
+		if err := m.snapshotter.SetVolumeID(pv, restoreVolID); err != nil {
+			return "ResetRestoreVolumeIDFailed", fmt.Errorf("failed to set pv-%s, %s", pv.Name, err.Error())
 		}
-
 		// Clear out non-core metadata fields and status
 		resetMetadataAndStatus(r, backupClusterName, pvc, pv)
+
+		pvs = append(pvs, pv)
+		pvcs = append(pvcs, pvc)
 	}
 
 	restoreSTSName := controller.TiKVMemberName(r.Spec.BR.Cluster)
-	sequentialPVCs, err := resetPVCSequence(restoreSTSName, pvcs)
+	sequentialPVCs, sequentialPVs, err := resetPVCSequence(restoreSTSName, pvcs, pvs)
 	if err != nil {
 		klog.Errorf("reset pvcs to sequential error: %s", err.Error())
 		return "InvalidPVCName", err
 	}
 
 	csb.Kubernetes.PVCs = sequentialPVCs
+	csb.Kubernetes.PVs = sequentialPVs
 	return "", nil
 }
 
 // If a backup cluster has scaled in and the tidb-operator enabled advanced-statefulset(ref: https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/advanced-statefulset)
 // the name of pvc can be not sequential, eg: [pvc-0, pvc-1, pvc-2, pvc-6, pvc-7, pvc-8]
 // When create cluster, we should ensure pvc name sequential, so we should reset it to [pvc-0, pvc-1, pvc-2, pvc-3, pvc-4, pvc-5]
-func resetPVCSequence(stsName string, backupPVCs []*corev1.PersistentVolumeClaim) ([]*corev1.PersistentVolumeClaim, error) {
+func resetPVCSequence(stsName string, pvcs []*corev1.PersistentVolumeClaim, pvs []*corev1.PersistentVolume) (
+	[]*corev1.PersistentVolumeClaim, []*corev1.PersistentVolume, error) {
 	type indexedPVC struct {
 		index int
 		pvc   *corev1.PersistentVolumeClaim
 	}
-	indexedPVCs := make([]*indexedPVC, 0, len(backupPVCs))
+	indexedPVCs := make([]*indexedPVC, 0, len(pvcs))
 	reStr := fmt.Sprintf(`%s-(\d+)$`, stsName)
 	re := regexp.MustCompile(reStr)
-	for _, pvc := range backupPVCs {
+	for _, pvc := range pvcs {
 		subMatches := re.FindStringSubmatch(pvc.Name)
 		if len(subMatches) != 2 {
-			return nil, fmt.Errorf("pvc name %s doesn't match regex %s", pvc.Name, reStr)
+			return nil, nil, fmt.Errorf("pvc name %s doesn't match regex %s", pvc.Name, reStr)
 		}
 		index, err := strconv.Atoi(subMatches[1])
 		if err != nil {
-			return nil, fmt.Errorf("parse index %s of pvc %s to int: %s", subMatches[1], pvc.Name, err.Error())
+			return nil, nil, fmt.Errorf("parse index %s of pvc %s to int: %s", subMatches[1], pvc.Name, err.Error())
 		}
 		indexedPVCs = append(indexedPVCs, &indexedPVC{
 			index: index,
@@ -527,17 +538,30 @@ func resetPVCSequence(stsName string, backupPVCs []*corev1.PersistentVolumeClaim
 	sort.Slice(indexedPVCs, func(i, j int) bool {
 		return indexedPVCs[i].index < indexedPVCs[j].index
 	})
-
-	results := make([]*corev1.PersistentVolumeClaim, 0, len(backupPVCs))
-	for i, iPVC := range indexedPVCs {
-		restorePVCName := fmt.Sprintf("%s-%d", stsName, i)
-		if i != iPVC.index {
-			klog.Infof("reset pvc name %s to %s", iPVC.pvc.Name, restorePVCName)
-		}
-		iPVC.pvc.Name = restorePVCName
-		results = append(results, iPVC.pvc)
+	pvc2pv := make(map[string]*corev1.PersistentVolume, len(pvs))
+	for _, pv := range pvs {
+		pvc2pv[pv.Spec.ClaimRef.Name] = pv
 	}
-	return results, nil
+
+	sequentialPVCs := make([]*corev1.PersistentVolumeClaim, 0, len(pvcs))
+	sequentialPVs := make([]*corev1.PersistentVolume, 0, len(pvs))
+	for i, iPVC := range indexedPVCs {
+		pv, ok := pvc2pv[iPVC.pvc.Name]
+		if !ok {
+			return nil, nil, fmt.Errorf("pv with claim %s not found", iPVC.pvc.Name)
+		}
+		if i != iPVC.index {
+			names := strings.Split(iPVC.pvc.Name, "-")
+			restorePVCName := fmt.Sprintf("%s-%d", strings.Join(names[:len(names)-1], "-"), i)
+
+			klog.Infof("reset pvc name %s to %s", iPVC.pvc.Name, restorePVCName)
+			iPVC.pvc.Name = restorePVCName
+			pv.Spec.ClaimRef.Name = restorePVCName
+		}
+		sequentialPVCs = append(sequentialPVCs, iPVC.pvc)
+		sequentialPVs = append(sequentialPVs, pv)
+	}
+	return sequentialPVCs, sequentialPVs, nil
 }
 
 func (m *StoresMixture) generateRestoreVolumeIDMap(stores []*StoresBackup) {
@@ -548,26 +572,6 @@ func (m *StoresMixture) generateRestoreVolumeIDMap(stores []*StoresBackup) {
 	for _, vol := range vols {
 		m.rsVolIDMap[vol.VolumeID] = vol.RestoreVolumeID
 	}
-}
-
-func (m *StoresMixture) resetRestoreVolumeID(pv *corev1.PersistentVolume) (string, error) {
-	// the reason for not using `snapshotter.GetVolumeID` directly here is to consider using
-	// a different driver or provisioner for backup and restore to extend conveniently later
-	volID, ok := pv.Annotations[constants.AnnTemporaryVolumeID]
-	if !ok {
-		return "GetVolumeIDFailed", fmt.Errorf("%s pv.annotations[%s] not found", pv.GetName(), constants.AnnTemporaryVolumeID)
-	}
-
-	var rsVolID string
-	if rsVolID, ok = m.rsVolIDMap[volID]; !ok {
-		return "GetRestoreVolumeIDFailed", fmt.Errorf("%s volumeID-%s mapping restoreVolumeID not found", pv.GetName(), volID)
-	}
-
-	if err := m.snapshotter.SetVolumeID(pv, rsVolID); err != nil {
-		return "ResetRestoreVolumeIDFailed", fmt.Errorf("failed to set pv-%s, %s", pv.Name, err.Error())
-	}
-
-	return "", nil
 }
 
 // resetVolumeBindingInfo clears any necessary metadata out of a PersistentVolume

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -1264,3 +1264,126 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 	}
 	assert.Equal(t, pvcsWanted, csb.Kubernetes.PVCs)
 }
+
+func TestResetPVCSequence(t *testing.T) {
+	type testcase struct {
+		stsName      string
+		backupPVCs   []*corev1.PersistentVolumeClaim
+		expectedPVCs []*corev1.PersistentVolumeClaim
+	}
+	testcases := []*testcase{
+		{
+			stsName: "pvc",
+			backupPVCs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-6",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-7",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-8",
+					},
+				},
+			},
+			expectedPVCs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-5",
+					},
+				},
+			},
+		},
+		{
+			stsName: "pvc",
+			backupPVCs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			expectedPVCs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		restorePVCs, err := resetPVCSequence(tc.stsName, tc.backupPVCs)
+		require.NoError(t, err)
+		for i := range restorePVCs {
+			require.Equal(t, tc.expectedPVCs[i], restorePVCs[i])
+		}
+	}
+
+}

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -942,7 +942,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 							},
 						},
 						ClaimRef: &corev1.ObjectReference{
-							Name:            "pvc-1",
+							Name:            "test-tikv-1",
 							UID:             "301b0e8b-3538-4f61-a0fd-a25abd9a3121",
 							ResourceVersion: "1957",
 						},
@@ -977,7 +977,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 							},
 						},
 						ClaimRef: &corev1.ObjectReference{
-							Name:            "pvc-2",
+							Name:            "test-tikv-2",
 							UID:             "301b0e8b-3538-4f61-a0fd-a25abd9a3123",
 							ResourceVersion: "1959",
 						},
@@ -1012,8 +1012,43 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 							},
 						},
 						ClaimRef: &corev1.ObjectReference{
-							Name:            "pvc-3",
+							Name:            "test-tikv-3",
 							UID:             "301b0e8b-3538-4f61-a0fd-a25abd9a3125",
+							ResourceVersion: "1961",
+						},
+					},
+					Status: corev1.PersistentVolumeStatus{
+						Phase: corev1.VolumeBound,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-4",
+						Labels: map[string]string{
+							"test/label": "retained",
+						},
+						Annotations: map[string]string{
+							constants.KubeAnnDynamicallyProvisioned: "ebs.csi.aws.com",
+							constants.AnnTemporaryVolumeID:          "vol-0e65f40961a9fcd23",
+							"test/annotation":                       "retained",
+						},
+						UID:             "301b0e8b-3538-4f61-a0fd-a25abd9acd23",
+						ResourceVersion: "1962",
+						Finalizers: []string{
+							"kubernetes.io/pv-protection",
+						},
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver:       "ebs.csi.aws.com",
+								VolumeHandle: "vol-0e65f40961a9fcd23",
+								FSType:       "ext4",
+							},
+						},
+						ClaimRef: &corev1.ObjectReference{
+							Name:            "test-tikv-4",
+							UID:             "301b0e8b-3538-4f61-a0fd-a25abd9acd23",
 							ResourceVersion: "1961",
 						},
 					},
@@ -1025,7 +1060,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 			PVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pvc-1",
+						Name:      "test-tikv-1",
 						Namespace: "default",
 						Labels: map[string]string{
 							"test/label": "retained",
@@ -1050,7 +1085,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pvc-2",
+						Name:      "test-tikv-2",
 						Namespace: "default",
 						Labels: map[string]string{
 							"test/label": "retained",
@@ -1075,7 +1110,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pvc-3",
+						Name:      "test-tikv-3",
 						Namespace: "default",
 						Labels: map[string]string{
 							"test/label": "retained",
@@ -1093,6 +1128,31 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-3",
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-tikv-4",
+						Namespace: "default",
+						Labels: map[string]string{
+							"test/label": "retained",
+						},
+						Annotations: map[string]string{
+							constants.KubeAnnBindCompleted:     "yes",
+							constants.KubeAnnBoundByController: "yes",
+							"test/annotation":                  "retained",
+						},
+						UID:             "301b0e8b-3538-4f61-a0fd-a25abd9acd23",
+						ResourceVersion: "1961",
+						Finalizers: []string{
+							"kubernetes.io/pvc-protection",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv-4",
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -1159,7 +1219,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 					},
 				},
 				ClaimRef: &corev1.ObjectReference{
-					Name: "pvc-1",
+					Name: "test-tikv-0",
 				},
 			},
 		},
@@ -1183,7 +1243,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 					},
 				},
 				ClaimRef: &corev1.ObjectReference{
-					Name: "pvc-2",
+					Name: "test-tikv-1",
 				},
 			},
 		},
@@ -1207,7 +1267,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 					},
 				},
 				ClaimRef: &corev1.ObjectReference{
-					Name: "pvc-3",
+					Name: "test-tikv-2",
 				},
 			},
 		},
@@ -1218,7 +1278,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 	pvcsWanted := []*corev1.PersistentVolumeClaim{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-1",
+				Name:      "test-tikv-0",
 				Namespace: "default",
 				Labels: map[string]string{
 					"test/label": "retained",
@@ -1233,7 +1293,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-2",
+				Name:      "test-tikv-1",
 				Namespace: "default",
 				Labels: map[string]string{
 					"test/label": "retained",
@@ -1248,7 +1308,7 @@ func TestProcessCSBPVCsAndPVs(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-3",
+				Name:      "test-tikv-2",
 				Namespace: "default",
 				Labels: map[string]string{
 					"test/label": "retained",
@@ -1269,109 +1329,299 @@ func TestResetPVCSequence(t *testing.T) {
 	type testcase struct {
 		stsName      string
 		backupPVCs   []*corev1.PersistentVolumeClaim
+		backupPVs    []*corev1.PersistentVolume
 		expectedPVCs []*corev1.PersistentVolumeClaim
+		expectedPVs  []*corev1.PersistentVolume
 	}
 	testcases := []*testcase{
 		{
-			stsName: "pvc",
+			stsName: "test-tikv",
 			backupPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-0",
+						Name: "tikv-test-tikv-0",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-1",
+						Name: "tikv-test-tikv-1",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-2",
+						Name: "tikv-test-tikv-2",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-6",
+						Name: "tikv-test-tikv-6",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-7",
+						Name: "tikv-test-tikv-7",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-8",
+						Name: "tikv-test-tikv-8",
 					},
 				},
 			},
 			expectedPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-0",
+						Name: "tikv-test-tikv-0",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-1",
+						Name: "tikv-test-tikv-1",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-2",
+						Name: "tikv-test-tikv-2",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-3",
+						Name: "tikv-test-tikv-3",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-4",
+						Name: "tikv-test-tikv-4",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-5",
+						Name: "tikv-test-tikv-5",
+					},
+				},
+			},
+			backupPVs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-0",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-2",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-2",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-6",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-6",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-7",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-7",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-8",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-8",
+						},
+					},
+				},
+			},
+			expectedPVs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-0",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-2",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-2",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-6",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-3",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-7",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-4",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-8",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-5",
+						},
 					},
 				},
 			},
 		},
 		{
-			stsName: "pvc",
+			stsName: "test-tikv",
 			backupPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-0",
+						Name: "tikv-test-tikv-0",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-1",
+						Name: "tikv-test-tikv-1",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-2",
+						Name: "tikv-test-tikv-2",
 					},
 				},
 			},
 			expectedPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-0",
+						Name: "tikv-test-tikv-0",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-1",
+						Name: "tikv-test-tikv-1",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pvc-2",
+						Name: "tikv-test-tikv-2",
+					},
+				},
+			},
+			backupPVs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-0",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-2",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-2",
+						},
+					},
+				},
+			},
+			expectedPVs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-0",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-2",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Name: "tikv-test-tikv-2",
+						},
 					},
 				},
 			},
@@ -1379,11 +1629,10 @@ func TestResetPVCSequence(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		restorePVCs, err := resetPVCSequence(tc.stsName, tc.backupPVCs)
+		restorePVCs, restorePVs, err := resetPVCSequence(tc.stsName, tc.backupPVCs, tc.backupPVs)
 		require.NoError(t, err)
-		for i := range restorePVCs {
-			require.Equal(t, tc.expectedPVCs[i], restorePVCs[i])
-		}
+		assert.Equal(t, tc.expectedPVCs, restorePVCs)
+		assert.Equal(t, tc.expectedPVs, restorePVs)
 	}
 
 }

--- a/pkg/backup/testutils/br.go
+++ b/pkg/backup/testutils/br.go
@@ -115,7 +115,7 @@ func ConstructRestoreMetaStr() string {
 		"kubernetes": {
 			"pvcs": [{
 				"metadata": {
-					"name": "pvc-1",
+					"name": "test-tikv-1",
 					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3121",
 					"resourceVersion": "1957",
 					"creationTimestamp": null,
@@ -138,7 +138,7 @@ func ConstructRestoreMetaStr() string {
 				}
 			}, {
 				"metadata": {
-					"name": "pvc-2",
+					"name": "test-tikv-2",
 					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3123",
 					"resourceVersion": "1959",
 					"creationTimestamp": null,
@@ -161,7 +161,7 @@ func ConstructRestoreMetaStr() string {
 				}
 			}, {
 				"metadata": {
-					"name": "pvc-3",
+					"name": "test-tikv-3",
 					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3125",
 					"resourceVersion": "1961",
 					"creationTimestamp": null,
@@ -206,7 +206,7 @@ func ConstructRestoreMetaStr() string {
 						"fsType": "ext4"
 					},
 					"claimRef": {
-						"name": "pvc-1",
+						"name": "test-tikv-1",
 						"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3121",
 						"resourceVersion": "1957"
 					}
@@ -237,7 +237,7 @@ func ConstructRestoreMetaStr() string {
 						"fsType": "ext4"
 					},
 					"claimRef": {
-						"name": "pvc-2",
+						"name": "test-tikv-2",
 						"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3123",
 						"resourceVersion": "1959"
 					}
@@ -268,7 +268,7 @@ func ConstructRestoreMetaStr() string {
 						"fsType": "ext4"
 					},
 					"claimRef": {
-						"name": "pvc-3",
+						"name": "test-tikv-3",
 						"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3125",
 						"resourceVersion": "1961"
 					}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #4884 (issue number)
-->
Closes #4884
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

precondition.
according to https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/advanced-statefulset, upgrade tide-operator with asts.

case#1
- create a cluster with 6 nodes
- scale out the cluster to 9 nodes
- scale in the cluster to 6 nodes, and set delete-slots [3,4,5]
- keep released existing pv/pvcs and then do the backup
- restore the backup
![4KPXRP1DmX](https://user-images.githubusercontent.com/85682690/219632164-046fdf60-432f-40f7-b240-d83c82427363.jpg)

case#2
- create a cluster with 6 nodes
- scale out the cluster to 9 nodes
- scale in the cluster to 6 nodes, and set delete-slots [3,4,5]
- remove released existing pv/pvcs and then do the backup
- restore the backup
![UVmA3RdkK2](https://user-images.githubusercontent.com/85682690/219633389-c7b27fa1-3293-4a57-bf0e-1ec9102b1a48.jpg)

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
