### PR TITLE
Remove tcp and http ports for tiflash >= 7.1.0

### DIFF
--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -37,6 +37,8 @@ const (
 var (
 	// the first version that tiflash change default config
 	tiflashEqualOrGreaterThanV540, _ = cmpver.NewConstraint(cmpver.GreaterOrEqual, "v5.4.0")
+	// the first version that tiflash discards http and tcp ports.
+	tiflashEqualOrGreaterThanV710, _ = cmpver.NewConstraint(cmpver.GreaterOrEqual, "v7.1.0")
 )
 
 func buildTiFlashSidecarContainers(tc *v1alpha1.TidbCluster) ([]corev1.Container, error) {
@@ -161,8 +163,11 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("tmp_path", "/data0/tmp")
 
 		// port
-		common.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
-		common.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
+		version := tc.TiFlashVersion()
+		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
+			common.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
+			common.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
+		}
 
 		// flash
 		tidbStatusAddr := fmt.Sprintf("%s.%s.svc:%d", controller.TiDBMemberName(name), ns, v1alpha1.DefaultTiDBStatusPort)

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -140,6 +140,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 	if tc.Spec.PreferIPv6 {
 		listenHost = listenHostForIPv6
 	}
+	version := tc.TiFlashVersion()
 
 	// common
 	{
@@ -163,7 +164,6 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("tmp_path", "/data0/tmp")
 
 		// port
-		version := tc.TiFlashVersion()
 		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
 			common.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
 			common.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
@@ -229,8 +229,10 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.Set("security.ca_path", path.Join(tiflashCertPath, corev1.ServiceAccountRootCAKey))
 		common.Set("security.cert_path", path.Join(tiflashCertPath, corev1.TLSCertKey))
 		common.Set("security.key_path", path.Join(tiflashCertPath, corev1.TLSPrivateKeyKey))
-		common.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
-		common.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
+		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
+			common.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
+			common.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
+		}
 		common.Del("http_port")
 		common.Del("tcp_port")
 

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1838,6 +1838,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				tc.Name = "test"
 				tc.Namespace = "default"
 				tc.Spec.TiFlash = &v1alpha1.TiFlashSpec{}
+				tc.Spec.TiFlash.BaseImage = "pingcap/tiflash"
 
 				if testcase.setTC != nil {
 					testcase.setTC(tc)
@@ -1848,7 +1849,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 
 					expectCommonCfg := testcase.expectCommonCfg
 					if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
-						if tc.Spec.TLSCluster.Enabled {
+						if tc.Spec.TLSCluster != nil && tc.Spec.TLSCluster.Enabled {
 							expectCommonCfg = `
 							https_port = 8123
 							tcp_port_secure = 9000` + expectCommonCfg

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1511,8 +1511,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.TiFlash.Config = nil
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1549,8 +1547,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.TLSCluster = &v1alpha1.TLSCluster{Enabled: true}
 				},
 				expectCommonCfg: `
-					https_port = 8123
-					tcp_port_secure = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1598,8 +1594,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.TLSCluster = &v1alpha1.TLSCluster{Enabled: true}
 				},
 				expectCommonCfg: `
-					https_port = 8123
-					tcp_port_secure = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1653,8 +1647,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1693,8 +1685,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.Cluster = &v1alpha1.TidbClusterRef{Name: "cluster-1", Namespace: "default"}
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1731,8 +1721,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.AcrossK8s = true
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1772,8 +1760,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.AcrossK8s = true
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1813,8 +1799,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					tc.Spec.AcrossK8s = true
 				},
 				expectCommonCfg: `
-					http_port = 8123
-					tcp_port = 9000
 					tmp_path = "/data0/tmp"
 					[flash]
 					  service_addr = "0.0.0.0:3930"
@@ -1859,24 +1843,41 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					testcase.setTC(tc)
 				}
 
-				cfg := getTiFlashConfigV2(tc)
+				for _, version := range []string{"v7.0.0", "v7.1.0"} {
+					tc.Spec.Version = version
 
-				commonCfgData, err := cfg.Common.MarshalTOML()
-				g.Expect(err).Should(Succeed())
-				proxyCfgData, err := cfg.Proxy.MarshalTOML()
-				g.Expect(err).Should(Succeed())
+					expectCommonCfg := testcase.expectCommonCfg
+					if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
+						if tc.Spec.TLSCluster.Enabled {
+							expectCommonCfg = `
+							https_port = 8123
+							tcp_port_secure = 9000` + expectCommonCfg
+						} else {
+							expectCommonCfg = `
+							http_port = 8123
+							tcp_port = 9000` + expectCommonCfg
+						}
+					}
 
-				outputCfg := v1alpha1.NewTiFlashConfig()
-				expectCfg := v1alpha1.NewTiFlashConfig()
-				outputCfg.Common.UnmarshalTOML(commonCfgData)
-				outputCfg.Proxy.UnmarshalTOML(proxyCfgData)
-				expectCfg.Common.UnmarshalTOML([]byte(testcase.expectCommonCfg))
-				expectCfg.Proxy.UnmarshalTOML([]byte(testcase.expectProxyCfg))
+					cfg := getTiFlashConfigV2(tc)
 
-				diff := cmp.Diff(outputCfg.Common.Inner(), expectCfg.Common.Inner())
-				g.Expect(diff).Should(BeEmpty())
-				diff = cmp.Diff(outputCfg.Proxy.Inner(), expectCfg.Proxy.Inner())
-				g.Expect(diff).Should(BeEmpty())
+					commonCfgData, err := cfg.Common.MarshalTOML()
+					g.Expect(err).Should(Succeed())
+					proxyCfgData, err := cfg.Proxy.MarshalTOML()
+					g.Expect(err).Should(Succeed())
+
+					outputCfg := v1alpha1.NewTiFlashConfig()
+					expectCfg := v1alpha1.NewTiFlashConfig()
+					outputCfg.Common.UnmarshalTOML(commonCfgData)
+					outputCfg.Proxy.UnmarshalTOML(proxyCfgData)
+					expectCfg.Common.UnmarshalTOML([]byte(testcase.expectCommonCfg))
+					expectCfg.Proxy.UnmarshalTOML([]byte(testcase.expectProxyCfg))
+
+					diff := cmp.Diff(outputCfg.Common.Inner(), expectCfg.Common.Inner())
+					g.Expect(diff).Should(BeEmpty())
+					diff = cmp.Diff(outputCfg.Proxy.Inner(), expectCfg.Proxy.Inner())
+					g.Expect(diff).Should(BeEmpty())
+				}
 			})
 		}
 	})

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1870,7 +1870,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					expectCfg := v1alpha1.NewTiFlashConfig()
 					outputCfg.Common.UnmarshalTOML(commonCfgData)
 					outputCfg.Proxy.UnmarshalTOML(proxyCfgData)
-					expectCfg.Common.UnmarshalTOML([]byte(testcase.expectCommonCfg))
+					expectCfg.Common.UnmarshalTOML([]byte(expectCommonCfg))
 					expectCfg.Proxy.UnmarshalTOML([]byte(testcase.expectProxyCfg))
 
 					diff := cmp.Diff(outputCfg.Common.Inner(), expectCfg.Common.Inner())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

The tcp_port and http_port are deprecated in tiflash since v7.1.0.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Remove those two ports for the corresponding versions.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
