### PR TITLE
Add startUpScriptVersion for dm-master spec

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1074,18 +1074,6 @@ SuspendAction
 <p>SuspendAction defines the suspend actions for all component.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>startUpScriptVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Start up script version</p>
-</td>
-</tr>
 </table>
 </td>
 </tr>
@@ -6168,18 +6156,6 @@ SuspendAction
 <p>SuspendAction defines the suspend actions for all component.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>startUpScriptVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Start up script version</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="dmclusterstatus">DMClusterStatus</h3>
@@ -8985,6 +8961,18 @@ MasterConfigWraper
 <td>
 <em>(Optional)</em>
 <p>Config is the Configuration of dm-master-servers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startUpScriptVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Start up script version</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1074,6 +1074,18 @@ SuspendAction
 <p>SuspendAction defines the suspend actions for all component.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>startUpScriptVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Start up script version</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -6154,6 +6166,18 @@ SuspendAction
 <td>
 <em>(Optional)</em>
 <p>SuspendAction defines the suspend actions for all component.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startUpScriptVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Start up script version</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6,6 +6,1531 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
+  name: backups.pingcap.com
+spec:
+  group: pingcap.com
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - bk
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: the type of backup, such as full, db, table. Only used when Mode
+        = snapshot.
+      jsonPath: .spec.backupType
+      name: Type
+      type: string
+    - description: the mode of backup, such as snapshot, log.
+      jsonPath: .spec.backupMode
+      name: Mode
+      type: string
+    - description: The current status of the backup
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: The full path of backup data
+      jsonPath: .status.backupPath
+      name: BackupPath
+      type: string
+    - description: The data size of the backup
+      jsonPath: .status.backupSizeReadable
+      name: BackupSize
+      type: string
+    - description: The commit ts of the backup
+      jsonPath: .status.commitTs
+      name: CommitTS
+      type: string
+    - description: The log backup truncate until ts
+      jsonPath: .status.logSuccessTruncateUntil
+      name: LogTruncateUntil
+      type: string
+    - description: The time at which the backup was started
+      jsonPath: .status.timeStarted
+      name: Started
+      priority: 1
+      type: date
+    - description: The time at which the backup was completed
+      jsonPath: .status.timeCompleted
+      name: Completed
+      priority: 1
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              affinity:
+                properties:
+                  nodeAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            preference:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              azblob:
+                properties:
+                  accessTier:
+                    type: string
+                  container:
+                    type: string
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  secretName:
+                    type: string
+                type: object
+              backoffRetryPolicy:
+                properties:
+                  maxRetryTimes:
+                    default: 2
+                    type: integer
+                  minRetryDuration:
+                    default: 300s
+                    type: string
+                  retryTimeout:
+                    default: 30m
+                    type: string
+                type: object
+              backupMode:
+                default: snapshot
+                type: string
+              backupType:
+                type: string
+              br:
+                properties:
+                  checkRequirements:
+                    type: boolean
+                  checksum:
+                    type: boolean
+                  cluster:
+                    type: string
+                  clusterNamespace:
+                    type: string
+                  concurrency:
+                    format: int32
+                    type: integer
+                  db:
+                    type: string
+                  logLevel:
+                    type: string
+                  onLine:
+                    type: boolean
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  rateLimit:
+                    type: integer
+                  sendCredToTikv:
+                    type: boolean
+                  statusAddr:
+                    type: string
+                  table:
+                    type: string
+                  timeAgo:
+                    type: string
+                required:
+                - cluster
+                type: object
+              cleanOption:
+                properties:
+                  backoffEnabled:
+                    type: boolean
+                  batchConcurrency:
+                    format: int32
+                    type: integer
+                  disableBatchConcurrency:
+                    type: boolean
+                  pageSize:
+                    format: int64
+                    type: integer
+                  retryCount:
+                    default: 5
+                    type: integer
+                  routineConcurrency:
+                    format: int32
+                    type: integer
+                type: object
+              cleanPolicy:
+                type: string
+              commitTs:
+                type: string
+              dumpling:
+                properties:
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  tableFilter:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              env:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          properties:
+                            apiVersion:
+                              type: string
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          properties:
+                            containerName:
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              from:
+                properties:
+                  host:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                  secretName:
+                    type: string
+                  tlsClientSecretName:
+                    type: string
+                  user:
+                    type: string
+                required:
+                - host
+                - secretName
+                type: object
+              gcs:
+                properties:
+                  bucket:
+                    type: string
+                  bucketAcl:
+                    type: string
+                  location:
+                    type: string
+                  objectAcl:
+                    type: string
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  projectId:
+                    type: string
+                  secretName:
+                    type: string
+                  storageClass:
+                    type: string
+                required:
+                - projectId
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
+              local:
+                properties:
+                  prefix:
+                    type: string
+                  volume:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  volumeMount:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                required:
+                - volume
+                - volumeMount
+                type: object
+              logStop:
+                type: boolean
+              logTruncateUntil:
+                type: string
+              podSecurityContext:
+                properties:
+                  fsGroup:
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    type: string
+                  runAsGroup:
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    type: boolean
+                  runAsUser:
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    properties:
+                      level:
+                        type: string
+                      role:
+                        type: string
+                      type:
+                        type: string
+                      user:
+                        type: string
+                    type: object
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    properties:
+                      gmsaCredentialSpec:
+                        type: string
+                      gmsaCredentialSpecName:
+                        type: string
+                      runAsUserName:
+                        type: string
+                    type: object
+                type: object
+              priorityClassName:
+                type: string
+              resources:
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              s3:
+                properties:
+                  acl:
+                    type: string
+                  bucket:
+                    type: string
+                  endpoint:
+                    type: string
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  provider:
+                    type: string
+                  region:
+                    type: string
+                  secretName:
+                    type: string
+                  sse:
+                    type: string
+                  storageClass:
+                    type: string
+                required:
+                - provider
+                type: object
+              serviceAccount:
+                type: string
+              storageClassName:
+                type: string
+              storageSize:
+                type: string
+              tableFilter:
+                items:
+                  type: string
+                type: array
+              tikvGCLifeTime:
+                type: string
+              tolerations:
+                items:
+                  properties:
+                    effect:
+                      type: string
+                    key:
+                      type: string
+                    operator:
+                      type: string
+                    tolerationSeconds:
+                      format: int64
+                      type: integer
+                    value:
+                      type: string
+                  type: object
+                type: array
+              toolImage:
+                type: string
+              useKMS:
+                type: boolean
+            type: object
+          status:
+            properties:
+              backoffRetryStatus:
+                items:
+                  properties:
+                    detectFailedAt:
+                      format: date-time
+                      type: string
+                    expectedRetryAt:
+                      format: date-time
+                      type: string
+                    originalReason:
+                      type: string
+                    realRetryAt:
+                      format: date-time
+                      type: string
+                    retryNum:
+                      type: integer
+                    retryReason:
+                      type: string
+                  type: object
+                type: array
+              backupPath:
+                type: string
+              backupSize:
+                format: int64
+                type: integer
+              backupSizeReadable:
+                type: string
+              commitTs:
+                type: string
+              conditions:
+                items:
+                  properties:
+                    command:
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              logCheckpointTs:
+                type: string
+              logSubCommandStatuses:
+                additionalProperties:
+                  properties:
+                    command:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          command:
+                            type: string
+                          lastTransitionTime:
+                            format: date-time
+                            nullable: true
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      nullable: true
+                      type: array
+                    logTruncatingUntil:
+                      type: string
+                    phase:
+                      type: string
+                    timeCompleted:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    timeStarted:
+                      format: date-time
+                      nullable: true
+                      type: string
+                  type: object
+                type: object
+              logSuccessTruncateUntil:
+                type: string
+              phase:
+                type: string
+              progresses:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    progress:
+                      type: number
+                    step:
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              timeCompleted:
+                format: date-time
+                nullable: true
+                type: string
+              timeStarted:
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: backupschedules.pingcap.com
 spec:
   group: pingcap.com
@@ -2715,1531 +4240,6 @@ spec:
                 format: date-time
                 type: string
               logBackup:
-                type: string
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
-  name: backups.pingcap.com
-spec:
-  group: pingcap.com
-  names:
-    kind: Backup
-    listKind: BackupList
-    plural: backups
-    shortNames:
-    - bk
-    singular: backup
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: the type of backup, such as full, db, table. Only used when Mode
-        = snapshot.
-      jsonPath: .spec.backupType
-      name: Type
-      type: string
-    - description: the mode of backup, such as snapshot, log.
-      jsonPath: .spec.backupMode
-      name: Mode
-      type: string
-    - description: The current status of the backup
-      jsonPath: .status.phase
-      name: Status
-      type: string
-    - description: The full path of backup data
-      jsonPath: .status.backupPath
-      name: BackupPath
-      type: string
-    - description: The data size of the backup
-      jsonPath: .status.backupSizeReadable
-      name: BackupSize
-      type: string
-    - description: The commit ts of the backup
-      jsonPath: .status.commitTs
-      name: CommitTS
-      type: string
-    - description: The log backup truncate until ts
-      jsonPath: .status.logSuccessTruncateUntil
-      name: LogTruncateUntil
-      type: string
-    - description: The time at which the backup was started
-      jsonPath: .status.timeStarted
-      name: Started
-      priority: 1
-      type: date
-    - description: The time at which the backup was completed
-      jsonPath: .status.timeCompleted
-      name: Completed
-      priority: 1
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              affinity:
-                properties:
-                  nodeAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            preference:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        properties:
-                          nodeSelectorTerms:
-                            items:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                    type: object
-                  podAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              azblob:
-                properties:
-                  accessTier:
-                    type: string
-                  container:
-                    type: string
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  secretName:
-                    type: string
-                type: object
-              backoffRetryPolicy:
-                properties:
-                  maxRetryTimes:
-                    default: 2
-                    type: integer
-                  minRetryDuration:
-                    default: 300s
-                    type: string
-                  retryTimeout:
-                    default: 30m
-                    type: string
-                type: object
-              backupMode:
-                default: snapshot
-                type: string
-              backupType:
-                type: string
-              br:
-                properties:
-                  checkRequirements:
-                    type: boolean
-                  checksum:
-                    type: boolean
-                  cluster:
-                    type: string
-                  clusterNamespace:
-                    type: string
-                  concurrency:
-                    format: int32
-                    type: integer
-                  db:
-                    type: string
-                  logLevel:
-                    type: string
-                  onLine:
-                    type: boolean
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  rateLimit:
-                    type: integer
-                  sendCredToTikv:
-                    type: boolean
-                  statusAddr:
-                    type: string
-                  table:
-                    type: string
-                  timeAgo:
-                    type: string
-                required:
-                - cluster
-                type: object
-              cleanOption:
-                properties:
-                  backoffEnabled:
-                    type: boolean
-                  batchConcurrency:
-                    format: int32
-                    type: integer
-                  disableBatchConcurrency:
-                    type: boolean
-                  pageSize:
-                    format: int64
-                    type: integer
-                  retryCount:
-                    default: 5
-                    type: integer
-                  routineConcurrency:
-                    format: int32
-                    type: integer
-                type: object
-              cleanPolicy:
-                type: string
-              commitTs:
-                type: string
-              dumpling:
-                properties:
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  tableFilter:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              env:
-                items:
-                  properties:
-                    name:
-                      type: string
-                    value:
-                      type: string
-                    valueFrom:
-                      properties:
-                        configMapKeyRef:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        fieldRef:
-                          properties:
-                            apiVersion:
-                              type: string
-                            fieldPath:
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                        resourceFieldRef:
-                          properties:
-                            containerName:
-                              type: string
-                            divisor:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            resource:
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                        secretKeyRef:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              from:
-                properties:
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                  secretName:
-                    type: string
-                  tlsClientSecretName:
-                    type: string
-                  user:
-                    type: string
-                required:
-                - host
-                - secretName
-                type: object
-              gcs:
-                properties:
-                  bucket:
-                    type: string
-                  bucketAcl:
-                    type: string
-                  location:
-                    type: string
-                  objectAcl:
-                    type: string
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  projectId:
-                    type: string
-                  secretName:
-                    type: string
-                  storageClass:
-                    type: string
-                required:
-                - projectId
-                type: object
-              imagePullSecrets:
-                items:
-                  properties:
-                    name:
-                      type: string
-                  type: object
-                type: array
-              local:
-                properties:
-                  prefix:
-                    type: string
-                  volume:
-                    properties:
-                      awsElasticBlockStore:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        properties:
-                          cachingMode:
-                            type: string
-                          diskName:
-                            type: string
-                          diskURI:
-                            type: string
-                          fsType:
-                            type: string
-                          kind:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          secretName:
-                            type: string
-                          shareName:
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        properties:
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretFile:
-                            type: string
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      csi:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          nodePublishSecretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      downwardAPI:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                              required:
-                              - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        properties:
-                          medium:
-                            type: string
-                          sizeLimit:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        type: object
-                      ephemeral:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          volumeClaimTemplate:
-                            properties:
-                              metadata:
-                                type: object
-                              spec:
-                                properties:
-                                  accessModes:
-                                    items:
-                                      type: string
-                                    type: array
-                                  dataSource:
-                                    properties:
-                                      apiGroup:
-                                        type: string
-                                      kind:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                    - kind
-                                    - name
-                                    type: object
-                                  resources:
-                                    properties:
-                                      limits:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                      requests:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                    type: object
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  storageClassName:
-                                    type: string
-                                  volumeMode:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                type: object
-                            required:
-                            - spec
-                            type: object
-                        type: object
-                      fc:
-                        properties:
-                          fsType:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          targetWWNs:
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      flocker:
-                        properties:
-                          datasetName:
-                            type: string
-                          datasetUUID:
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          pdName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        properties:
-                          directory:
-                            type: string
-                          repository:
-                            type: string
-                          revision:
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        properties:
-                          endpoints:
-                            type: string
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        properties:
-                          path:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      iscsi:
-                        properties:
-                          chapAuthDiscovery:
-                            type: boolean
-                          chapAuthSession:
-                            type: boolean
-                          fsType:
-                            type: string
-                          initiatorName:
-                            type: string
-                          iqn:
-                            type: string
-                          iscsiInterface:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          portals:
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          targetPortal:
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        type: string
-                      nfs:
-                        properties:
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          server:
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        properties:
-                          claimName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          pdID:
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          sources:
-                            items:
-                              properties:
-                                configMap:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  properties:
-                                    audience:
-                                      type: string
-                                    expirationSeconds:
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      quobyte:
-                        properties:
-                          group:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          registry:
-                            type: string
-                          tenant:
-                            type: string
-                          user:
-                            type: string
-                          volume:
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        properties:
-                          fsType:
-                            type: string
-                          image:
-                            type: string
-                          keyring:
-                            type: string
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        properties:
-                          fsType:
-                            type: string
-                          gateway:
-                            type: string
-                          protectionDomain:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          sslEnabled:
-                            type: boolean
-                          storageMode:
-                            type: string
-                          storagePool:
-                            type: string
-                          system:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          optional:
-                            type: boolean
-                          secretName:
-                            type: string
-                        type: object
-                      storageos:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeName:
-                            type: string
-                          volumeNamespace:
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          storagePolicyID:
-                            type: string
-                          storagePolicyName:
-                            type: string
-                          volumePath:
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  volumeMount:
-                    properties:
-                      mountPath:
-                        type: string
-                      mountPropagation:
-                        type: string
-                      name:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                      subPathExpr:
-                        type: string
-                    required:
-                    - mountPath
-                    - name
-                    type: object
-                required:
-                - volume
-                - volumeMount
-                type: object
-              logStop:
-                type: boolean
-              logTruncateUntil:
-                type: string
-              podSecurityContext:
-                properties:
-                  fsGroup:
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    type: string
-                  runAsGroup:
-                    format: int64
-                    type: integer
-                  runAsNonRoot:
-                    type: boolean
-                  runAsUser:
-                    format: int64
-                    type: integer
-                  seLinuxOptions:
-                    properties:
-                      level:
-                        type: string
-                      role:
-                        type: string
-                      type:
-                        type: string
-                      user:
-                        type: string
-                    type: object
-                  seccompProfile:
-                    properties:
-                      localhostProfile:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  supplementalGroups:
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        value:
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
-                  windowsOptions:
-                    properties:
-                      gmsaCredentialSpec:
-                        type: string
-                      gmsaCredentialSpecName:
-                        type: string
-                      runAsUserName:
-                        type: string
-                    type: object
-                type: object
-              priorityClassName:
-                type: string
-              resources:
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                type: object
-              s3:
-                properties:
-                  acl:
-                    type: string
-                  bucket:
-                    type: string
-                  endpoint:
-                    type: string
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  provider:
-                    type: string
-                  region:
-                    type: string
-                  secretName:
-                    type: string
-                  sse:
-                    type: string
-                  storageClass:
-                    type: string
-                required:
-                - provider
-                type: object
-              serviceAccount:
-                type: string
-              storageClassName:
-                type: string
-              storageSize:
-                type: string
-              tableFilter:
-                items:
-                  type: string
-                type: array
-              tikvGCLifeTime:
-                type: string
-              tolerations:
-                items:
-                  properties:
-                    effect:
-                      type: string
-                    key:
-                      type: string
-                    operator:
-                      type: string
-                    tolerationSeconds:
-                      format: int64
-                      type: integer
-                    value:
-                      type: string
-                  type: object
-                type: array
-              toolImage:
-                type: string
-              useKMS:
-                type: boolean
-            type: object
-          status:
-            properties:
-              backoffRetryStatus:
-                items:
-                  properties:
-                    detectFailedAt:
-                      format: date-time
-                      type: string
-                    expectedRetryAt:
-                      format: date-time
-                      type: string
-                    originalReason:
-                      type: string
-                    realRetryAt:
-                      format: date-time
-                      type: string
-                    retryNum:
-                      type: integer
-                    retryReason:
-                      type: string
-                  type: object
-                type: array
-              backupPath:
-                type: string
-              backupSize:
-                format: int64
-                type: integer
-              backupSizeReadable:
-                type: string
-              commitTs:
-                type: string
-              conditions:
-                items:
-                  properties:
-                    command:
-                      type: string
-                    lastTransitionTime:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                nullable: true
-                type: array
-              logCheckpointTs:
-                type: string
-              logSubCommandStatuses:
-                additionalProperties:
-                  properties:
-                    command:
-                      type: string
-                    conditions:
-                      items:
-                        properties:
-                          command:
-                            type: string
-                          lastTransitionTime:
-                            format: date-time
-                            nullable: true
-                            type: string
-                          message:
-                            type: string
-                          reason:
-                            type: string
-                          status:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      nullable: true
-                      type: array
-                    logTruncatingUntil:
-                      type: string
-                    phase:
-                      type: string
-                    timeCompleted:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    timeStarted:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-                type: object
-              logSuccessTruncateUntil:
-                type: string
-              phase:
-                type: string
-              progresses:
-                items:
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    progress:
-                      type: number
-                    step:
-                      type: string
-                  type: object
-                nullable: true
-                type: array
-              timeCompleted:
-                format: date-time
-                nullable: true
-                type: string
-              timeStarted:
-                format: date-time
-                nullable: true
                 type: string
             type: object
         required:
@@ -9403,6 +9403,11 @@ spec:
                 default: Retain
                 type: string
               schedulerName:
+                type: string
+              startUpScriptVersion:
+                enum:
+                - ""
+                - v1
                 type: string
               statefulSetUpdateStrategy:
                 type: string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -9280,6 +9280,11 @@ spec:
                       type:
                         type: string
                     type: object
+                  startUpScriptVersion:
+                    enum:
+                    - ""
+                    - v1
+                    type: string
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:
@@ -9403,11 +9408,6 @@ spec:
                 default: Retain
                 type: string
               schedulerName:
-                type: string
-              startUpScriptVersion:
-                enum:
-                - ""
-                - v1
                 type: string
               statefulSetUpdateStrategy:
                 type: string

--- a/manifests/crd/v1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_dmclusters.yaml
@@ -5023,6 +5023,11 @@ spec:
                       type:
                         type: string
                     type: object
+                  startUpScriptVersion:
+                    enum:
+                    - ""
+                    - v1
+                    type: string
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:
@@ -5146,11 +5151,6 @@ spec:
                 default: Retain
                 type: string
               schedulerName:
-                type: string
-              startUpScriptVersion:
-                enum:
-                - ""
-                - v1
                 type: string
               statefulSetUpdateStrategy:
                 type: string

--- a/manifests/crd/v1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_dmclusters.yaml
@@ -5147,6 +5147,11 @@ spec:
                 type: string
               schedulerName:
                 type: string
+              startUpScriptVersion:
+                enum:
+                - ""
+                - v1
+                type: string
               statefulSetUpdateStrategy:
                 type: string
               suspendAction:

--- a/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
@@ -5017,6 +5017,11 @@ spec:
                     type:
                       type: string
                   type: object
+                startUpScriptVersion:
+                  enum:
+                  - ""
+                  - v1
+                  type: string
                 statefulSetUpdateStrategy:
                   type: string
                 storageClassName:
@@ -5139,11 +5144,6 @@ spec:
             pvReclaimPolicy:
               type: string
             schedulerName:
-              type: string
-            startUpScriptVersion:
-              enum:
-              - ""
-              - v1
               type: string
             statefulSetUpdateStrategy:
               type: string

--- a/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_dmclusters.yaml
@@ -5140,6 +5140,11 @@ spec:
               type: string
             schedulerName:
               type: string
+            startUpScriptVersion:
+              enum:
+              - ""
+              - v1
+              type: string
             statefulSetUpdateStrategy:
               type: string
             suspendAction:

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -9263,6 +9263,11 @@ spec:
                     type:
                       type: string
                   type: object
+                startUpScriptVersion:
+                  enum:
+                  - ""
+                  - v1
+                  type: string
                 statefulSetUpdateStrategy:
                   type: string
                 storageClassName:
@@ -9385,11 +9390,6 @@ spec:
             pvReclaimPolicy:
               type: string
             schedulerName:
-              type: string
-            startUpScriptVersion:
-              enum:
-              - ""
-              - v1
               type: string
             statefulSetUpdateStrategy:
               type: string

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -6,6 +6,1528 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
+  name: backups.pingcap.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.backupType
+    description: the type of backup, such as full, db, table. Only used when Mode
+      = snapshot.
+    name: Type
+    type: string
+  - JSONPath: .spec.backupMode
+    description: the mode of backup, such as snapshot, log.
+    name: Mode
+    type: string
+  - JSONPath: .status.phase
+    description: The current status of the backup
+    name: Status
+    type: string
+  - JSONPath: .status.backupPath
+    description: The full path of backup data
+    name: BackupPath
+    type: string
+  - JSONPath: .status.backupSizeReadable
+    description: The data size of the backup
+    name: BackupSize
+    type: string
+  - JSONPath: .status.commitTs
+    description: The commit ts of the backup
+    name: CommitTS
+    type: string
+  - JSONPath: .status.logSuccessTruncateUntil
+    description: The log backup truncate until ts
+    name: LogTruncateUntil
+    type: string
+  - JSONPath: .status.timeStarted
+    description: The time at which the backup was started
+    name: Started
+    priority: 1
+    type: date
+  - JSONPath: .status.timeCompleted
+    description: The time at which the backup was completed
+    name: Completed
+    priority: 1
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: pingcap.com
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - bk
+    singular: backup
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            affinity:
+              properties:
+                nodeAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          preference:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - preference
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      properties:
+                        nodeSelectorTerms:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          podAffinityTerm:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          namespaces:
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          podAffinityTerm:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          namespaces:
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            azblob:
+              properties:
+                accessTier:
+                  type: string
+                container:
+                  type: string
+                path:
+                  type: string
+                prefix:
+                  type: string
+                secretName:
+                  type: string
+              type: object
+            backoffRetryPolicy:
+              properties:
+                maxRetryTimes:
+                  type: integer
+                minRetryDuration:
+                  type: string
+                retryTimeout:
+                  type: string
+              type: object
+            backupMode:
+              type: string
+            backupType:
+              type: string
+            br:
+              properties:
+                checkRequirements:
+                  type: boolean
+                checksum:
+                  type: boolean
+                cluster:
+                  type: string
+                clusterNamespace:
+                  type: string
+                concurrency:
+                  format: int32
+                  type: integer
+                db:
+                  type: string
+                logLevel:
+                  type: string
+                onLine:
+                  type: boolean
+                options:
+                  items:
+                    type: string
+                  type: array
+                rateLimit:
+                  type: integer
+                sendCredToTikv:
+                  type: boolean
+                statusAddr:
+                  type: string
+                table:
+                  type: string
+                timeAgo:
+                  type: string
+              required:
+              - cluster
+              type: object
+            cleanOption:
+              properties:
+                backoffEnabled:
+                  type: boolean
+                batchConcurrency:
+                  format: int32
+                  type: integer
+                disableBatchConcurrency:
+                  type: boolean
+                pageSize:
+                  format: int64
+                  type: integer
+                retryCount:
+                  type: integer
+                routineConcurrency:
+                  format: int32
+                  type: integer
+              type: object
+            cleanPolicy:
+              type: string
+            commitTs:
+              type: string
+            dumpling:
+              properties:
+                options:
+                  items:
+                    type: string
+                  type: array
+                tableFilter:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            env:
+              items:
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                  valueFrom:
+                    properties:
+                      configMapKeyRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      fieldRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                        required:
+                        - fieldPath
+                        type: object
+                      resourceFieldRef:
+                        properties:
+                          containerName:
+                            type: string
+                          divisor:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          resource:
+                            type: string
+                        required:
+                        - resource
+                        type: object
+                      secretKeyRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+            from:
+              properties:
+                host:
+                  type: string
+                port:
+                  format: int32
+                  type: integer
+                secretName:
+                  type: string
+                tlsClientSecretName:
+                  type: string
+                user:
+                  type: string
+              required:
+              - host
+              - secretName
+              type: object
+            gcs:
+              properties:
+                bucket:
+                  type: string
+                bucketAcl:
+                  type: string
+                location:
+                  type: string
+                objectAcl:
+                  type: string
+                path:
+                  type: string
+                prefix:
+                  type: string
+                projectId:
+                  type: string
+                secretName:
+                  type: string
+                storageClass:
+                  type: string
+              required:
+              - projectId
+              type: object
+            imagePullSecrets:
+              items:
+                properties:
+                  name:
+                    type: string
+                type: object
+              type: array
+            local:
+              properties:
+                prefix:
+                  type: string
+                volume:
+                  properties:
+                    awsElasticBlockStore:
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          format: int32
+                          type: integer
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      properties:
+                        cachingMode:
+                          type: string
+                        diskName:
+                          type: string
+                        diskURI:
+                          type: string
+                        fsType:
+                          type: string
+                        kind:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      properties:
+                        readOnly:
+                          type: boolean
+                        secretName:
+                          type: string
+                        shareName:
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      properties:
+                        monitors:
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretFile:
+                          type: string
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        user:
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                      type: object
+                    csi:
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        nodePublishSecretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        readOnly:
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      properties:
+                        readOnly:
+                          type: boolean
+                        volumeClaimTemplate:
+                          properties:
+                            metadata:
+                              type: object
+                            spec:
+                              properties:
+                                accessModes:
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  properties:
+                                    apiGroup:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  type: string
+                                volumeMode:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      properties:
+                        fsType:
+                          type: string
+                        lun:
+                          format: int32
+                          type: integer
+                        readOnly:
+                          type: boolean
+                        targetWWNs:
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      properties:
+                        datasetName:
+                          type: string
+                        datasetUUID:
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          format: int32
+                          type: integer
+                        pdName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      properties:
+                        directory:
+                          type: string
+                        repository:
+                          type: string
+                        revision:
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      properties:
+                        endpoints:
+                          type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      properties:
+                        chapAuthDiscovery:
+                          type: boolean
+                        chapAuthSession:
+                          type: boolean
+                        fsType:
+                          type: string
+                        initiatorName:
+                          type: string
+                        iqn:
+                          type: string
+                        iscsiInterface:
+                          type: string
+                        lun:
+                          format: int32
+                          type: integer
+                        portals:
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        targetPortal:
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      type: string
+                    nfs:
+                      properties:
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        server:
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      properties:
+                        claimName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      properties:
+                        fsType:
+                          type: string
+                        pdID:
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        sources:
+                          items:
+                            properties:
+                              configMap:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              serviceAccountToken:
+                                properties:
+                                  audience:
+                                    type: string
+                                  expirationSeconds:
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    quobyte:
+                      properties:
+                        group:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        registry:
+                          type: string
+                        tenant:
+                          type: string
+                        user:
+                          type: string
+                        volume:
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      properties:
+                        fsType:
+                          type: string
+                        image:
+                          type: string
+                        keyring:
+                          type: string
+                        monitors:
+                          items:
+                            type: string
+                          type: array
+                        pool:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        user:
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      properties:
+                        fsType:
+                          type: string
+                        gateway:
+                          type: string
+                        protectionDomain:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        sslEnabled:
+                          type: boolean
+                        storageMode:
+                          type: string
+                        storagePool:
+                          type: string
+                        system:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        optional:
+                          type: boolean
+                        secretName:
+                          type: string
+                      type: object
+                    storageos:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        volumeName:
+                          type: string
+                        volumeNamespace:
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      properties:
+                        fsType:
+                          type: string
+                        storagePolicyID:
+                          type: string
+                        storagePolicyName:
+                          type: string
+                        volumePath:
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                volumeMount:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+              required:
+              - volume
+              - volumeMount
+              type: object
+            logStop:
+              type: boolean
+            logTruncateUntil:
+              type: string
+            podSecurityContext:
+              properties:
+                fsGroup:
+                  format: int64
+                  type: integer
+                fsGroupChangePolicy:
+                  type: string
+                runAsGroup:
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  type: boolean
+                runAsUser:
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  properties:
+                    level:
+                      type: string
+                    role:
+                      type: string
+                    type:
+                      type: string
+                    user:
+                      type: string
+                  type: object
+                seccompProfile:
+                  properties:
+                    localhostProfile:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  type: object
+                supplementalGroups:
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                windowsOptions:
+                  properties:
+                    gmsaCredentialSpec:
+                      type: string
+                    gmsaCredentialSpecName:
+                      type: string
+                    runAsUserName:
+                      type: string
+                  type: object
+              type: object
+            priorityClassName:
+              type: string
+            resources:
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  type: object
+              type: object
+            s3:
+              properties:
+                acl:
+                  type: string
+                bucket:
+                  type: string
+                endpoint:
+                  type: string
+                options:
+                  items:
+                    type: string
+                  type: array
+                path:
+                  type: string
+                prefix:
+                  type: string
+                provider:
+                  type: string
+                region:
+                  type: string
+                secretName:
+                  type: string
+                sse:
+                  type: string
+                storageClass:
+                  type: string
+              required:
+              - provider
+              type: object
+            serviceAccount:
+              type: string
+            storageClassName:
+              type: string
+            storageSize:
+              type: string
+            tableFilter:
+              items:
+                type: string
+              type: array
+            tikvGCLifeTime:
+              type: string
+            tolerations:
+              items:
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    format: int64
+                    type: integer
+                  value:
+                    type: string
+                type: object
+              type: array
+            toolImage:
+              type: string
+            useKMS:
+              type: boolean
+          type: object
+        status:
+          properties:
+            backoffRetryStatus:
+              items:
+                properties:
+                  detectFailedAt:
+                    format: date-time
+                    type: string
+                  expectedRetryAt:
+                    format: date-time
+                    type: string
+                  originalReason:
+                    type: string
+                  realRetryAt:
+                    format: date-time
+                    type: string
+                  retryNum:
+                    type: integer
+                  retryReason:
+                    type: string
+                type: object
+              type: array
+            backupPath:
+              type: string
+            backupSize:
+              format: int64
+              type: integer
+            backupSizeReadable:
+              type: string
+            commitTs:
+              type: string
+            conditions:
+              items:
+                properties:
+                  command:
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              nullable: true
+              type: array
+            logCheckpointTs:
+              type: string
+            logSubCommandStatuses:
+              additionalProperties:
+                properties:
+                  command:
+                    type: string
+                  conditions:
+                    items:
+                      properties:
+                        command:
+                          type: string
+                        lastTransitionTime:
+                          format: date-time
+                          nullable: true
+                          type: string
+                        message:
+                          type: string
+                        reason:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    nullable: true
+                    type: array
+                  logTruncatingUntil:
+                    type: string
+                  phase:
+                    type: string
+                  timeCompleted:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  timeStarted:
+                    format: date-time
+                    nullable: true
+                    type: string
+                type: object
+              type: object
+            logSuccessTruncateUntil:
+              type: string
+            phase:
+              type: string
+            progresses:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  progress:
+                    type: number
+                  step:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            timeCompleted:
+              format: date-time
+              nullable: true
+              type: string
+            timeStarted:
+              format: date-time
+              nullable: true
+              type: string
+          type: object
+      required:
+      - metadata
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: backupschedules.pingcap.com
 spec:
   additionalPrinterColumns:
@@ -2705,1528 +4227,6 @@ spec:
               format: date-time
               type: string
             logBackup:
-              type: string
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
-  name: backups.pingcap.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.backupType
-    description: the type of backup, such as full, db, table. Only used when Mode
-      = snapshot.
-    name: Type
-    type: string
-  - JSONPath: .spec.backupMode
-    description: the mode of backup, such as snapshot, log.
-    name: Mode
-    type: string
-  - JSONPath: .status.phase
-    description: The current status of the backup
-    name: Status
-    type: string
-  - JSONPath: .status.backupPath
-    description: The full path of backup data
-    name: BackupPath
-    type: string
-  - JSONPath: .status.backupSizeReadable
-    description: The data size of the backup
-    name: BackupSize
-    type: string
-  - JSONPath: .status.commitTs
-    description: The commit ts of the backup
-    name: CommitTS
-    type: string
-  - JSONPath: .status.logSuccessTruncateUntil
-    description: The log backup truncate until ts
-    name: LogTruncateUntil
-    type: string
-  - JSONPath: .status.timeStarted
-    description: The time at which the backup was started
-    name: Started
-    priority: 1
-    type: date
-  - JSONPath: .status.timeCompleted
-    description: The time at which the backup was completed
-    name: Completed
-    priority: 1
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  group: pingcap.com
-  names:
-    kind: Backup
-    listKind: BackupList
-    plural: backups
-    shortNames:
-    - bk
-    singular: backup
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            affinity:
-              properties:
-                nodeAffinity:
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      items:
-                        properties:
-                          preference:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        required:
-                        - preference
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      properties:
-                        nodeSelectorTerms:
-                          items:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          type: array
-                      required:
-                      - nodeSelectorTerms
-                      type: object
-                  type: object
-                podAffinity:
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      items:
-                        properties:
-                          podAffinityTerm:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      items:
-                        properties:
-                          labelSelector:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          namespaces:
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      items:
-                        properties:
-                          podAffinityTerm:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      items:
-                        properties:
-                          labelSelector:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          namespaces:
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            azblob:
-              properties:
-                accessTier:
-                  type: string
-                container:
-                  type: string
-                path:
-                  type: string
-                prefix:
-                  type: string
-                secretName:
-                  type: string
-              type: object
-            backoffRetryPolicy:
-              properties:
-                maxRetryTimes:
-                  type: integer
-                minRetryDuration:
-                  type: string
-                retryTimeout:
-                  type: string
-              type: object
-            backupMode:
-              type: string
-            backupType:
-              type: string
-            br:
-              properties:
-                checkRequirements:
-                  type: boolean
-                checksum:
-                  type: boolean
-                cluster:
-                  type: string
-                clusterNamespace:
-                  type: string
-                concurrency:
-                  format: int32
-                  type: integer
-                db:
-                  type: string
-                logLevel:
-                  type: string
-                onLine:
-                  type: boolean
-                options:
-                  items:
-                    type: string
-                  type: array
-                rateLimit:
-                  type: integer
-                sendCredToTikv:
-                  type: boolean
-                statusAddr:
-                  type: string
-                table:
-                  type: string
-                timeAgo:
-                  type: string
-              required:
-              - cluster
-              type: object
-            cleanOption:
-              properties:
-                backoffEnabled:
-                  type: boolean
-                batchConcurrency:
-                  format: int32
-                  type: integer
-                disableBatchConcurrency:
-                  type: boolean
-                pageSize:
-                  format: int64
-                  type: integer
-                retryCount:
-                  type: integer
-                routineConcurrency:
-                  format: int32
-                  type: integer
-              type: object
-            cleanPolicy:
-              type: string
-            commitTs:
-              type: string
-            dumpling:
-              properties:
-                options:
-                  items:
-                    type: string
-                  type: array
-                tableFilter:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            env:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    properties:
-                      configMapKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        properties:
-                          apiVersion:
-                            type: string
-                          fieldPath:
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        properties:
-                          containerName:
-                            type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          resource:
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            from:
-              properties:
-                host:
-                  type: string
-                port:
-                  format: int32
-                  type: integer
-                secretName:
-                  type: string
-                tlsClientSecretName:
-                  type: string
-                user:
-                  type: string
-              required:
-              - host
-              - secretName
-              type: object
-            gcs:
-              properties:
-                bucket:
-                  type: string
-                bucketAcl:
-                  type: string
-                location:
-                  type: string
-                objectAcl:
-                  type: string
-                path:
-                  type: string
-                prefix:
-                  type: string
-                projectId:
-                  type: string
-                secretName:
-                  type: string
-                storageClass:
-                  type: string
-              required:
-              - projectId
-              type: object
-            imagePullSecrets:
-              items:
-                properties:
-                  name:
-                    type: string
-                type: object
-              type: array
-            local:
-              properties:
-                prefix:
-                  type: string
-                volume:
-                  properties:
-                    awsElasticBlockStore:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      properties:
-                        cachingMode:
-                          type: string
-                        diskName:
-                          type: string
-                        diskURI:
-                          type: string
-                        fsType:
-                          type: string
-                        kind:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      properties:
-                        readOnly:
-                          type: boolean
-                        secretName:
-                          type: string
-                        shareName:
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      properties:
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretFile:
-                          type: string
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        user:
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      type: object
-                    csi:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        nodePublishSecretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        readOnly:
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      properties:
-                        medium:
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    ephemeral:
-                      properties:
-                        readOnly:
-                          type: boolean
-                        volumeClaimTemplate:
-                          properties:
-                            metadata:
-                              type: object
-                            spec:
-                              properties:
-                                accessModes:
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  properties:
-                                    apiGroup:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                  type: object
-                                selector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                storageClassName:
-                                  type: string
-                                volumeMode:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              type: object
-                          required:
-                          - spec
-                          type: object
-                      type: object
-                    fc:
-                      properties:
-                        fsType:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        targetWWNs:
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      properties:
-                        datasetName:
-                          type: string
-                        datasetUUID:
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        pdName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      properties:
-                        directory:
-                          type: string
-                        repository:
-                          type: string
-                        revision:
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      properties:
-                        endpoints:
-                          type: string
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      properties:
-                        path:
-                          type: string
-                        type:
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      properties:
-                        chapAuthDiscovery:
-                          type: boolean
-                        chapAuthSession:
-                          type: boolean
-                        fsType:
-                          type: string
-                        initiatorName:
-                          type: string
-                        iqn:
-                          type: string
-                        iscsiInterface:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        portals:
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        targetPortal:
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      type: string
-                    nfs:
-                      properties:
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        server:
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      properties:
-                        claimName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        pdID:
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        sources:
-                          items:
-                            properties:
-                              configMap:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                properties:
-                                  audience:
-                                    type: string
-                                  expirationSeconds:
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      type: object
-                    quobyte:
-                      properties:
-                        group:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        registry:
-                          type: string
-                        tenant:
-                          type: string
-                        user:
-                          type: string
-                        volume:
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      properties:
-                        fsType:
-                          type: string
-                        image:
-                          type: string
-                        keyring:
-                          type: string
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        user:
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      properties:
-                        fsType:
-                          type: string
-                        gateway:
-                          type: string
-                        protectionDomain:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        sslEnabled:
-                          type: boolean
-                        storageMode:
-                          type: string
-                        storagePool:
-                          type: string
-                        system:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          type: boolean
-                        secretName:
-                          type: string
-                      type: object
-                    storageos:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        volumeName:
-                          type: string
-                        volumeNamespace:
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        storagePolicyID:
-                          type: string
-                        storagePolicyName:
-                          type: string
-                        volumePath:
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                volumeMount:
-                  properties:
-                    mountPath:
-                      type: string
-                    mountPropagation:
-                      type: string
-                    name:
-                      type: string
-                    readOnly:
-                      type: boolean
-                    subPath:
-                      type: string
-                    subPathExpr:
-                      type: string
-                  required:
-                  - mountPath
-                  - name
-                  type: object
-              required:
-              - volume
-              - volumeMount
-              type: object
-            logStop:
-              type: boolean
-            logTruncateUntil:
-              type: string
-            podSecurityContext:
-              properties:
-                fsGroup:
-                  format: int64
-                  type: integer
-                fsGroupChangePolicy:
-                  type: string
-                runAsGroup:
-                  format: int64
-                  type: integer
-                runAsNonRoot:
-                  type: boolean
-                runAsUser:
-                  format: int64
-                  type: integer
-                seLinuxOptions:
-                  properties:
-                    level:
-                      type: string
-                    role:
-                      type: string
-                    type:
-                      type: string
-                    user:
-                      type: string
-                  type: object
-                seccompProfile:
-                  properties:
-                    localhostProfile:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - type
-                  type: object
-                supplementalGroups:
-                  items:
-                    format: int64
-                    type: integer
-                  type: array
-                sysctls:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                    required:
-                    - name
-                    - value
-                    type: object
-                  type: array
-                windowsOptions:
-                  properties:
-                    gmsaCredentialSpec:
-                      type: string
-                    gmsaCredentialSpecName:
-                      type: string
-                    runAsUserName:
-                      type: string
-                  type: object
-              type: object
-            priorityClassName:
-              type: string
-            resources:
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  type: object
-              type: object
-            s3:
-              properties:
-                acl:
-                  type: string
-                bucket:
-                  type: string
-                endpoint:
-                  type: string
-                options:
-                  items:
-                    type: string
-                  type: array
-                path:
-                  type: string
-                prefix:
-                  type: string
-                provider:
-                  type: string
-                region:
-                  type: string
-                secretName:
-                  type: string
-                sse:
-                  type: string
-                storageClass:
-                  type: string
-              required:
-              - provider
-              type: object
-            serviceAccount:
-              type: string
-            storageClassName:
-              type: string
-            storageSize:
-              type: string
-            tableFilter:
-              items:
-                type: string
-              type: array
-            tikvGCLifeTime:
-              type: string
-            tolerations:
-              items:
-                properties:
-                  effect:
-                    type: string
-                  key:
-                    type: string
-                  operator:
-                    type: string
-                  tolerationSeconds:
-                    format: int64
-                    type: integer
-                  value:
-                    type: string
-                type: object
-              type: array
-            toolImage:
-              type: string
-            useKMS:
-              type: boolean
-          type: object
-        status:
-          properties:
-            backoffRetryStatus:
-              items:
-                properties:
-                  detectFailedAt:
-                    format: date-time
-                    type: string
-                  expectedRetryAt:
-                    format: date-time
-                    type: string
-                  originalReason:
-                    type: string
-                  realRetryAt:
-                    format: date-time
-                    type: string
-                  retryNum:
-                    type: integer
-                  retryReason:
-                    type: string
-                type: object
-              type: array
-            backupPath:
-              type: string
-            backupSize:
-              format: int64
-              type: integer
-            backupSizeReadable:
-              type: string
-            commitTs:
-              type: string
-            conditions:
-              items:
-                properties:
-                  command:
-                    type: string
-                  lastTransitionTime:
-                    format: date-time
-                    nullable: true
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              nullable: true
-              type: array
-            logCheckpointTs:
-              type: string
-            logSubCommandStatuses:
-              additionalProperties:
-                properties:
-                  command:
-                    type: string
-                  conditions:
-                    items:
-                      properties:
-                        command:
-                          type: string
-                        lastTransitionTime:
-                          format: date-time
-                          nullable: true
-                          type: string
-                        message:
-                          type: string
-                        reason:
-                          type: string
-                        status:
-                          type: string
-                        type:
-                          type: string
-                      required:
-                      - status
-                      - type
-                      type: object
-                    nullable: true
-                    type: array
-                  logTruncatingUntil:
-                    type: string
-                  phase:
-                    type: string
-                  timeCompleted:
-                    format: date-time
-                    nullable: true
-                    type: string
-                  timeStarted:
-                    format: date-time
-                    nullable: true
-                    type: string
-                type: object
-              type: object
-            logSuccessTruncateUntil:
-              type: string
-            phase:
-              type: string
-            progresses:
-              items:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    nullable: true
-                    type: string
-                  progress:
-                    type: number
-                  step:
-                    type: string
-                type: object
-              nullable: true
-              type: array
-            timeCompleted:
-              format: date-time
-              nullable: true
-              type: string
-            timeStarted:
-              format: date-time
-              nullable: true
               type: string
           type: object
       required:
@@ -9385,6 +9385,11 @@ spec:
             pvReclaimPolicy:
               type: string
             schedulerName:
+              type: string
+            startUpScriptVersion:
+              enum:
+              - ""
+              - v1
               type: string
             statefulSetUpdateStrategy:
               type: string

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -2191,6 +2191,13 @@ func schema_pkg_apis_pingcap_v1alpha1_DMClusterSpec(ref common.ReferenceCallback
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.SuspendAction"),
 						},
 					},
+					"startUpScriptVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Start up script version",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -2191,13 +2191,6 @@ func schema_pkg_apis_pingcap_v1alpha1_DMClusterSpec(ref common.ReferenceCallback
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.SuspendAction"),
 						},
 					},
-					"startUpScriptVersion": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Start up script version",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
 			},
 		},
@@ -4464,6 +4457,13 @@ func schema_pkg_apis_pingcap_v1alpha1_MasterSpec(ref common.ReferenceCallback) c
 						SchemaProps: spec.SchemaProps{
 							Description: "Config is the Configuration of dm-master-servers",
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.MasterConfigWraper"),
+						},
+					},
+					"startUpScriptVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Start up script version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2619,6 +2619,11 @@ type DMClusterSpec struct {
 	// SuspendAction defines the suspend actions for all component.
 	// +optional
 	SuspendAction *SuspendAction `json:"suspendAction,omitempty"`
+
+	// Start up script version
+	// +optional
+	// +kubebuilder:validation:Enum:="";"v1"
+	StartUpScriptVersion string `json:"startUpScriptVersion,omitempty"`
 }
 
 // DMClusterStatus represents the current status of a dm cluster.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2619,11 +2619,6 @@ type DMClusterSpec struct {
 	// SuspendAction defines the suspend actions for all component.
 	// +optional
 	SuspendAction *SuspendAction `json:"suspendAction,omitempty"`
-
-	// Start up script version
-	// +optional
-	// +kubebuilder:validation:Enum:="";"v1"
-	StartUpScriptVersion string `json:"startUpScriptVersion,omitempty"`
 }
 
 // DMClusterStatus represents the current status of a dm cluster.
@@ -2689,6 +2684,11 @@ type MasterSpec struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	Config *MasterConfigWraper `json:"config,omitempty"`
+
+	// Start up script version
+	// +optional
+	// +kubebuilder:validation:Enum:="";"v1"
+	StartUpScriptVersion string `json:"startUpScriptVersion,omitempty"`
 }
 
 type MasterServiceSpec struct {

--- a/pkg/manager/member/dm_master_member_manager.go
+++ b/pkg/manager/member/dm_master_member_manager.go
@@ -775,7 +775,7 @@ func getMasterConfigMap(dc *v1alpha1.DMCluster) (*corev1.ConfigMap, error) {
 		Scheme:  dc.Scheme(),
 		DataDir: filepath.Join(dmMasterDataVolumeMountPath, dc.Spec.Master.DataSubDir),
 	}
-	if dc.Spec.StartUpScriptVersion == "v1" {
+	if dc.Spec.Master.StartUpScriptVersion == "v1" {
 		model.CheckDomainScript = v1.DMMasterCheckDNSV1
 	}
 	startScript, err := startscriptv1.RenderDMMasterStartScript(model)

--- a/pkg/manager/member/dm_master_member_manager.go
+++ b/pkg/manager/member/dm_master_member_manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/manager"
 	startscriptv1 "github.com/pingcap/tidb-operator/pkg/manager/member/startscript/v1"
+	v1 "github.com/pingcap/tidb-operator/pkg/manager/member/startscript/v1"
 	"github.com/pingcap/tidb-operator/pkg/manager/suspender"
 	mngerutils "github.com/pingcap/tidb-operator/pkg/manager/utils"
 	"github.com/pingcap/tidb-operator/pkg/util"
@@ -770,10 +771,14 @@ func getMasterConfigMap(dc *v1alpha1.DMCluster) (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 
-	startScript, err := startscriptv1.RenderDMMasterStartScript(&startscriptv1.DMMasterStartScriptModel{
+	model := &startscriptv1.DMMasterStartScriptModel{
 		Scheme:  dc.Scheme(),
 		DataDir: filepath.Join(dmMasterDataVolumeMountPath, dc.Spec.Master.DataSubDir),
-	})
+	}
+	if dc.Spec.StartUpScriptVersion == "v1" {
+		model.CheckDomainScript = v1.DMMasterCheckDNSV1
+	}
+	startScript, err := startscriptv1.RenderDMMasterStartScript(model)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -508,12 +508,13 @@ echo "waiting for dm-master cluster ready timeout" >&2
 exit 1
 fi
 
-if nslookup ${domain} 2>/dev/null
+digRes=$(dig ${domain} A ${domain} AAAA +search +short 2>/dev/null)
+if [ -z "${digRes}" ]
 then
-echo "nslookup domain ${domain} success"
-break
+echo "dig domain ${domain} failed" >&2
 else
-echo "nslookup domain ${domain} failed" >&2
+echo "dig domain ${domain} success"
+break
 fi
 done
 

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -550,7 +550,8 @@ echo "/dm-master ${ARGS}"
 exec /dm-master ${ARGS}
 `))
 
-var dmMasterCheckDNSV1 string = `
+// TODO: refactor to confine the checking script within the package
+var DMMasterCheckDNSV1 string = `
 digRes=$(dig ${domain} A ${domain} AAAA +search +short 2>/dev/null)
 if [ -z "${digRes}" ]
 then

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1969,7 +1969,7 @@ exec /dm-master ${ARGS}
 		{
 			name:     "check-dns-v1",
 			modifyDM: func(tc *v1alpha1.DMCluster) {},
-			checkDNS: dmMasterCheckDNSV1,
+			checkDNS: DMMasterCheckDNSV1,
 			result: `#!/bin/sh
 
 # This script is used to start dm-master containers in kubernetes cluster


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Originally in the startup script, it's only checking against `A` record which is `IPv4` only and cannot handle `AAAA` record which is for `IPv6`. Fixed the domain check to make it work for `AAAA`-only records during startup.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Fixed the startup script to check against both `A` and `AAAA` records.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Introduce `startUpScriptVersion` field for DM master to specify startup script version
```

---

## Manual tests
### Existing DM cluster won't be affected
The existing DM clusters won't be affected. After applying the change, the start script in config will be updated, but DM pods won't be affected.
```console
ubuntu@ip-172-31-71-58:~/tidb-operator$ kubectl get cm basic-dm-master -oyaml | grep dig
    digRes=$(dig ${domain} A ${domain} AAAA +search +short 2>/dev/null)
    if [ -z "${digRes}" ]
    echo "dig domain ${domain} failed" >&2
    echo "dig domain ${domain} success"
ubuntu@ip-172-31-71-58:~/tidb-operator$ kubectl get pod
NAME                                  READY   STATUS    RESTARTS   AGE
basic-dm-discovery-5f77894769-wfpgq   1/1     Running   0          30m
basic-dm-master-0                     1/1     Running   0          30m
ubuntu@ip-172-31-71-58:~/tidb-operator$ kubectl logs basic-dm-master-0 | head -n 10
Server:		10.96.0.10
Address:	10.96.0.10#53

Name:	basic-dm-master-0.basic-dm-master-peer.default.svc.cluster.local
Address: 10.244.0.9

nslookup domain basic-dm-master-0.basic-dm-master-peer success
starting dm-master ...
/dm-master --data-dir=/var/lib/dm-master --name=basic-dm-master-0 --peer-urls=http://0.0.0.0:8291 --advertise-peer-urls=http://basic-dm-master-0.basic-dm-master-peer:8291 --master-addr=:8261 --advertise-addr=basic-dm-master-0.basic-dm-master-peer:8261 --config=/etc/dm-master/dm-master.toml --initial-cluster=basic-dm-master-0=http://basic-dm-master-0.basic-dm-master-peer:8291
[2023/04/13 22:50:09.660 +00:00] [INFO] [version.go:47] ["Welcome to dm-master"] [release-version=v6.5.0] [git-hash=9e91cff866d240ab6c1737680c17f5c5d0586911] [git-branch=heads/refs/tags/v6.5.0] [utc-build-time="2022-12-23 08:44:26"] [go-version="go version go1.19.3 linux/amd64"] [failpoint-build=false]
```
We can see that the config map contains the change (using `dig` instead of using `nslookup`), but the related DM pods are not restarted and from its log it's using `nslookup` still, which is expected.

### New DM clusters can work
Create a new DM cluster and check if the startup process works:
```console
ubuntu@ip-172-31-71-58:~$ kubectl get pods
NAME                                   READY   STATUS    RESTARTS   AGE
basic-dm-discovery-5f77894769-wfpgq    1/1     Running   0          32m
basic-dm-master-0                      1/1     Running   0          32m
basic2-dm-discovery-589fc648b7-md9bk   1/1     Running   0          21s
basic2-dm-master-0                     1/1     Running   0          21s
ubuntu@ip-172-31-71-58:~$ kubectl logs basic2-dm-master-0 | head -n 5
dig domain basic2-dm-master-0.basic2-dm-master-peer success
starting dm-master ...
/dm-master --data-dir=/var/lib/dm-master --name=basic2-dm-master-0 --peer-urls=http://0.0.0.0:8291 --advertise-peer-urls=http://basic2-dm-master-0.basic2-dm-master-peer:8291 --master-addr=:8261 --advertise-addr=basic2-dm-master-0.basic2-dm-master-peer:8261 --config=/etc/dm-master/dm-master.toml --initial-cluster=basic2-dm-master-0=http://basic2-dm-master-0.basic2-dm-master-peer:8291
[2023/04/13 23:22:36.808 +00:00] [INFO] [version.go:47] ["Welcome to dm-master"] [release-version=v6.5.0] [git-hash=9e91cff866d240ab6c1737680c17f5c5d0586911] [git-branch=heads/refs/tags/v6.5.0] [utc-build-time="2022-12-23 08:44:26"] [go-version="go version go1.19.3 linux/amd64"] [failpoint-build=false]
[2023/04/13 23:22:36.808 +00:00] [INFO] [main.go:63] ["dm-master config"="{\"log-level\":\"info\",\"log-file\":\"\",\"log-format\":\"text\",\"log-rotate\":\"\",\"rpc-timeout\":\"30s\",\"rpc-rate-limit\":10,\"rpc-rate-burst\":40,\"master-addr\":\":8261\",\"advertise-addr\":\"basic2-dm-master-0.basic2-dm-master-peer:8261\",\"config-file\":\"/etc/dm-master/dm-master.toml\",\"name\":\"basic2-dm-master-0\",\"data-dir\":\"/var/lib/dm-master\",\"peer-urls\":\"http://0.0.0.0:8291\",\"advertise-peer-urls\":\"http://basic2-dm-master-0.basic2-dm-master-peer:8291\",\"initial-cluster\":\"basic2-dm-master-0=http://basic2-dm-master-0.basic2-dm-master-peer:8291\",\"initial-cluster-state\":\"new\",\"join\":\"\",\"max-txn-ops\":2048,\"max-request-bytes\":1572864,\"auto-compaction-mode\":\"periodic\",\"auto-compaction-retention\":\"1h\",\"quota-backend-bytes\":2147483648,\"openapi\":false,\"v1-sources-path\":\"\",\"ssl-ca\":\"\",\"ssl-cert\":\"\",\"ssl-key\":\"\",\"cert-allowed-cn\":null,\"ExperimentalFeatures\":{\"OpenAPI\":false}}"]
```
We can see that the pod status is running and from the log, it's using `dig` for domain name validity check.

### Field `dmcluster.spec.master.startUpScriptVersion` taking effect
Create a DM cluster and specify the startup script version:
```console
ubuntu@ip-172-31-71-58:~$ cat dm3.yaml 
apiVersion: pingcap.com/v1alpha1
kind: DMCluster
metadata:
  name: basic3
spec:
  version: v6.5.0
  pvReclaimPolicy: Retain
  discovery: {}
  master:
    baseImage: pingcap/dm
    maxFailoverCount: 0
    replicas: 1
    # if storageClassName is not set, the default Storage Class of the Kubernetes cluster will be used
    # storageClassName: local-storage
    storageSize: "10Gi"
    requests: {}
    config: {}
    startUpScriptVersion: "v1"
  worker:
    baseImage: pingcap/dm
    maxFailoverCount: 0
    replicas: 0
    # if storageClassName is not set, the default Storage Class of the Kubernetes cluster will be used
    # storageClassName: local-storage
    storageSize: "100Gi"
    requests: {}
    config: {}
ubuntu@ip-172-31-71-58:~$ kubectl get pod,dc
NAME                                      READY   STATUS    RESTARTS   AGE
pod/basic3-dm-discovery-8776c5587-9s8x6   1/1     Running   0          63s
pod/basic3-dm-master-0                    1/1     Running   0          63s

NAME                           READY   MASTER              STORAGE   READY   DESIRE   WORKER              STORAGE   READY   DESIRE   AGE
dmcluster.pingcap.com/basic3   True    pingcap/dm:v6.5.0   10Gi      1       1        pingcap/dm:v6.5.0   100Gi             0        63s
ubuntu@ip-172-31-71-58:~$ kubectl logs basic3-dm-master-0 | head -n 5
dig domain basic3-dm-master-0.basic3-dm-master-peer success
starting dm-master ...
/dm-master --data-dir=/var/lib/dm-master --name=basic3-dm-master-0 --peer-urls=http://0.0.0.0:8291 --advertise-peer-urls=http://basic3-dm-master-0.basic3-dm-master-peer:8291 --master-addr=:8261 --advertise-addr=basic3-dm-master-0.basic3-dm-master-peer:8261 --config=/etc/dm-master/dm-master.toml --initial-cluster=basic3-dm-master-0=http://basic3-dm-master-0.basic3-dm-master-peer:8291
[2023/04/14 04:01:21.784 +00:00] [INFO] [version.go:47] ["Welcome to dm-master"] [release-version=v6.5.0] [git-hash=9e91cff866d240ab6c1737680c17f5c5d0586911] [git-branch=heads/refs/tags/v6.5.0] [utc-build-time="2022-12-23 08:44:26"] [go-version="go version go1.19.3 linux/amd64"] [failpoint-build=false]
[2023/04/14 04:01:21.784 +00:00] [INFO] [main.go:63] ["dm-master config"="{\"log-level\":\"info\",\"log-file\":\"\",\"log-format\":\"text\",\"log-rotate\":\"\",\"rpc-timeout\":\"30s\",\"rpc-rate-limit\":10,\"rpc-rate-burst\":40,\"master-addr\":\":8261\",\"advertise-addr\":\"basic3-dm-master-0.basic3-dm-master-peer:8261\",\"config-file\":\"/etc/dm-master/dm-master.toml\",\"name\":\"basic3-dm-master-0\",\"data-dir\":\"/var/lib/dm-master\",\"peer-urls\":\"http://0.0.0.0:8291\",\"advertise-peer-urls\":\"http://basic3-dm-master-0.basic3-dm-master-peer:8291\",\"initial-cluster\":\"basic3-dm-master-0=http://basic3-dm-master-0.basic3-dm-master-peer:8291\",\"initial-cluster-state\":\"new\",\"join\":\"\",\"max-txn-ops\":2048,\"max-request-bytes\":1572864,\"auto-compaction-mode\":\"periodic\",\"auto-compaction-retention\":\"1h\",\"quota-backend-bytes\":2147483648,\"openapi\":false,\"v1-sources-path\":\"\",\"ssl-ca\":\"\",\"ssl-cert\":\"\",\"ssl-key\":\"\",\"cert-allowed-cn\":null,\"ExperimentalFeatures\":{\"OpenAPI\":false}}"]
```
We can see the DM cluster and pods are running as expected and from its log it's using the updated startup script which is expected.