### PR TITLE
br: refactor restore controller to support across k8s

### DIFF
--- a/cmd/backup-manager/app/cmd/restore.go
+++ b/cmd/backup-manager/app/cmd/restore.go
@@ -52,6 +52,7 @@ func NewRestoreCommand() *cobra.Command {
 	cmd.Flags().StringVar(&ro.Mode, "mode", string(v1alpha1.RestoreModeSnapshot), "restore mode, which is pitr or snapshot(default)")
 	cmd.Flags().StringVar(&ro.PitrRestoredTs, "pitrRestoredTs", "0", "The pitr restored ts")
 	cmd.Flags().BoolVar(&ro.Prepare, "prepare", false, "Whether to prepare for restore")
+	cmd.Flags().StringVar(&ro.TargetAZ, "target-az", "", "For volume-snapshot restore, which az the volume snapshots restore to")
 	return cmd
 }
 

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -42,6 +42,8 @@ type Options struct {
 	backupUtil.GenericOptions
 	// Prepare to restore data. It's used in volume-snapshot mode.
 	Prepare bool
+	// TargetAZ indicates which az the volume snapshots restore to. It's used in volume-snapshot mode.
+	TargetAZ string
 }
 
 func (ro *Options) restoreData(
@@ -103,6 +105,7 @@ func (ro *Options) restoreData(
 			args = append(args, "--prepare")
 			csbPath = path.Join(util.BRBinPath, "csb_restore.json")
 			args = append(args, fmt.Sprintf("--output-file=%s", csbPath))
+			args = append(args, fmt.Sprintf("--target-az=%s", ro.TargetAZ))
 			progressStep = "Volume Restore"
 		} else {
 			progressStep = "Data Restore"

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -63,6 +63,10 @@ func validCmdFlagFunc(flag *pflag.Flag) {
 	if len(flag.Value.String()) > 0 {
 		return
 	}
+	// optional flag
+	if flag.Name == "target-az" {
+		return
+	}
 
 	cmdutil.CheckErr(fmt.Errorf(cmdHelpMsg, flag.Name))
 }

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1292,6 +1292,19 @@ FederalVolumeRestorePhase
 </tr>
 <tr>
 <td>
+<code>volumeAZ</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeAZ indicates which AZ the volume snapshots restore to.
+it is only valid for mode of volume-snapshot</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tikvGCLifeTime</code></br>
 <em>
 string
@@ -13678,6 +13691,19 @@ FederalVolumeRestorePhase
 <td>
 <em>(Optional)</em>
 <p>FederalVolumeRestorePhase indicates which phase to execute in federal volume restore</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeAZ</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeAZ indicates which AZ the volume snapshots restore to.
+it is only valid for mode of volume-snapshot</p>
 </td>
 </tr>
 <tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -14303,6 +14303,8 @@ spec:
                 type: string
               useKMS:
                 type: boolean
+              volumeAZ:
+                type: string
             type: object
           status:
             properties:

--- a/manifests/crd/v1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1/pingcap.com_restores.yaml
@@ -2081,6 +2081,8 @@ spec:
                 type: string
               useKMS:
                 type: boolean
+              volumeAZ:
+                type: string
             type: object
           status:
             properties:

--- a/manifests/crd/v1beta1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_restores.yaml
@@ -2080,6 +2080,8 @@ spec:
               type: string
             useKMS:
               type: boolean
+            volumeAZ:
+              type: string
           type: object
         status:
           properties:

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -14283,6 +14283,8 @@ spec:
               type: string
             useKMS:
               type: boolean
+            volumeAZ:
+              type: string
           type: object
         status:
           properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -7415,6 +7415,13 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"volumeAZ": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VolumeAZ indicates which AZ the volume snapshots restore to. it is only valid for mode of volume-snapshot",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tikvGCLifeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TikvGCLifeTime is to specify the safe gc life time for restore. The time limit during which data is retained for each GC, in the format of Go Duration. When a GC happens, the current time minus this value is the safe point.",

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -137,6 +137,12 @@ func IsRestoreVolumeComplete(restore *Restore) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsRestoreTiKVComplete returns true if all TiKVs run successfully during volume restore
+func IsRestoreTiKVComplete(restore *Restore) bool {
+	_, condition := GetRestoreCondition(&restore.Status, RestoreTiKVComplete)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsRestoreDataComplete returns true if a Restore for data consistency has successfully completed
 func IsRestoreDataComplete(restore *Restore) bool {
 	_, condition := GetRestoreCondition(&restore.Status, RestoreDataComplete)

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -70,16 +70,9 @@ func UpdateRestoreCondition(status *RestoreStatus, condition *RestoreCondition) 
 		return false
 	}
 	condition.LastTransitionTime = metav1.Now()
+	status.Phase = condition.Type
 	// Try to find this Restore condition.
 	conditionIndex, oldCondition := GetRestoreCondition(status, condition.Type)
-
-	switch condition.Type {
-	case RestoreVolumeComplete, RestoreDataComplete:
-		// VolumeComplete and DataComplete are intermediately conditions,
-		// they can not represent the current phase of restore.
-	default:
-		status.Phase = condition.Type
-	}
 
 	if oldCondition == nil {
 		// We are adding new Restore condition.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2381,6 +2381,10 @@ type RestoreSpec struct {
 	// FederalVolumeRestorePhase indicates which phase to execute in federal volume restore
 	// +optional
 	FederalVolumeRestorePhase FederalVolumeRestorePhase `json:"federalVolumeRestorePhase,omitempty"`
+	// VolumeAZ indicates which AZ the volume snapshots restore to.
+	// it is only valid for mode of volume-snapshot
+	// +optional
+	VolumeAZ string `json:"volumeAZ,omitempty"`
 	// TikvGCLifeTime is to specify the safe gc life time for restore.
 	// The time limit during which data is retained for each GC, in the format of Go Duration.
 	// When a GC happens, the current time minus this value is the safe point.

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -947,7 +947,7 @@ func (bm *backupManager) teardownVolumeBackup(backup *v1alpha1.Backup) (err erro
 		}
 		// if job exists but isn't running, we can't ensure GC and PD schedules are stopped during volume backup
 		// the volume snapshots are invalid, we should set backup failed
-		if !jobCompleteOrFailed {
+		if jobCompleteOrFailed {
 			backupCondition = v1alpha1.BackupFailed
 		}
 		err = bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{

--- a/pkg/backup/backup/backup_test.go
+++ b/pkg/backup/backup/backup_test.go
@@ -245,7 +245,7 @@ func TestBackupManagerBR(t *testing.T) {
 		helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupRetryTheFailed, "failed to fetch tidbcluster")
 
 		// create relate tc and try again should success and job created.
-		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster)
+		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false)
 		err = bm.syncBackupJob(backup)
 		g.Expect(err).Should(BeNil())
 		helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupScheduled, "")
@@ -285,7 +285,7 @@ func TestClean(t *testing.T) {
 		_, err := deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
 		g.Expect(err).Should(BeNil())
 		helper.CreateSecret(backup)
-		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster)
+		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false)
 
 		statusUpdater := controller.NewRealBackupConditionUpdater(deps.Clientset, deps.BackupLister, deps.Recorder)
 		bc := NewBackupCleaner(deps, statusUpdater)

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -94,7 +94,7 @@ const (
 	KubeAnnBoundByController      = "pv.kubernetes.io/bound-by-controller"
 	KubeAnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
 
-	NodeAffinityCsiAzKey = "topology.ebs.csi.aws.com/zone"
+	NodeAffinityCsiEbsAzKey = "topology.ebs.csi.aws.com/zone"
 
 	LocalTmp           = "/tmp"
 	ClusterBackupMeta  = "clustermeta"

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -94,6 +94,8 @@ const (
 	KubeAnnBoundByController      = "pv.kubernetes.io/bound-by-controller"
 	KubeAnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
 
+	NodeAffinityCsiAzKey = "topology.ebs.csi.aws.com/zone"
+
 	LocalTmp           = "/tmp"
 	ClusterBackupMeta  = "clustermeta"
 	ClusterRestoreMeta = "restoremeta"

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -148,7 +148,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 
 		if restore.Spec.FederalVolumeRestorePhase == v1alpha1.FederalVolumeRestoreFinish {
 			if !v1alpha1.IsRestoreComplete(restore) {
-				return controller.RequeueErrorf("restore %s/%s: waiting for restore status complete", ns, name, tc.Namespace, tc.Name)
+				return controller.RequeueErrorf("restore %s/%s: waiting for restore status complete in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
 			} else {
 				return nil
 			}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -656,6 +656,9 @@ func (rm *restoreManager) makeRestoreJob(restore *v1alpha1.Restore) (*batchv1.Jo
 		args = append(args, fmt.Sprintf("--mode=%s", v1alpha1.RestoreModeVolumeSnapshot))
 		if !v1alpha1.IsRestoreVolumeComplete(restore) {
 			args = append(args, "--prepare")
+			if restore.Spec.VolumeAZ != "" {
+				args = append(args, fmt.Sprintf("--target-az=%s", restore.Spec.VolumeAZ))
+			}
 		}
 	default:
 		args = append(args, fmt.Sprintf("--mode=%s", v1alpha1.RestoreModeSnapshot))

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -74,7 +74,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 	)
 
 	if restore.Spec.BR == nil {
-		err = backuputil.ValidateRestore(restore, "")
+		err = backuputil.ValidateRestore(restore, "", false)
 	} else {
 		restoreNamespace = restore.GetNamespace()
 		if restore.Spec.BR.ClusterNamespace != "" {
@@ -94,7 +94,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 		}
 
 		tikvImage := tc.TiKVImage()
-		err = backuputil.ValidateRestore(restore, tikvImage)
+		err = backuputil.ValidateRestore(restore, tikvImage, tc.Spec.AcrossK8s)
 	}
 
 	if err != nil {
@@ -134,8 +134,24 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 		if !tc.PDAllMembersReady() {
 			return controller.RequeueErrorf("restore %s/%s: waiting for all PD members are ready in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
 		}
-		if v1alpha1.IsRestoreVolumeComplete(restore) && !v1alpha1.IsRestoreDataComplete(restore) && !tc.AllTiKVsAreAvailable() {
-			return controller.RequeueErrorf("restore %s/%s: waiting for all TiKVs are available in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
+
+		if v1alpha1.IsRestoreVolumeComplete(restore) && !v1alpha1.IsRestoreTiKVComplete(restore) {
+			if !tc.AllTiKVsAreAvailable() {
+				return controller.RequeueErrorf("restore %s/%s: waiting for all TiKVs are available in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
+			} else {
+				return rm.statusUpdater.Update(restore, &v1alpha1.RestoreCondition{
+					Type:   v1alpha1.RestoreTiKVComplete,
+					Status: corev1.ConditionTrue,
+				}, nil)
+			}
+		}
+
+		if restore.Spec.FederalVolumeRestorePhase == v1alpha1.FederalVolumeRestoreFinish {
+			if !v1alpha1.IsRestoreComplete(restore) {
+				return controller.RequeueErrorf("restore %s/%s: waiting for restore status complete", ns, name, tc.Namespace, tc.Name)
+			} else {
+				return nil
+			}
 		}
 	}
 
@@ -365,8 +381,8 @@ func (rm *restoreManager) volumeSnapshotRestore(r *v1alpha1.Restore, tc *v1alpha
 		return "", nil
 	}
 
-	if v1alpha1.IsRestoreDataComplete(r) {
-		klog.Infof("restore-manager prepares to deal with the phase DataComplete")
+	if r.Spec.FederalVolumeRestorePhase == v1alpha1.FederalVolumeRestoreFinish {
+		klog.Infof("restore-manager prepares to deal with the phase restore-finish")
 
 		// When restore is based on volume snapshot, we need to restart all TiKV pods
 		// after restore data is complete.
@@ -403,7 +419,7 @@ func (rm *restoreManager) volumeSnapshotRestore(r *v1alpha1.Restore, tc *v1alpha
 		return "", nil
 	}
 
-	if v1alpha1.IsRestoreVolumeComplete(r) {
+	if v1alpha1.IsRestoreVolumeComplete(r) && r.Spec.FederalVolumeRestorePhase == v1alpha1.FederalVolumeRestoreVolume {
 		klog.Infof("restore-manager prepares to deal with the phase VolumeComplete")
 
 		// TiKV volumes are ready, we can skip prepare restore metadata.

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -206,7 +206,7 @@ func TestBRRestore(t *testing.T) {
 	for i, restore := range genValidBRRestores() {
 		helper.createRestore(restore)
 		helper.CreateSecret(restore)
-		helper.CreateTC(restore.Spec.BR.ClusterNamespace, restore.Spec.BR.Cluster)
+		helper.CreateTC(restore.Spec.BR.ClusterNamespace, restore.Spec.BR.Cluster, false)
 
 		m := NewRestoreManager(deps)
 		err = m.Sync(restore)
@@ -439,7 +439,7 @@ func TestBRRestoreByEBS(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 
-			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster)
+			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true)
 			helper.CreateRestore(tt.restore)
 			m := NewRestoreManager(deps)
 			err := m.Sync(tt.restore)

--- a/pkg/backup/snapshotter/snapshotter_gcp.go
+++ b/pkg/backup/snapshotter/snapshotter_gcp.go
@@ -98,3 +98,7 @@ func (s *GCPSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID strin
 func (s *GCPSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
 	return s.BaseSnapshotter.prepareRestoreMetadata(r, csb, s)
 }
+
+func (s *GCPSnapshotter) ResetPvAvailableZone(r *v1alpha1.Restore, pv *corev1.PersistentVolume) {
+	// TODO implement it if support to restore snapshots to another az on GCP
+}

--- a/pkg/backup/snapshotter/snapshotter_none.go
+++ b/pkg/backup/snapshotter/snapshotter_none.go
@@ -41,3 +41,5 @@ func (s *NoneSnapshotter) SetVolumeID(pv *corev1.PersistentVolume, volumeID stri
 func (s *NoneSnapshotter) PrepareRestoreMetadata(r *v1alpha1.Restore, csb *CloudSnapBackup) (string, error) {
 	return "", nil
 }
+
+func (s *NoneSnapshotter) ResetPvAvailableZone(r *v1alpha1.Restore, pv *corev1.PersistentVolume) {}

--- a/pkg/backup/testutils/helpers.go
+++ b/pkg/backup/testutils/helpers.go
@@ -124,13 +124,14 @@ func (h *Helper) CreateSecret(obj interface{}) {
 }
 
 // CreateTC creates a TidbCluster with name `clusterName` in ns `namespace`
-func (h *Helper) CreateTC(namespace, clusterName string) {
+func (h *Helper) CreateTC(namespace, clusterName string, acrossK8s bool) {
 	h.T.Helper()
 	g := NewGomegaWithT(h.T)
 	var err error
 
 	tc := &v1alpha1.TidbCluster{
 		Spec: v1alpha1.TidbClusterSpec{
+			AcrossK8s:  acrossK8s,
 			TLSCluster: &v1alpha1.TLSCluster{Enabled: true},
 			TiKV: &v1alpha1.TiKVSpec{
 				BaseImage: "pingcap/tikv",

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -564,7 +564,7 @@ func ValidateBackup(backup *v1alpha1.Backup, tikvImage string, acrossK8s bool) e
 }
 
 // ValidateRestore checks whether a restore spec is valid.
-func ValidateRestore(restore *v1alpha1.Restore, tikvImage string) error {
+func ValidateRestore(restore *v1alpha1.Restore, tikvImage string, acrossK8s bool) error {
 	ns := restore.Namespace
 	name := restore.Name
 
@@ -612,6 +612,13 @@ func ValidateRestore(restore *v1alpha1.Restore, tikvImage string) error {
 		} else if restore.Spec.Local != nil {
 			if err := validateLocal(ns, name, restore.Spec.Local); err != nil {
 				return err
+			}
+		}
+
+		if restore.Spec.Mode == v1alpha1.RestoreModeVolumeSnapshot {
+			// only support across k8s now. TODO compatible for single k8s
+			if !acrossK8s {
+				return errors.New("only support volume snapshot restore across k8s clusters")
 			}
 		}
 	}

--- a/pkg/backup/util/utils_test.go
+++ b/pkg/backup/util/utils_test.go
@@ -529,7 +529,7 @@ func TestValidateRestore(t *testing.T) {
 	restore := new(v1alpha1.Restore)
 	match := func(sub string) {
 		t.Helper()
-		err := ValidateRestore(restore, "tikv:v4.0.8")
+		err := ValidateRestore(restore, "tikv:v4.0.8", false)
 		if sub == "" {
 			g.Expect(err).Should(BeNil())
 		} else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Refactor restore controller to support across k8s volume restore

Closes #5009

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Divide volume snapshot backup into 3 phases: `restore-volume`, `restore-data` and `restore-finish`

for `restore-volume` phase, restore all the tikv volumes from volume snapshots, then start all the tikv instances. After all the tikv instances are up, the restore enters `TikvComplete` status.

for `restore-data` phase, execute volume restore data command to restore the data of tikv to min-resolved ts. After it is complete, the restore enters `DataComplete` status.

for `restore-finish` phase, restart tikv instances and set `tc.spec.recoveryMode` to `false` to start tidb. Then the restore enters `Complete` status.


### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
