### PR TITLE
try to Graceful Drain TiCDC for improper constraint image tag

### DIFF
--- a/pkg/controller/ticdc_control.go
+++ b/pkg/controller/ticdc_control.go
@@ -115,8 +115,9 @@ func (c *defaultTiCDCControl) DrainCapture(tc *v1alpha1.TidbCluster, ordinal int
 		// Let caller retry drain capture.
 		return 0, true, nil
 	}
-	if len(captures) == 1 {
+	if len(captures) == 1 || len(captures) == 0 {
 		// No way to drain a single node TiCDC cluster, ignore.
+		// Can't get capture info, ignore.
 		return 0, false, nil
 	}
 
@@ -186,8 +187,9 @@ func (c *defaultTiCDCControl) ResignOwner(tc *v1alpha1.TidbCluster, ordinal int3
 		// Let caller retry resign owner.
 		return false, nil
 	}
-	if len(captures) == 1 {
+	if len(captures) == 1 || len(captures) == 0 {
 		// No way to resign owner in a single node TiCDC cluster, ignore.
+		// Can't get capture info, ignore.
 		return true, nil
 	}
 
@@ -236,6 +238,10 @@ func (c *defaultTiCDCControl) IsHealthy(tc *v1alpha1.TidbCluster, ordinal int32)
 	if retry {
 		// Let caller retry.
 		return false, nil
+	}
+	if len(captures) == 0 {
+		// No way to get capture info, ignore.
+		return true, nil
 	}
 
 	_, owner := getOrdinalAndOwnerCaptureInfo(tc, ordinal, captures)

--- a/pkg/manager/member/ticdc_scaler.go
+++ b/pkg/manager/member/ticdc_scaler.go
@@ -235,7 +235,7 @@ func isTiCDCPodSupportGracefulUpgrade(
 	currentVersion := tc.TiCDCVersion()
 	ge, err := cmpver.Compare(podVersion, cmpver.GreaterOrEqual, currentVersion)
 	if err != nil {
-		klog.Warningf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, skip graceful shutdown",
+		klog.Warningf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, still try to graceful shutdown",
 			action, podVersion, currentVersion, err)
 		// if parse version failed, we still try to graftfully shutdown TiCDC,
 		// as we already checked `http.StatusNotFound` in `DrainCapture`, `ResignOwner` and `IsHealthy`
@@ -243,7 +243,7 @@ func isTiCDCPodSupportGracefulUpgrade(
 	}
 	le, err := cmpver.Compare(podVersion, cmpver.LessOrEqual, currentVersion)
 	if err != nil {
-		klog.Warningf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, skip graceful shutdown",
+		klog.Warningf("ticdc.%s: fail to compare TiCDC pod version \"%s\", version \"%s\", error: %v, still try to graceful shutdown",
 			action, podVersion, currentVersion, err)
 		return true, nil
 	}

--- a/pkg/manager/member/ticdc_scaler_test.go
+++ b/pkg/manager/member/ticdc_scaler_test.go
@@ -708,7 +708,7 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			caseName: "v6.3.0 -> latest, skip graceful upgrade",
+			caseName: "v6.3.0 -> latest, still try to graceful upgrade",
 			cdcCtl: &controller.FakeTiCDCControl{
 				GetStatusFn: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					return &controller.CaptureStatus{
@@ -720,7 +720,7 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 				v := "latest"
 				tc.Spec.TiCDC.Version = &v
 			},
-			expectedOk:  false,
+			expectedOk:  true,
 			expectedErr: false,
 		},
 		{
@@ -734,7 +734,7 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			caseName: "malformed pod version, skip graceful upgrade",
+			caseName: "malformed pod version, still try to graceful upgrade",
 			cdcCtl: &controller.FakeTiCDCControl{
 				GetStatusFn: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					return &controller.CaptureStatus{
@@ -742,11 +742,11 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 					}, nil
 				},
 			},
-			expectedOk:  false,
+			expectedOk:  true,
 			expectedErr: false,
 		},
 		{
-			caseName: "malformed tc version, skip graceful upgrade",
+			caseName: "malformed tc version, still try to graceful upgrade",
 			cdcCtl: &controller.FakeTiCDCControl{
 				GetStatusFn: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					return &controller.CaptureStatus{
@@ -757,11 +757,11 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 			changeTc: func(tc *v1alpha1.TidbCluster) {
 				tc.Spec.Version = "malformed"
 			},
-			expectedOk:  false,
+			expectedOk:  true,
 			expectedErr: false,
 		},
 		{
-			caseName: "malformed ticdc spec version, skip graceful upgrade",
+			caseName: "malformed ticdc spec version, still try to graceful upgrade",
 			cdcCtl: &controller.FakeTiCDCControl{
 				GetStatusFn: func(tc *v1alpha1.TidbCluster, ordinal int32) (*controller.CaptureStatus, error) {
 					return &controller.CaptureStatus{
@@ -773,7 +773,7 @@ func TestTiCDCIsSupportGracefulUpgrade(t *testing.T) {
 				v := "malformed"
 				tc.Spec.TiCDC.Version = &v
 			},
-			expectedOk:  false,
+			expectedOk:  true,
 			expectedErr: false,
 		},
 		{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #4912

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    - upgrade TiCDC to a version with improper constraint image tag
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
