### PR TITLE
make pd start timeout configurable

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -11528,6 +11528,17 @@ string
 <p>Start up script version</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>startTimeout</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Timeout threshold when pd get started</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="pdstatus">PDStatus</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -19683,6 +19683,9 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  startTimeout:
+                    default: 30
+                    type: integer
                   startUpScriptVersion:
                     enum:
                     - ""

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -5065,6 +5065,9 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  startTimeout:
+                    default: 30
+                    type: integer
                   startUpScriptVersion:
                     enum:
                     - ""

--- a/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_tidbclusters.yaml
@@ -5059,6 +5059,8 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
+                startTimeout:
+                  type: integer
                 startUpScriptVersion:
                   enum:
                   - ""

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -19661,6 +19661,8 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
+                startTimeout:
+                  type: integer
                 startUpScriptVersion:
                   enum:
                   - ""

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -6177,6 +6177,13 @@ func schema_pkg_apis_pingcap_v1alpha1_PDSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"startTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Timeout threshold when pd get started",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"replicas"},
 			},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -514,6 +514,10 @@ type PDSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum:="";"v1"
 	StartUpScriptVersion string `json:"startUpScriptVersion,omitempty"`
+
+	// Timeout threshold when pd get started
+	// +kubebuilder:default=30
+	StartTimeout int `json:"startTimeout,omitempty"`
 }
 
 // TiKVSpec contains details of TiKV members

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -63,9 +63,9 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 			AcrossK8s:     tc.AcrossK8s(),
 			ClusterDomain: tc.Spec.ClusterDomain,
 		},
-		Scheme:       tc.Scheme(),
-		DataDir:      filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir),
-		StartTimeout: tc.Spec.PD.StartTimeout,
+		Scheme:         tc.Scheme(),
+		DataDir:        filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir),
+		PDStartTimeout: tc.Spec.PD.StartTimeout,
 	}
 	if tc.Spec.PD.StartUpScriptVersion == "v1" {
 		model.CheckDomainScript = checkDNSV1

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -63,8 +63,9 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 			AcrossK8s:     tc.AcrossK8s(),
 			ClusterDomain: tc.Spec.ClusterDomain,
 		},
-		Scheme:  tc.Scheme(),
-		DataDir: filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir),
+		Scheme:       tc.Scheme(),
+		DataDir:      filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir),
+		StartTimeout: tc.Spec.PD.StartTimeout,
 	}
 	if tc.Spec.PD.StartUpScriptVersion == "v1" {
 		model.CheckDomainScript = checkDNSV1

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -155,7 +155,7 @@ encoded_domain_url=` + "`" + `echo ${domain}:2380 | base64 | tr "\n" " " | sed "
 	`
 elapseTime=0
 period=1
-threshold=30
+threshold={{ .PDStartTimeout }} 
 while true; do
 sleep ${period}
 elapseTime=$(( elapseTime+period ))
@@ -245,6 +245,7 @@ type PDStartScriptModel struct {
 	Scheme            string
 	DataDir           string
 	CheckDomainScript string
+	StartTimeout      int
 }
 
 var tikvStartScriptTplText = `#!/bin/sh

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -155,7 +155,7 @@ encoded_domain_url=` + "`" + `echo ${domain}:2380 | base64 | tr "\n" " " | sed "
 	`
 elapseTime=0
 period=1
-threshold={{ .PDStartTimeout }} 
+threshold={{ .PDStartTimeout }}
 while true; do
 sleep ${period}
 elapseTime=$(( elapseTime+period ))
@@ -245,7 +245,7 @@ type PDStartScriptModel struct {
 	Scheme            string
 	DataDir           string
 	CheckDomainScript string
-	StartTimeout      int
+	PDStartTimeout    int
 }
 
 var tikvStartScriptTplText = `#!/bin/sh

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1227,7 +1227,9 @@ exec /pd-server ${ARGS}
 
 			tc := &v1alpha1.TidbCluster{
 				Spec: v1alpha1.TidbClusterSpec{
-					PD: &v1alpha1.PDSpec{},
+					PD: &v1alpha1.PDSpec{
+						StartTimeout: 30,
+					},
 				},
 			}
 			tc.Name = "test-pd"

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -35,6 +35,7 @@ type PDStartScriptModel struct {
 	AdvertiseClientURL string
 	DiscoveryAddr      string
 	ExtraArgs          string
+	PDStartTimeout     int
 }
 
 // RenderPDStartScript renders PD start script from TidbCluster
@@ -66,6 +67,8 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	m.DiscoveryAddr = fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS)
 
+	m.PDStartTimeout = tc.Spec.PD.StartTimeout
+
 	return renderTemplateFunc(pdStartScriptTpl, m)
 }
 
@@ -77,13 +80,14 @@ const (
 	pdStartScript = `
 PD_POD_NAME=${POD_NAME:-$HOSTNAME}
 PD_DOMAIN={{ .PDDomain }}
+threshold={{ .PDStartTimeout }} 
 
 elapseTime=0
 period=1
-threshold=30
 while true; do
     sleep ${period}
     elapseTime=$(( elapseTime+period ))
+	echo "waiting threshold for pd ${threshold}" 
 
     if [[ ${elapseTime} -ge ${threshold} ]]; then
         echo "waiting for pd cluster ready timeout" >&2

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -80,14 +80,13 @@ const (
 	pdStartScript = `
 PD_POD_NAME=${POD_NAME:-$HOSTNAME}
 PD_DOMAIN={{ .PDDomain }}
-threshold={{ .PDStartTimeout }} 
 
 elapseTime=0
 period=1
+threshold={{ .PDStartTimeout }} 
 while true; do
     sleep ${period}
     elapseTime=$(( elapseTime+period ))
-	echo "waiting threshold for pd ${threshold}" 
 
     if [[ ${elapseTime} -ge ${threshold} ]]; then
         echo "waiting for pd cluster ready timeout" >&2

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -83,7 +83,7 @@ PD_DOMAIN={{ .PDDomain }}
 
 elapseTime=0
 period=1
-threshold={{ .PDStartTimeout }} 
+threshold={{ .PDStartTimeout }}
 while true; do
     sleep ${period}
     elapseTime=$(( elapseTime+period ))

--- a/pkg/manager/member/startscript/v2/pd_start_script_test.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script_test.go
@@ -543,7 +543,9 @@ exec /pd-server ${ARGS}
 
 		tc := &v1alpha1.TidbCluster{
 			Spec: v1alpha1.TidbClusterSpec{
-				PD: &v1alpha1.PDSpec{},
+				PD: &v1alpha1.PDSpec{
+					StartTimeout: 30,
+				},
 			},
 		}
 		tc.Name = "start-script-test"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
make pd start timeout configurable
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Update pd start timeout value to make it configurable 
### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
