### PR TITLE
fix PD StartTimeout if no CRD updated

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -43,6 +43,7 @@ const (
 	// defaultTiCDCGracefulShutdownTimeout is the timeout limit of graceful
 	// shutdown a TiCDC pod.
 	defaultTiCDCGracefulShutdownTimeout = 10 * time.Minute
+	defaultPDStartTimeout               = 30
 
 	// the latest version
 	versionLatest = "latest"
@@ -1249,4 +1250,11 @@ func (tc *TidbCluster) StartScriptVersion() StartScriptVersion {
 	default:
 		return StartScriptV1
 	}
+}
+
+func (tc *TidbCluster) PDStartTimeout() int {
+	if tc.Spec.PD != nil && tc.Spec.PD.StartTimeout != 0 {
+		return tc.Spec.PD.StartTimeout
+	}
+	return defaultPDStartTimeout
 }

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -65,7 +65,7 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 		},
 		Scheme:         tc.Scheme(),
 		DataDir:        filepath.Join(constants.PDDataVolumeMountPath, tc.Spec.PD.DataSubDir),
-		PDStartTimeout: tc.Spec.PD.StartTimeout,
+		PDStartTimeout: tc.PDStartTimeout(),
 	}
 	if tc.Spec.PD.StartUpScriptVersion == "v1" {
 		model.CheckDomainScript = checkDNSV1

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1227,9 +1227,7 @@ exec /pd-server ${ARGS}
 
 			tc := &v1alpha1.TidbCluster{
 				Spec: v1alpha1.TidbClusterSpec{
-					PD: &v1alpha1.PDSpec{
-						StartTimeout: 30,
-					},
+					PD: &v1alpha1.PDSpec{},
 				},
 			}
 			tc.Name = "test-pd"

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -67,7 +67,7 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	m.DiscoveryAddr = fmt.Sprintf("%s-discovery.%s:10261", tcName, tcNS)
 
-	m.PDStartTimeout = tc.Spec.PD.StartTimeout
+	m.PDStartTimeout = tc.PDStartTimeout()
 
 	return renderTemplateFunc(pdStartScriptTpl, m)
 }

--- a/pkg/manager/member/startscript/v2/pd_start_script_test.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script_test.go
@@ -543,9 +543,7 @@ exec /pd-server ${ARGS}
 
 		tc := &v1alpha1.TidbCluster{
 			Spec: v1alpha1.TidbClusterSpec{
-				PD: &v1alpha1.PDSpec{
-					StartTimeout: 30,
-				},
+				PD: &v1alpha1.PDSpec{},
 			},
 		}
 		tc.Name = "start-script-test"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

in #5071, a new `startTimeout` field for PD spec is introduced, and it's default value is set via CRD.

If a user upgrades the TiDB-Operator image before updating the CRD, this new field will become `0` and PD will be rolling restarted.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - ensure no rolling restart for PD after updated the image to this PD's version.
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
