### PR TITLE
Consider cluster domain when draining capture servers across multiple kubernetes clusters

### DIFF
--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -281,7 +281,14 @@ func getCaptureAdvertiseAddressPrefix(tc *v1alpha1.TidbCluster, ordinal int32) s
 	ns := tc.GetNamespace()
 	hostName := fmt.Sprintf("%s-%d", TiCDCMemberName(tcName), ordinal)
 
-	return fmt.Sprintf("%s.%s.%s", hostName, TiCDCPeerMemberName(tcName), ns)
+	prefix := fmt.Sprintf("%s.%s.%s", hostName, TiCDCPeerMemberName(tcName), ns)
+	if len(tc.Spec.ClusterDomain) > 0 {
+		// When setting up TiCDC across multiple Kubernetes clusters,
+		// it is important to consider the cluster domain if two CDC pods
+		// share the same in-cluster dns name (without cluster domain).
+		prefix = fmt.Sprintf("%s.%s", prefix, tc.Spec.ClusterDomain)
+	}
+	return prefix
 }
 
 func getCaptures(httpClient *http.Client, baseURL string) ([]captureInfo, bool, error) {

--- a/pkg/controller/tidb_control_test.go
+++ b/pkg/controller/tidb_control_test.go
@@ -334,6 +334,26 @@ func getTidbCluster() *v1alpha1.TidbCluster {
 	}
 }
 
+func getTidbClusterWithClusterDomain(
+	clusterDomain string,
+) *v1alpha1.TidbCluster {
+	return &v1alpha1.TidbCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TidbCluster",
+			APIVersion: "pingcap.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: corev1.NamespaceDefault,
+			UID:       types.UID("test"),
+		},
+		Spec: v1alpha1.TidbClusterSpec{
+			TiDB:          &v1alpha1.TiDBSpec{},
+			ClusterDomain: clusterDomain,
+		},
+	}
+}
+
 func fakeSecret(fakeClient *fake.Clientset) {
 	fakeClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
 		return true, &corev1.Secret{


### PR DESCRIPTION
### What problem does this PR solve?
When deploying TiCDC cluster containing capture servers managed by different tidb cluster CRs across multiple Kubernetes clusters. In this case, the existing tidb operator won't be able to pick the right capture to drain, as two caputre servers may share similar advertise address prefix. 

### What is changed and how does it work?

Consider cluster domain when draining capture servers across multiple kubernetes clusters

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
`None`
```
