### PR TITLE
ebs: calc full snapshot size and report backup size for failed backup

### DIFF
--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -317,8 +317,8 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 	backupErr := bm.backupData(ctx, backup, bm.StatusUpdater)
 
 	defer func() {
+		// Calculate the backup size for ebs backup job even if it fails
 		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
-			// Calculate the backup size for failed ebs backup job
 			backupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
 			if err != nil {
 				klog.Warningf("Failed to calc volume snapshot backup size %d bytes, %v", backupSize, err)

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -322,7 +322,7 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 			backupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
 			if err != nil {
 				klog.Warningf("Failed to calc volume snapshot backup size %d bytes, %v", backupSize, err)
-				errs = append(errs, err)
+				return
 			}
 
 			backupSizeReadable := humanize.Bytes(uint64(backupSize))

--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/dustin/go-humanize"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
@@ -150,27 +149,4 @@ func (bm *Manager) getVolumeSnapshotBackup(backups []*v1alpha1.Backup) *v1alpha1
 
 	// reach end of backup list, there is no volume snapshot backups
 	return nil
-}
-
-// updateVolumeSnapshotBackupSize update a volume-snapshot backup size
-func (bm *Manager) updateVolumeSnapshotBackupSize(ctx context.Context, backup *v1alpha1.Backup) error {
-	var updateStatus *controller.BackupUpdateStatus
-
-	backupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
-
-	if err != nil {
-		klog.Warningf("Failed to parse BackupSize %d KB, %v", backupSize, err)
-	}
-
-	backupSizeReadable := humanize.Bytes(uint64(backupSize))
-
-	updateStatus = &controller.BackupUpdateStatus{
-		BackupSize:         &backupSize,
-		BackupSizeReadable: &backupSizeReadable,
-	}
-
-	return bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{
-		Type:   v1alpha1.BackupComplete,
-		Status: corev1.ConditionTrue,
-	}, updateStatus)
 }

--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -89,11 +89,6 @@ func (bm *Manager) performCleanBackup(ctx context.Context, backup *v1alpha1.Back
 			klog.Errorf("delete backup %s for cluster %s backup failure", backup.Name, bm)
 		}
 
-		// update the next backup size
-		if nextNackup != nil {
-			bm.updateVolumeSnapshotBackupSize(ctx, nextNackup)
-		}
-
 	} else {
 		if backup.Spec.BR != nil {
 			err = bm.CleanBRRemoteBackupData(ctx, backup)

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -17,14 +17,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ebs"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -44,15 +42,8 @@ import (
 // interface CalcVolSnapBackupSize called by backup and backup clean.
 
 const (
-	// This value can be between 5 and 1,000; if MaxResults is given a value larger than 1,000, only 1,000 results are returned.
-	DescribeSnapMaxReturnResult = 1000
-
 	// This value can be between 100 and 1,0000, and charge ~0.6$/1 million request
 	ListSnapMaxReturnResult = 10000
-
-	// This value can be between 100 and 1,0000, and charge ~0.6$/1 million request
-	ListBlocksMaxReturnResult = 10000
-
 	// This value can be between 1 and 50 due to aws service quota
 	EbsApiConcurrency = 40
 )
@@ -139,69 +130,6 @@ func getSnapshotsFromBackupmeta(ctx context.Context, provider v1alpha1.StoragePr
 	return volumeIDMap, nil
 }
 
-// getBackupVolSnapshots get a volume-snapshots map contains map[volumeId]{snapshot1, snapshot2, snapshot3}
-func getBackupVolSnapshots(volumes map[string]string) (map[string][]*ec2.Snapshot, error) {
-	volWithTheirSnapshots := make(map[string][]*ec2.Snapshot)
-
-	// read all snapshots from aws
-	ec2Session, err := util.NewEC2Session(util.CloudAPIConcurrency)
-	if err != nil {
-		klog.Errorf("new a ec2 session failure.")
-		return nil, err
-	}
-
-	// init search filter.Values
-	// init volWithTheirSnapshots
-	volValues := make([]*string, 0)
-	for volumeId := range volumes {
-		volValues = append(volValues, aws.String(volumeId))
-		if volWithTheirSnapshots[volumeId] == nil {
-			volWithTheirSnapshots[volumeId] = make([]*ec2.Snapshot, 0)
-		}
-	}
-
-	filters := []*ec2.Filter{{Name: aws.String("volume-id"), Values: volValues}}
-	// describe snapshot is heavy operator, try to call only once
-	// api has limit with max 1000 snapshots
-	// search with filter volume id the backupmeta contains
-	var nextToken *string
-	for {
-		resp, err := ec2Session.EC2.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
-			OwnerIds:   aws.StringSlice([]string{"self"}),
-			MaxResults: aws.Int64(DescribeSnapMaxReturnResult),
-			Filters:    filters,
-			NextToken:  nextToken,
-		})
-
-		if err != nil {
-			return nil, err
-		}
-
-		for i, s := range resp.Snapshots {
-			if *s.State == ec2.SnapshotStateCompleted {
-				if volWithTheirSnapshots[*s.VolumeId] == nil {
-					klog.Errorf("search with filter[volume-id] received unexpected result, volumeId:%s, snapshotId:%s", *s.VolumeId, *s.SnapshotId)
-					break
-				}
-				klog.Infof("the snapshot#%d %s created for volume %s", i, *s.SnapshotId, *s.VolumeId)
-				volWithTheirSnapshots[*s.VolumeId] = append(volWithTheirSnapshots[*s.VolumeId], s)
-			} else { // skip ongoing snapshots
-				klog.Infof("the snapshot#%d %s creating... skip it", i, *s.SnapshotId)
-				continue
-			}
-		}
-
-		// check if there's more to retrieve
-		if resp.NextToken == nil {
-			break
-		}
-		klog.Infof("the total number of snapshot is %d", len(resp.Snapshots))
-		nextToken = resp.NextToken
-	}
-
-	return volWithTheirSnapshots, nil
-}
-
 // calcBackupSize get a volume-snapshots backup size
 func calcBackupSize(ctx context.Context, volumes map[string]string) (uint64, error) {
 	var backupSize uint64
@@ -267,74 +195,5 @@ func calculateSnapshotSize(snapshotId string) (uint64, uint64, error) {
 		nextToken = resp.NextToken
 	}
 	klog.Infof("full backup snapshot size %d bytes, num of ListSnapshotBlocks request %d", snapshotSize, numApiReq)
-	return snapshotSize, numApiReq, nil
-}
-
-func getPrevSnapshotId(snapshotId string, volSnapshots []*ec2.Snapshot) (string, error) {
-	var prevSnapshotId string
-
-	sort.Slice(volSnapshots, func(i, j int) bool {
-		return volSnapshots[i].StartTime.Before(*volSnapshots[j].StartTime)
-	})
-
-	for i, snapshot := range volSnapshots {
-		if snapshotId == *snapshot.SnapshotId {
-			// the first snapshot for the volume
-			if i == 0 {
-				return "", nil
-			}
-			prevSnapshotId = *volSnapshots[i-1].SnapshotId
-			klog.Infof("the prevSnapshot index is %d, ID is %s", i, *snapshot.SnapshotId)
-			break
-		}
-	}
-	if len(prevSnapshotId) == 0 {
-		return "", fmt.Errorf("Could not find the prevousely snapshot id, current snapshotId: %s.", snapshotId)
-	}
-	return prevSnapshotId, nil
-}
-
-// changedBlocksSize calculates changed blocks total size in bytes between two snapshots with common ancestry.
-func changedBlocksSize(preSnapshotId string, snapshotId string) (uint64, uint64, error) {
-	var numBlocks int
-	var snapshotSize uint64
-	var numApiReq uint64
-
-	klog.Infof("the calc snapshot size for %s, base on prev snapshot %s", snapshotId, preSnapshotId)
-	ebsSession, err := util.NewEBSSession(util.CloudAPIConcurrency)
-	if err != nil {
-		klog.Errorf("new a ebs session failure.")
-		return 0, numApiReq, err
-	}
-
-	var nextToken *string
-
-	for {
-		resp, err := ebsSession.EBS.ListChangedBlocks(&ebs.ListChangedBlocksInput{
-			FirstSnapshotId:  aws.String(preSnapshotId),
-			MaxResults:       aws.Int64(ListBlocksMaxReturnResult),
-			SecondSnapshotId: aws.String(snapshotId),
-			NextToken:        nextToken,
-		})
-		numApiReq += 1
-		if err != nil {
-			return 0, numApiReq, err
-		}
-		numBlocks += len(resp.ChangedBlocks)
-
-		// retrieve only changed block and blocks only existed in current snapshot (new add blocks)
-		for _, block := range resp.ChangedBlocks {
-			if block.SecondBlockToken != nil && resp.BlockSize != nil {
-				snapshotSize += uint64(*resp.BlockSize)
-			}
-		}
-
-		// check if there is more to retrieve
-		if resp.NextToken == nil {
-			break
-		}
-		nextToken = resp.NextToken
-	}
-	klog.Infof("the total size of snapshot %d, num of api ListChangedBlocks request %d, snapshot id %s", snapshotSize, numApiReq, snapshotId)
 	return snapshotSize, numApiReq, nil
 }

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -214,7 +214,7 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (uint64, err
 		snapshotId := id
 		// sort snapshots by timestamp
 		workerPool.ApplyOnErrorGroup(eg, func() error {
-			snapSize, apiReq, err := initialSnapshotSize(snapshotId)
+			snapSize, apiReq, err := calculateSnapshotSize(snapshotId)
 			if err != nil {
 				return err
 			}
@@ -234,9 +234,8 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (uint64, err
 	return backupSize, nil
 }
 
-// initialSnapshotSize calculate size of an initial snapshot in bytes by listing its blocks.
-// initial snapshot always a ful backup of volume
-func initialSnapshotSize(snapshotId string) (uint64, uint64, error) {
+// calculateSnapshotSize calculate size of an snapshot in bytes by listing its blocks.
+func calculateSnapshotSize(snapshotId string) (uint64, uint64, error) {
 	var snapshotSize uint64
 	var numApiReq uint64
 	ebsSession, err := util.NewEBSSession(util.CloudAPIConcurrency)

--- a/pkg/backup/util/remote.go
+++ b/pkg/backup/util/remote.go
@@ -215,7 +215,7 @@ type BatchDeleteObjectsResult struct {
 	Errors  []ObjectError
 }
 
-// BatchDeleteObjects delete mutli objects
+// BatchDeleteObjects delete multi objects
 //
 // Depending on storage type, it use function 'BatchDeleteObjectsOfS3' or 'BatchDeleteObjectsConcurrently'
 func (b *StorageBackend) BatchDeleteObjects(ctx context.Context, objs []*blob.ListObject, opt v1alpha1.BatchDeleteOption) *BatchDeleteObjectsResult {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #4993 
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

1. Backup  size attribute of a backup CR is now the expected size after restore instead of the delta.
2. Backup size will be reported for both successful and failed ebs backup job
3. No need to recalculate backupsize at clean time

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
