### PR TITLE
Add annotation to graceful shutdown tidb pod

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1380,6 +1380,8 @@ const (
 	EvictLeaderAnnKeyForResize = "tidb.pingcap.com/evict-leader-for-resize"
 	// PDLeaderTransferAnnKey is the annotation key to transfer PD leader used by user.
 	PDLeaderTransferAnnKey = "tidb.pingcap.com/pd-transfer-leader"
+	// TiDBTransferAnnKey is the annotation key to graceful shutdown tidb pod by user.
+	TiDBGracefulShutdownAnnKey = "tidb.pingcap.com/tidb-graceful-shutdown"
 )
 
 // The `Value` of annotation controls the behavior when the leader count drops to zero, the valid value is one of:
@@ -1398,6 +1400,15 @@ const (
 const (
 	TransferLeaderValueNone      = "none"
 	TransferLeaderValueDeletePod = "delete-pod"
+)
+
+// The `Value` of TiDB deletion annotation controls the behavior when the tidb pod got deleted, the valid value is one of:
+//
+// - `none`: doing nothing.
+// - `delete-pod`: delete pod.
+const (
+	TiDBPodDeletionValueNone = "none"
+	TiDBPodDeletionDeletePod = "delete-pod"
 )
 
 type EvictLeaderStatus struct {

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -216,6 +216,8 @@ func (c *PodController) sync(key string) (reconcile.Result, error) {
 		return c.syncPDPod(ctx, pod, tc)
 	case label.TiKVLabelVal:
 		return c.syncTiKVPod(ctx, pod, tc)
+	case label.TiDBLabelVal:
+		return c.syncTiDBPod(ctx, pod, tc)
 	default:
 		return reconcile.Result{}, nil
 	}
@@ -410,6 +412,57 @@ func (c *PodController) syncTiKVPod(ctx context.Context, pod *corev1.Pod, tc *v1
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (c *PodController) syncTiDBPod(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
+	value, ok := needDeleteTiDBPod(pod)
+	if !ok {
+		// No need to delete tidb pod
+		return reconcile.Result{}, nil
+	}
+
+	ns := tc.GetNamespace()
+	tcName := tc.GetName()
+
+	if tc.Status.PD.Phase == v1alpha1.UpgradePhase || tc.Status.PD.Phase == v1alpha1.ScalePhase ||
+		tc.Status.TiKV.Phase == v1alpha1.UpgradePhase || tc.Status.TiKV.Phase == v1alpha1.ScalePhase ||
+		tc.Status.TiFlash.Phase == v1alpha1.UpgradePhase || tc.Status.TiFlash.Phase == v1alpha1.ScalePhase ||
+		tc.Status.Pump.Phase == v1alpha1.UpgradePhase || tc.Status.Pump.Phase == v1alpha1.ScalePhase ||
+		tc.TiDBScaling() {
+		klog.Infof("TidbCluster: [%s/%s]'s pd status is %s, "+
+			"tikv status is %s, tiflash status is %s, pump status is %s, "+
+			"tidb status is %s, can not delete tidb",
+			ns, tcName,
+			tc.Status.PD.Phase, tc.Status.TiKV.Phase, tc.Status.TiFlash.Phase,
+			tc.Status.Pump.Phase, tc.Status.TiDB.Phase)
+		return reconcile.Result{RequeueAfter: RequeueInterval}, nil
+	}
+
+	switch value {
+	case v1alpha1.TiDBPodDeletionValueNone:
+	case v1alpha1.TiDBPodDeletionDeletePod:
+	default:
+		klog.Warningf("Ignore unknown value %q of annotation %q for Pod %s/%s", value, v1alpha1.PDLeaderTransferAnnKey, pod.Namespace, pod.Name)
+		return reconcile.Result{}, nil
+	}
+
+	if value == v1alpha1.TiDBPodDeletionDeletePod {
+		err := c.deps.KubeClientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return reconcile.Result{}, perrors.Annotatef(err, "failed to delete pod %q", pod.Name)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func needDeleteTiDBPod(pod *corev1.Pod) (string, bool) {
+	value, exist := pod.Annotations[v1alpha1.TiDBGracefulShutdownAnnKey]
+	if exist {
+		return value, true
+	}
+
+	return "", false
 }
 
 func needEvictLeader(pod *corev1.Pod) (string, string, bool) {

--- a/pkg/controller/tidbcluster/pod_control_test.go
+++ b/pkg/controller/tidbcluster/pod_control_test.go
@@ -319,6 +319,132 @@ func TestPDPodSync(t *testing.T) {
 	}
 }
 
+func TestTiDBPodSync(t *testing.T) {
+	const (
+		interval = 100 * time.Millisecond
+		timeout  = time.Minute
+	)
+	testCases := []struct {
+		name         string
+		pdPhase      v1alpha1.MemberPhase
+		tikvPhase    v1alpha1.MemberPhase
+		shouldDelete bool
+		target       int
+	}{
+		{
+			name:         "delete tidb pod successfully",
+			pdPhase:      v1alpha1.NormalPhase,
+			tikvPhase:    v1alpha1.NormalPhase,
+			shouldDelete: true,
+			target:       0,
+		},
+		{
+			name:         "PD rolling restart",
+			pdPhase:      v1alpha1.UpgradePhase,
+			tikvPhase:    v1alpha1.NormalPhase,
+			shouldDelete: false,
+			target:       0,
+		},
+		{
+			name:         "TiKV rolling restart",
+			pdPhase:      v1alpha1.NormalPhase,
+			tikvPhase:    v1alpha1.UpgradePhase,
+			shouldDelete: false,
+			target:       0,
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+			g := NewGomegaWithT(t)
+			tc := newTidbCluster()
+			deps := controller.NewFakeDependencies()
+			podController := NewPodController(deps)
+
+			stop := make(chan struct{})
+			go func() {
+				deps.KubeInformerFactory.Start(stop)
+			}()
+			deps.KubeInformerFactory.WaitForCacheSync(stop)
+			go func() {
+				deps.InformerFactory.Start(stop)
+			}()
+			deps.InformerFactory.WaitForCacheSync(stop)
+
+			defer close(stop)
+			go func() {
+				podController.Run(1, stop)
+			}()
+
+			tc.Status.PD = v1alpha1.PDStatus{
+				Synced: true,
+				Phase:  c.pdPhase,
+				Leader: v1alpha1.PDMember{
+					Name:   fmt.Sprintf("%s-%d", controller.PDMemberName(tc.Name), 0),
+					Health: true,
+				},
+				Members: make(map[string]v1alpha1.PDMember),
+			}
+
+			tc.Status.TiKV = v1alpha1.TiKVStatus{
+				Synced: true,
+				Phase:  c.pdPhase,
+				Stores: map[string]v1alpha1.TiKVStore{
+					"0": {
+						PodName: fmt.Sprintf("%s-%d", controller.TiKVMemberName(tc.Name), 0),
+						ID:      "0",
+					},
+				},
+			}
+
+			tc, err := deps.Clientset.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(ctx, tc, metav1.CreateOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Eventually(func() error {
+				_, err := deps.TiDBClusterLister.TidbClusters(tc.Namespace).Get(tc.Name)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%d", controller.TiDBMemberName(tc.Name), c.target),
+					Namespace: tc.Namespace,
+					Labels: map[string]string{
+						label.ManagedByLabelKey: "tidb-operator",
+						label.ComponentLabelKey: "tidb",
+						label.InstanceLabelKey:  tc.Name,
+					},
+					Annotations: make(map[string]string),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dummy-name",
+						},
+					},
+				},
+			}
+
+			pod.Annotations[v1alpha1.TiDBGracefulShutdownAnnKey] = v1alpha1.TiDBPodDeletionDeletePod
+
+			pod, err = deps.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// verify end state
+			if c.shouldDelete {
+				g.Eventually(func() bool {
+					_, err := deps.KubeClientset.CoreV1().Pods(tc.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue(), "should delete pod")
+			} else {
+				g.Consistently(func() bool {
+					_, err := deps.KubeClientset.CoreV1().Pods(tc.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					return err == nil
+				}, timeout, interval).Should(BeTrue(), "should not delete pod")
+			}
+		})
+	}
+}
+
 func TestNeedEvictLeader(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Add annotation to graceful shutdown tidb pod
Closes: https://github.com/pingcap/tidb-operator/issues/4758
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
