### PR TITLE
Fix TidbDashboard baseImage parsing fault

### DIFF
--- a/pkg/manager/tidbdashboard/manager.go
+++ b/pkg/manager/tidbdashboard/manager.go
@@ -348,10 +348,12 @@ func EnsureImage(td *v1alpha1.TidbDashboard) string {
 		if version == nil || *version == "" {
 			image = baseImage
 		} else if l, s := strings.LastIndex(baseImage, ":"), strings.LastIndex(baseImage, "/"); l >= 0 && l > s {
-			// i.e. example.registry.com:30000/foo/pincap/tidb-dashboard:vx.x.x
-			// If there is only one ':', it MUST NOT be the seprator of hostname and port.
 			// Version is specified and base image has tag suffix, override the tag.
 			image = baseImage[:l+1] + *version
+
+			// Prevent inaccurate replacement of the port which also after a colon.
+			// i.e. baseImage: example.registry.com:30000/foo/pincap/tidb-dashboard
+			//      version:  vx.y.z
 		} else {
 			// Version is specified and base image does not have tag suffix, append the version.
 			image = baseImage + ":" + *version

--- a/pkg/manager/tidbdashboard/manager.go
+++ b/pkg/manager/tidbdashboard/manager.go
@@ -347,7 +347,9 @@ func EnsureImage(td *v1alpha1.TidbDashboard) string {
 		version := td.Spec.Version
 		if version == nil || *version == "" {
 			image = baseImage
-		} else if l := strings.LastIndex(baseImage, ":"); l >= 0 {
+		} else if l, s := strings.LastIndex(baseImage, ":"), strings.LastIndex(baseImage, "/"); l >= 0 && l > s {
+			// i.e. example.registry.com:30000/foo/pincap/tidb-dashboard:vx.x.x
+			// If there is only one ':', it MUST NOT be the seprator of hostname and port.
 			// Version is specified and base image has tag suffix, override the tag.
 			image = baseImage[:l+1] + *version
 		} else {


### PR DESCRIPTION
Fix wrong baseImage version adapt for image tag while the repo has specified a unique port with ':'.

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Fix the bug that  baseImage auto version adapt can be executed unexpected while the repo has specified a unique port with ':'.

e.g. 
 If baseImage = example.registry.com:30000/foo/pingcap/tidb-dashboard:vx.y.z,  the final image will be "example.registry.com:vx.y.z".

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Judge whether there were '\' after the last ':'.  If there is one, it is not a ':' for the image tag.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix TidbDashboard baseImage parsing fault.
```
