### PR TITLE
br: GC by MaxReservedTime works on completed or failed backups

### DIFF
--- a/pkg/backup/backup/backup_test.go
+++ b/pkg/backup/backup/backup_test.go
@@ -245,7 +245,7 @@ func TestBackupManagerBR(t *testing.T) {
 		helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupRetryTheFailed, "failed to fetch tidbcluster")
 
 		// create relate tc and try again should success and job created.
-		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false)
+		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false, false)
 		err = bm.syncBackupJob(backup)
 		g.Expect(err).Should(BeNil())
 		helper.hasCondition(backup.Namespace, backup.Name, v1alpha1.BackupScheduled, "")
@@ -285,7 +285,7 @@ func TestClean(t *testing.T) {
 		_, err := deps.Clientset.PingcapV1alpha1().Backups(backup.Namespace).Create(context.TODO(), backup, metav1.CreateOptions{})
 		g.Expect(err).Should(BeNil())
 		helper.CreateSecret(backup)
-		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false)
+		helper.CreateTC(backup.Spec.BR.ClusterNamespace, backup.Spec.BR.Cluster, false, false)
 
 		statusUpdater := controller.NewRealBackupConditionUpdater(deps.Clientset, deps.BackupLister, deps.Recorder)
 		bc := NewBackupCleaner(deps, statusUpdater)

--- a/pkg/backup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager_test.go
@@ -368,7 +368,7 @@ func (h *helper) checkBacklist(ns string, num int, checkLogBackupTruncate bool) 
 	g := NewGomegaWithT(t)
 
 	check := func(backups []*v1alpha1.Backup) error {
-		snapshotBackups, logBackup := separateSnapshotBackupsAndLogBackup(backups)
+		snapshotBackups, logBackup := separateAllSnapshotBackupsAndLogBackup(backups)
 		// check snapshot backup num
 		if len(snapshotBackups) != num {
 			var names []string

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -120,7 +120,7 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 			}, nil)
 			return err
 		}
-		// restore based volume snapshot for cloud provider
+		// restore based on volume snapshot for cloud provider
 		reason, err := rm.volumeSnapshotRestore(restore, tc)
 		if err != nil {
 			rm.statusUpdater.Update(restore, &v1alpha1.RestoreCondition{
@@ -313,24 +313,43 @@ func (rm *restoreManager) readRestoreMetaFromExternalStorage(r *v1alpha1.Restore
 	return csb, "", nil
 }
 func (rm *restoreManager) validateRestore(r *v1alpha1.Restore, tc *v1alpha1.TidbCluster) error {
-	// check tiflash replicas
-	replicas, reason, err := rm.readTiFlashReplicasFromBackupMeta(r)
+	// check tiflash and tikv replicas
+	tiflashReplicas, tikvReplicas, reason, err := rm.readTiFlashAndTiKVReplicasFromBackupMeta(r)
 	if err != nil {
 		klog.Errorf("read tiflash replica failure with reason %s", reason)
 		return err
 	}
 
 	if tc.Spec.TiFlash == nil {
-		if replicas != 0 {
-			klog.Errorf("tiflash is not configured, backupmeta has %d tiflash", replicas)
+		if tiflashReplicas != 0 {
+			klog.Errorf("tiflash is not configured, backupmeta has %d tiflash", tiflashReplicas)
 			return fmt.Errorf("tiflash replica missmatched")
 		}
 
 	} else {
-		if tc.Spec.TiFlash.Replicas != replicas {
-			klog.Errorf("cluster has %d tiflash configured, backupmeta has %d tiflash", tc.Spec.TiFlash.Replicas, replicas)
+		if tc.Spec.TiFlash.Replicas != tiflashReplicas {
+			klog.Errorf("cluster has %d tiflash configured, backupmeta has %d tiflash", tc.Spec.TiFlash.Replicas, tiflashReplicas)
 			return fmt.Errorf("tiflash replica missmatched")
 		}
+	}
+
+	if tc.Spec.TiKV == nil {
+		if tikvReplicas != 0 {
+			klog.Errorf("tikv is not configured, backupmeta has %d tikv", tikvReplicas)
+			return fmt.Errorf("tikv replica missmatched")
+		}
+
+	} else {
+		if tc.Spec.TiKV.Replicas != tikvReplicas {
+			klog.Errorf("cluster has %d tikv configured, backupmeta has %d tikv", tc.Spec.TiKV.Replicas, tikvReplicas)
+			return fmt.Errorf("tikv replica missmatched")
+		}
+	}
+
+	// Check recovery mode is on for EBS br across k8s
+	if r.Spec.Mode == v1alpha1.RestoreModeVolumeSnapshot && tc.Spec.AcrossK8s && !tc.Spec.RecoveryMode {
+		klog.Errorf("recovery mode is not set for across k8s EBS snapshot restore")
+		return fmt.Errorf("recovery mode is off")
 	}
 
 	// check tikv encrypt config
@@ -394,17 +413,27 @@ func (rm *restoreManager) checkTiKVEncryption(r *v1alpha1.Restore, tc *v1alpha1.
 	return nil
 }
 
-func (rm *restoreManager) readTiFlashReplicasFromBackupMeta(r *v1alpha1.Restore) (int32, string, error) {
+func (rm *restoreManager) readTiFlashAndTiKVReplicasFromBackupMeta(r *v1alpha1.Restore) (int32, int32, string, error) {
 	metaInfo, err := backuputil.GetVolSnapBackupMetaData(r, rm.deps.SecretLister)
 	if err != nil {
-		return 0, "GetVolSnapBackupMetaData failed", err
+		return 0, 0, "GetVolSnapBackupMetaData failed", err
 	}
+
+	var tiflashReplicas, tikvReplicas int32
 
 	if metaInfo.KubernetesMeta.TiDBCluster.Spec.TiFlash == nil {
-		return 0, "", nil
+		tiflashReplicas = 0
+	} else {
+		tiflashReplicas = metaInfo.KubernetesMeta.TiDBCluster.Spec.TiFlash.Replicas
 	}
 
-	return metaInfo.KubernetesMeta.TiDBCluster.Spec.TiFlash.Replicas, "", nil
+	if metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV == nil {
+		tikvReplicas = 0
+	} else {
+		tikvReplicas = metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV.Replicas
+	}
+
+	return tiflashReplicas, tikvReplicas, "", nil
 }
 
 func (rm *restoreManager) readTiKVConfigFromBackupMeta(r *v1alpha1.Restore) (*v1alpha1.TiKVConfigWraper, string, error) {

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -206,7 +206,7 @@ func TestBRRestore(t *testing.T) {
 	for i, restore := range genValidBRRestores() {
 		helper.createRestore(restore)
 		helper.CreateSecret(restore)
-		helper.CreateTC(restore.Spec.BR.ClusterNamespace, restore.Spec.BR.Cluster, false)
+		helper.CreateTC(restore.Spec.BR.ClusterNamespace, restore.Spec.BR.Cluster, false, false)
 
 		m := NewRestoreManager(deps)
 		err = m.Sync(restore)
@@ -439,11 +439,111 @@ func TestBRRestoreByEBS(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 
-			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true)
+			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
 			helper.CreateRestore(tt.restore)
 			m := NewRestoreManager(deps)
 			err := m.Sync(tt.restore)
 			g.Expect(err).Should(BeNil())
 		})
 	}
+}
+
+func TestInvalidBRRestoreByEBS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.Close()
+	deps := helper.Deps
+
+	cases := []struct {
+		name    string
+		restore *v1alpha1.Restore
+	}{
+		{
+			name: "restore-volume",
+			restore: &v1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-1",
+					Namespace: "ns-1",
+				},
+				Spec: v1alpha1.RestoreSpec{
+					Type: v1alpha1.BackupTypeFull,
+					Mode: v1alpha1.RestoreModeVolumeSnapshot,
+					BR: &v1alpha1.BRConfig{
+						ClusterNamespace: "ns-1",
+						Cluster:          "cluster-1",
+					},
+					StorageProvider: v1alpha1.StorageProvider{
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.RestoreStatus{},
+			},
+		},
+	}
+
+	// Verify invalid tc with mismatch tikv replicas
+	//generate the restore meta in local nfs, with only 2 tikv replicas
+	err := os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestore2TiKVMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+
+	//generate the backup meta in local nfs, tiflash check need backupmeta to validation
+	err = os.WriteFile("/tmp/backupmeta", []byte(testutils.ConstructRestore2TiKVMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+	defer func() {
+		err = os.Remove("/tmp/restoremeta")
+		g.Expect(err).To(Succeed())
+
+		err = os.Remove("/tmp/backupmeta")
+		g.Expect(err).To(Succeed())
+	}()
+
+	t.Run(cases[0].name, func(t *testing.T) {
+		helper.CreateTC(cases[0].restore.Spec.BR.ClusterNamespace, cases[0].restore.Spec.BR.Cluster, true, true)
+		helper.CreateRestore(cases[0].restore)
+		m := NewRestoreManager(deps)
+		err := m.Sync(cases[0].restore)
+		g.Expect(err).Should(MatchError("tikv replica missmatched"))
+	})
+
+	// Verify invalid tc recovery mode
+	err = os.Remove("/tmp/restoremeta")
+	g.Expect(err).To(Succeed())
+
+	err = os.Remove("/tmp/backupmeta")
+	g.Expect(err).To(Succeed())
+
+	//generate the restore meta in local nfs
+	err = os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+
+	//generate the backup meta in local nfs, tiflash check need backupmeta to validation
+	err = os.WriteFile("/tmp/backupmeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+
+	t.Run(cases[0].name, func(t *testing.T) {
+		helper.DeleteTC(cases[0].restore.Spec.BR.ClusterNamespace, cases[0].restore.Spec.BR.Cluster)
+		helper.DeleteRestore(cases[0].restore)
+
+		helper.CreateTC(cases[0].restore.Spec.BR.ClusterNamespace, cases[0].restore.Spec.BR.Cluster, true, false)
+		helper.CreateRestore(cases[0].restore)
+		m := NewRestoreManager(deps)
+		err := m.Sync(cases[0].restore)
+		g.Expect(err).Should(MatchError("recovery mode is off"))
+	})
 }

--- a/pkg/backup/testutils/br.go
+++ b/pkg/backup/testutils/br.go
@@ -313,3 +313,181 @@ func ConstructRestoreMetaStr() string {
 		"options": null
 	}`
 }
+
+func ConstructRestore2TiKVMetaStr() string {
+	return `{
+		"tikv": {
+			"replicas": 2,
+			"stores": [{
+				"store_id": 1,
+				"volumes": [{
+					"volume_id": "vol-0e65f40961a9f6244",
+					"type": "",
+					"mount_path": "",
+					"snapshot_id": "snap-1234567890abcdef0",
+					"restore_volume_id": "vol-0e65f40961a9f0001"
+				}]
+			}, {
+				"store_id": 2,
+				"volumes": [{
+					"volume_id": "vol-0e65f40961a9f6245",
+					"type": "",
+					"mount_path": "",
+					"snapshot_id": "snap-1234567890abcdef1",
+					"restore_volume_id": "vol-0e65f40961a9f0002"
+				}]
+			}]
+		},
+		"pd": {
+			"replicas": 0
+		},
+		"tidb": {
+			"replicas": 0
+		},
+		"kubernetes": {
+			"pvcs": [{
+				"metadata": {
+					"name": "tikv-test-tikv-1",
+					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3121",
+					"resourceVersion": "1957",
+					"creationTimestamp": null,
+					"labels": {
+						"test/label": "retained"
+					},
+					"annotations": {
+						"pv.kubernetes.io/bind-completed": "yes",
+						"pv.kubernetes.io/bound-by-controller": "yes",
+						"test/annotation": "retained"
+					},
+					"finalizers": ["kubernetes.io/pvc-protection"]
+				},
+				"spec": {
+					"resources": {},
+					"volumeName": "pv-1"
+				},
+				"status": {
+					"phase": "Bound"
+				}
+			}, {
+				"metadata": {
+					"name": "tikv-test-tikv-2",
+					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3123",
+					"resourceVersion": "1959",
+					"creationTimestamp": null,
+					"labels": {
+						"test/label": "retained"
+					},
+					"annotations": {
+						"pv.kubernetes.io/bind-completed": "yes",
+						"pv.kubernetes.io/bound-by-controller": "yes",
+						"test/annotation": "retained"
+					},
+					"finalizers": ["kubernetes.io/pvc-protection"]
+				},
+				"spec": {
+					"resources": {},
+					"volumeName": "pv-2"
+				},
+				"status": {
+					"phase": "Bound"
+				}
+			}],
+			"pvs": [{
+				"metadata": {
+					"name": "pv-1",
+					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3122",
+					"resourceVersion": "1958",
+					"creationTimestamp": null,
+					"labels": {
+						"test/label": "retained"
+					},
+					"annotations": {
+						"pv.kubernetes.io/provisioned-by": "ebs.csi.aws.com",
+						"temporary/volume-id": "vol-0e65f40961a9f6244",
+						"test/annotation": "retained"
+					},
+					"finalizers": ["kubernetes.io/pv-protection"]
+				},
+				"spec": {
+					"csi": {
+						"driver": "ebs.csi.aws.com",
+						"volumeHandle": "vol-0e65f40961a9f6244",
+						"fsType": "ext4"
+					},
+					"claimRef": {
+						"name": "tikv-test-tikv-1",
+						"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3121",
+						"resourceVersion": "1957"
+					}
+				},
+				"status": {
+					"phase": "Bound"
+				}
+			}, {
+				"metadata": {
+					"name": "pv-2",
+					"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3124",
+					"resourceVersion": "1960",
+					"creationTimestamp": null,
+					"labels": {
+						"test/label": "retained"
+					},
+					"annotations": {
+						"pv.kubernetes.io/provisioned-by": "ebs.csi.aws.com",
+						"temporary/volume-id": "vol-0e65f40961a9f6245",
+						"test/annotation": "retained"
+					},
+					"finalizers": ["kubernetes.io/pv-protection"]
+				},
+				"spec": {
+					"csi": {
+						"driver": "ebs.csi.aws.com",
+						"volumeHandle": "vol-0e65f40961a9f6245",
+						"fsType": "ext4"
+					},
+					"claimRef": {
+						"name": "tikv-test-tikv-2",
+						"uid": "301b0e8b-3538-4f61-a0fd-a25abd9a3123",
+						"resourceVersion": "1959"
+					}
+				},
+				"status": {
+					"phase": "Bound"
+				}
+			}],
+			"crd_tidb_cluster": {
+				"metadata": {
+					"name": "test",
+					"creationTimestamp": null
+				},
+				"spec": {
+					"discovery": {},
+					"version": "",
+					"tikv": {
+						"maxFailoverCount": 0,
+						"replicas": 2
+					}
+				},
+				"status": {
+					"pd": {
+						"synced": false,
+						"leader": {
+							"name": "",
+							"id": "",
+							"clientURL": "",
+							"health": false,
+							"lastTransitionTime": null
+						}
+					},
+					"tikv": {},
+					"tidb": {},
+					"pump": {},
+					"tiflash": {},
+					"ticdc": {}
+				}
+			},
+			"options": null
+		},
+		"options": null
+	}`
+}

--- a/pkg/backup/testutils/helpers.go
+++ b/pkg/backup/testutils/helpers.go
@@ -176,15 +176,6 @@ func (h *Helper) CreateTC(namespace, clusterName string, acrossK8s, recoverMode 
 	g.Expect(err).Should(BeNil())
 }
 
-// DeleteTC deletes a TidbCluster with name `clusterName` in ns `namespace`
-func (h *Helper) DeleteTC(namespace, clusterName string) {
-	h.T.Helper()
-	g := NewGomegaWithT(h.T)
-
-	err := h.Deps.Clientset.PingcapV1alpha1().TidbClusters(namespace).Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
-	g.Expect(err).Should(BeNil())
-}
-
 func (h *Helper) CreateRestore(restore *v1alpha1.Restore) {
 	h.T.Helper()
 	g := NewGomegaWithT(h.T)
@@ -195,12 +186,5 @@ func (h *Helper) CreateRestore(restore *v1alpha1.Restore) {
 		_, err := h.Deps.RestoreLister.Restores(restore.Namespace).Get(restore.Name)
 		return err
 	}, time.Second).Should(BeNil())
-	g.Expect(err).Should(BeNil())
-}
-
-func (h *Helper) DeleteRestore(restore *v1alpha1.Restore) {
-	h.T.Helper()
-	g := NewGomegaWithT(h.T)
-	err := h.Deps.Clientset.PingcapV1alpha1().Restores(restore.Namespace).Delete(context.TODO(), restore.Name, metav1.DeleteOptions{})
 	g.Expect(err).Should(BeNil())
 }

--- a/pkg/backup/testutils/helpers.go
+++ b/pkg/backup/testutils/helpers.go
@@ -180,9 +180,8 @@ func (h *Helper) CreateTC(namespace, clusterName string, acrossK8s, recoverMode 
 func (h *Helper) DeleteTC(namespace, clusterName string) {
 	h.T.Helper()
 	g := NewGomegaWithT(h.T)
-	var err error
 
-	err = h.Deps.Clientset.PingcapV1alpha1().TidbClusters(namespace).Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
+	err := h.Deps.Clientset.PingcapV1alpha1().TidbClusters(namespace).Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
 	g.Expect(err).Should(BeNil())
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #5147 #4992 #5129

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
This PR addresses 3 problems
1. Make sure backup schedule will GC completed and failed backups when they are expired.
2. Precheck tikv replicas in restore tc with the backup metadata for EBS restore
3. Make sure recovery mode is on when doing EBS across k8s restore

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [X] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
