### PR TITLE
Fix cluster meta data existing

### DIFF
--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -262,7 +262,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, *
 					Reason:  reason,
 					Message: err.Error(),
 				}, nil)
-				return nil, nil, "", controller.IgnoreErrorf(reason)
+				return nil, nil, "", controller.IgnoreErrorf("backup failed [%s], reason is [%s]", err.Error(), reason)
 			} else {
 				bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 					Command: logBackupSubcommand,

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -262,7 +262,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, *
 					Reason:  reason,
 					Message: err.Error(),
 				}, nil)
-				return nil, nil, "", controller.IgnoreErrorf("backup failed [%s], reason is [%s]", err.Error(), reason)
+				return nil, nil, "", controller.IgnoreErrorf("%s, reason is %s", err.Error(), reason)
 			} else {
 				bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 					Command: logBackupSubcommand,

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -14,7 +14,6 @@
 package backup
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -263,6 +262,7 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, *
 					Reason:  reason,
 					Message: err.Error(),
 				}, nil)
+				return nil, nil, "", controller.IgnoreErrorf(reason)
 			} else {
 				bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 					Command: logBackupSubcommand,
@@ -271,8 +271,8 @@ func (bm *backupManager) makeBackupJob(backup *v1alpha1.Backup) (*batchv1.Job, *
 					Reason:  reason,
 					Message: err.Error(),
 				}, nil)
+				return nil, nil, "", err
 			}
-			return nil, nil, "", err
 		}
 
 		if logBackupSubcommand == v1alpha1.LogStartCommand {
@@ -689,19 +689,7 @@ func (bm *backupManager) saveClusterMetaToExternalStorage(b *v1alpha1.Backup, cs
 		return "FileExistedInExternalStorageFailed", err
 	}
 	if exist {
-		// check to see if content of existing meta file is identical to what to save
-		// if yes, reuse it; else fail the backup
-		existingClustermeta, err := externalStorage.ReadAll(ctx, constants.ClusterBackupMeta)
-		if err != nil {
-			return "ExistingMetaFileReadFailed", err
-		}
-
-		if bytes.Equal(data, existingClustermeta) {
-			klog.Infof("reuse existing cluster meta in external storage")
-			return "", nil
-		} else {
-			return "FileExistedInExternalStorage", fmt.Errorf("%s exist", constants.ClusterBackupMeta)
-		}
+		return "FileExistedInExternalStorage", fmt.Errorf("%s exist", constants.ClusterBackupMeta)
 	}
 
 	err = externalStorage.WriteAll(ctx, constants.ClusterBackupMeta, data, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #5002 
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

If cluster metadata file already exists, fail the backup job immediately.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
With this patch, meta data file existing error will be skipped without repeating retrying as before.
![img_v2_c9b1334f-415d-4380-9e8a-fce5667a483g](https://github.com/pingcap/tidb-operator/assets/97348524/01304f8c-9b21-44ed-b5c9-814727387a2e)
![img_v2_5157d581-3d0e-4bc1-a89d-a5ffe4f09c5g](https://github.com/pingcap/tidb-operator/assets/97348524/139e59c6-bc9c-4077-a9ec-85dbcf3cf821)


- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
