### PR TITLE
chore: ioutil has been deprecated in go 1.16

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -17,7 +17,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -264,7 +264,7 @@ func (bo *Options) brCommandRunWithLogCallback(ctx context.Context, fullArgs []s
 			break
 		}
 	}
-	tmpErr, _ := ioutil.ReadAll(stdErr)
+	tmpErr, _ := io.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
 		klog.Info(string(tmpErr))
 		errMsg += string(tmpErr)

--- a/cmd/backup-manager/app/import/import.go
+++ b/cmd/backup-manager/app/import/import.go
@@ -16,7 +16,7 @@ package _import
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -66,11 +66,11 @@ func (ro *Options) downloadBackupData(ctx context.Context, localPath string, opt
 	}
 
 	var errMsg string
-	tmpOut, _ := ioutil.ReadAll(stdOut)
+	tmpOut, _ := io.ReadAll(stdOut)
 	if len(tmpOut) > 0 {
 		klog.Info(string(tmpOut))
 	}
-	tmpErr, _ := ioutil.ReadAll(stdErr)
+	tmpErr, _ := io.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
 		klog.Info(string(tmpErr))
 		errMsg = string(tmpErr)

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -166,7 +165,7 @@ func (ro *Options) restoreData(
 			break
 		}
 	}
-	tmpErr, _ := ioutil.ReadAll(stdErr)
+	tmpErr, _ := io.ReadAll(stdErr)
 	if len(tmpErr) > 0 {
 		klog.Info(string(tmpErr))
 		errMsg += string(tmpErr)

--- a/pkg/autoscaler/autoscaler/query/external.go
+++ b/pkg/autoscaler/autoscaler/query/external.go
@@ -17,7 +17,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -69,7 +69,7 @@ func sendRequest(tc *v1alpha1.TidbCluster, memberType v1alpha1.MemberType, endpo
 		return nil, err
 	}
 	defer r.Body.Close()
-	bytes, err := ioutil.ReadAll(r.Body)
+	bytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -260,7 +260,7 @@ func (c *Client) offline(addr string, nodeID string) error {
 			resp.Request.URL, resp.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -155,7 +155,7 @@ func (c *defaultTiCDCControl) DrainCapture(tc *v1alpha1.TidbCluster, ordinal int
 		klog.Infof("ticdc control: %s service unavailable drain capture, retry", this.AdvertiseAddr)
 		return 0, true, nil
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, false, fmt.Errorf("ticdc drain capture failed, read response error: %v", err)
 	}
@@ -299,7 +299,7 @@ func getCaptures(httpClient *http.Client, baseURL string) ([]captureInfo, bool, 
 		return nil, true, nil
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, false, fmt.Errorf("ticdc get captures failed, read response error: %v", err)
 	}

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -91,7 +91,7 @@ func (c *defaultTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*
 		return nil, err
 	}
 	defer httputil.DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (c *defaultTiDBControl) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32
 		return nil, err
 	}
 	defer httputil.DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func getBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
 		return nil, err
 	}
 	defer httputil.DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/tidb_control_test.go
+++ b/pkg/controller/tidb_control_test.go
@@ -16,7 +16,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -349,7 +349,7 @@ func TestSetLabels(t *testing.T) {
 			g.Expect(request.URL.Path).To(Equal("/labels"), "check url")
 			buffer := bytes.NewBuffer([]byte{})
 			g.Expect(json.NewEncoder(buffer).Encode(c.labels)).NotTo(HaveOccurred())
-			body, err := ioutil.ReadAll(request.Body)
+			body, err := io.ReadAll(request.Body)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(body).To(Equal(buffer.Bytes()))
 

--- a/pkg/discovery/server/proxy_test.go
+++ b/pkg/discovery/server/proxy_test.go
@@ -14,7 +14,7 @@
 package server
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -46,7 +46,7 @@ func TestProxyServer(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status code expects %v, got %v", http.StatusOK, resp.StatusCode)
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/discovery/server/server_test.go
+++ b/pkg/discovery/server/server_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -116,7 +116,7 @@ func TestServer(t *testing.T) {
 					time.Sleep(time.Millisecond * 100)
 					continue
 				}
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -200,7 +200,7 @@ func TestDMServer(t *testing.T) {
 					time.Sleep(time.Millisecond * 100)
 					continue
 				}
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -253,7 +253,7 @@ func TestVerifyServer(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/pdapi/pdapi.go
+++ b/pkg/pdapi/pdapi.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -382,7 +382,7 @@ func (c *pdClient) DeleteStore(storeID uint64) error {
 	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound {
 		return nil
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (c *pdClient) SetStoreState(storeID uint64, state string) error {
 	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound {
 		return nil
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/pdapi/pdapi_test.go
+++ b/pkg/pdapi/pdapi_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -730,7 +729,7 @@ func TestGetEvictLeaderSchedulersForStores(t *testing.T) {
 func readJSON(r io.ReadCloser, data interface{}) error {
 	defer r.Close()
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/http/httputil.go
+++ b/pkg/util/http/httputil.go
@@ -16,7 +16,6 @@ package httputil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/klog/v2"
@@ -33,7 +32,7 @@ func DeferClose(c io.Closer) {
 // ReadErrorBody in the error case ready the body message.
 // But return it as an error (or return an error from reading the body).
 func ReadErrorBody(body io.Reader) (err error) {
-	bodyBytes, err := ioutil.ReadAll(body)
+	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
 		return err
 	}
@@ -71,7 +70,7 @@ func DoBodyOK(httpClient *http.Client, apiURL, method string, reqBody io.Reader)
 		return nil, err
 	}
 	defer DeferClose(res.Body)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/http/httputil_test.go
+++ b/pkg/util/http/httputil_test.go
@@ -16,7 +16,6 @@ package httputil
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,7 +45,7 @@ func TestDoBodyOK(t *testing.T) {
 		switch r.URL.Path {
 		case "/ok":
 			// just echo the body
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(403)
 			}

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os/exec"
 	"path/filepath"
@@ -1106,7 +1106,7 @@ func getDatasourceID(addr string) (int, error) {
 		}
 	}()
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}
@@ -1201,7 +1201,7 @@ func (oa *OperatorActions) pumpIsHealthy(tcName, ns, podName string, tlsEnabled 
 		log.Logf("Error response %v", res.StatusCode)
 		return false
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Logf("cluster:[%s] read response body failed,error:%v", tcName, err)
 		return false
@@ -1265,7 +1265,7 @@ func (oa *OperatorActions) drainerHealth(tcName, ns, podName string, tlsEnabled 
 		log.Logf("Error response %v", res.StatusCode)
 		return false
 	}
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		log.Logf("cluster:[%s] read response body failed,error:%v", tcName, err)
 		return false

--- a/tests/crd_test_util.go
+++ b/tests/crd_test_util.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os/exec"
 	"time"
@@ -637,7 +637,7 @@ func (ctu *CrdTestUtil) pumpHealth(tc *v1alpha1.TidbCluster, podName string) boo
 		log.Logf("ERROR: Error response %v", res.StatusCode)
 		return false
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Logf("ERROR: cluster:[%s] read response body failed,error:%v", tc.Name, err)
 		return false

--- a/tests/e2e/tidbdashboard/dashboard.go
+++ b/tests/e2e/tidbdashboard/dashboard.go
@@ -16,7 +16,7 @@ package tidbdashboard
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -157,7 +157,7 @@ func checkHttp200(addr string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusContinue || resp.StatusCode >= http.StatusBadRequest {
-		respData, err := ioutil.ReadAll(resp.Body)
+		respData, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("read body failed: %s", err)
 		}

--- a/tests/e2e/util/pd/pd.go
+++ b/tests/e2e/util/pd/pd.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -41,7 +41,7 @@ func GetMembersV2(addr string) (*GetMembersResponse, error) {
 	}
 	defer httpResp.Body.Close()
 
-	data, err := ioutil.ReadAll(httpResp.Body)
+	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read body failed: %s", err)
 	}
@@ -83,7 +83,7 @@ func UpdateMemberPeerURLs(addr string, id string, peerURLs []string) error {
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode < http.StatusContinue || httpResp.StatusCode >= http.StatusBadRequest {
-		respData, err := ioutil.ReadAll(httpResp.Body)
+		respData, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return fmt.Errorf("read body failed: %s", err)
 		}

--- a/tests/e2e/util/proxiedtidbclient/proxiedtidbclient.go
+++ b/tests/e2e/util/proxiedtidbclient/proxiedtidbclient.go
@@ -18,7 +18,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -81,7 +81,7 @@ func (p *proxiedTiDBClient) GetSettings(tc *v1alpha1.TidbCluster, ordinal int32)
 		errMsg := fmt.Errorf(fmt.Sprintf("Error response %v URL: %s", resp.StatusCode, u.String()))
 		return nil, errMsg
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/util/tngm/ng_monitoring_client.go
+++ b/tests/e2e/util/tngm/ng_monitoring_client.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -49,7 +49,7 @@ func GetConfig(addr string) (*NGMConfig, error) {
 	}
 	defer httpResp.Body.Close()
 
-	data, err := ioutil.ReadAll(httpResp.Body)
+	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read body failed: %s", err)
 	}
@@ -88,7 +88,7 @@ func SetConfig(addr string, req *ConfigureNGMReq) error {
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode < http.StatusContinue || httpResp.StatusCode >= http.StatusBadRequest {
-		respData, err := ioutil.ReadAll(httpResp.Body)
+		respData, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return fmt.Errorf("read body failed: %s", err)
 		}

--- a/tests/monitor.go
+++ b/tests/monitor.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -151,7 +151,7 @@ func checkPrometheusCommon(name, namespace string, fw portforward.PortForward, e
 			return false, nil
 		}
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Logf("ERROR: %v", err)
 			return false, nil
@@ -184,7 +184,7 @@ func checkPrometheusCommon(name, namespace string, fw portforward.PortForward, e
 			return false, nil
 		}
 		defer targetResponse.Body.Close()
-		body, err := ioutil.ReadAll(targetResponse.Body)
+		body, err := io.ReadAll(targetResponse.Body)
 		if err != nil {
 			log.Logf("ERROR: %v", err)
 			return false, nil
@@ -273,7 +273,7 @@ func checkGrafanaDataCommon(name, namespace string, grafanaClient *metrics.Clien
 			return false, nil
 		}
 		defer resp.Body.Close()
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, nil
 		}
@@ -337,7 +337,7 @@ func CheckThanosQueryData(name, namespace string, fw portforward.PortForward, ex
 			return false, nil
 		}
 		defer storesResponse.Body.Close()
-		storesBody, err := ioutil.ReadAll(storesResponse.Body)
+		storesBody, err := io.ReadAll(storesResponse.Body)
 		if err != nil {
 			log.Logf("ERROR: %v", err)
 			return false, nil
@@ -363,7 +363,7 @@ func CheckThanosQueryData(name, namespace string, fw portforward.PortForward, ex
 			return false, nil
 		}
 		defer instanceUpResponse.Body.Close()
-		instanceUpResponseBody, err := ioutil.ReadAll(instanceUpResponse.Body)
+		instanceUpResponseBody, err := io.ReadAll(instanceUpResponse.Body)
 		if err != nil {
 			log.Logf("ERROR: %v", err)
 			return false, nil

--- a/tests/pkg/fault-trigger/client/client.go
+++ b/tests/pkg/fault-trigger/client/client.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pingcap/tidb-operator/tests/pkg/fault-trigger/api"
@@ -100,7 +100,7 @@ func (c client) do(req *http.Request) (*http.Response, []byte, error) {
 		}
 	}
 
-	bodyByte, err := ioutil.ReadAll(resp.Body)
+	bodyByte, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp, nil, &clientError{
 			code: code,

--- a/tests/pkg/metrics/annotation_util.go
+++ b/tests/pkg/metrics/annotation_util.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -115,7 +115,7 @@ func (cli *Client) AddAnnotation(annotation Annotation) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("add annotation faield, statusCode=%v", resp.Status)
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	return err
 }
 

--- a/tests/pkg/mock/monitor.go
+++ b/tests/pkg/mock/monitor.go
@@ -16,7 +16,7 @@ package mock
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pingcap/tidb-operator/pkg/autoscaler/autoscaler/calculate"
@@ -74,7 +74,7 @@ func (m *mockPrometheus) ServeQuery(w http.ResponseWriter, r *http.Request) {
 
 func (m *mockPrometheus) SetResponse(w http.ResponseWriter, r *http.Request) {
 	mp := &MonitorParams{}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeResponse(w, err.Error())
 		return

--- a/tests/pkg/mock/util.go
+++ b/tests/pkg/mock/util.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -77,7 +77,7 @@ func SetPrometheusResponse(monitorName, monitorNamespace string, mp *MonitorPara
 	if err != nil {
 		return err
 	}
-	b, err = ioutil.ReadAll(r.Body)
+	b, err = io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/tests/pkg/webhook/route.go
+++ b/tests/pkg/webhook/route.go
@@ -16,7 +16,7 @@ package webhook
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"k8s.io/api/admission/v1beta1"
@@ -49,7 +49,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 
 	// The AdmissionReview that will be returned
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		} else {
 			responseAdmissionReview.Response = toAdmissionResponse(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Replace the ioutil package with the io package, ioutil.ReadAll() has been deprecated in go 1.16 (https://golang.google.cn/pkg/io/ioutil/)

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
