### PR TITLE
customize TiDB components port when building TiDB Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 LDFLAGS ?= $(shell ./hack/version.sh)
+LDFLAGS_PORTS ?= $(shell ./hack/custom-port.sh)
+ifeq ($(LDFLAGS_PORTS),)
+else
+LDFLAGS := $(LDFLAGS) $(LDFLAGS_PORTS)
+endif
 
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")

--- a/charts/tidb-drainer/templates/drainer-service.yaml
+++ b/charts/tidb-drainer/templates/drainer-service.yaml
@@ -13,7 +13,7 @@ spec:
   clusterIP: None
   ports:
   - name: drainer
-    port: 8249
+    port: {{ .Values.port | default 8249 }}
   selector:
     app.kubernetes.io/name: {{ include "drainer.name" . }}
     app.kubernetes.io/instance: {{ .Values.clusterName }}

--- a/charts/tidb-drainer/templates/drainer-statefulset.yaml
+++ b/charts/tidb-drainer/templates/drainer-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8249"
+        prometheus.io/port: "{{ .Values.port | default 8249 }}"
       labels:
         app.kubernetes.io/name: {{ include "drainer.name" . }}
         app.kubernetes.io/instance: {{ .Values.clusterName }}
@@ -44,7 +44,7 @@ spec:
         - |-
 {{ tuple "scripts/_start_drainer.sh.tpl" . | include "helm-toolkit.utils.template" | indent 10 }}
         ports:
-        - containerPort: 8249
+        - containerPort: {{ .Values.port | default 8249 }}
           name: drainer
         volumeMounts:
         - name: data

--- a/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
@@ -27,8 +27,8 @@ done
 /drainer \
 -L={{ .Values.logLevel | default "info" }} \
 -pd-urls={{ include "cluster.scheme" . }}://{{ .Values.clusterName }}-pd:{{ .Values.pdClientPort | default 2379 }} \
--addr=0.0.0.0:8249 \
--advertise-addr=`echo ${HOSTNAME}`.{{ include "drainer.name" . }}:8249 \
+-addr=0.0.0.0:{{ .Values.port | default 8249 }} \
+-advertise-addr=`echo ${HOSTNAME}`.{{ include "drainer.name" . }}:{{ .Values.port | default 8249 }} \
 -config=/etc/drainer/drainer.toml \
 -disable-detect={{ .Values.disableDetect | default false }} \
 -initial-commit-ts={{ .Values.initialCommitTs | default -1 }} \

--- a/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
+++ b/charts/tidb-drainer/templates/scripts/_start_drainer.sh.tpl
@@ -26,7 +26,7 @@ done
 
 /drainer \
 -L={{ .Values.logLevel | default "info" }} \
--pd-urls={{ include "cluster.scheme" . }}://{{ .Values.clusterName }}-pd:2379 \
+-pd-urls={{ include "cluster.scheme" . }}://{{ .Values.clusterName }}-pd:{{ .Values.pdClientPort | default 2379 }} \
 -addr=0.0.0.0:8249 \
 -advertise-addr=`echo ${HOSTNAME}`.{{ include "drainer.name" . }}:8249 \
 -config=/etc/drainer/drainer.toml \

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -30,6 +30,9 @@ disableDetect: false
 # if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint
 initialCommitTs: "-1"
 
+# The port that Drainer listens on
+port: 8249
+
 # The PD client port connected by Drainer
 pdClientPort: 2379
 

--- a/charts/tidb-drainer/values.yaml
+++ b/charts/tidb-drainer/values.yaml
@@ -30,6 +30,9 @@ disableDetect: false
 # if drainer donesn't have checkpoint, use initial commitTS to initial checkpoint
 initialCommitTs: "-1"
 
+# The PD client port connected by Drainer
+pdClientPort: 2379
+
 # Whether enable the TLS connection between TiDB server components
 tlsCluster:
   # The steps to enable this feature:

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -27,7 +27,7 @@ fi
 sed "s#CHECKPOINT_USE_DATA_DIR#$data_dir#g" /etc/tidb-lightning/tidb-lightning.toml > /tidb-lightning.toml
 
 /tidb-lightning \
-    --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:2379 \
+    --pd-urls={{ .Values.targetTidbCluster.name }}-pd.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:{{ .Values.targetTidbCluster.pdClientPort | default 2379 }} \
     --status-addr=0.0.0.0:8289 \
 {{- if eq .Values.backend "importer" }}
     --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:8287 \

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -37,6 +37,7 @@ sed "s#CHECKPOINT_USE_DATA_DIR#$data_dir#g" /etc/tidb-lightning/tidb-lightning.t
 {{- else if eq .Values.backend "local" }}
     --backend=local \
     --sorted-kv-dir=/var/lib/sorted-kv \
+    --tidb-status={{ .Values.targetTidbCluster.statusPort | default 10080 }} \
 {{- end }}
     --server-mode=false \
 {{- if and .Values.targetTidbCluster.secretName .Values.targetTidbCluster.secretUserKey -}}

--- a/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
+++ b/charts/tidb-lightning/templates/scripts/_start_lightning.sh.tpl
@@ -33,7 +33,7 @@ sed "s#CHECKPOINT_USE_DATA_DIR#$data_dir#g" /etc/tidb-lightning/tidb-lightning.t
     --importer={{ .Values.targetTidbCluster.name }}-importer.{{ .Values.targetTidbCluster.namespace | default .Release.Namespace }}:8287 \
 {{- else if eq .Values.backend "tidb" }}
     --backend=tidb \
-    --tidb-port=4000 \
+    --tidb-port={{ .Values.targetTidbCluster.port | default 4000 }} \
 {{- else if eq .Values.backend "local" }}
     --backend=local \
     --sorted-kv-dir=/var/lib/sorted-kv \

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -53,6 +53,8 @@ targetTidbCluster:
   user: root
   # the tidb cluster port, which is used in `tidb` backend
   port: 4000
+  # the tidb server status port, which is used in `local` backend
+  statusPort: 10080
   # If the `secretName` and `secretUserKey` are set,
   # the `user` will be ignored and the user in the
   # `secretName` will be used by lightning.

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -63,6 +63,7 @@ targetTidbCluster:
   #secretName: ""
   #secretUserKey: user
   #secretPwdKey: password
+  pdClientPort: 2379
 
 # Whether enable the TLS connection between TiDB cluster components.
 # If enabled, a Secret named "<targetTidbCluster.name>-lightning-cluster-secret" must exist.

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -55,6 +55,8 @@ targetTidbCluster:
   port: 4000
   # the tidb server status port, which is used in `local` backend
   statusPort: 10080
+  # the pd client port, which is used in `local` backend
+  pdClientPort: 2379
   # If the `secretName` and `secretUserKey` are set,
   # the `user` will be ignored and the user in the
   # `secretName` will be used by lightning.
@@ -63,7 +65,6 @@ targetTidbCluster:
   #secretName: ""
   #secretUserKey: user
   #secretPwdKey: password
-  pdClientPort: 2379
 
 # Whether enable the TLS connection between TiDB cluster components.
 # If enabled, a Secret named "<targetTidbCluster.name>-lightning-cluster-secret" must exist.

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -51,6 +51,8 @@ targetTidbCluster:
   # namespace is the target tidb cluster namespace, can be omitted if the lightning is deployed in the same namespace of the target tidb cluster
   namespace: ""
   user: root
+  # the tidb cluster port, which is used in `tidb` backend
+  port: 5000
   # If the `secretName` and `secretUserKey` are set,
   # the `user` will be ignored and the user in the
   # `secretName` will be used by lightning.

--- a/charts/tidb-lightning/values.yaml
+++ b/charts/tidb-lightning/values.yaml
@@ -52,7 +52,7 @@ targetTidbCluster:
   namespace: ""
   user: root
   # the tidb cluster port, which is used in `tidb` backend
-  port: 5000
+  port: 4000
   # If the `secretName` and `secretUserKey` are set,
   # the `user` will be ignored and the user in the
   # `secretName` will be used by lightning.

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -41,6 +41,7 @@ properties([
         string(name: 'CUSTOM_PORT_TIFLASH_INTERNAL_STATUS', defaultValue: '', description: 'custom component port: tiflash internal status'),
         string(name: 'CUSTOM_PORT_PUMP', defaultValue: '', description: 'custom component port: pump'),
         string(name: 'CUSTOM_PORT_DRAINER', defaultValue: '', description: 'custom component port: drainer'),
+        string(name: 'CUSTOM_PORT_TICDC', defaultValue: '', description: 'custom component port: ticdc')
     ])
 ])
 
@@ -272,6 +273,7 @@ try {
     def CUSTOM_PORT_TIFLASH_INTERNAL_STATUS = params.CUSTOM_PORT_TIFLASH_INTERNAL_STATUS
     def CUSTOM_PORT_PUMP = params.CUSTOM_PORT_PUMP
     def CUSTOM_PORT_DRAINER = params.CUSTOM_PORT_DRAINER
+    def CUSTOM_PORT_TICDC = params.CUSTOM_PORT_TICDC
 
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
@@ -368,6 +370,7 @@ try {
                             export CUSTOM_PORT_TIFLASH_INTERNAL_STATUS=${CUSTOM_PORT_TIFLASH_INTERNAL_STATUS}
                             export CUSTOM_PORT_PUMP=${CUSTOM_PORT_PUMP}
                             export CUSTOM_PORT_DRAINER=${CUSTOM_PORT_DRAINER}
+                            export CUSTOM_PORT_TICDC=${CUSTOM_PORT_TICDC}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -147,14 +147,14 @@ String buildPodYAML(Map m = [:]) {
 
 e2ePodResources = [
     requests: [
-        cpu: "3",
-        memory: "6Gi",
-        storage: "200Gi"
-    ],
-    limits: [
         cpu: "8",
         memory: "16Gi",
-        storage: "200Gi"
+        storage: "250Gi"
+    ],
+    limits: [
+        cpu: "16",
+        memory: "32Gi",
+        storage: "250Gi"
     ],
 ]
 

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -38,8 +38,9 @@ properties([
         string(name: 'CUSTOM_PORT_TIFLASH_PROXY', defaultValue: '', description: 'custom component port: tiflash proxy'),
         string(name: 'CUSTOM_PORT_TIFLASH_METRICS', defaultValue: '', description: 'custom component port: tiflash metrics'),
         string(name: 'CUSTOM_PORT_TIFLASH_PROXY_STATUS', defaultValue: '', description: 'custom component port: tiflash proxy status'),
-        string(name: 'CUSTOM_PORT_TIFLASH_INTERNAL_STATUS', defaultValue: '', description: 'custom component port: tiflash internal status')
+        string(name: 'CUSTOM_PORT_TIFLASH_INTERNAL_STATUS', defaultValue: '', description: 'custom component port: tiflash internal status'),
         string(name: 'CUSTOM_PORT_PUMP', defaultValue: '', description: 'custom component port: pump'),
+        string(name: 'CUSTOM_PORT_DRAINER', defaultValue: '', description: 'custom component port: drainer'),
     ])
 ])
 
@@ -270,6 +271,7 @@ try {
     def CUSTOM_PORT_TIFLASH_PROXY_STATUS = params.CUSTOM_PORT_TIFLASH_PROXY_STATUS
     def CUSTOM_PORT_TIFLASH_INTERNAL_STATUS = params.CUSTOM_PORT_TIFLASH_INTERNAL_STATUS
     def CUSTOM_PORT_PUMP = params.CUSTOM_PORT_PUMP
+    def CUSTOM_PORT_DRAINER = params.CUSTOM_PORT_DRAINER
 
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
@@ -365,6 +367,7 @@ try {
                             export CUSTOM_PORT_TIFLASH_PROXY_STATUS=${CUSTOM_PORT_TIFLASH_PROXY_STATUS}
                             export CUSTOM_PORT_TIFLASH_INTERNAL_STATUS=${CUSTOM_PORT_TIFLASH_INTERNAL_STATUS}
                             export CUSTOM_PORT_PUMP=${CUSTOM_PORT_PUMP}
+                            export CUSTOM_PORT_DRAINER=${CUSTOM_PORT_DRAINER}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -29,7 +29,16 @@ properties([
         string(name: 'CUSTOM_PORT_TIDB_SERVER', defaultValue: '', description: 'custom component port: tidb server'),
         string(name: 'CUSTOM_PORT_TIDB_STATUS', defaultValue: '', description: 'custom component port: tidb status'),
         string(name: 'CUSTOM_PORT_PD_CLIENT', defaultValue: '', description: 'custom component port: pd client'),
-        string(name: 'CUSTOM_PORT_PD_PEER', defaultValue: '', description: 'custom component port: pd peer')
+        string(name: 'CUSTOM_PORT_PD_PEER', defaultValue: '', description: 'custom component port: pd peer'),
+        string(name: 'CUSTOM_PORT_TIKV_SERVER', defaultValue: '', description: 'custom component port: tikv server'),
+        string(name: 'CUSTOM_PORT_TIKV_STATUS', defaultValue: '', description: 'custom component port: tikv status'),
+        string(name: 'CUSTOM_PORT_TIFLASH_TCP', defaultValue: '', description: 'custom component port: tiflash tcp'),
+        string(name: 'CUSTOM_PORT_TIFLASH_HTTP', defaultValue: '', description: 'custom component port: tiflash http'),
+        string(name: 'CUSTOM_PORT_TIFLASH_FLASH', defaultValue: '', description: 'custom component port: tiflash flash'),
+        string(name: 'CUSTOM_PORT_TIFLASH_PROXY', defaultValue: '', description: 'custom component port: tiflash proxy'),
+        string(name: 'CUSTOM_PORT_TIFLASH_METRICS', defaultValue: '', description: 'custom component port: tiflash metrics'),
+        string(name: 'CUSTOM_PORT_TIFLASH_PROXY_STATUS', defaultValue: '', description: 'custom component port: tiflash proxy status'),
+        string(name: 'CUSTOM_PORT_TIFLASH_INTERNAL_STATUS', defaultValue: '', description: 'custom component port: tiflash internal status')
     ])
 ])
 
@@ -250,6 +259,15 @@ try {
     def CUSTOM_PORT_TIDB_STATUS = params.CUSTOM_PORT_TIDB_STATUS
     def CUSTOM_PORT_PD_CLIENT = params.CUSTOM_PORT_PD_CLIENT
     def CUSTOM_PORT_PD_PEER = params.CUSTOM_PORT_PD_PEER
+    def CUSTOM_PORT_TIKV_SERVER = params.CUSTOM_PORT_TIKV_SERVER
+    def CUSTOM_PORT_TIKV_STATUS = params.CUSTOM_PORT_TIKV_STATUS
+    def CUSTOM_PORT_TIFLASH_TCP = params.CUSTOM_PORT_TIFLASH_TCP
+    def CUSTOM_PORT_TIFLASH_HTTP = params.CUSTOM_PORT_TIFLASH_HTTP
+    def CUSTOM_PORT_TIFLASH_FLASH = params.CUSTOM_PORT_TIFLASH_FLASH
+    def CUSTOM_PORT_TIFLASH_PROXY = params.CUSTOM_PORT_TIFLASH_PROXY
+    def CUSTOM_PORT_TIFLASH_METRICS = params.CUSTOM_PORT_TIFLASH_METRICS
+    def CUSTOM_PORT_TIFLASH_PROXY_STATUS = params.CUSTOM_PORT_TIFLASH_PROXY_STATUS
+    def CUSTOM_PORT_TIFLASH_INTERNAL_STATUS = params.CUSTOM_PORT_TIFLASH_INTERNAL_STATUS
 
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
@@ -335,6 +353,15 @@ try {
                             export CUSTOM_PORT_TIDB_STATUS=${CUSTOM_PORT_TIDB_STATUS}
                             export CUSTOM_PORT_PD_CLIENT=${CUSTOM_PORT_PD_CLIENT}
                             export CUSTOM_PORT_PD_PEER=${CUSTOM_PORT_PD_PEER}
+                            export CUSTOM_PORT_TIKV_SERVER=${CUSTOM_PORT_TIKV_SERVER}
+                            export CUSTOM_PORT_TIKV_STATUS=${CUSTOM_PORT_TIKV_STATUS}
+                            export CUSTOM_PORT_TIFLASH_TCP=${CUSTOM_PORT_TIFLASH_TCP}
+                            export CUSTOM_PORT_TIFLASH_HTTP=${CUSTOM_PORT_TIFLASH_HTTP}
+                            export CUSTOM_PORT_TIFLASH_FLASH=${CUSTOM_PORT_TIFLASH_FLASH}
+                            export CUSTOM_PORT_TIFLASH_PROXY=${CUSTOM_PORT_TIFLASH_PROXY}
+                            export CUSTOM_PORT_TIFLASH_METRICS=${CUSTOM_PORT_TIFLASH_METRICS}
+                            export CUSTOM_PORT_TIFLASH_PROXY_STATUS=${CUSTOM_PORT_TIFLASH_PROXY_STATUS}
+                            export CUSTOM_PORT_TIFLASH_INTERNAL_STATUS=${CUSTOM_PORT_TIFLASH_INTERNAL_STATUS}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -24,10 +24,12 @@ properties([
         string(name: 'PR_ID', defaultValue: '', description: 'pull request ID, this will override GIT_REF if set, e.g. 1889'),
         string(name: 'GINKGO_NODES', defaultValue: env.DEFAULT_GINKGO_NODES, description: 'the number of ginkgo nodes'),
         string(name: 'E2E_ARGS', defaultValue: env.DEFAULT_E2E_ARGS, description: "e2e args, e.g. --ginkgo.focus='\\[Stability\\]'"),
-        string(name: 'DELETE_NAMESPACE_ON_FAILURE', defaultValue: env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE, description: 'delete ns after test case fails')
+        string(name: 'DELETE_NAMESPACE_ON_FAILURE', defaultValue: env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE, description: 'delete ns after test case fails'),
 
         string(name: 'CUSTOM_PORT_TIDB_SERVER', defaultValue: '', description: 'custom component port: tidb server'),
         string(name: 'CUSTOM_PORT_TIDB_STATUS', defaultValue: '', description: 'custom component port: tidb status'),
+        string(name: 'CUSTOM_PORT_PD_CLIENT', defaultValue: '', description: 'custom component port: pd client'),
+        string(name: 'CUSTOM_PORT_PD_PEER', defaultValue: '', description: 'custom component port: pd peer')
     ])
 ])
 
@@ -246,6 +248,8 @@ try {
 
     def CUSTOM_PORT_TIDB_SERVER = params.CUSTOM_PORT_TIDB_SERVER
     def CUSTOM_PORT_TIDB_STATUS = params.CUSTOM_PORT_TIDB_STATUS
+    def CUSTOM_PORT_PD_CLIENT = params.CUSTOM_PORT_PD_CLIENT
+    def CUSTOM_PORT_PD_PEER = params.CUSTOM_PORT_PD_PEER
 
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
@@ -329,6 +333,8 @@ try {
                             ./hack/e2e-patch-codecov.sh
                             export CUSTOM_PORT_TIDB_SERVER=${CUSTOM_PORT_TIDB_SERVER}
                             export CUSTOM_PORT_TIDB_STATUS=${CUSTOM_PORT_TIDB_STATUS}
+                            export CUSTOM_PORT_PD_CLIENT=${CUSTOM_PORT_PD_CLIENT}
+                            export CUSTOM_PORT_PD_PEER=${CUSTOM_PORT_PD_PEER}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -39,6 +39,7 @@ properties([
         string(name: 'CUSTOM_PORT_TIFLASH_METRICS', defaultValue: '', description: 'custom component port: tiflash metrics'),
         string(name: 'CUSTOM_PORT_TIFLASH_PROXY_STATUS', defaultValue: '', description: 'custom component port: tiflash proxy status'),
         string(name: 'CUSTOM_PORT_TIFLASH_INTERNAL_STATUS', defaultValue: '', description: 'custom component port: tiflash internal status')
+        string(name: 'CUSTOM_PORT_PUMP', defaultValue: '', description: 'custom component port: pump'),
     ])
 ])
 
@@ -268,6 +269,7 @@ try {
     def CUSTOM_PORT_TIFLASH_METRICS = params.CUSTOM_PORT_TIFLASH_METRICS
     def CUSTOM_PORT_TIFLASH_PROXY_STATUS = params.CUSTOM_PORT_TIFLASH_PROXY_STATUS
     def CUSTOM_PORT_TIFLASH_INTERNAL_STATUS = params.CUSTOM_PORT_TIFLASH_INTERNAL_STATUS
+    def CUSTOM_PORT_PUMP = params.CUSTOM_PORT_PUMP
 
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
@@ -362,6 +364,7 @@ try {
                             export CUSTOM_PORT_TIFLASH_METRICS=${CUSTOM_PORT_TIFLASH_METRICS}
                             export CUSTOM_PORT_TIFLASH_PROXY_STATUS=${CUSTOM_PORT_TIFLASH_PROXY_STATUS}
                             export CUSTOM_PORT_TIFLASH_INTERNAL_STATUS=${CUSTOM_PORT_TIFLASH_INTERNAL_STATUS}
+                            export CUSTOM_PORT_PUMP=${CUSTOM_PORT_PUMP}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/ci/pull_e2e_kind.groovy
+++ b/ci/pull_e2e_kind.groovy
@@ -25,6 +25,9 @@ properties([
         string(name: 'GINKGO_NODES', defaultValue: env.DEFAULT_GINKGO_NODES, description: 'the number of ginkgo nodes'),
         string(name: 'E2E_ARGS', defaultValue: env.DEFAULT_E2E_ARGS, description: "e2e args, e.g. --ginkgo.focus='\\[Stability\\]'"),
         string(name: 'DELETE_NAMESPACE_ON_FAILURE', defaultValue: env.DEFAULT_DELETE_NAMESPACE_ON_FAILURE, description: 'delete ns after test case fails')
+
+        string(name: 'CUSTOM_PORT_TIDB_SERVER', defaultValue: '', description: 'custom component port: tidb server'),
+        string(name: 'CUSTOM_PORT_TIDB_STATUS', defaultValue: '', description: 'custom component port: tidb status'),
     ])
 ])
 
@@ -255,6 +258,9 @@ try {
         GIT_REF = env.ghprbActualCommit
     }
 
+    def CUSTOM_PORT_TIDB_SERVER = params.CUSTOM_PORT_TIDB_SERVER
+    def CUSTOM_PORT_TIDB_STATUS = params.CUSTOM_PORT_TIDB_STATUS
+
     timeout (time: 2, unit: 'HOURS') {
         // use fixed label, so we can reuse previous workers
         // increase version in pod label when we update pod template
@@ -335,6 +341,8 @@ try {
                             echo "info: building"
                             echo "info: patch charts and golang code to enable coverage profile"
                             ./hack/e2e-patch-codecov.sh
+                            export CUSTOM_PORT_TIDB_SERVER=${CUSTOM_PORT_TIDB_SERVER}
+                            export CUSTOM_PORT_TIDB_STATUS=${CUSTOM_PORT_TIDB_STATUS}
                             E2E=y make build e2e-build
                             make gocovmerge
                             """

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -229,7 +229,7 @@ func (bo *Options) backupCommandTemplate(backup *v1alpha1.Backup, specificArgs [
 		clusterNamespace = backup.Namespace
 	}
 	args := make([]string, 0)
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", backup.Spec.BR.Cluster, clusterNamespace))
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:%d", backup.Spec.BR.Cluster, clusterNamespace, v1alpha1.DefaultPDClientPort))
 	if bo.TLSCluster {
 		args = append(args, fmt.Sprintf("--ca=%s", path.Join(util.ClusterClientTLSPath, corev1.ServiceAccountRootCAKey)))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSCertKey)))

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -63,7 +63,7 @@ func (bm *Manager) setFromDBOptions(backup *v1alpha1.Backup) {
 	if backup.Spec.From.Port != 0 {
 		bm.Options.Port = backup.Spec.From.Port
 	} else {
-		bm.Options.Port = v1alpha1.DefaultTiDBServicePort
+		bm.Options.Port = v1alpha1.DefaultTiDBServerPort
 	}
 
 	if backup.Spec.From.User != "" {

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -61,7 +61,7 @@ func (bm *BackupManager) setOptions(backup *v1alpha1.Backup) (string, error) {
 	if backup.Spec.From.Port != 0 {
 		bm.Options.Port = backup.Spec.From.Port
 	} else {
-		bm.Options.Port = v1alpha1.DefaultTiDBServicePort
+		bm.Options.Port = v1alpha1.DefaultTiDBServerPort
 	}
 
 	if backup.Spec.From.User != "" {

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -55,7 +55,7 @@ func (rm *RestoreManager) setOptions(restore *v1alpha1.Restore) {
 	if restore.Spec.To.Port != 0 {
 		rm.Options.Port = restore.Spec.To.Port
 	} else {
-		rm.Options.Port = v1alpha1.DefaultTiDBServicePort
+		rm.Options.Port = v1alpha1.DefaultTiDBServerPort
 	}
 
 	if restore.Spec.To.User != "" {

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -61,7 +61,7 @@ func (rm *Manager) setOptions(restore *v1alpha1.Restore) {
 	if restore.Spec.To.Port != 0 {
 		rm.Options.Port = restore.Spec.To.Port
 	} else {
-		rm.Options.Port = v1alpha1.DefaultTiDBServicePort
+		rm.Options.Port = v1alpha1.DefaultTiDBServerPort
 	}
 
 	if restore.Spec.To.User != "" {

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -55,7 +55,7 @@ func (ro *Options) restoreData(
 		clusterNamespace = restore.Namespace
 	}
 	args := make([]string, 0)
-	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:2379", restore.Spec.BR.Cluster, clusterNamespace))
+	args = append(args, fmt.Sprintf("--pd=%s-pd.%s:%d", restore.Spec.BR.Cluster, clusterNamespace, v1alpha1.DefaultPDClientPort))
 	if ro.TLSCluster {
 		args = append(args, fmt.Sprintf("--ca=%s", path.Join(util.ClusterClientTLSPath, corev1.ServiceAccountRootCAKey)))
 		args = append(args, fmt.Sprintf("--cert=%s", path.Join(util.ClusterClientTLSPath, corev1.TLSCertKey)))

--- a/cmd/backup-manager/app/util/util_test.go
+++ b/cmd/backup-manager/app/util/util_test.go
@@ -643,7 +643,7 @@ func newBackup() *v1alpha1.Backup {
 		Spec: v1alpha1.BackupSpec{
 			From: &v1alpha1.TiDBAccessConfig{
 				Host:       "10.1.1.2",
-				Port:       v1alpha1.DefaultTiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       v1alpha1.DefaultTidbUser,
 				SecretName: "demo1-tidb-secret",
 			},
@@ -675,7 +675,7 @@ func newRestore() *v1alpha1.Restore {
 		Spec: v1alpha1.RestoreSpec{
 			To: &v1alpha1.TiDBAccessConfig{
 				Host:       "10.1.1.2",
-				Port:       v1alpha1.DefaultTiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       v1alpha1.DefaultTidbUser,
 				SecretName: "demo1-tidb-secret",
 			},

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -290,7 +290,8 @@ func logCustomPorts() {
 		v1alpha1.DefaultTiFlashProxyStatusPort != 20292 ||
 		v1alpha1.DefaultTiFlashInternalPort != 9009 ||
 		v1alpha1.DefaultPumpPort != 8250 ||
-		v1alpha1.DefaultDrainerPort != 8249 {
+		v1alpha1.DefaultDrainerPort != 8249 ||
+		v1alpha1.DefaultTiCDCPort != 8301 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
 			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
 			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
@@ -312,6 +313,8 @@ func logCustomPorts() {
 			PumpPort: v1alpha1.DefaultPumpPort,
 
 			DrainerPort: v1alpha1.DefaultDrainerPort,
+
+			TiCDCPort: v1alpha1.DefaultTiCDCPort,
 		})
 	}
 }
@@ -337,4 +340,6 @@ type CustomPorts struct {
 	PumpPort int32 `json:"Pump-Port"`
 
 	DrainerPort int32 `json:"Drainer-Port"`
+
+	TiCDCPort int32 `json:"TiCDC-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -289,7 +289,8 @@ func logCustomPorts() {
 		v1alpha1.DefaultTiFlashMetricsPort != 8234 ||
 		v1alpha1.DefaultTiFlashProxyStatusPort != 20292 ||
 		v1alpha1.DefaultTiFlashInternalPort != 9009 ||
-		v1alpha1.DefaultPumpPort != 8250 {
+		v1alpha1.DefaultPumpPort != 8250 ||
+		v1alpha1.DefaultDrainerPort != 8249 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
 			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
 			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
@@ -309,6 +310,8 @@ func logCustomPorts() {
 			TiFlashInternalPort:    v1alpha1.DefaultTiFlashInternalPort,
 
 			PumpPort: v1alpha1.DefaultPumpPort,
+
+			DrainerPort: v1alpha1.DefaultDrainerPort,
 		})
 	}
 }
@@ -332,4 +335,6 @@ type CustomPorts struct {
 	TiFlashInternalPort    int32 `json:"TiFlash-Internal-Port"`
 
 	PumpPort int32 `json:"Pump-Port"`
+
+	DrainerPort int32 `json:"Drainer-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -278,21 +278,27 @@ func createHTTPServer() *http.Server {
 func logCustomPorts() {
 	if v1alpha1.DefaultTiDBServerPort != 4000 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
-			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
-			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
-			PDClientPort:   v1alpha1.DefaultPDClientPort,
-			PDPeerPort:     v1alpha1.DefaultPDPeerPort,
-			TiKVServerPort: v1alpha1.DefaultTiKVServerPort,
-			TiKVStatusPort: v1alpha1.DefaultTiKVStatusPort,
+			TiDBServerPort:   v1alpha1.DefaultTiDBServerPort,
+			TiDBStatusPort:   v1alpha1.DefaultTiDBStatusPort,
+			PDClientPort:     v1alpha1.DefaultPDClientPort,
+			PDPeerPort:       v1alpha1.DefaultPDPeerPort,
+			TiKVServerPort:   v1alpha1.DefaultTiKVServerPort,
+			TiKVStatusPort:   v1alpha1.DefaultTiKVStatusPort,
+			TiFlashTcpPort:   v1alpha1.DefaultTiFlashTcpPort,
+			TiFlashHttpPort:  v1alpha1.DefaultTiFlashHttpPort,
+			TiFlashFlashPort: v1alpha1.DefaultTiFlashFlashPort,
 		})
 	}
 }
 
 type CustomPorts struct {
-	TiDBServerPort int32 `json:"TiDB-Server-Port"`
-	TiDBStatusPort int32 `json:"TiDB-Status-Port"`
-	PDClientPort   int32 `json:"PD-Client-Port"`
-	PDPeerPort     int32 `json:"PD-Peer-Port"`
-	TiKVServerPort int32 `json:"TiKV-Server-Port"`
-	TiKVStatusPort int32 `json:"TiKV-Status-Port"`
+	TiDBServerPort   int32 `json:"TiDB-Server-Port"`
+	TiDBStatusPort   int32 `json:"TiDB-Status-Port"`
+	PDClientPort     int32 `json:"PD-Client-Port"`
+	PDPeerPort       int32 `json:"PD-Peer-Port"`
+	TiKVServerPort   int32 `json:"TiKV-Server-Port"`
+	TiKVStatusPort   int32 `json:"TiKV-Status-Port"`
+	TiFlashTcpPort   int32 `json:"TiFlash-TCP-Port"`
+	TiFlashHttpPort  int32 `json:"TiFlash-HTTP-Port"`
+	TiFlashFlashPort int32 `json:"TiFlash-Flash-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -282,6 +282,8 @@ func logCustomPorts() {
 			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
 			PDClientPort:   v1alpha1.DefaultPDClientPort,
 			PDPeerPort:     v1alpha1.DefaultPDPeerPort,
+			TiKVServerPort: v1alpha1.DefaultTiKVServerPort,
+			TiKVStatusPort: v1alpha1.DefaultTiKVStatusPort,
 		})
 	}
 }
@@ -291,4 +293,6 @@ type CustomPorts struct {
 	TiDBStatusPort int32 `json:"TiDB-Status-Port"`
 	PDClientPort   int32 `json:"PD-Client-Port"`
 	PDPeerPort     int32 `json:"PD-Peer-Port"`
+	TiKVServerPort int32 `json:"TiKV-Server-Port"`
+	TiKVStatusPort int32 `json:"TiKV-Status-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -279,6 +279,9 @@ func logCustomPorts() {
 	if v1alpha1.DefaultTiDBServerPort != 4000 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
 			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
+			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
+			PDClientPort:   v1alpha1.DefaultPDClientPort,
+			PDPeerPort:     v1alpha1.DefaultPDPeerPort,
 		})
 	}
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -288,7 +288,8 @@ func logCustomPorts() {
 		v1alpha1.DefaultTiFlashProxyPort != 20170 ||
 		v1alpha1.DefaultTiFlashMetricsPort != 8234 ||
 		v1alpha1.DefaultTiFlashProxyStatusPort != 20292 ||
-		v1alpha1.DefaultTiFlashInternalPort != 9009 {
+		v1alpha1.DefaultTiFlashInternalPort != 9009 ||
+		v1alpha1.DefaultPumpPort != 8250 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
 			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
 			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
@@ -306,6 +307,8 @@ func logCustomPorts() {
 			TiFlashMetricsPort:     v1alpha1.DefaultTiFlashMetricsPort,
 			TiFlashProxyStatusPort: v1alpha1.DefaultTiFlashProxyStatusPort,
 			TiFlashInternalPort:    v1alpha1.DefaultTiFlashInternalPort,
+
+			PumpPort: v1alpha1.DefaultPumpPort,
 		})
 	}
 }
@@ -327,4 +330,6 @@ type CustomPorts struct {
 	TiFlashMetricsPort     int32 `json:"TiFlash-Metrics-Port"`
 	TiFlashProxyStatusPort int32 `json:"TiFlash-Proxy-Status-Port"`
 	TiFlashInternalPort    int32 `json:"TiFlash-Internal-Port"`
+
+	PumpPort int32 `json:"Pump-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -276,29 +276,55 @@ func createHTTPServer() *http.Server {
 }
 
 func logCustomPorts() {
-	if v1alpha1.DefaultTiDBServerPort != 4000 {
+	if v1alpha1.DefaultTiDBServerPort != 4000 ||
+		v1alpha1.DefaultTiDBStatusPort != 10080 ||
+		v1alpha1.DefaultPDClientPort != 2379 ||
+		v1alpha1.DefaultPDPeerPort != 2380 ||
+		v1alpha1.DefaultTiKVServerPort != 20160 ||
+		v1alpha1.DefaultTiKVStatusPort != 20180 ||
+		v1alpha1.DefaultTiFlashTcpPort != 9000 ||
+		v1alpha1.DefaultTiFlashHttpPort != 8123 ||
+		v1alpha1.DefaultTiFlashFlashPort != 3930 ||
+		v1alpha1.DefaultTiFlashProxyPort != 20170 ||
+		v1alpha1.DefaultTiFlashMetricsPort != 8234 ||
+		v1alpha1.DefaultTiFlashProxyStatusPort != 20292 ||
+		v1alpha1.DefaultTiFlashInternalPort != 9009 {
 		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
-			TiDBServerPort:   v1alpha1.DefaultTiDBServerPort,
-			TiDBStatusPort:   v1alpha1.DefaultTiDBStatusPort,
-			PDClientPort:     v1alpha1.DefaultPDClientPort,
-			PDPeerPort:       v1alpha1.DefaultPDPeerPort,
-			TiKVServerPort:   v1alpha1.DefaultTiKVServerPort,
-			TiKVStatusPort:   v1alpha1.DefaultTiKVStatusPort,
-			TiFlashTcpPort:   v1alpha1.DefaultTiFlashTcpPort,
-			TiFlashHttpPort:  v1alpha1.DefaultTiFlashHttpPort,
-			TiFlashFlashPort: v1alpha1.DefaultTiFlashFlashPort,
+			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
+			TiDBStatusPort: v1alpha1.DefaultTiDBStatusPort,
+
+			PDClientPort: v1alpha1.DefaultPDClientPort,
+			PDPeerPort:   v1alpha1.DefaultPDPeerPort,
+
+			TiKVServerPort: v1alpha1.DefaultTiKVServerPort,
+			TiKVStatusPort: v1alpha1.DefaultTiKVStatusPort,
+
+			TiFlashTcpPort:         v1alpha1.DefaultTiFlashTcpPort,
+			TiFlashHttpPort:        v1alpha1.DefaultTiFlashHttpPort,
+			TiFlashFlashPort:       v1alpha1.DefaultTiFlashFlashPort,
+			TiFlashProxyPort:       v1alpha1.DefaultTiFlashProxyPort,
+			TiFlashMetricsPort:     v1alpha1.DefaultTiFlashMetricsPort,
+			TiFlashProxyStatusPort: v1alpha1.DefaultTiFlashProxyStatusPort,
+			TiFlashInternalPort:    v1alpha1.DefaultTiFlashInternalPort,
 		})
 	}
 }
 
 type CustomPorts struct {
-	TiDBServerPort   int32 `json:"TiDB-Server-Port"`
-	TiDBStatusPort   int32 `json:"TiDB-Status-Port"`
-	PDClientPort     int32 `json:"PD-Client-Port"`
-	PDPeerPort       int32 `json:"PD-Peer-Port"`
-	TiKVServerPort   int32 `json:"TiKV-Server-Port"`
-	TiKVStatusPort   int32 `json:"TiKV-Status-Port"`
-	TiFlashTcpPort   int32 `json:"TiFlash-TCP-Port"`
-	TiFlashHttpPort  int32 `json:"TiFlash-HTTP-Port"`
-	TiFlashFlashPort int32 `json:"TiFlash-Flash-Port"`
+	TiDBServerPort int32 `json:"TiDB-Server-Port"`
+	TiDBStatusPort int32 `json:"TiDB-Status-Port"`
+
+	PDClientPort int32 `json:"PD-Client-Port"`
+	PDPeerPort   int32 `json:"PD-Peer-Port"`
+
+	TiKVServerPort int32 `json:"TiKV-Server-Port"`
+	TiKVStatusPort int32 `json:"TiKV-Status-Port"`
+
+	TiFlashTcpPort         int32 `json:"TiFlash-TCP-Port"`
+	TiFlashHttpPort        int32 `json:"TiFlash-HTTP-Port"`
+	TiFlashFlashPort       int32 `json:"TiFlash-Flash-Port"`
+	TiFlashProxyPort       int32 `json:"TiFlash-Proxy-Port"`
+	TiFlashMetricsPort     int32 `json:"TiFlash-Metrics-Port"`
+	TiFlashProxyStatusPort int32 `json:"TiFlash-Proxy-Status-Port"`
+	TiFlashInternalPort    int32 `json:"TiFlash-Internal-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
 	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/controller/autoscaler"
@@ -75,6 +76,8 @@ func main() {
 	flag.VisitAll(func(flag *flag.Flag) {
 		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
+
+	logCustomPorts()
 
 	hostName, err := os.Hostname()
 	if err != nil {
@@ -270,4 +273,16 @@ func createHTTPServer() *http.Server {
 		Addr:    ":6060",
 		Handler: serverMux,
 	}
+}
+
+func logCustomPorts() {
+	if v1alpha1.DefaultTiDBServerPort != 4000 {
+		klog.Infof("running TiDB Operator with custom ports: %#v", CustomPorts{
+			TiDBServerPort: v1alpha1.DefaultTiDBServerPort,
+		})
+	}
+}
+
+type CustomPorts struct {
+	TiDBServerPort int32 `json:"TiDB-Server-Port"`
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -320,26 +320,26 @@ func logCustomPorts() {
 }
 
 type CustomPorts struct {
-	TiDBServerPort int32 `json:"TiDB-Server-Port"`
-	TiDBStatusPort int32 `json:"TiDB-Status-Port"`
+	TiDBServerPort int32
+	TiDBStatusPort int32
 
-	PDClientPort int32 `json:"PD-Client-Port"`
-	PDPeerPort   int32 `json:"PD-Peer-Port"`
+	PDClientPort int32
+	PDPeerPort   int32
 
-	TiKVServerPort int32 `json:"TiKV-Server-Port"`
-	TiKVStatusPort int32 `json:"TiKV-Status-Port"`
+	TiKVServerPort int32
+	TiKVStatusPort int32
 
-	TiFlashTcpPort         int32 `json:"TiFlash-TCP-Port"`
-	TiFlashHttpPort        int32 `json:"TiFlash-HTTP-Port"`
-	TiFlashFlashPort       int32 `json:"TiFlash-Flash-Port"`
-	TiFlashProxyPort       int32 `json:"TiFlash-Proxy-Port"`
-	TiFlashMetricsPort     int32 `json:"TiFlash-Metrics-Port"`
-	TiFlashProxyStatusPort int32 `json:"TiFlash-Proxy-Status-Port"`
-	TiFlashInternalPort    int32 `json:"TiFlash-Internal-Port"`
+	TiFlashTcpPort         int32
+	TiFlashHttpPort        int32
+	TiFlashFlashPort       int32
+	TiFlashProxyPort       int32
+	TiFlashMetricsPort     int32
+	TiFlashProxyStatusPort int32
+	TiFlashInternalPort    int32
 
-	PumpPort int32 `json:"Pump-Port"`
+	PumpPort int32
 
-	DrainerPort int32 `json:"Drainer-Port"`
+	DrainerPort int32
 
-	TiCDCPort int32 `json:"TiCDC-Port"`
+	TiCDCPort int32
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -285,4 +285,7 @@ func logCustomPorts() {
 
 type CustomPorts struct {
 	TiDBServerPort int32 `json:"TiDB-Server-Port"`
+	TiDBStatusPort int32 `json:"TiDB-Status-Port"`
+	PDClientPort   int32 `json:"PD-Client-Port"`
+	PDPeerPort     int32 `json:"PD-Peer-Port"`
 }

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -42,6 +42,13 @@ function tidb_operator::port::ldflags() {
   ldflags+=($(tidb_operator::port::ldflag "customPortPDPeer" "${PD_PEER_PORT}"))
   fi
 
+  if [[ -n ${TIKV_SERVER_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiKVServer" "${TIKV_SERVER_PORT}"))
+  fi
+  if [[ -n ${TIKV_STATUS_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiKVStatus" "${TIKV_STATUS_PORT}"))
+  fi
+
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"
 }

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is similar with `./hack/version.sh`, but used to customize ports when building.
+
+set -euo pipefail
+
+function tidb_operator::port::ldflag() {
+  local key=${1}
+  local val=${2}
+
+  echo "-X 'github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.${key}=${val}'"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+function tidb_operator::port::ldflags() {
+  local -a ldflags=()
+
+  if [[ -n ${TIDB_SERVER_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiDBServer" "${TIDB_SERVER_PORT}"))
+  fi
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}
+
+# output -ldflags parameters
+tidb_operator::port::ldflags

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -31,6 +31,9 @@ function tidb_operator::port::ldflags() {
   if [[ -n ${TIDB_SERVER_PORT-} ]]; then
   ldflags+=($(tidb_operator::port::ldflag "customPortTiDBServer" "${TIDB_SERVER_PORT}"))
   fi
+  if [[ -n ${TIDB_STATUS_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiDBStatus" "${TIDB_STATUS_PORT}"))
+  fi
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -70,6 +70,10 @@ function tidb_operator::port::ldflags() {
   if [[ -n ${TIFLASH_INTERNAL_PORT-} ]]; then
   ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashInternal" "${TIFLASH_INTERNAL_PORT}"))
   fi
+  
+  if [[ -n ${PUMP_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortPump" "${PUMP_PORT}"))
+  fi
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -74,6 +74,10 @@ function tidb_operator::port::ldflags() {
   if [[ -n ${PUMP_PORT-} ]]; then
   ldflags+=($(tidb_operator::port::ldflag "customPortPump" "${PUMP_PORT}"))
   fi
+  
+  if [[ -n ${DRAINER_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortDrainer" "${DRAINER_PORT}"))
+  fi
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -79,6 +79,10 @@ function tidb_operator::port::ldflags() {
   ldflags+=($(tidb_operator::port::ldflag "customPortDrainer" "${DRAINER_PORT}"))
   fi
 
+  if [[ -n ${TICDC_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiCDC" "${TICDC_PORT}"))
+  fi
+
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"
 }

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -58,6 +58,18 @@ function tidb_operator::port::ldflags() {
   if [[ -n ${TIFLASH_FLASH_PORT-} ]]; then
   ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashFlash" "${TIFLASH_FLASH_PORT}"))
   fi
+  if [[ -n ${TIFLASH_PROXY_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashProxy" "${TIFLASH_PROXY_PORT}"))
+  fi
+  if [[ -n ${TIFLASH_METRICS_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashMetrics" "${TIFLASH_METRICS_PORT}"))
+  fi
+  if [[ -n ${TIFLASH_PROXY_STATUS_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashProxyStatus" "${TIFLASH_PROXY_STATUS_PORT}"))
+  fi
+  if [[ -n ${TIFLASH_INTERNAL_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashInternal" "${TIFLASH_INTERNAL_PORT}"))
+  fi
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -49,6 +49,16 @@ function tidb_operator::port::ldflags() {
   ldflags+=($(tidb_operator::port::ldflag "customPortTiKVStatus" "${TIKV_STATUS_PORT}"))
   fi
 
+  if [[ -n ${TIFLASH_TCP_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashTcp" "${TIFLASH_TCP_PORT}"))
+  fi
+  if [[ -n ${TIFLASH_HTTP_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashHttp" "${TIFLASH_HTTP_PORT}"))
+  fi
+  if [[ -n ${TIFLASH_FLASH_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortTiFlashFlash" "${TIFLASH_FLASH_PORT}"))
+  fi
+
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"
 }

--- a/hack/custom-port.sh
+++ b/hack/custom-port.sh
@@ -35,6 +35,13 @@ function tidb_operator::port::ldflags() {
   ldflags+=($(tidb_operator::port::ldflag "customPortTiDBStatus" "${TIDB_STATUS_PORT}"))
   fi
 
+  if [[ -n ${PD_CLIENT_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortPDClient" "${PD_CLIENT_PORT}"))
+  fi
+  if [[ -n ${PD_PEER_PORT-} ]]; then
+  ldflags+=($(tidb_operator::port::ldflag "customPortPDPeer" "${PD_PEER_PORT}"))
+  fi
+
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"
 }

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -61,6 +61,10 @@ var (
 	// in fact, only used in tests now
 	DefaultDrainerPort = int32(8249)
 	customPortDrainer  = "8249"
+
+	// NOTE: this should be 8300 in TiCDC itself, but we have used 8301 in TiDB Operator at the beginning
+	DefaultTiCDCPort = int32(8301)
+	customPortTiCDC  = "8301"
 )
 
 func init() {
@@ -141,6 +145,12 @@ func init() {
 
 	if port, err := strconv.ParseUint(customPortDrainer, 10, 32); err == nil {
 		DefaultDrainerPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortTiCDC, 10, 32); err == nil {
+		DefaultTiCDCPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -29,11 +29,19 @@ var (
 	DefaultTiDBServerPort = int32(4000)
 	// `string` type so that they can be set by `go build -ldflags "-X ..."`
 	customPortTiDBServer = "4000"
+
+	DefaultTiDBStatusPort = int32(10080)
+	customPortTiDBStatus  = "10080"
 )
 
 func init() {
-	if port, err := strconv.Atoi(customPortTiDBServer); err == nil {
+	if port, err := strconv.ParseUint(customPortTiDBServer, 10, 32); err == nil {
 		DefaultTiDBServerPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiDBStatus, 10, 32); err == nil {
+		DefaultTiDBStatusPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -23,13 +23,10 @@ const (
 	DefaultTidbUser = "root"
 )
 
+// Default component ports, can be overridden with ENV variables when building
 var (
-	// DefaultTiDBServerPort is the default tidb cluster port for connecting
-	// It is used both fo Pods and Services.
 	DefaultTiDBServerPort = int32(4000)
-	// `string` type so that they can be set by `go build -ldflags "-X ..."`
-	customPortTiDBServer = "4000"
-
+	customPortTiDBServer  = "4000" // `string` type so that they can be set by `go build -ldflags "-X ..."`
 	DefaultTiDBStatusPort = int32(10080)
 	customPortTiDBStatus  = "10080"
 
@@ -43,12 +40,20 @@ var (
 	DefaultTiKVStatusPort = int32(20180)
 	customPortTiKVStatus  = "20180"
 
-	DefaultTiFlashTcpPort = int32(9000)
-	customPortTiFlashTcp  = "9000"
-	DefaultTiFlashHttpPort = int32(8123)
-	customPortTiFlashHttp  = "8123"
-	DefaultTiFlashFlashPort = int32(3930)
-	customPortTiFlashFlash  = "3930"
+	DefaultTiFlashTcpPort         = int32(9000)
+	customPortTiFlashTcp          = "9000"
+	DefaultTiFlashHttpPort        = int32(8123)
+	customPortTiFlashHttp         = "8123"
+	DefaultTiFlashFlashPort       = int32(3930)
+	customPortTiFlashFlash        = "3930"
+	DefaultTiFlashProxyPort       = int32(20170)
+	customPortTiFlashProxy        = "20170"
+	DefaultTiFlashMetricsPort     = int32(8234)
+	customPortTiFlashMetrics      = "8234"
+	DefaultTiFlashProxyStatusPort = int32(20292)
+	customPortTiFlashProxyStatus  = "20292"
+	DefaultTiFlashInternalPort    = int32(9009)
+	customPortTiFlashInternal     = "9009"
 )
 
 func init() {
@@ -97,6 +102,26 @@ func init() {
 	}
 	if port, err := strconv.ParseUint(customPortTiFlashFlash, 10, 32); err == nil {
 		DefaultTiFlashFlashPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashProxy, 10, 32); err == nil {
+		DefaultTiFlashProxyPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashMetrics, 10, 32); err == nil {
+		DefaultTiFlashMetricsPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashProxyStatus, 10, 32); err == nil {
+		DefaultTiFlashProxyStatusPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashInternal, 10, 32); err == nil {
+		DefaultTiFlashInternalPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -37,6 +37,11 @@ var (
 	customPortPDClient  = "2379"
 	DefaultPDPeerPort   = int32(2380)
 	customPortPDPeer    = "2380"
+
+	DefaultTiKVServerPort = int32(20160)
+	customPortTiKVServer  = "20160"
+	DefaultTiKVStatusPort = int32(20180)
+	customPortTiKVStatus  = "20180"
 )
 
 func init() {
@@ -58,6 +63,17 @@ func init() {
 	}
 	if port, err := strconv.ParseUint(customPortPDPeer, 10, 32); err == nil {
 		DefaultPDPeerPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortTiKVServer, 10, 32); err == nil {
+		DefaultTiKVServerPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiKVStatus, 10, 32); err == nil {
+		DefaultTiKVStatusPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -54,6 +54,9 @@ var (
 	customPortTiFlashProxyStatus  = "20292"
 	DefaultTiFlashInternalPort    = int32(9009)
 	customPortTiFlashInternal     = "9009"
+
+	DefaultPumpPort = int32(8250)
+	customPortPump  = "8250"
 )
 
 func init() {
@@ -122,6 +125,12 @@ func init() {
 	}
 	if port, err := strconv.ParseUint(customPortTiFlashInternal, 10, 32); err == nil {
 		DefaultTiFlashInternalPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortPump, 10, 32); err == nil {
+		DefaultPumpPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -42,6 +42,13 @@ var (
 	customPortTiKVServer  = "20160"
 	DefaultTiKVStatusPort = int32(20180)
 	customPortTiKVStatus  = "20180"
+
+	DefaultTiFlashTcpPort = int32(9000)
+	customPortTiFlashTcp  = "9000"
+	DefaultTiFlashHttpPort = int32(8123)
+	customPortTiFlashHttp  = "8123"
+	DefaultTiFlashFlashPort = int32(3930)
+	customPortTiFlashFlash  = "3930"
 )
 
 func init() {
@@ -74,6 +81,22 @@ func init() {
 	}
 	if port, err := strconv.ParseUint(customPortTiKVStatus, 10, 32); err == nil {
 		DefaultTiKVStatusPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortTiFlashTcp, 10, 32); err == nil {
+		DefaultTiFlashTcpPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashHttp, 10, 32); err == nil {
+		DefaultTiFlashHttpPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortTiFlashFlash, 10, 32); err == nil {
+		DefaultTiFlashFlashPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -24,14 +24,11 @@ const (
 )
 
 var (
-	// `string` type so that they can be set by `go build -ldflags "-X ..."
-	customPortTiDBServer = "4000"
-)
-
-var (
 	// DefaultTiDBServerPort is the default tidb cluster port for connecting
 	// It is used both fo Pods and Services.
 	DefaultTiDBServerPort = int32(4000)
+	// `string` type so that they can be set by `go build -ldflags "-X ..."`
+	customPortTiDBServer = "4000"
 )
 
 func init() {

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -32,6 +32,11 @@ var (
 
 	DefaultTiDBStatusPort = int32(10080)
 	customPortTiDBStatus  = "10080"
+
+	DefaultPDClientPort = int32(2379)
+	customPortPDClient  = "2379"
+	DefaultPDPeerPort   = int32(2380)
+	customPortPDPeer    = "2380"
 )
 
 func init() {
@@ -42,6 +47,17 @@ func init() {
 	}
 	if port, err := strconv.ParseUint(customPortTiDBStatus, 10, 32); err == nil {
 		DefaultTiDBStatusPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortPDClient, 10, 32); err == nil {
+		DefaultPDClientPort = int32(port)
+	} else {
+		panic(err)
+	}
+	if port, err := strconv.ParseUint(customPortPDPeer, 10, 32); err == nil {
+		DefaultPDPeerPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -13,13 +13,31 @@
 
 package v1alpha1
 
+import "strconv"
+
 const (
 	// BackupNameTimeFormat is the time format for generate backup CR name
 	BackupNameTimeFormat = "2006-01-02t15-04-05"
 
-	// DefaultTiDBServicePort is the default tidb cluster port for connecting
-	DefaultTiDBServicePort = int32(4000)
-
 	// DefaultTidbUser is the default tidb user for login tidb cluster
 	DefaultTidbUser = "root"
 )
+
+var (
+	// `string` type so that they can be set by `go build -ldflags "-X ..."
+	customPortTiDBServer = "4000"
+)
+
+var (
+	// DefaultTiDBServerPort is the default tidb cluster port for connecting
+	// It is used both fo Pods and Services.
+	DefaultTiDBServerPort = int32(4000)
+)
+
+func init() {
+	if port, err := strconv.Atoi(customPortTiDBServer); err == nil {
+		DefaultTiDBServerPort = int32(port)
+	} else {
+		panic(err)
+	}
+}

--- a/pkg/apis/pingcap/v1alpha1/constants.go
+++ b/pkg/apis/pingcap/v1alpha1/constants.go
@@ -57,6 +57,10 @@ var (
 
 	DefaultPumpPort = int32(8250)
 	customPortPump  = "8250"
+
+	// in fact, only used in tests now
+	DefaultDrainerPort = int32(8249)
+	customPortDrainer  = "8249"
 )
 
 func init() {
@@ -131,6 +135,12 @@ func init() {
 
 	if port, err := strconv.ParseUint(customPortPump, 10, 32); err == nil {
 		DefaultPumpPort = int32(port)
+	} else {
+		panic(err)
+	}
+
+	if port, err := strconv.ParseUint(customPortDrainer, 10, 32); err == nil {
+		DefaultDrainerPort = int32(port)
 	} else {
 		panic(err)
 	}

--- a/pkg/apis/pingcap/v1alpha1/helpers.go
+++ b/pkg/apis/pingcap/v1alpha1/helpers.go
@@ -35,7 +35,7 @@ func (tac *TiDBAccessConfig) GetTidbPort() int32 {
 	if tac.Port != 0 {
 		return tac.Port
 	}
-	return DefaultTiDBServicePort
+	return DefaultTiDBServerPort
 }
 
 // GetTidbUser return the tidb user

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -1008,7 +1008,7 @@ func (tidb *TiDBSpec) GetSlowLogTailerSpec() TiDBSlowLogTailerSpec {
 
 // GetServicePort returns the service port for tidb
 func (tidb *TiDBSpec) GetServicePort() int32 {
-	port := DefaultTiDBServicePort
+	port := DefaultTiDBServerPort
 	if tidb.Service != nil && tidb.Service.Port != nil {
 		port = *tidb.Service.Port
 	}

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -240,7 +240,7 @@ func buildBackup(bs *v1alpha1.BackupSchedule, timestamp time.Time) *v1alpha1.Bac
 		if backupSpec.BR.ClusterNamespace == "" {
 			clusterNamespace = ns
 		}
-		pdAddress = fmt.Sprintf("%s-pd.%s:2379", backupSpec.BR.Cluster, clusterNamespace)
+		pdAddress = fmt.Sprintf("%s-pd.%s:%d", backupSpec.BR.Cluster, clusterNamespace, v1alpha1.DefaultPDClientPort)
 
 		backupPrefix := strings.ReplaceAll(pdAddress, ":", "-") + "-" + timestamp.UTC().Format(v1alpha1.BackupNameTimeFormat)
 		if backupSpec.S3 != nil {

--- a/pkg/controller/backup/backup_controller_test.go
+++ b/pkg/controller/backup/backup_controller_test.go
@@ -310,7 +310,7 @@ func newBackup() *v1alpha1.Backup {
 		Spec: v1alpha1.BackupSpec{
 			From: &v1alpha1.TiDBAccessConfig{
 				Host:       "10.1.1.2",
-				Port:       v1alpha1.DefaultTiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       v1alpha1.DefaultTidbUser,
 				SecretName: "demo1-tidb-secret",
 			},

--- a/pkg/controller/backupschedule/backup_schedule_controller_test.go
+++ b/pkg/controller/backupschedule/backup_schedule_controller_test.go
@@ -162,7 +162,7 @@ func newBackupSchedule() *v1alpha1.BackupSchedule {
 			BackupTemplate: v1alpha1.BackupSpec{
 				From: &v1alpha1.TiDBAccessConfig{
 					Host:       "10.1.1.2",
-					Port:       v1alpha1.DefaultTiDBServicePort,
+					Port:       v1alpha1.DefaultTiDBServerPort,
 					User:       v1alpha1.DefaultTidbUser,
 					SecretName: "demo1-tidb-secret",
 				},

--- a/pkg/controller/restore/restore_controller_test.go
+++ b/pkg/controller/restore/restore_controller_test.go
@@ -267,7 +267,7 @@ func newRestore() *v1alpha1.Restore {
 		Spec: v1alpha1.RestoreSpec{
 			To: &v1alpha1.TiDBAccessConfig{
 				Host:       "10.1.1.2",
-				Port:       v1alpha1.DefaultTiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       v1alpha1.DefaultTidbUser,
 				SecretName: "demo1-tidb-secret",
 			},

--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -270,7 +270,7 @@ func (c *defaultTiCDCControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32
 
 	scheme := tc.Scheme()
 	addr := getCaptureAdvertiseAddressPrefix(tc, ordinal)
-	return fmt.Sprintf("%s://%s:8301", scheme, addr)
+	return fmt.Sprintf("%s://%s:%d", scheme, addr, v1alpha1.DefaultTiCDCPort)
 }
 
 // getCaptureAdvertiseAddressPrefix is the prefix of TiCDC advertiseAddress

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -149,7 +149,7 @@ func (c *defaultTiDBControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32)
 	scheme := tc.Scheme()
 	hostName := fmt.Sprintf("%s-%d", TiDBMemberName(tcName), ordinal)
 
-	return fmt.Sprintf("%s://%s.%s.%s:10080", scheme, hostName, TiDBPeerMemberName(tcName), ns)
+	return fmt.Sprintf("%s://%s.%s.%s:%d", scheme, hostName, TiDBPeerMemberName(tcName), ns, v1alpha1.DefaultTiDBStatusPort)
 }
 
 // FakeTiDBControl is a fake implementation of TiDBControlInterface.

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -17,9 +17,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/dmapi"
@@ -174,7 +176,7 @@ func (d *tidbDiscovery) Discover(advertisePeerUrl string) (string, error) {
 		if member.Name == podName || member.Name == strArr[0] {
 			continue
 		}
-		memberURL := strings.ReplaceAll(member.PeerUrls[0], ":2380", ":2379")
+		memberURL := strings.ReplaceAll(member.PeerUrls[0], fmt.Sprintf(":%d", v1alpha1.DefaultPDPeerPort), fmt.Sprintf(":%d", v1alpha1.DefaultPDClientPort))
 		membersArr = append(membersArr, memberURL)
 	}
 	delete(currentCluster.peers, podName)
@@ -290,7 +292,7 @@ func parsePDURL(pdURL string) pdEndpointURL {
 	pdEndpoint := pdEndpointURL{
 		scheme:       "",
 		pdMemberName: "",
-		pdMemberPort: "2379",
+		pdMemberPort: strconv.FormatInt(int64(v1alpha1.DefaultPDClientPort), 10),
 		tcName:       "",
 	}
 

--- a/pkg/discovery/server/proxy.go
+++ b/pkg/discovery/server/proxy.go
@@ -23,13 +23,14 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/manager/member"
 	"k8s.io/klog/v2"
 )
 
 func buildUrl(tcName string, tlsEnabled bool) *url.URL {
 	url := &url.URL{
-		Host:   fmt.Sprintf("%s-pd:2379", tcName),
+		Host:   fmt.Sprintf("%s-pd:%d", tcName, v1alpha1.DefaultPDClientPort),
 		Scheme: "http",
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -461,8 +461,8 @@ func (m *pdMemberManager) getNewPDServiceForTidbCluster(tc *v1alpha1.TidbCluster
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "client",
-					Port:       2379,
-					TargetPort: intstr.FromInt(2379),
+					Port:       v1alpha1.DefaultPDClientPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -521,9 +521,9 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
-					Name:       "tcp-peer-2379",
-					Port:       2379,
-					TargetPort: intstr.FromInt(2379),
+					Name:       fmt.Sprintf("tcp-peer-%d", v1alpha1.DefaultPDClientPort),
+					Port:       v1alpha1.DefaultPDClientPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -708,7 +708,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 	setName := controller.PDMemberName(tcName)
 	stsLabels := label.New().Instance(instanceName).PD()
 	podLabels := util.CombineStringMap(stsLabels, basePDSpec.Labels())
-	podAnnotations := util.CombineStringMap(basePDSpec.Annotations(), controller.AnnProm(2379, "/metrics"))
+	podAnnotations := util.CombineStringMap(basePDSpec.Annotations(), controller.AnnProm(v1alpha1.DefaultPDClientPort, "/metrics"))
 	stsAnnotations := getStsAnnotations(tc.Annotations, label.PDLabelVal)
 
 	deleteSlotsNumber, err := util.GetDeleteSlotsNumber(stsAnnotations)
@@ -729,7 +729,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 			},
 			{
 				Name:          "client",
-				ContainerPort: int32(2379),
+				ContainerPort: v1alpha1.DefaultPDClientPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
@@ -967,7 +967,7 @@ func (m *pdMemberManager) collectUnjoinedMembers(tc *v1alpha1.TidbCluster, set *
 func buildPDReadinessProbHandler(tc *v1alpha1.TidbCluster) corev1.Handler {
 	return corev1.Handler{
 		TCPSocket: &corev1.TCPSocketAction{
-			Port: intstr.FromInt(2379),
+			Port: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 		},
 	}
 }

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -515,9 +515,9 @@ func getNewPDHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.Ser
 			ClusterIP: "None",
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "tcp-peer-2380",
-					Port:       2380,
-					TargetPort: intstr.FromInt(2380),
+					Name:       fmt.Sprintf("tcp-peer-%d", v1alpha1.DefaultPDPeerPort),
+					Port:       v1alpha1.DefaultPDPeerPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDPeerPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
@@ -724,7 +724,7 @@ func getNewPDSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "server",
-				ContainerPort: int32(2380),
+				ContainerPort: v1alpha1.DefaultPDPeerPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -1050,8 +1050,8 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "tcp-peer-2380",
-							Port:       2380,
-							TargetPort: intstr.FromInt(2380),
+							Port:       v1alpha1.DefaultPDPeerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDPeerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 						{

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -1056,8 +1056,8 @@ func TestGetNewPDHeadlessServiceForTidbCluster(t *testing.T) {
 						},
 						{
 							Name:       "tcp-peer-2379",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2380,8 +2380,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "client",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2448,8 +2448,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "client",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2516,8 +2516,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "client",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2585,8 +2585,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "client",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2657,8 +2657,8 @@ func TestGetNewPdServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "http-pd",
-							Port:       2379,
-							TargetPort: intstr.FromInt(2379),
+							Port:       v1alpha1.DefaultPDClientPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPDClientPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -305,8 +305,8 @@ func getNewPumpHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "pump",
-					Port:       8250,
-					TargetPort: intstr.FromInt(8250),
+					Port:       v1alpha1.DefaultPumpPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultPumpPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -368,7 +368,7 @@ func getNewPumpStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*app
 	replicas := tc.Spec.Pump.Replicas
 	storageClass := tc.Spec.Pump.StorageClassName
 	podLabels := util.CombineStringMap(stsLabels.Labels(), spec.Labels())
-	podAnnos := util.CombineStringMap(spec.Annotations(), controller.AnnProm(8250, "/metrics"))
+	podAnnos := util.CombineStringMap(spec.Annotations(), controller.AnnProm(v1alpha1.DefaultPumpPort, "/metrics"))
 	storageRequest, err := controller.ParseStorageRequest(tc.Spec.Pump.Requests)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse storage request for pump, tidbcluster %s/%s, error: %v", tc.Namespace, tc.Name, err)
@@ -458,7 +458,7 @@ func getNewPumpStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*app
 			},
 			Ports: []corev1.ContainerPort{{
 				Name:          "pump",
-				ContainerPort: 8250,
+				ContainerPort: v1alpha1.DefaultPumpPort,
 			}},
 			Resources:    controller.ContainerResource(tc.Spec.Pump.ResourceRequirements),
 			Env:          util.AppendEnv(envs, spec.Env()),
@@ -467,7 +467,7 @@ func getNewPumpStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*app
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.FromInt(8250),
+						Port: intstr.FromInt(int(v1alpha1.DefaultPumpPort)),
 					},
 				},
 			},

--- a/pkg/manager/member/pump_member_manager_test.go
+++ b/pkg/manager/member/pump_member_manager_test.go
@@ -578,8 +578,8 @@ func TestGetNewPumpHeadlessService(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "pump",
-							Port:       8250,
-							TargetPort: intstr.FromInt(8250),
+							Port:       v1alpha1.DefaultPumpPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultPumpPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -125,9 +125,9 @@ func RenderTiCDCStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	// NB: TiCDC control relies the format.
 	// TODO move advertise addr format to package controller.
-	advertiseAddr := fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:8301",
-		controller.FormatClusterDomain(tc.Spec.ClusterDomain))
-	cmdArgs := []string{"/cdc server", "--addr=0.0.0.0:8301", fmt.Sprintf("--advertise-addr=%s", advertiseAddr)}
+	advertiseAddr := fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:%d",
+		controller.FormatClusterDomain(tc.Spec.ClusterDomain), v1alpha1.DefaultTiCDCPort)
+	cmdArgs := []string{"/cdc server", fmt.Sprintf("--addr=0.0.0.0:%d", v1alpha1.DefaultTiCDCPort), fmt.Sprintf("--advertise-addr=%s", advertiseAddr)}
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--gc-ttl=%d", tc.TiCDCGCTTL()))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--log-file=%s", tc.TiCDCLogFile()))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--log-level=%s", tc.TiCDCLogLevel()))

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -51,8 +51,8 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	if tc.Spec.PreferIPv6 {
 		listenHost = "[::]"
 	}
-	model.Addr = fmt.Sprintf("%s:20160", listenHost)
-	model.StatusAddr = fmt.Sprintf("%s:20180", listenHost)
+	model.Addr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiKVServerPort)
+	model.StatusAddr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiKVStatusPort)
 
 	return renderTemplateFunc(tikvStartScriptTpl, model)
 }

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -40,11 +40,11 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 		model.EnableAdvertiseStatusAddr = true
 	}
 
-	model.PDAddress = tc.Scheme() + fmt.Sprintf("://${CLUSTER_NAME}-pd:%d", v1alpha1.DefaultPDClientPort)
+	model.PDAddress = fmt.Sprintf("%s://${CLUSTER_NAME}-pd:%d", tc.Scheme(), v1alpha1.DefaultPDClientPort)
 	if tc.AcrossK8s() {
-		model.PDAddress = tc.Scheme() + fmt.Sprintf("://${CLUSTER_NAME}-pd:%d", v1alpha1.DefaultPDClientPort) // get pd addr from discovery in startup script
+		model.PDAddress = fmt.Sprintf("%s://${CLUSTER_NAME}-pd:%d", tc.Scheme(), v1alpha1.DefaultPDClientPort) // get pd addr from discovery in startup script
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		model.PDAddress = tc.Scheme() + "://" + controller.PDMemberName(tc.Spec.Cluster.Name) + fmt.Sprintf(":%d", v1alpha1.DefaultPDClientPort) // use pd of reference cluster
+		model.PDAddress = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	listenHost := "0.0.0.0"
@@ -87,7 +87,7 @@ func RenderTiDBStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	if tc.AcrossK8s() {
 		model.Path = fmt.Sprintf("${CLUSTER_NAME}-pd:%d", v1alpha1.DefaultPDClientPort) // get pd addr from discovery in startup script
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		model.Path = controller.PDMemberName(tc.Spec.Cluster.Name) + fmt.Sprintf(":%d", v1alpha1.DefaultPDClientPort) // use pd of reference cluster
+		model.Path = fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	return renderTemplateFunc(tidbStartScriptTpl, model)

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -213,6 +213,9 @@ func replacePDStartScriptCustomPorts(startScript string) string {
 	if v1alpha1.DefaultPDClientPort != 2379 {
 		startScript = strings.ReplaceAll(startScript, ":2379", fmt.Sprintf(":%d", v1alpha1.DefaultPDClientPort))
 	}
+	if v1alpha1.DefaultPDPeerPort != 2380 {
+		startScript = strings.ReplaceAll(startScript, ":2380", fmt.Sprintf(":%d", v1alpha1.DefaultPDPeerPort))
+	}
 	return startScript
 }
 

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -209,7 +209,7 @@ exec /pd-server ${ARGS}
 `
 
 func replacePDStartScriptCustomPorts(startScript string) string {
-	// `DefaultPDClientPort` may be changed when building the binary
+	// `DefaultPDClientPort`/`DefaultPDPeerPort` may be changed when building the binary
 	if v1alpha1.DefaultPDClientPort != 2379 {
 		startScript = strings.ReplaceAll(startScript, ":2379", fmt.Sprintf(":%d", v1alpha1.DefaultPDClientPort))
 	}
@@ -247,7 +247,7 @@ type PDStartScriptModel struct {
 	CheckDomainScript string
 }
 
-var tikvStartScriptTpl = template.Must(template.New("tikv-start-script").Parse(`#!/bin/sh
+var tikvStartScriptTplText = `#!/bin/sh
 
 # This script is used to start tikv containers in kubernetes cluster
 
@@ -306,7 +306,20 @@ fi
 echo "starting tikv-server ..."
 echo "/tikv-server ${ARGS}"
 exec /tikv-server ${ARGS}
-`))
+`
+
+func replaceTiKVStartScriptCustomPorts(startScript string) string {
+	// `DefaultTiKVServerPort`/`DefaultTiKVStatusPort` may be changed when building the binary
+	if v1alpha1.DefaultTiKVServerPort != 20160 {
+		startScript = strings.ReplaceAll(startScript, ":20160", fmt.Sprintf(":%d", v1alpha1.DefaultTiKVServerPort))
+	}
+	if v1alpha1.DefaultTiKVStatusPort != 20180 {
+		startScript = strings.ReplaceAll(startScript, ":20180", fmt.Sprintf(":%d", v1alpha1.DefaultTiKVStatusPort))
+	}
+	return startScript
+}
+
+var tikvStartScriptTpl = template.Must(template.New("tikv-start-script").Parse(replaceTiKVStartScriptCustomPorts(tikvStartScriptTplText)))
 
 type TiKVStartScriptModel struct {
 	CommonModel

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1702,7 +1702,7 @@ func TestRenderTiDBInitStartScript(t *testing.T) {
 				CAPath:          "/var/lib/tidb-client-tls/ca.crt",
 				CertPath:        "/var/lib/tidb-client-tls/tls.crt",
 				KeyPath:         "/var/lib/tidb-client-tls/tls.key",
-				TiDBServicePort: 4000,
+				TiDBServicePort: v1alpha1.DefaultTiDBServerPort,
 			},
 			result: `import os, sys, time, MySQLdb
 host = 'test-tidb'
@@ -1755,7 +1755,7 @@ conn.close()
 				CAPath:          "/var/lib/tidb-client-tls/ca.crt",
 				CertPath:        "/var/lib/tidb-client-tls/tls.crt",
 				KeyPath:         "/var/lib/tidb-client-tls/tls.key",
-				TiDBServicePort: 4000,
+				TiDBServicePort: v1alpha1.DefaultTiDBServerPort,
 			},
 			result: `import os, sys, time, MySQLdb
 host = 'test-tidb'

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -59,9 +59,9 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	m.AdvertisePeerURL = fmt.Sprintf("%s://${PD_DOMAIN}:2380", tc.Scheme())
 
-	m.ClientURL = fmt.Sprintf("%s://0.0.0.0:2379", tc.Scheme())
+	m.ClientURL = fmt.Sprintf("%s://0.0.0.0:%d", tc.Scheme(), v1alpha1.DefaultPDClientPort)
 
-	m.AdvertiseClientURL = fmt.Sprintf("%s://${PD_DOMAIN}:2379", tc.Scheme())
+	m.AdvertiseClientURL = fmt.Sprintf("%s://${PD_DOMAIN}:%d", tc.Scheme(), v1alpha1.DefaultPDClientPort)
 
 	m.DiscoveryAddr = fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS)
 

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -55,9 +55,9 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	m.DataDir = filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir)
 
-	m.PeerURL = fmt.Sprintf("%s://0.0.0.0:2380", tc.Scheme())
+	m.PeerURL = fmt.Sprintf("%s://0.0.0.0:%d", tc.Scheme(), v1alpha1.DefaultPDPeerPort)
 
-	m.AdvertisePeerURL = fmt.Sprintf("%s://${PD_DOMAIN}:2380", tc.Scheme())
+	m.AdvertisePeerURL = fmt.Sprintf("%s://${PD_DOMAIN}:%d", tc.Scheme(), v1alpha1.DefaultPDPeerPort)
 
 	m.ClientURL = fmt.Sprintf("%s://0.0.0.0:%d", tc.Scheme(), v1alpha1.DefaultPDClientPort)
 

--- a/pkg/manager/member/startscript/v2/pump_start_script.go
+++ b/pkg/manager/member/startscript/v2/pump_start_script.go
@@ -57,7 +57,7 @@ func RenderPumpStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	} else if tc.Spec.ClusterDomain == "" && tc.AcrossK8s() {
 		advertiseAddr = advertiseAddr + fmt.Sprintf(".%s.svc", tcNS)
 	}
-	m.AdvertiseAddr = advertiseAddr + ":8250"
+	m.AdvertiseAddr = fmt.Sprintf("%s:%d", advertiseAddr, v1alpha1.DefaultPumpPort)
 
 	m.ExtraArgs = ""
 

--- a/pkg/manager/member/startscript/v2/pump_start_script.go
+++ b/pkg/manager/member/startscript/v2/pump_start_script.go
@@ -38,15 +38,15 @@ func RenderPumpStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	tcNS := tc.Namespace
 	peerServiceName := controller.PumpPeerMemberName(tcName)
 
-	m.PDAddr = fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tcName))
+	m.PDAddr = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort)
 	if tc.AcrossK8s() {
 		m.AcrossK8s = &AcrossK8sScriptModel{
-			PDAddr:        fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tcName)),
+			PDAddr:        fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort),
 			DiscoveryAddr: fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS),
 		}
 		m.PDAddr = "${result}" // get pd addr in subscript
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		m.PDAddr = fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name)) // use pd of reference cluster
+		m.PDAddr = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	m.LogLevel = tc.PumpLogLevel()

--- a/pkg/manager/member/startscript/v2/ticdc_start_script.go
+++ b/pkg/manager/member/startscript/v2/ticdc_start_script.go
@@ -58,15 +58,15 @@ func RenderTiCDCStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	m.LogLevel = tc.TiCDCLogLevel()
 
-	m.PDAddr = fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tcName))
+	m.PDAddr = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort)
 	if tc.AcrossK8s() {
 		m.AcrossK8s = &AcrossK8sScriptModel{
-			PDAddr:        fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tcName)),
+			PDAddr:        fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort),
 			DiscoveryAddr: fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS),
 		}
 		m.PDAddr = "${result}" // get pd addr in subscript
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		m.PDAddr = fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name)) // use pd of reference cluster
+		m.PDAddr = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	extraArgs := []string{}

--- a/pkg/manager/member/startscript/v2/tidb_start_script.go
+++ b/pkg/manager/member/startscript/v2/tidb_start_script.go
@@ -38,15 +38,15 @@ func RenderTiDBStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	tcNS := tc.Namespace
 	peerServiceName := controller.TiDBPeerMemberName(tcName)
 
-	m.PDAddr = fmt.Sprintf("%s:2379", controller.PDMemberName(tcName))
+	m.PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort)
 	if tc.AcrossK8s() {
 		m.AcrossK8s = &AcrossK8sScriptModel{
-			PDAddr:        fmt.Sprintf("%s:2379", controller.PDMemberName(tcName)),
+			PDAddr:        fmt.Sprintf("%s:%d", controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort),
 			DiscoveryAddr: fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS),
 		}
 		m.PDAddr = "${result}" // get pd addr in subscript
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		m.PDAddr = fmt.Sprintf("%s:2379", controller.PDMemberName(tc.Spec.Cluster.Name)) // use pd of reference cluster
+		m.PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	m.AdvertiseAddr = fmt.Sprintf("${TIDB_POD_NAME}.%s.%s.svc", peerServiceName, tcNS)

--- a/pkg/manager/member/startscript/v2/tiflash_init_script.go
+++ b/pkg/manager/member/startscript/v2/tiflash_init_script.go
@@ -34,7 +34,7 @@ func RenderTiFlashInitScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	if tc.AcrossK8s() {
 		m.AcrossK8s = &AcrossK8sScriptModel{
-			PDAddr:        fmt.Sprintf("%s://%s:2379", tc.Scheme(), controller.PDMemberName(tcName)),
+			PDAddr:        fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort),
 			DiscoveryAddr: fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS),
 		}
 	}

--- a/pkg/manager/member/startscript/v2/tikv_start_script.go
+++ b/pkg/manager/member/startscript/v2/tikv_start_script.go
@@ -59,14 +59,14 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	if tc.Spec.PreferIPv6 {
 		listenHost = "[::]"
 	}
-	m.Addr = fmt.Sprintf("%s:20160", listenHost)
-	m.StatusAddr = fmt.Sprintf("%s:20180", listenHost)
+	m.Addr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiKVServerPort)
+	m.StatusAddr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiKVStatusPort)
 
 	advertiseAddr := fmt.Sprintf("${TIKV_POD_NAME}.%s.%s.svc", peerServiceName, tcNS)
 	if tc.Spec.ClusterDomain != "" {
 		advertiseAddr = advertiseAddr + "." + tc.Spec.ClusterDomain
 	}
-	m.AdvertiseAddr = advertiseAddr + ":20160"
+	m.AdvertiseAddr = advertiseAddr + fmt.Sprintf(":%d", v1alpha1.DefaultTiKVServerPort)
 
 	m.DataDir = filepath.Join(constants.TiKVDataVolumeMountPath, tc.Spec.TiKV.DataSubDir)
 
@@ -78,7 +78,7 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 		if tc.Spec.ClusterDomain != "" {
 			advertiseStatusAddr = advertiseStatusAddr + "." + tc.Spec.ClusterDomain
 		}
-		extraArgs = append(extraArgs, fmt.Sprintf("--advertise-status-addr=%s:20180", advertiseStatusAddr))
+		extraArgs = append(extraArgs, fmt.Sprintf("--advertise-status-addr=%s:%d", advertiseStatusAddr, v1alpha1.DefaultTiKVStatusPort))
 	}
 	if len(extraArgs) > 0 {
 		m.ExtraArgs = strings.Join(extraArgs, " ")

--- a/pkg/manager/member/startscript/v2/tikv_start_script.go
+++ b/pkg/manager/member/startscript/v2/tikv_start_script.go
@@ -44,15 +44,15 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	tcNS := tc.Namespace
 	peerServiceName := controller.TiKVPeerMemberName(tcName)
 
-	m.PDAddr = fmt.Sprintf("%s:2379", controller.PDMemberName(tcName))
+	m.PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort)
 	if tc.AcrossK8s() {
 		m.AcrossK8s = &AcrossK8sScriptModel{
-			PDAddr:        fmt.Sprintf("%s:2379", controller.PDMemberName(tcName)),
+			PDAddr:        fmt.Sprintf("%s:%d", controller.PDMemberName(tcName), v1alpha1.DefaultPDClientPort),
 			DiscoveryAddr: fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS),
 		}
 		m.PDAddr = "${result}" // get pd addr in subscript
 	} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		m.PDAddr = fmt.Sprintf("%s:2379", controller.PDMemberName(tc.Spec.Cluster.Name)) // use pd of reference cluster
+		m.PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	listenHost := "0.0.0.0"

--- a/pkg/manager/member/startscript/v2/tikv_start_script.go
+++ b/pkg/manager/member/startscript/v2/tikv_start_script.go
@@ -66,7 +66,7 @@ func RenderTiKVStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	if tc.Spec.ClusterDomain != "" {
 		advertiseAddr = advertiseAddr + "." + tc.Spec.ClusterDomain
 	}
-	m.AdvertiseAddr = advertiseAddr + fmt.Sprintf(":%d", v1alpha1.DefaultTiKVServerPort)
+	m.AdvertiseAddr = fmt.Sprintf("%s:%d", advertiseAddr, v1alpha1.DefaultTiKVServerPort)
 
 	m.DataDir = filepath.Join(constants.TiKVDataVolumeMountPath, tc.Spec.TiKV.DataSubDir)
 

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -349,8 +349,8 @@ func getNewCDCHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "ticdc",
-					Port:       8301,
-					TargetPort: intstr.FromInt(int(8301)),
+					Port:       v1alpha1.DefaultTiCDCPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiCDCPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -375,7 +375,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 	stsLabels := labelTiCDC(tc)
 	stsName := controller.TiCDCMemberName(tcName)
 	podLabels := util.CombineStringMap(stsLabels, baseTiCDCSpec.Labels())
-	podAnnotations := util.CombineStringMap(baseTiCDCSpec.Annotations(), controller.AnnProm(8301, "/metrics"))
+	podAnnotations := util.CombineStringMap(baseTiCDCSpec.Annotations(), controller.AnnProm(v1alpha1.DefaultTiCDCPort, "/metrics"))
 	stsAnnotations := getStsAnnotations(tc.Annotations, label.TiCDCLabelVal)
 	headlessSvcName := controller.TiCDCPeerMemberName(tcName)
 
@@ -462,7 +462,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "ticdc",
-				ContainerPort: int32(8301),
+				ContainerPort: v1alpha1.DefaultTiCDCPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -585,9 +585,13 @@ func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	if tc.Spec.TiDB.IsBootstrapSQLEnabled() {
 		config.Set("initialize-sql-file", path.Join(bootstrapSQLFilePath, bootstrapSQLFileName))
 	}
-	// `DefaultTiDBServerPort` may be changed when building the binary
+
+	// `DefaultTiDBServerPort`/`DefaultTiDBStatusPort` may be changed when building the binary
 	if v1alpha1.DefaultTiDBServerPort != int32(4000) {
 		config.Set("port", int64(v1alpha1.DefaultTiDBServerPort)) // `int64` to avoid marshal to string
+	}
+	if v1alpha1.DefaultTiDBStatusPort != int32(10080) {
+		config.Set("status.status-port", int64(v1alpha1.DefaultTiDBStatusPort))
 	}
 
 	confText, err := config.MarshalTOML()
@@ -647,8 +651,8 @@ func getNewTiDBServiceOrNil(tc *v1alpha1.TidbCluster) *corev1.Service {
 	if svcSpec.ShouldExposeStatus() {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "status",
-			Port:       10080,
-			TargetPort: intstr.FromInt(10080),
+			Port:       v1alpha1.DefaultTiDBStatusPort,
+			TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 			Protocol:   corev1.ProtocolTCP,
 			NodePort:   svcSpec.GetStatusNodePort(),
 		})
@@ -709,8 +713,8 @@ func getNewTiDBHeadlessServiceForTidbCluster(tc *v1alpha1.TidbCluster) *corev1.S
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "status",
-					Port:       10080,
-					TargetPort: intstr.FromInt(10080),
+					Port:       v1alpha1.DefaultTiDBStatusPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -973,7 +977,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 			},
 			{
 				Name:          "status", // pprof, status, metrics
-				ContainerPort: int32(10080),
+				ContainerPort: v1alpha1.DefaultTiDBStatusPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
@@ -1018,7 +1022,7 @@ func getNewTiDBSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 
 	stsLabels := label.New().Instance(instanceName).TiDB()
 	podLabels := util.CombineStringMap(stsLabels, baseTiDBSpec.Labels())
-	podAnnotations := util.CombineStringMap(baseTiDBSpec.Annotations(), controller.AnnProm(10080, "/metrics"))
+	podAnnotations := util.CombineStringMap(baseTiDBSpec.Annotations(), controller.AnnProm(v1alpha1.DefaultTiDBStatusPort, "/metrics"))
 	stsAnnotations := getStsAnnotations(tc.Annotations, label.TiDBLabelVal)
 
 	deleteSlotsNumber, err := util.GetDeleteSlotsNumber(stsAnnotations)
@@ -1275,7 +1279,7 @@ func buildTiDBReadinessProbHandler(tc *v1alpha1.TidbCluster) corev1.Handler {
 func buildTiDBProbeCommand(tc *v1alpha1.TidbCluster) (command []string) {
 	host := "127.0.0.1"
 
-	readinessURL := fmt.Sprintf("%s://%s:10080/status", tc.Scheme(), host)
+	readinessURL := fmt.Sprintf("%s://%s:%d/status", tc.Scheme(), host, v1alpha1.DefaultTiDBStatusPort)
 	command = append(command, "curl")
 	command = append(command, readinessURL)
 

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -919,8 +919,8 @@ func TestGetNewTiDBHeadlessServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "status",
-							Port:       10080,
-							TargetPort: intstr.FromInt(10080),
+							Port:       v1alpha1.DefaultTiDBStatusPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -1761,8 +1761,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						},
 						{
 							Name:       "status",
-							Port:       10080,
-							TargetPort: intstr.FromInt(10080),
+							Port:       v1alpha1.DefaultTiDBStatusPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -1845,8 +1845,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						},
 						{
 							Name:       "status",
-							Port:       10080,
-							TargetPort: intstr.FromInt(10080),
+							Port:       v1alpha1.DefaultTiDBStatusPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -1915,8 +1915,8 @@ func TestGetNewTiDBService(t *testing.T) {
 						},
 						{
 							Name:       "status",
-							Port:       10080,
-							TargetPort: intstr.FromInt(10080),
+							Port:       v1alpha1.DefaultTiDBStatusPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBStatusPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -2490,7 +2490,7 @@ func TestBuildTiDBProbeHandler(t *testing.T) {
 		Exec: &corev1.ExecAction{
 			Command: []string{
 				"curl",
-				"http://127.0.0.1:10080/status",
+				fmt.Sprintf("http://127.0.0.1:%d/status", v1alpha1.DefaultTiDBStatusPort),
 				"--fail",
 				"--location",
 			},
@@ -2501,7 +2501,7 @@ func TestBuildTiDBProbeHandler(t *testing.T) {
 		Exec: &corev1.ExecAction{
 			Command: []string{
 				"curl",
-				"https://127.0.0.1:10080/status",
+				fmt.Sprintf("https://127.0.0.1:%d/status", v1alpha1.DefaultTiDBStatusPort),
 				"--fail",
 				"--location",
 				"--cacert", path.Join(clusterCertPath, tlsSecretRootCAKey),

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -1694,8 +1694,8 @@ func TestGetNewTiDBService(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "mysql-client",
-							Port:       4000,
-							TargetPort: intstr.FromInt(4000),
+							Port:       v1alpha1.DefaultTiDBServerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},
@@ -1755,8 +1755,8 @@ func TestGetNewTiDBService(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "mysql-client",
-							Port:       4000,
-							TargetPort: intstr.FromInt(4000),
+							Port:       v1alpha1.DefaultTiDBServerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 						{
@@ -1839,8 +1839,8 @@ func TestGetNewTiDBService(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "mysql-client",
-							Port:       4000,
-							TargetPort: intstr.FromInt(4000),
+							Port:       v1alpha1.DefaultTiDBServerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 						{
@@ -1910,7 +1910,7 @@ func TestGetNewTiDBService(t *testing.T) {
 						{
 							Name:       "mysql-client",
 							Port:       5000,
-							TargetPort: intstr.FromInt(4000),
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiDBServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 						{
@@ -2482,7 +2482,7 @@ func TestBuildTiDBProbeHandler(t *testing.T) {
 
 	defaultHandler := corev1.Handler{
 		TCPSocket: &corev1.TCPSocketAction{
-			Port: intstr.FromInt(4000),
+			Port: intstr.FromInt(int(v1alpha1.DefaultTiDBServerPort)),
 		},
 	}
 

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -338,21 +338,21 @@ func getNewHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 				},
 				{
 					Name:       "proxy",
-					Port:       20170,
-					TargetPort: intstr.FromInt(int(20170)),
+					Port:       v1alpha1.DefaultTiFlashProxyPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiFlashProxyPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       "metrics",
-					Port:       8234,
-					TargetPort: intstr.FromInt(int(8234)),
+					Port:       v1alpha1.DefaultTiFlashMetricsPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiFlashMetricsPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 
 				{
 					Name:       "proxy-metrics",
-					Port:       20292,
-					TargetPort: intstr.FromInt(int(20292)),
+					Port:       v1alpha1.DefaultTiFlashProxyStatusPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiFlashProxyStatusPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -504,8 +504,8 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 	stsLabels := labelTiFlash(tc)
 	setName := controller.TiFlashMemberName(tcName)
 	podLabels := util.CombineStringMap(stsLabels, baseTiFlashSpec.Labels())
-	podAnnotations := util.CombineStringMap(baseTiFlashSpec.Annotations(), controller.AnnProm(8234, "/metrics"))
-	podAnnotations = util.CombineStringMap(controller.AnnAdditionalProm("tiflash.proxy", 20292), podAnnotations)
+	podAnnotations := util.CombineStringMap(baseTiFlashSpec.Annotations(), controller.AnnProm(v1alpha1.DefaultTiFlashMetricsPort, "/metrics"))
+	podAnnotations = util.CombineStringMap(controller.AnnAdditionalProm("tiflash.proxy", v1alpha1.DefaultTiFlashProxyStatusPort), podAnnotations)
 	stsAnnotations := getStsAnnotations(tc.Annotations, label.TiFlashLabelVal)
 	capacity := controller.TiKVCapacity(tc.Spec.TiFlash.Limits)
 	headlessSvcName := controller.TiFlashPeerMemberName(tcName)
@@ -563,7 +563,7 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			},
 			{
 				Name:          "proxy",
-				ContainerPort: int32(20170),
+				ContainerPort: v1alpha1.DefaultTiFlashProxyPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
@@ -578,12 +578,12 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			},
 			{
 				Name:          "internal",
-				ContainerPort: int32(9009),
+				ContainerPort: v1alpha1.DefaultTiFlashInternalPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
 				Name:          "metrics",
-				ContainerPort: int32(8234),
+				ContainerPort: v1alpha1.DefaultTiFlashMetricsPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -332,8 +332,8 @@ func getNewHeadlessService(tc *v1alpha1.TidbCluster) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "tiflash",
-					Port:       3930,
-					TargetPort: intstr.FromInt(int(3930)),
+					Port:       v1alpha1.DefaultTiFlashFlashPort,
+					TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiFlashFlashPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
@@ -558,7 +558,7 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "tiflash",
-				ContainerPort: int32(3930),
+				ContainerPort: v1alpha1.DefaultTiFlashFlashPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
@@ -568,12 +568,12 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			},
 			{
 				Name:          "tcp",
-				ContainerPort: int32(9000),
+				ContainerPort: v1alpha1.DefaultTiFlashTcpPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
 				Name:          "http",
-				ContainerPort: int32(8123),
+				ContainerPort: v1alpha1.DefaultTiFlashHttpPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -1387,7 +1387,7 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 			},
 			svcConfig: SvcConfig{
 				Name:       "peer",
-				Port:       20160,
+				Port:       v1alpha1.DefaultTiKVServerPort,
 				Headless:   true,
 				SvcLabel:   func(l label.Label) label.Label { return l.TiFlash() },
 				MemberName: controller.TiFlashPeerMemberName,
@@ -1423,8 +1423,8 @@ func TestGetNewServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "peer",
-							Port:       20160,
-							TargetPort: intstr.FromInt(20160),
+							Port:       v1alpha1.DefaultTiKVServerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiKVServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -194,11 +194,12 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("logger.log", defaultServerLog)
 
 		// raft
-		pdAddr := fmt.Sprintf("%s.%s.svc:2379", controller.PDMemberName(name), ns)
+		pdAddr := fmt.Sprintf("%s.%s.svc:%d", controller.PDMemberName(name), ns, v1alpha1.DefaultPDClientPort)
 		if tc.AcrossK8s() {
 			pdAddr = "PD_ADDR" // get pd addr from discovery in startup script
 		} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
-			pdAddr = fmt.Sprintf("%s.%s.svc%s:2379", controller.PDMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain)) // use pd of reference cluster
+			pdAddr = fmt.Sprintf("%s.%s.svc%s:%d", controller.PDMemberName(ref.Name), ref.Namespace,
+				controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 		}
 		common.SetIfNil("raft.pd_addr", pdAddr)
 
@@ -431,8 +432,9 @@ func setTiFlashRaftConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, ref
 	if acrossK8s {
 		config.SetIfNil("raft.pd_addr", "PD_ADDR") // get pd addr from discovery in startup script
 	} else if ref != nil && noLocalPD {
-		config.SetIfNil("raft.pd_addr", fmt.Sprintf("%s.%s.svc%s:2379", controller.PDMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain)))
+		config.SetIfNil("raft.pd_addr", fmt.Sprintf("%s.%s.svc%s:%d", controller.PDMemberName(ref.Name), ref.Namespace,
+			controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultPDClientPort))
 	} else {
-		config.SetIfNil("raft.pd_addr", fmt.Sprintf("%s.%s.svc:2379", controller.PDMemberName(clusterName), ns))
+		config.SetIfNil("raft.pd_addr", fmt.Sprintf("%s.%s.svc:%d", controller.PDMemberName(clusterName), ns, v1alpha1.DefaultPDClientPort))
 	}
 }

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -161,8 +161,8 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("tmp_path", "/data0/tmp")
 
 		// port
-		common.SetIfNil("tcp_port", int64(9000))
-		common.SetIfNil("http_port", int64(8123))
+		common.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
+		common.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 
 		// flash
 		tidbStatusAddr := fmt.Sprintf("%s.%s.svc:%d", controller.TiDBMemberName(name), ns, v1alpha1.DefaultTiDBStatusPort)
@@ -181,7 +181,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 			}
 		}
 		common.SetIfNil("flash.tidb_status_addr", tidbStatusAddr)
-		common.SetIfNil("flash.service_addr", listenHost+":3930")
+		common.SetIfNil("flash.service_addr", listenHost+fmt.Sprintf(":%d", v1alpha1.DefaultTiFlashFlashPort))
 		common.SetIfNil("flash.flash_cluster.log", defaultClusterLog)
 		common.SetIfNil("flash.proxy.addr", listenHost+":20170")
 		common.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20170", controller.TiFlashMemberName(name),
@@ -212,7 +212,8 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 	// proxy
 	{
 		proxy.SetIfNil("log-level", "info")
-		proxy.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:3930", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain)))
+		proxy.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns,
+			controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashFlashPort))
 		proxy.SetIfNil("server.status-addr", listenHost+":20292")
 		proxy.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20292", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain)))
 	}
@@ -222,8 +223,8 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.Set("security.ca_path", path.Join(tiflashCertPath, corev1.ServiceAccountRootCAKey))
 		common.Set("security.cert_path", path.Join(tiflashCertPath, corev1.TLSCertKey))
 		common.Set("security.key_path", path.Join(tiflashCertPath, corev1.TLSPrivateKeyKey))
-		common.SetIfNil("tcp_port_secure", int64(9000))
-		common.SetIfNil("https_port", int64(8123))
+		common.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
+		common.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 		common.Del("http_port")
 		common.Del("tcp_port")
 
@@ -323,7 +324,8 @@ func setTiFlashConfigDefault(config *v1alpha1.TiFlashConfigWraper, ref *v1alpha1
 
 func setTiFlashProxyConfigDefault(config *v1alpha1.TiFlashProxyConfigWraper, clusterName, ns, clusterDomain, listenHost string) {
 	config.SetIfNil("log-level", "info")
-	config.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:3930", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns, controller.FormatClusterDomain(clusterDomain)))
+	config.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns,
+		controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashFlashPort))
 	config.SetIfNil("server.status-addr", listenHost+":20292")
 	config.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20292", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns, controller.FormatClusterDomain(clusterDomain)))
 }
@@ -336,10 +338,10 @@ func setTiFlashCommonConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, r
 	config.SetIfNil("path_realtime_mode", false)
 	config.SetIfNil("mark_cache_size", int64(5368709120))
 	config.SetIfNil("minmax_index_cache_size", int64(5368709120))
-	config.SetIfNil("tcp_port", int64(9000))
-	config.SetIfNil("tcp_port_secure", int64(9000))
-	config.SetIfNil("https_port", int64(8123))
-	config.SetIfNil("http_port", int64(8123))
+	config.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
+	config.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
+	config.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
+	config.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 	config.SetIfNil("interserver_http_port", int64(9009))
 	setTiFlashFlashConfigDefault(config, ref, clusterName, ns, clusterDomain, listenHost, noLocalTiDB, acrossK8s)
 	setTiFlashLoggerConfigDefault(config)
@@ -394,7 +396,7 @@ func setTiFlashFlashConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, re
 	}
 
 	config.SetIfNil("flash.tidb_status_addr", tidbStatusAddr)
-	config.SetIfNil("flash.service_addr", listenHost+":3930")
+	config.SetIfNil("flash.service_addr", listenHost+fmt.Sprintf(":%d", v1alpha1.DefaultTiFlashFlashPort))
 	config.SetIfNil("flash.overlap_threshold", 0.6)
 	config.SetIfNil("flash.compact_log_min_period", int64(200))
 

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -165,18 +165,18 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("http_port", int64(8123))
 
 		// flash
-		tidbStatusAddr := fmt.Sprintf("%s.%s.svc:10080", controller.TiDBMemberName(name), ns)
+		tidbStatusAddr := fmt.Sprintf("%s.%s.svc:%d", controller.TiDBMemberName(name), ns, v1alpha1.DefaultTiDBStatusPort)
 		if tc.WithoutLocalTiDB() {
 			// TODO: support first cluster which don't contain TiDB when deploy cluster across mutli Kubernete clusters
 			if tc.Heterogeneous() {
 				if tc.AcrossK8s() {
 					// use headless service of TiDB in reference cluster
-					tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:10080",
-						controller.TiDBPeerMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain))
+					tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:%d",
+						controller.TiDBPeerMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultTiDBStatusPort)
 				} else {
 					// use service of TiDB in reference cluster
-					tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:10080",
-						controller.TiDBMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain))
+					tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:%d",
+						controller.TiDBMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultTiDBStatusPort)
 				}
 			}
 		}
@@ -376,16 +376,18 @@ func setTiFlashCommonConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, r
 }
 
 func setTiFlashFlashConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, ref *v1alpha1.TidbClusterRef, clusterName, ns, clusterDomain, listenHost string, noLocalTiDB, acrossK8s bool) {
-	tidbStatusAddr := fmt.Sprintf("%s.%s.svc:10080", controller.TiDBMemberName(clusterName), ns)
+	tidbStatusAddr := fmt.Sprintf("%s.%s.svc:%d", controller.TiDBMemberName(clusterName), ns, v1alpha1.DefaultTiDBStatusPort)
 	if noLocalTiDB {
 		// TODO: support first cluster without TiDB when deploy cluster across mutli Kubernete clusters
 		if ref != nil {
 			if acrossK8s {
 				// use headless service of TiDB in reference cluster
-				tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:10080", controller.TiDBPeerMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain))
+				tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:%d", controller.TiDBPeerMemberName(ref.Name), ref.Namespace,
+					controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultTiDBStatusPort)
 			} else {
 				// use service of TiDB in reference cluster
-				tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:10080", controller.TiDBMemberName(ref.Name), ref.Namespace, controller.FormatClusterDomain(ref.ClusterDomain))
+				tidbStatusAddr = fmt.Sprintf("%s.%s.svc%s:%d", controller.TiDBMemberName(ref.Name), ref.Namespace,
+					controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultTiDBStatusPort)
 			}
 		}
 	}

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -181,11 +181,11 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 			}
 		}
 		common.SetIfNil("flash.tidb_status_addr", tidbStatusAddr)
-		common.SetIfNil("flash.service_addr", listenHost+fmt.Sprintf(":%d", v1alpha1.DefaultTiFlashFlashPort))
+		common.SetIfNil("flash.service_addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort))
 		common.SetIfNil("flash.flash_cluster.log", defaultClusterLog)
-		common.SetIfNil("flash.proxy.addr", listenHost+":20170")
-		common.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20170", controller.TiFlashMemberName(name),
-			controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain)))
+		common.SetIfNil("flash.proxy.addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyPort))
+		common.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name),
+			controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyPort))
 		common.SetIfNil("flash.proxy.data-dir", "/data0/proxy")
 		common.SetIfNil("flash.proxy.config", "/data0/proxy.toml")
 
@@ -205,7 +205,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 
 		if listenHost == listenHostForIPv6 {
 			common.SetIfNil("listen_host", "::") // listen host must be "::" not "[::]"
-			common.SetIfNil("status.metrics_port", int64(8234))
+			common.SetIfNil("status.metrics_port", int64(v1alpha1.DefaultTiFlashMetricsPort))
 		}
 	}
 
@@ -214,8 +214,9 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		proxy.SetIfNil("log-level", "info")
 		proxy.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns,
 			controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashFlashPort))
-		proxy.SetIfNil("server.status-addr", listenHost+":20292")
-		proxy.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20292", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain)))
+		proxy.SetIfNil("server.status-addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyStatusPort))
+		proxy.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns,
+			controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyStatusPort))
 	}
 
 	// Note the config of tiflash use "_" by convention, others(proxy) use "-".
@@ -326,8 +327,9 @@ func setTiFlashProxyConfigDefault(config *v1alpha1.TiFlashProxyConfigWraper, clu
 	config.SetIfNil("log-level", "info")
 	config.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns,
 		controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashFlashPort))
-	config.SetIfNil("server.status-addr", listenHost+":20292")
-	config.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20292", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns, controller.FormatClusterDomain(clusterDomain)))
+	config.SetIfNil("server.status-addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyStatusPort))
+	config.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns,
+		controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyStatusPort))
 }
 
 func setTiFlashCommonConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, ref *v1alpha1.TidbClusterRef, clusterName, ns, clusterDomain, listenHost string, noLocalPD bool, noLocalTiDB bool, acrossK8s bool) {
@@ -342,7 +344,7 @@ func setTiFlashCommonConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, r
 	config.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
 	config.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 	config.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
-	config.SetIfNil("interserver_http_port", int64(9009))
+	config.SetIfNil("interserver_http_port", int64(v1alpha1.DefaultTiFlashInternalPort))
 	setTiFlashFlashConfigDefault(config, ref, clusterName, ns, clusterDomain, listenHost, noLocalTiDB, acrossK8s)
 	setTiFlashLoggerConfigDefault(config)
 	setTiFlashApplicationConfigDefault(config)
@@ -354,7 +356,7 @@ func setTiFlashCommonConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, r
 	} else {
 		config.SetIfNil("listen_host", listenHost)
 	}
-	config.SetIfNil("status.metrics_port", int64(8234))
+	config.SetIfNil("status.metrics_port", int64(v1alpha1.DefaultTiFlashMetricsPort))
 
 	config.SetIfNil("quotas.default.interval.duration", int64(3600))
 	config.SetIfNil("quotas.default.interval.queries", int64(0))
@@ -396,7 +398,7 @@ func setTiFlashFlashConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, re
 	}
 
 	config.SetIfNil("flash.tidb_status_addr", tidbStatusAddr)
-	config.SetIfNil("flash.service_addr", listenHost+fmt.Sprintf(":%d", v1alpha1.DefaultTiFlashFlashPort))
+	config.SetIfNil("flash.service_addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort))
 	config.SetIfNil("flash.overlap_threshold", 0.6)
 	config.SetIfNil("flash.compact_log_min_period", int64(200))
 
@@ -408,8 +410,9 @@ func setTiFlashFlashConfigDefault(config *v1alpha1.TiFlashCommonConfigWraper, re
 	config.SetIfNil("flash.flash_cluster.master_ttl", int64(60))
 
 	// set proxy
-	config.SetIfNil("flash.proxy.addr", listenHost+":20170")
-	config.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:20170", controller.TiFlashMemberName(clusterName), controller.TiFlashPeerMemberName(clusterName), ns, controller.FormatClusterDomain(clusterDomain)))
+	config.SetIfNil("flash.proxy.addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyPort))
+	config.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(clusterName),
+		controller.TiFlashPeerMemberName(clusterName), ns, controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyPort))
 	config.SetIfNil("flash.proxy.data-dir", "/data0/proxy")
 	config.SetIfNil("flash.proxy.config", "/data0/proxy.toml")
 }

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -53,11 +53,11 @@ var (
 					Config:        pointer.StringPtr("/data0/proxy.toml"),
 					DataDir:       pointer.StringPtr("/data0/proxy"),
 				},
-				ServiceAddr:    pointer.StringPtr("0.0.0.0:3930"),
+				ServiceAddr:    pointer.StringPtr(fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultTiFlashFlashPort)),
 				TiDBStatusAddr: pointer.StringPtr(fmt.Sprintf("test-tidb.test.svc:%d", v1alpha1.DefaultTiDBStatusPort)),
 			},
-			HTTPPort:               pointer.Int32Ptr(8123),
-			HTTPSPort:              pointer.Int32Ptr(8123),
+			HTTPPort:               pointer.Int32Ptr(v1alpha1.DefaultTiFlashHttpPort),
+			HTTPSPort:              pointer.Int32Ptr(v1alpha1.DefaultTiFlashHttpPort),
 			InternalServerHTTPPort: pointer.Int32Ptr(9009),
 			ListenHost:             pointer.StringPtr("0.0.0.0"),
 			FlashLogger: &v1alpha1.FlashLogger{
@@ -101,8 +101,8 @@ var (
 			FlashStatus: &v1alpha1.FlashStatus{
 				MetricsPort: pointer.Int32Ptr(8234),
 			},
-			TCPPort:       pointer.Int32Ptr(9000),
-			TCPPortSecure: pointer.Int32Ptr(9000),
+			TCPPort:       pointer.Int32Ptr(v1alpha1.DefaultTiFlashTcpPort),
+			TCPPortSecure: pointer.Int32Ptr(v1alpha1.DefaultTiFlashTcpPort),
 			TmpPath:       pointer.StringPtr("/data0/tmp"),
 			FlashUser: &v1alpha1.FlashUser{
 				Default: &v1alpha1.User{
@@ -124,7 +124,7 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				EngineAddr:          pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashFlashPort)),
 				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
 				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},
@@ -153,7 +153,7 @@ var (
 					Config:        pointer.StringPtr("/data0/proxy1.toml"),
 					DataDir:       pointer.StringPtr("/data0/proxy1"),
 				},
-				ServiceAddr:    pointer.StringPtr("0.0.0.0:3930"),
+				ServiceAddr:    pointer.StringPtr(fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultTiFlashFlashPort)),
 				TiDBStatusAddr: pointer.StringPtr("test-tidb.test.svc:10081"),
 			},
 			HTTPPort:               pointer.Int32Ptr(8121),
@@ -224,7 +224,7 @@ var (
 		ProxyConfig: &v1alpha1.ProxyConfig{
 			LogLevel: pointer.StringPtr("info1"),
 			Server: &v1alpha1.FlashServerConfig{
-				EngineAddr:          pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:3930"),
+				EngineAddr:          pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashFlashPort)),
 				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
 				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
 			},

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -15,6 +15,7 @@ package member
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -53,7 +54,7 @@ var (
 					DataDir:       pointer.StringPtr("/data0/proxy"),
 				},
 				ServiceAddr:    pointer.StringPtr("0.0.0.0:3930"),
-				TiDBStatusAddr: pointer.StringPtr("test-tidb.test.svc:10080"),
+				TiDBStatusAddr: pointer.StringPtr(fmt.Sprintf("test-tidb.test.svc:%d", v1alpha1.DefaultTiDBStatusPort)),
 			},
 			HTTPPort:               pointer.Int32Ptr(8123),
 			HTTPSPort:              pointer.Int32Ptr(8123),

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -48,8 +48,8 @@ var (
 				},
 				OverlapThreshold: pointer.Float64Ptr(0.6),
 				FlashProxy: &v1alpha1.FlashProxy{
-					Addr:          pointer.StringPtr("0.0.0.0:20170"),
-					AdvertiseAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20170"),
+					Addr:          pointer.StringPtr(fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultTiFlashProxyPort)),
+					AdvertiseAddr: pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashProxyPort)),
 					Config:        pointer.StringPtr("/data0/proxy.toml"),
 					DataDir:       pointer.StringPtr("/data0/proxy"),
 				},
@@ -58,7 +58,7 @@ var (
 			},
 			HTTPPort:               pointer.Int32Ptr(v1alpha1.DefaultTiFlashHttpPort),
 			HTTPSPort:              pointer.Int32Ptr(v1alpha1.DefaultTiFlashHttpPort),
-			InternalServerHTTPPort: pointer.Int32Ptr(9009),
+			InternalServerHTTPPort: pointer.Int32Ptr(v1alpha1.DefaultTiFlashInternalPort),
 			ListenHost:             pointer.StringPtr("0.0.0.0"),
 			FlashLogger: &v1alpha1.FlashLogger{
 				Count:     pointer.Int32Ptr(10),
@@ -99,7 +99,7 @@ var (
 				StorageEngine: pointer.StringPtr("dt"),
 			},
 			FlashStatus: &v1alpha1.FlashStatus{
-				MetricsPort: pointer.Int32Ptr(8234),
+				MetricsPort: pointer.Int32Ptr(v1alpha1.DefaultTiFlashMetricsPort),
 			},
 			TCPPort:       pointer.Int32Ptr(v1alpha1.DefaultTiFlashTcpPort),
 			TCPPortSecure: pointer.Int32Ptr(v1alpha1.DefaultTiFlashTcpPort),
@@ -125,8 +125,8 @@ var (
 			LogLevel: pointer.StringPtr("info"),
 			Server: &v1alpha1.FlashServerConfig{
 				EngineAddr:          pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashFlashPort)),
-				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
-				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
+				StatusAddr:          pointer.StringPtr(fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultTiFlashProxyStatusPort)),
+				AdvertiseStatusAddr: pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashProxyStatusPort)),
 			},
 		},
 	}
@@ -225,8 +225,8 @@ var (
 			LogLevel: pointer.StringPtr("info1"),
 			Server: &v1alpha1.FlashServerConfig{
 				EngineAddr:          pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashFlashPort)),
-				StatusAddr:          pointer.StringPtr("0.0.0.0:20292"),
-				AdvertiseStatusAddr: pointer.StringPtr("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:20292"),
+				StatusAddr:          pointer.StringPtr(fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultTiFlashProxyStatusPort)),
+				AdvertiseStatusAddr: pointer.StringPtr(fmt.Sprintf("test-tiflash-POD_NUM.test-tiflash-peer.test.svc:%d", v1alpha1.DefaultTiFlashProxyStatusPort)),
 			},
 		},
 	}

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -120,7 +120,7 @@ func (m *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	svcList := []SvcConfig{
 		{
 			Name:       "peer",
-			Port:       20160,
+			Port:       v1alpha1.DefaultTiKVServerPort,
 			Headless:   true,
 			SvcLabel:   func(l label.Label) label.Label { return l.TiKV() },
 			MemberName: controller.TiKVPeerMemberName,
@@ -466,7 +466,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	stsLabels := labelTiKV(tc)
 	podLabels := util.CombineStringMap(stsLabels.Labels(), baseTiKVSpec.Labels())
 	setName := controller.TiKVMemberName(tcName)
-	podAnnotations := util.CombineStringMap(baseTiKVSpec.Annotations(), controller.AnnProm(20180, "/metrics"))
+	podAnnotations := util.CombineStringMap(baseTiKVSpec.Annotations(), controller.AnnProm(v1alpha1.DefaultTiKVStatusPort, "/metrics"))
 	stsAnnotations := getStsAnnotations(tc.Annotations, label.TiKVLabelVal)
 	capacity := controller.TiKVCapacity(tc.Spec.TiKV.Limits)
 	headlessSvcName := controller.TiKVPeerMemberName(tcName)
@@ -613,7 +613,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "server",
-				ContainerPort: int32(20160),
+				ContainerPort: v1alpha1.DefaultTiKVServerPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
@@ -640,7 +640,7 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 	if tc.Spec.TiKV.EnableNamedStatusPort {
 		kvStatusPort := corev1.ContainerPort{
 			Name:          "status",
-			ContainerPort: int32(20180),
+			ContainerPort: v1alpha1.DefaultTiKVStatusPort,
 			Protocol:      corev1.ProtocolTCP,
 		}
 
@@ -1054,7 +1054,7 @@ func tikvStatefulSetIsUpgrading(podLister corelisters.PodLister, pdControl pdapi
 func buildTiKVReadinessProbHandler(tc *v1alpha1.TidbCluster) corev1.Handler {
 	return corev1.Handler{
 		TCPSocket: &corev1.TCPSocketAction{
-			Port: intstr.FromInt(20160),
+			Port: intstr.FromInt(int(v1alpha1.DefaultTiKVServerPort)),
 		},
 	}
 }

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -1649,7 +1649,7 @@ func TestGetNewTiKVServiceForTidbCluster(t *testing.T) {
 			},
 			svcConfig: SvcConfig{
 				Name:       "peer",
-				Port:       20160,
+				Port:       v1alpha1.DefaultTiKVServerPort,
 				Headless:   true,
 				SvcLabel:   func(l label.Label) label.Label { return l.TiKV() },
 				MemberName: controller.TiKVPeerMemberName,
@@ -1685,8 +1685,8 @@ func TestGetNewTiKVServiceForTidbCluster(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "peer",
-							Port:       20160,
-							TargetPort: intstr.FromInt(20160),
+							Port:       v1alpha1.DefaultTiKVServerPort,
+							TargetPort: intstr.FromInt(int(v1alpha1.DefaultTiKVServerPort)),
 							Protocol:   corev1.ProtocolTCP,
 						},
 					},

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -103,13 +103,13 @@ func (m *tiproxyMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 }
 
 func (m *tiproxyMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *apps.StatefulSet) (*corev1.ConfigMap, error) {
-	PDAddr := fmt.Sprintf("%s:2379", controller.PDMemberName(tc.Name))
+	PDAddr := fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Name), v1alpha1.DefaultPDClientPort)
 	// TODO: support it
 	if tc.AcrossK8s() {
 		return nil, fmt.Errorf("across k8s is not supported for")
 	}
 	if tc.Heterogeneous() && tc.WithoutLocalPD() {
-		PDAddr = fmt.Sprintf("%s:2379", controller.PDMemberName(tc.Spec.Cluster.Name)) // use pd of reference cluster
+		PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
 	var cfgWrapper *v1alpha1.TiProxyConfigWraper

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -572,7 +572,7 @@ func BuildProbeCommand(tc *v1alpha1.TidbCluster, componentType string) (command 
 		readinessURL = fmt.Sprintf("%s://%s:2379/status", tc.Scheme(), host)
 	}
 	if componentType == label.TiDBLabelVal {
-		readinessURL = fmt.Sprintf("%s://%s:10080/status", tc.Scheme(), host)
+		readinessURL = fmt.Sprintf("%s://%s:%d/status", tc.Scheme(), host, v1alpha1.DefaultTiDBStatusPort)
 	}
 	command = append(command, "curl")
 	command = append(command, readinessURL)

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -569,7 +569,7 @@ func BuildProbeCommand(tc *v1alpha1.TidbCluster, componentType string) (command 
 	host := "127.0.0.1"
 	var readinessURL string
 	if componentType == label.PDLabelVal {
-		readinessURL = fmt.Sprintf("%s://%s:2379/status", tc.Scheme(), host)
+		readinessURL = fmt.Sprintf("%s://%s:%d/status", tc.Scheme(), host, v1alpha1.DefaultPDClientPort)
 	}
 	if componentType == label.TiDBLabelVal {
 		readinessURL = fmt.Sprintf("%s://%s:%d/status", tc.Scheme(), host, v1alpha1.DefaultTiDBStatusPort)

--- a/pkg/manager/tidbdashboard/manager.go
+++ b/pkg/manager/tidbdashboard/manager.go
@@ -415,7 +415,7 @@ func dashboardStartArgs(
 	clusterTLSEnable, mysqlTLSEnable, telemetry, experimental bool,
 	tc *v1alpha1.TidbCluster,
 ) []string {
-	pdAddress := fmt.Sprintf("%s.%s:2379", controller.PDMemberName(tc.Name), tc.Namespace)
+	pdAddress := fmt.Sprintf("%s.%s:%d", controller.PDMemberName(tc.Name), tc.Namespace, v1alpha1.DefaultPDClientPort)
 
 	base := []string{
 		"-h=0.0.0.0",

--- a/pkg/manager/tidbngmonitoring/start_script.go
+++ b/pkg/manager/tidbngmonitoring/start_script.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"html/template"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 )
 
@@ -41,7 +42,7 @@ func (m *NGMonitoringStartScriptModel) FormatClusterDomain() string {
 func (m *NGMonitoringStartScriptModel) PDAddress() string {
 	// don't need add scheme, ng monitoring will use https if cert is configured
 	// TODO: support across kubernetes
-	return fmt.Sprintf("%s.%s:2379", controller.PDMemberName(m.TCName), m.TCNamespace)
+	return fmt.Sprintf("%s.%s:%d", controller.PDMemberName(m.TCName), m.TCNamespace, v1alpha1.DefaultPDClientPort)
 }
 
 func (m *NGMonitoringStartScriptModel) RenderStartScript() (string, error) {

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	"k8s.io/client-go/kubernetes"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
@@ -262,12 +263,12 @@ func genClientUrl(namespace Namespace, clusterName string, scheme string, cluste
 		svc = "pd-peer"
 	}
 	if len(namespace) == 0 {
-		return fmt.Sprintf("%s://%s-%s:2379", scheme, clusterName, svc)
+		return fmt.Sprintf("%s://%s-%s:%d", scheme, clusterName, svc, v1alpha1.DefaultPDClientPort)
 	}
 	if len(clusterDomain) == 0 {
-		return fmt.Sprintf("%s://%s-%s.%s:2379", scheme, clusterName, svc, string(namespace))
+		return fmt.Sprintf("%s://%s-%s.%s:%d", scheme, clusterName, svc, string(namespace), v1alpha1.DefaultPDClientPort)
 	}
-	return fmt.Sprintf("%s://%s-%s.%s.svc.%s:2379", scheme, clusterName, svc, string(namespace), clusterDomain)
+	return fmt.Sprintf("%s://%s-%s.%s.svc.%s:%d", scheme, clusterName, svc, string(namespace), clusterDomain, v1alpha1.DefaultPDClientPort)
 }
 
 // genEtcdClientUrl builds the url of cluster pd etcd client
@@ -277,9 +278,9 @@ func genEtcdClientUrl(namespace Namespace, clusterName, clusterDomain string, he
 		svc = "pd-peer"
 	}
 	if clusterDomain == "" {
-		return fmt.Sprintf("%s-%s.%s:2379", clusterName, svc, string(namespace))
+		return fmt.Sprintf("%s-%s.%s:%d", clusterName, svc, string(namespace), v1alpha1.DefaultPDClientPort)
 	}
-	return fmt.Sprintf("%s-%s.%s.svc.%s:2379", clusterName, svc, string(namespace), clusterDomain)
+	return fmt.Sprintf("%s-%s.%s.svc.%s:%d", clusterName, svc, string(namespace), clusterDomain, v1alpha1.DefaultPDClientPort)
 }
 
 // FakePDControl implements a fake version of PDControlInterface.

--- a/pkg/tiflashapi/tiflash_control.go
+++ b/pkg/tiflashapi/tiflash_control.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
@@ -74,7 +75,7 @@ func tiflashPodClientKey(schema, namespace, clusterName, podName string) string 
 
 // TiFlashPodClientURL builds the url of tiflash pod client
 func TiFlashPodClientURL(namespace, clusterName, podName, scheme string) string {
-	return fmt.Sprintf("%s://%s.%s-tiflash-peer.%s:20292", scheme, podName, clusterName, namespace)
+	return fmt.Sprintf("%s://%s.%s-tiflash-peer.%s:%d", scheme, podName, clusterName, namespace, v1alpha1.DefaultTiFlashProxyStatusPort)
 }
 
 // FakeTiFlashControl implements a fake version of TiFlashControlInterface.

--- a/pkg/tikvapi/tikv_control.go
+++ b/pkg/tikvapi/tikv_control.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
@@ -70,7 +71,7 @@ func tikvPodClientKey(schema, namespace, clusterName, podName string) string {
 
 // TiKVPodClientURL builds the url of tikv pod client
 func TiKVPodClientURL(namespace, clusterName, podName, scheme string) string {
-	return fmt.Sprintf("%s://%s.%s-tikv-peer.%s:20180", scheme, podName, clusterName, namespace)
+	return fmt.Sprintf("%s://%s.%s-tikv-peer.%s:%d", scheme, podName, clusterName, namespace, v1alpha1.DefaultTiKVStatusPort)
 }
 
 // FakeTiKVControl implements a fake version of TiKVControlInterface.

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1169,15 +1169,15 @@ func (oa *OperatorActions) pumpIsHealthy(tcName, ns, podName string, tlsEnabled 
 	var err error
 	var addr string
 	if oa.fw != nil {
-		localHost, localPort, cancel, err := portforward.ForwardOnePort(oa.fw, ns, fmt.Sprintf("pod/%s", podName), 8250)
+		localHost, localPort, cancel, err := portforward.ForwardOnePort(oa.fw, ns, fmt.Sprintf("pod/%s", podName), uint16(v1alpha1.DefaultPumpPort))
 		if err != nil {
-			log.Logf("failed to forward port %d for %s/%s", 8250, ns, podName)
+			log.Logf("failed to forward port %d for %s/%s", v1alpha1.DefaultPumpPort, ns, podName)
 			return false
 		}
 		defer cancel()
 		addr = fmt.Sprintf("%s:%d", localHost, localPort)
 	} else {
-		addr = fmt.Sprintf("%s.%s-pump.%s:8250", podName, tcName, ns)
+		addr = fmt.Sprintf("%s.%s-pump.%s:%d", podName, tcName, ns, v1alpha1.DefaultPumpPort)
 	}
 	var tlsConfig *tls.Config
 	scheme := "http"

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -1233,15 +1233,15 @@ func (oa *OperatorActions) drainerHealth(tcName, ns, podName string, tlsEnabled 
 	var err error
 	var addr string
 	if oa.fw != nil {
-		localHost, localPort, cancel, err := portforward.ForwardOnePort(oa.fw, ns, fmt.Sprintf("pod/%s", podName), 8249)
+		localHost, localPort, cancel, err := portforward.ForwardOnePort(oa.fw, ns, fmt.Sprintf("pod/%s", podName), uint16(v1alpha1.DefaultDrainerPort))
 		if err != nil {
-			log.Logf("failed to forward port %d for %s/%s", 8249, ns, podName)
+			log.Logf("failed to forward port %d for %s/%s", v1alpha1.DefaultDrainerPort, ns, podName)
 			return false
 		}
 		defer cancel()
 		addr = fmt.Sprintf("%s:%d", localHost, localPort)
 	} else {
-		addr = fmt.Sprintf("%s.%s-drainer.%s:8249", podName, tcName, ns)
+		addr = fmt.Sprintf("%s.%s-drainer.%s:%d", podName, tcName, ns, v1alpha1.DefaultDrainerPort)
 	}
 	var tlsConfig *tls.Config
 	scheme := "http"

--- a/tests/cmd/blockwriter/main.go
+++ b/tests/cmd/blockwriter/main.go
@@ -24,6 +24,7 @@ import (
 	// To register MySQL driver
 	_ "github.com/go-sql-driver/mysql"
 
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/tests/pkg/blockwriter"
 	"github.com/pingcap/tidb-operator/tests/pkg/util"
 	flag "github.com/spf13/pflag"
@@ -49,7 +50,7 @@ func init() {
 	flag.StringVar(&optClusterName, "cluster-name", optClusterName, "cluster name")
 	flag.StringVar(&optDatabase, "database", optDatabase, "database")
 	flag.StringVar(&optPassword, "password", optPassword, "password")
-	flag.Int32Var(&optTiDBSvcPort, "tidb-service-port", 4000, "tidb service port")
+	flag.Int32Var(&optTiDBSvcPort, "tidb-service-port", v1alpha1.DefaultTiDBServerPort, "tidb service port")
 }
 
 func getDSN(ns, tcName, databaseName, password string, port int32) string {
@@ -84,7 +85,7 @@ func main() {
 }
 
 func initDB() error {
-	s := fmt.Sprintf("root:%s@(%s-tidb.%s:4000)/?charset=utf8", optPassword, optClusterName, optNamespace)
+	s := fmt.Sprintf("root:%s@(%s-tidb.%s:%d)/?charset=utf8", optPassword, optClusterName, optNamespace, v1alpha1.DefaultTiDBServerPort)
 	db, err := sql.Open("mysql", s)
 	if err != nil {
 		return err

--- a/tests/crd_test_util.go
+++ b/tests/crd_test_util.go
@@ -626,7 +626,7 @@ func (ctu *CrdTestUtil) pumpMembersReadyFn(tc *v1alpha1.TidbCluster) (bool, erro
 }
 
 func (ctu *CrdTestUtil) pumpHealth(tc *v1alpha1.TidbCluster, podName string) bool {
-	addr := fmt.Sprintf("%s.%s-pump.%s:8250", podName, tc.Name, tc.Namespace)
+	addr := fmt.Sprintf("%s.%s-pump.%s:%d", podName, tc.Name, tc.Namespace, v1alpha1.DefaultPumpPort)
 	pumpHealthURL := fmt.Sprintf("http://%s/status", addr)
 	res, err := http.Get(pumpHealthURL)
 	if err != nil {

--- a/tests/dm.go
+++ b/tests/dm.go
@@ -80,9 +80,6 @@ const (
 	// the service port for client requests to DM-master.
 	dmMasterSvcPort = uint16(8261)
 
-	// the service port for client requests to TiDB.
-	dmTiDBSvcPort = uint16(v1alpha1.DefaultTiDBServicePort)
-
 	// PK steps for generated data between MySQL tables.
 	dmPKStepForTable = 10000
 
@@ -91,6 +88,9 @@ const (
 )
 
 var (
+	// the service port for client requests to TiDB.
+	dmTiDBSvcPort = uint16(v1alpha1.DefaultTiDBServerPort)
+
 	dmMySQLLabels = map[string]string{
 		label.NameLabelKey:      DMLabelName,
 		label.ComponentLabelKey: "mysql",
@@ -213,7 +213,7 @@ timezone: "UTC"
 
 target-database:
   host: "dm-tidb-tidb.dm-tidb"
-  port: 4000
+  port: %d # replace this with the real TiDB port
   user: "root"
   password: ""
 
@@ -240,7 +240,7 @@ timezone: "UTC"
 
 target-database:
   host: "dm-tidb-tidb.dm-tidb"
-  port: 4000
+  port: %s # replace this with the real TiDB port
   user: "root"
   password: ""
 
@@ -569,7 +569,7 @@ func StartDMTask(fw portforward.PortForward, ns, masterSvcName, taskConf, errSub
 	}
 
 	var req = Req{
-		Task: fmt.Sprintf(taskConf, DMTaskName(ns), DMTaskName(ns)),
+		Task: fmt.Sprintf(taskConf, DMTaskName(ns), v1alpha1.DefaultTiDBServerPort, DMTaskName(ns)),
 	}
 	data, err := json.Marshal(req)
 	if err != nil {

--- a/tests/dm.go
+++ b/tests/dm.go
@@ -240,7 +240,7 @@ timezone: "UTC"
 
 target-database:
   host: "dm-tidb-tidb.dm-tidb"
-  port: %s # replace this with the real TiDB port
+  port: %d # replace this with the real TiDB port
   user: "root"
   password: ""
 

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 		}
 
 		ginkgo.By("Forward backup TiDB cluster service")
-		backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(brutil.TiDBServicePort))
+		backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(v1alpha1.DefaultTiDBServerPort))
 		framework.ExpectNoError(err)
 		err = initDatabase(backupHost, dbName)
 		framework.ExpectNoError(err)
@@ -235,7 +235,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Forward restore TiDB cluster service")
-		restoreHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(restoreClusterName), int(brutil.TiDBServicePort))
+		restoreHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(restoreClusterName), int(v1alpha1.DefaultTiDBServerPort))
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Validate restore result")
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Forward backup TiDB cluster service")
-			backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(brutil.TiDBServicePort))
+			backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(v1alpha1.DefaultTiDBServerPort))
 			framework.ExpectNoError(err)
 			err = initDatabase(backupHost, dbName)
 			framework.ExpectNoError(err)
@@ -810,7 +810,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNotEqual(fullBackup.Status.CommitTs, "")
 
 			ginkgo.By("Forward master TiDB cluster service")
-			masterHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(masterClusterName), int(brutil.TiDBServicePort))
+			masterHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(masterClusterName), int(v1alpha1.DefaultTiDBServerPort))
 			framework.ExpectNoError(err)
 			err = initDatabase(masterHost, dbName)
 			framework.ExpectNoError(err)
@@ -821,7 +821,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Forward master PD service")
-			masterPDHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getPDServiceResourceName(masterClusterName), int(brutil.PDServicePort))
+			masterPDHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getPDServiceResourceName(masterClusterName), int(v1alpha1.DefaultTiDBServerPort))
 			framework.ExpectNoError(err)
 			ginkgo.By("Wait log backup reach current ts")
 			currentTS := strconv.FormatUint(config.GoTimeToTS(time.Now()), 10)
@@ -854,7 +854,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Forward restore TiDB cluster service")
-			backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(brutil.TiDBServicePort))
+			backupHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getTiDBServiceResourceName(backupClusterName), int(v1alpha1.DefaultTiDBServerPort))
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Validate pitr restore result")

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -821,7 +821,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Forward master PD service")
-			masterPDHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getPDServiceResourceName(masterClusterName), int(v1alpha1.DefaultTiDBServerPort))
+			masterPDHost, err := portforward.ForwardOnePort(ctx, f.PortForwarder, ns, getPDServiceResourceName(masterClusterName), int(v1alpha1.DefaultPDClientPort))
 			framework.ExpectNoError(err)
 			ginkgo.By("Wait log backup reach current ts")
 			currentTS := strconv.FormatUint(config.GoTimeToTS(time.Now()), 10)

--- a/tests/e2e/br/framework/br/data.go
+++ b/tests/e2e/br/framework/br/data.go
@@ -25,10 +25,9 @@ import (
 )
 
 const (
-	BRType          = "br"
-	DumperType      = "dumper"
-	TiDBServicePort = int32(4000)
-	PDServicePort   = int32(2379)
+	BRType        = "br"
+	DumperType    = "dumper"
+	PDServicePort = int32(2379)
 )
 
 // GetRole returns a role for br test.
@@ -123,7 +122,7 @@ func GetBackup(ns, name, tcName, typ string, s3Config *v1alpha1.S3StorageProvide
 			From: &v1alpha1.TiDBAccessConfig{
 				Host:       util.GetTidbServiceName(tcName),
 				SecretName: name,
-				Port:       TiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       "root",
 			},
 			BR: &v1alpha1.BRConfig{
@@ -159,7 +158,7 @@ func GetRestore(ns, name, tcName, typ string, s3Config *v1alpha1.S3StorageProvid
 			To: &v1alpha1.TiDBAccessConfig{
 				Host:       util.GetTidbServiceName(tcName),
 				SecretName: name,
-				Port:       TiDBServicePort,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       "root",
 			},
 			BR: &v1alpha1.BRConfig{

--- a/tests/e2e/br/framework/br/data.go
+++ b/tests/e2e/br/framework/br/data.go
@@ -25,9 +25,8 @@ import (
 )
 
 const (
-	BRType        = "br"
-	DumperType    = "dumper"
-	PDServicePort = int32(2379)
+	BRType     = "br"
+	DumperType = "dumper"
 )
 
 // GetRole returns a role for br test.

--- a/tests/e2e/dmcluster/dmcluster.go
+++ b/tests/e2e/dmcluster/dmcluster.go
@@ -456,7 +456,7 @@ var _ = ginkgo.Describe("DMCluster", func() {
     ssl-key: /var/lib/source-tls/%[1]s/tls.key
 `, tidbClientSecretName))
 			taskCfg = strings.ReplaceAll(taskCfg, "dm-tidb-tidb.dm-tidb", fmt.Sprintf("%s-tidb", dcName))
-			taskCfg = fmt.Sprintf(taskCfg, tests.DMTaskName(ns), tests.DMTaskName(ns))
+			taskCfg = fmt.Sprintf(taskCfg, tests.DMTaskName(ns), v1alpha1.DefaultTiDBServerPort, tests.DMTaskName(ns))
 			filename = "/tmp/dm-with-tls-task.yaml"
 			framework.ExpectNoError(ioutil.WriteFile(filename, []byte(taskCfg), 0o644), "failed to write task config file")
 			_, err = framework.RunKubectl(ns, "cp", filename, fmt.Sprintf("%s/%s:%s", ns, podName, filename))

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -246,7 +246,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			err = oa.WaitForTidbClusterReady(tc1, 25*time.Minute, 30*time.Second)
 			framework.ExpectNoError(err, "failed to wait for cluster-1 ready: %s/%s", tc1.Namespace, tc1.Name)
 
-			localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, tc1.Namespace, fmt.Sprintf("svc/%s-pd", tc1.Name), 2379)
+			localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, tc1.Namespace, fmt.Sprintf("svc/%s-pd", tc1.Name), uint16(v1alpha1.DefaultPDClientPort))
 			framework.ExpectNoError(err, "failed to port-forward pd server of cluster-1 %s/%s", tc1.Namespace, tc1.Name)
 			defer cancel()
 

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -1690,7 +1690,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				"--",
 				"/cdc", "cli", "changefeed", "create",
 				fmt.Sprintf("--sink-uri=tidb://root:@%s:%d/", controller.TiDBMemberName(toTCName), toTc.Spec.TiDB.GetServicePort()),
-				fmt.Sprintf("--pd=http://%s:2379", controller.PDMemberName(fromTCName)),
+				fmt.Sprintf("--pd=http://%s:%d", controller.PDMemberName(fromTCName), v1alpha1.DefaultPDClientPort),
 			}
 			data, err := framework.RunKubectl(ns, args...)
 			framework.ExpectNoError(err, "failed to create change feed task: %s, %v", string(data), err)
@@ -1818,7 +1818,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				"--",
 				"/cdc", "cli", "changefeed", "create",
 				fmt.Sprintf("--sink-uri=tidb://root:@%s:%d/", controller.TiDBMemberName(toTCName), toTc.Spec.TiDB.GetServicePort()),
-				fmt.Sprintf("--pd=http://%s:2379", controller.PDMemberName(fromTCName)),
+				fmt.Sprintf("--pd=http://%s:%d", controller.PDMemberName(fromTCName), v1alpha1.DefaultPDClientPort),
 			}
 			data, err := framework.RunKubectl(ns, args...)
 			framework.ExpectNoError(err, "failed to create change feed task: %s, %v", string(data), err)

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -1086,7 +1086,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					BaseImage:            "pingcap/tidb-binlog",
 					ResourceRequirements: fixture.WithStorage(fixture.BurstableSmall, "1Gi"),
 					Config: tcconfig.New(map[string]interface{}{
-						"addr": "0.0.0.0:8250",
+						"addr": fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultPumpPort),
 						"storage": map[string]interface{}{
 							"stop-write-at-available-space": 0,
 						},
@@ -1277,7 +1277,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				BaseImage:            "pingcap/tidb-binlog",
 				ResourceRequirements: fixture.WithStorage(fixture.BurstableSmall, "1Gi"),
 				Config: tcconfig.New(map[string]interface{}{
-					"addr": "0.0.0.0:8250",
+					"addr": fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultPumpPort),
 					"storage": map[string]interface{}{
 						"stop-write-at-available-space": 0,
 					},
@@ -3238,7 +3238,7 @@ func checkPumpStatus(pcli versioned.Interface, ns string, name string, onlineNum
 func testBinlog(oa *tests.OperatorActions, tc *v1alpha1.TidbCluster, cli ctrlCli.Client, pcli versioned.Interface) {
 	config := tcconfig.New(map[string]interface{}{})
 	config.Set("storage.stop-write-at-available-space", 0)
-	config.Set("addr", "0.0.0.0:8250")
+	config.Set("addr", fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultPumpPort))
 
 	pumpSpec := &v1alpha1.PumpSpec{
 		BaseImage: "pingcap/tidb-binlog",

--- a/tests/e2e/tidbcluster/tls.go
+++ b/tests/e2e/tidbcluster/tls.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
@@ -743,7 +744,7 @@ func dataInClusterIsCorrect(fw portforward.PortForward, c clientset.Interface, n
 func connectToTiDBWithTLSSupport(fw portforward.PortForward, c clientset.Interface, ns, tcName, passwd string, tlsEnabled bool) (*sql.DB, context.CancelFunc, error) {
 	var tlsParams string
 
-	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, ns, fmt.Sprintf("svc/%s", controller.TiDBMemberName(tcName)), 4000)
+	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, ns, fmt.Sprintf("svc/%s", controller.TiDBMemberName(tcName)), uint16(v1alpha1.DefaultTiDBServerPort))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/e2e/util/proxiedpdclient/proxiedpdclient.go
+++ b/tests/e2e/util/proxiedpdclient/proxiedpdclient.go
@@ -49,7 +49,7 @@ func NewProxiedPDClient(secretLister corelisterv1.SecretLister, fw utilportforwa
 			return nil, nil, err
 		}
 	}
-	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, namespace, fmt.Sprintf("svc/%s", controller.PDMemberName(tcName)), 2379)
+	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, namespace, fmt.Sprintf("svc/%s", controller.PDMemberName(tcName)), uint16(v1alpha1.DefaultPDClientPort))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/e2e/util/tidb/tidb.go
+++ b/tests/e2e/util/tidb/tidb.go
@@ -20,6 +20,7 @@ import (
 
 	// To register MySQL driver
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/tests/e2e/util/portforward"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,7 +30,7 @@ var dummyCancel = func() {}
 
 // PortForwardAndGetTiDBDSN create a portforward for TiDB and return its DSN
 func PortForwardAndGetTiDBDSN(fw portforward.PortForward, ns, tc, user, password, database string) (string, context.CancelFunc, error) {
-	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, ns, fmt.Sprintf("svc/%s", controller.TiDBMemberName(tc)), 4000)
+	localHost, localPort, cancel, err := portforward.ForwardOnePort(fw, ns, fmt.Sprintf("svc/%s", controller.TiDBMemberName(tc)), uint16(v1alpha1.DefaultTiDBServerPort))
 	if err != nil {
 		return "", dummyCancel, err
 	}

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -767,7 +767,7 @@ func AddPumpForTidbCluster(tc *v1alpha1.TidbCluster) *v1alpha1.TidbCluster {
 			},
 		},
 		Config: tcconfig.New(map[string]interface{}{
-			"addr":               "0.0.0.0:8250",
+			"addr":               fmt.Sprintf("0.0.0.0:%d", v1alpha1.DefaultPumpPort),
 			"gc":                 7,
 			"data-dir":           "/data",
 			"heartbeat-interval": 2,

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -574,7 +574,7 @@ func GetBackupCRDWithS3(tc *v1alpha1.TidbCluster, fromSecretName, brType string,
 			From: &v1alpha1.TiDBAccessConfig{
 				Host:       util.GetTidbServiceName(tc.Name),
 				SecretName: fromSecretName,
-				Port:       4000,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       "root",
 			},
 			BR: &v1alpha1.BRConfig{
@@ -610,7 +610,7 @@ func GetRestoreCRDWithS3(tc *v1alpha1.TidbCluster, toSecretName, restoreType str
 			To: &v1alpha1.TiDBAccessConfig{
 				Host:       util.GetTidbServiceName(tc.Name),
 				SecretName: toSecretName,
-				Port:       4000,
+				Port:       v1alpha1.DefaultTiDBServerPort,
 				User:       "root",
 			},
 			BR: &v1alpha1.BRConfig{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Support to customize TiDB components port when building TiDB Operator via `-ldflags`

- TiDB
  - Server, default 4000
  - Status, default 10080
- PD
  - Client, default 2379
  - Peer, default 2380
- TiKV
  - Server, default 20160
  - Status, default 20180
- TiFlash
  - TCP, default 9000
  - HTTP, default 8123
  - Flash, 3930
  - Proxy, 20170
  - Metrics, 8234
  - ProxyStatus, 20292
  - Internal, 9009
- Pump, default 8250
- Drainer, default 8249
- TiCDC, default 8301 in Operator (but default 8300 in TiCDC itself)

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

- refactor the code
- add ENV variables for overwrite components ports

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

NOTE: run the tests with both `startScriptVersion: v1` and `startScriptVersion: v2`

also check no restart happen for pods after upgrade from a TiDB Operator v1.5.0-beta.1 to this PR's version.

1. build a docker image with custom ports
    ```bash
    TIDB_SERVER_PORT=4800 TIDB_STATUS_PORT=18080 PD_CLIENT_PORT=2879 PD_PEER_PORT=2880 TIKV_SERVER_PORT=28160 TIKV_STATUS_PORT=28180 TIFLASH_TCP_PORT=9800 TIFLASH_HTTP_PORT=8823 TIFLASH_FLASH_PORT=3980 TIFLASH_PROXY_PORT=28170 TIFLASH_METRICS_PORT=8834 TIFLASH_PROXY_STATUS_PORT=28292 TIFLASH_INTERNAL_PORT=9809 PUMP_PORT=8850 TICDC_PORT=8800 make docker
    ```
2. setup TiDB Operator with the above image
3. deploy a TidbCluster
    NOTE: for Pump, update the config item `addr` to match the new port
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
      name: tc-1
    spec:
      version: v6.5.0
      pvReclaimPolicy: Delete
      configUpdateStrategy: RollingUpdate
      helper:
        image: alpine:3.16.0
      pd:
        replicas: 1
        requests:
          storage: "1Gi"
        config: {}
      tikv:
        evictLeaderTimeout: 1m
        enableNamedStatusPort: true
        replicas: 1
        requests:
          storage: "1Gi"
        config:
          storage:
            reserve-space: "0MB"
          rocksdb:
            max-open-files: 256
          raftdb:
            max-open-files: 256
      tiflash:
        replicas: 1
        storageClaims:
        - resources:
            requests:
              storage: 1Gi
        config: {}
      tidb:
        replicas: 1
        service:
          type: ClusterIP
        config: {}
      pump:
        version: v6.5.0
        replicas: 1
        requests:
          storage: 1Gi
        config: |
          addr = "0.0.0.0:8850"
      ticdc:
        replicas: 1
        config: {}
    ```
4. wait until TidbCluster is ready, and check both pod and service are using the custom ports
5. check TiDB Dashboard in PD can be accessed
6. deploy and check the independent TiDB Dashboard is work
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbDashboard
    metadata:
      name: dashboard
    spec:
      version: v6.5.0
      clusters:
        - name: tc-1
      requests:
        storage: 1Gi
    ```
7. deploy and check NgMonitoring is working
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbNGMonitoring
    metadata:
      name: ngm
    spec:
      clusters:
      - name: tc-1
      ngMonitoring:
        requests:
          storage: 1Gi
        version: v6.5.0
    ```
8. deploy TidbMonitor for the TidbCluster and check Grafana Dashboard has data for PD, TiKV, TiFlash, TiDB, TiCDC and Pump
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbMonitor
    metadata:
      name: monitor
    spec:
      replicas: 1
      clusters:
      - name: tc-1
      prometheus:
        baseImage: prom/prometheus
        version: v2.27.1
      grafana:
        baseImage: grafana/grafana
        version: 7.5.11
      initializer:
        baseImage: pingcap/tidb-monitor-initializer
        version: v6.5.0
      reloader:
        baseImage: pingcap/tidb-monitor-reloader
        version: v1.0.1
      prometheusReloader:
        baseImage: quay.io/prometheus-operator/prometheus-config-reloader
        version: v0.49.0
    ```
9. connect to the TiDB cluster via the custom port and execute some SQL to write data into the cluster
10. export the data via dumpling
11. create another TidbCluster (`tc-2`) and wait for ready
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
      name: tc-2
    spec:
      version: v6.5.0
      pvReclaimPolicy: Delete
      configUpdateStrategy: RollingUpdate
      helper:
        image: alpine:3.16.0
      pd:
        replicas: 1
        requests:
          storage: "1Gi"
        config: {}
      tikv:
        evictLeaderTimeout: 1m
        enableNamedStatusPort: true
        replicas: 1
        requests:
          storage: "1Gi"
        config:
          storage:
            reserve-space: "0MB"
          rocksdb:
            max-open-files: 256
          raftdb:
            max-open-files: 256
      tidb:
        replicas: 1
        service:
          type: ClusterIP
        config: {}
    ```
12. import data into `tc-2` via tidb-lightning Helm Chart with `tidb` backend and check data
    ```yaml
    dataSource:
      local:
        nodeName: {node-hold-exported-data}
        hostPath: "{path-to-data}"
    targetTidbCluster:
      name: tc-2
      user: root
      port: 4800
    backend: tidb
    ```
13. drop the above imported data of `tc-2`, and import again via tidb-lightning Helm chart with `local` backend and check data
    ```yaml
    dataSource:
      local:
        nodeName: {node-hold-exported-data}
        hostPath: "{path-to-data}"
    targetTidbCluster:
      name: tc-2
      user: root
      statusPort: 18080
      pdClientPort: 2879
    sortedKV:
      storage: 1Gi
    backend: local
    ```
14. export the data of `tc-1` via Backup CR with dumpling
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: Backup
    metadata:
      name: backup-dumpling
    spec:
      from:
        host: tc-1-tidb
        port: 4800
        user: root
        secretName: backup-tidb-secret
      s3:
        provider: aws
        secretName: s3-secret
        region: {region}
        bucket: {bucket-name}
      storageSize: 1Gi
    ```
15. drop the above imported data of `tc-2`, and import again via Restore CR with Lightning and check data
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: Restore
    metadata:
      name: restore-lightning
    spec:
      backupType: full
      to:
        host: tc-2-tidb
        port: 4800
        user: root
        secretName: restore-tidb-secret
      s3:
        provider: aws
        secretName: s3-secret
        region: {region}
        path: s3://${backup_path}
      storageSize: 1Gi
    ```
16. backup data of `tc-1` via Backup CR with BR
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: Backup
    metadata:
      name: backup-br
    spec:
      backupType: full
      br:
        cluster: tc-1
      s3:
        provider: aws
        secretName: s3-secret
        region: {region}
        bucket: {bucket-name}
    ```
17. drop the above imported data of `tc-2`, and restore again via Restore CR with BR and check data
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: Restore
    metadata:
      name: restore-br
    spec:
      br:
        cluster: tc-2
      s3:
        provider: aws
        secretName: s3-secret
        region: {region}
        bucket: {bucket-name}
        prefix: {bucket-folder}
    ```
18. deploy Drainer via drainer Helm chart
    ```yaml
    clusterName: tc-1
    port: 8849
    pdClientPort: 2879
    config: |
      db-type = "tidb"
      [syncer.to]
      host = "tc-2-tidb"
      user = "root"
      password = ""
      port = 4800
    ```
19. write some data via SQL in `tc-1` and check the data is synced to `tc-2` via Drainer
20. check Grafana Dashboard has data for Drainer
21. destroy Drainer
22. enter the TiCDC pod of `tc-1` and create a changefeed to `tc-2`
    ```bash
    /cdc cli changefeed create --server=http://tc-1-ticdc-peer:8800 --sink-uri="mysql://root:@tc-2-tidb:4800/" --changefeed-id="tc-1-to-tc-2"
    ```
23. write some data via SQL in `tc-1` and check the data is synced to `tc-2` via TiCDC
24. check Grafana Dashboard has data for TiCDC

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
