### PR TITLE
Add annotation to graceful shutdown tidb pod

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1407,8 +1407,8 @@ const (
 // - `none`: doing nothing.
 // - `delete-pod`: delete pod.
 const (
-	TiDBPodDeletionValueNone      = "none"
-	TiDBPodDeletionDeletePod      =  "delete-pod"
+	TiDBPodDeletionValueNone = "none"
+	TiDBPodDeletionDeletePod = "delete-pod"
 )
 
 type EvictLeaderStatus struct {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1380,6 +1380,8 @@ const (
 	EvictLeaderAnnKeyForResize = "tidb.pingcap.com/evict-leader-for-resize"
 	// PDLeaderTransferAnnKey is the annotation key to transfer PD leader used by user.
 	PDLeaderTransferAnnKey = "tidb.pingcap.com/pd-transfer-leader"
+	// TiDBTransferAnnKey is the annotation key to graceful shutdown tidb pod by user.
+	TiDBGracefulShutdownAnnKey = "tidb.pingcap.com/tidb-graceful-shutdown"
 )
 
 // The `Value` of annotation controls the behavior when the leader count drops to zero, the valid value is one of:
@@ -1398,6 +1400,15 @@ const (
 const (
 	TransferLeaderValueNone      = "none"
 	TransferLeaderValueDeletePod = "delete-pod"
+)
+
+// The `Value` of TiDB deletion annotation controls the behavior when the tidb pod got deleted, the valid value is one of:
+//
+// - `none`: doing nothing.
+// - `delete-pod`: delete pod.
+const (
+	TiDBPodDeletionValueNone      = "none"
+	TiDBPodDeletionDeletePod      =  "delete-pod"
 )
 
 type EvictLeaderStatus struct {

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -309,7 +309,7 @@ func (c *PodController) syncTiDBPod(ctx context.Context, pod *corev1.Pod, tc *v1
 		klog.Warningf("Ignore unknown value %q of annotation %q for Pod %s/%s", value, v1alpha1.PDLeaderTransferAnnKey, pod.Namespace, pod.Name)
 		return reconcile.Result{}, nil
 	}
-	
+
 	if value == v1alpha1.TiDBPodDeletionDeletePod {
 		err := c.deps.KubeClientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
@@ -325,7 +325,7 @@ func needDeleteTiDBPod(pod *corev1.Pod) (string, bool) {
 	if exist {
 		return value, true
 	}
-	
+
 	return "", false
 }
 

--- a/pkg/controller/tidbcluster/pod_control_test.go
+++ b/pkg/controller/tidbcluster/pod_control_test.go
@@ -324,32 +324,32 @@ func TestTiDBPodSync(t *testing.T) {
 		timeout  = time.Minute
 	)
 	testCases := []struct {
-		name                string
-		pdPhase             v1alpha1.MemberPhase
-		tikvPhase           v1alpha1.MemberPhase
-		shouldDelete        bool
-		target              int
+		name         string
+		pdPhase      v1alpha1.MemberPhase
+		tikvPhase    v1alpha1.MemberPhase
+		shouldDelete bool
+		target       int
 	}{
 		{
-			name:                "delete tidb pod successfully",
-			pdPhase:             v1alpha1.NormalPhase,
-			tikvPhase: 					 v1alpha1.NormalPhase,
-			shouldDelete:        true,
-			target:              0,
+			name:         "delete tidb pod successfully",
+			pdPhase:      v1alpha1.NormalPhase,
+			tikvPhase:    v1alpha1.NormalPhase,
+			shouldDelete: true,
+			target:       0,
 		},
 		{
-			name:                "PD rolling restart",
-			pdPhase:             v1alpha1.UpgradePhase,
-			tikvPhase: 					 v1alpha1.NormalPhase,
-			shouldDelete:        false,
-			target:              0,
+			name:         "PD rolling restart",
+			pdPhase:      v1alpha1.UpgradePhase,
+			tikvPhase:    v1alpha1.NormalPhase,
+			shouldDelete: false,
+			target:       0,
 		},
 		{
-			name:                "TiKV rolling restart",
-			pdPhase:             v1alpha1.NormalPhase,
-			tikvPhase:           v1alpha1.UpgradePhase,
-			shouldDelete:        false,
-			target:              0,
+			name:         "TiKV rolling restart",
+			pdPhase:      v1alpha1.NormalPhase,
+			tikvPhase:    v1alpha1.UpgradePhase,
+			shouldDelete: false,
+			target:       0,
 		},
 	}
 	for _, c := range testCases {
@@ -387,7 +387,7 @@ func TestTiDBPodSync(t *testing.T) {
 
 			tc.Status.TiKV = v1alpha1.TiKVStatus{
 				Synced: true,
-				Phase:  c.pdPhase,
+				Phase:  c.tikvPhase,
 				Stores: map[string]v1alpha1.TiKVStore{
 					"0": {
 						PodName: fmt.Sprintf("%s-%d", controller.TiKVMemberName(tc.Name), 0),
@@ -424,7 +424,7 @@ func TestTiDBPodSync(t *testing.T) {
 			}
 
 			pod.Annotations[v1alpha1.TiDBGracefulShutdownAnnKey] = v1alpha1.TiDBPodDeletionDeletePod
-			
+
 			pod, err = deps.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -437,6 +437,8 @@ func TestTiDBPodSync(t *testing.T) {
 			} else {
 				g.Consistently(func() bool {
 					_, err := deps.KubeClientset.CoreV1().Pods(tc.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					t.Log("error is ")
+					t.Log(err)
 					return err == nil
 				}, timeout, interval).Should(BeTrue(), "should not delete pod")
 			}

--- a/pkg/controller/tidbcluster/pod_control_test.go
+++ b/pkg/controller/tidbcluster/pod_control_test.go
@@ -318,6 +318,131 @@ func TestPDPodSync(t *testing.T) {
 		})
 	}
 }
+func TestTiDBPodSync(t *testing.T) {
+	const (
+		interval = 100 * time.Millisecond
+		timeout  = time.Minute
+	)
+	testCases := []struct {
+		name                string
+		pdPhase             v1alpha1.MemberPhase
+		tikvPhase           v1alpha1.MemberPhase
+		shouldDelete        bool
+		target              int
+	}{
+		{
+			name:                "delete tidb pod successfully",
+			pdPhase:             v1alpha1.NormalPhase,
+			tikvPhase: 					 v1alpha1.NormalPhase,
+			shouldDelete:        true,
+			target:              0,
+		},
+		{
+			name:                "PD rolling restart",
+			pdPhase:             v1alpha1.UpgradePhase,
+			tikvPhase: 					 v1alpha1.NormalPhase,
+			shouldDelete:        false,
+			target:              0,
+		},
+		{
+			name:                "TiKV rolling restart",
+			pdPhase:             v1alpha1.NormalPhase,
+			tikvPhase:           v1alpha1.UpgradePhase,
+			shouldDelete:        false,
+			target:              0,
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+			g := NewGomegaWithT(t)
+			tc := newTidbCluster()
+			deps := controller.NewFakeDependencies()
+			podController := NewPodController(deps)
+
+			stop := make(chan struct{})
+			go func() {
+				deps.KubeInformerFactory.Start(stop)
+			}()
+			deps.KubeInformerFactory.WaitForCacheSync(stop)
+			go func() {
+				deps.InformerFactory.Start(stop)
+			}()
+			deps.InformerFactory.WaitForCacheSync(stop)
+
+			defer close(stop)
+			go func() {
+				podController.Run(1, stop)
+			}()
+
+			tc.Status.PD = v1alpha1.PDStatus{
+				Synced: true,
+				Phase:  c.pdPhase,
+				Leader: v1alpha1.PDMember{
+					Name:   fmt.Sprintf("%s-%d", controller.PDMemberName(tc.Name), 0),
+					Health: true,
+				},
+				Members: make(map[string]v1alpha1.PDMember),
+			}
+
+			tc.Status.TiKV = v1alpha1.TiKVStatus{
+				Synced: true,
+				Phase:  c.pdPhase,
+				Stores: map[string]v1alpha1.TiKVStore{
+					"0": {
+						PodName: fmt.Sprintf("%s-%d", controller.TiKVMemberName(tc.Name), 0),
+						ID:      "0",
+					},
+				},
+			}
+
+			tc, err := deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(ctx, tc, metav1.CreateOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Eventually(func() error {
+				_, err := deps.TiDBClusterLister.TidbClusters(tc.Namespace).Get(tc.Name)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%d", controller.TiDBMemberName(tc.Name), c.target),
+					Namespace: tc.Namespace,
+					Labels: map[string]string{
+						label.ManagedByLabelKey: "tidb-operator",
+						label.ComponentLabelKey: "tidb",
+						label.InstanceLabelKey:  tc.Name,
+					},
+					Annotations: make(map[string]string),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dummy-name",
+						},
+					},
+				},
+			}
+
+			pod.Annotations[v1alpha1.TiDBGracefulShutdownAnnKey] = v1alpha1.TiDBPodDeletionDeletePod
+			
+			pod, err = deps.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// verify end state
+			if c.shouldDelete {
+				g.Eventually(func() bool {
+					_, err := deps.KubeClientset.CoreV1().Pods(tc.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue(), "should delete pod")
+			} else {
+				g.Consistently(func() bool {
+					_, err := deps.KubeClientset.CoreV1().Pods(tc.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					return err == nil
+				}, timeout, interval).Should(BeTrue(), "should not delete pod")
+			}
+		})
+	}
+}
 
 func TestNeedEvictLeader(t *testing.T) {
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
