### PR TITLE
ebs br: make snapshot size calculation optional

### DIFF
--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -318,17 +318,8 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 
 	defer func() {
 		// Calculate the backup size for ebs backup job even if it fails
-<<<<<<< HEAD
-<<<<<<< HEAD
 		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
-			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
-=======
-		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize && !bm.Initialize {
-=======
-		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
->>>>>>> f91a7b4e7 (*: fix typo)
 			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider, backup.Spec.CalcSizeLevel)
->>>>>>> 44eefb26c (*: code format)
 			if err != nil {
 				klog.Errorf("Failed to calc volume snapshot backup, err: %v", err)
 				return

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -318,8 +318,13 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 
 	defer func() {
 		// Calculate the backup size for ebs backup job even if it fails
+<<<<<<< HEAD
 		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
 			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
+=======
+		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize && !bm.Initialize {
+			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider, backup.Spec.CalcSizeLevel)
+>>>>>>> 44eefb26c (*: code format)
 			if err != nil {
 				klog.Errorf("Failed to calc volume snapshot backup, err: %v", err)
 				return

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -319,10 +319,14 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 	defer func() {
 		// Calculate the backup size for ebs backup job even if it fails
 <<<<<<< HEAD
+<<<<<<< HEAD
 		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
 			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider)
 =======
 		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize && !bm.Initialize {
+=======
+		if bm.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && !bm.Initialize {
+>>>>>>> f91a7b4e7 (*: fix typo)
 			fullBackupSize, incrementalBackupSize, err := util.CalcVolSnapBackupSize(ctx, backup.Spec.StorageProvider, backup.Spec.CalcSizeLevel)
 >>>>>>> 44eefb26c (*: code format)
 			if err != nil {

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -332,6 +332,7 @@ func (bm *Manager) performBackup(ctx context.Context, backup *v1alpha1.Backup, d
 				BackupSizeReadable:            &backupSizeReadable,
 				IncrementalBackupSize:         &incrementalBackupSize,
 				IncrementalBackupSizeReadable: &incrementalBackupSizeReadable,
+				TimeCompleted:                 &metav1.Time{Time: time.Now()},
 			}
 
 			if err := bm.StatusUpdater.Update(backup, nil, updateStatus); err != nil {

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -53,6 +53,10 @@ const (
 	ListSnapMaxReturnResult = 10000
 	// This value can be between 1 and 50 due to aws service quota
 	EbsApiConcurrency = 40
+
+	CalculateFullSize    = "full"
+	CalculateIncremental = "incremental"
+	CalculateAll         = "all"
 )
 
 // CalcVolSnapBackupSize get snapshots from backup meta and then calc the backup size of snapshots.
@@ -155,7 +159,7 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (fullBackupS
 				return err
 =======
 			var snapSize uint64
-			if level == backup.CalculateFullSize || level == backup.CalculateFullSize {
+			if level == CalculateFullSize || level == CalculateFullSize {
 				snapSize, apiReq, err := calculateSnapshotSize(volumeId, snapshotId)
 				if err != nil {
 					return err
@@ -164,6 +168,7 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (fullBackupS
 				atomic.AddUint64(&apiReqCount, apiReq)
 >>>>>>> 33580d9dc (*: manual cp)
 			}
+<<<<<<< HEAD
 			atomic.AddInt64(&fullBackupSize, int64(snapSize))
 			atomic.AddUint64(&apiReqCount, apiReq)
 
@@ -173,6 +178,10 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (fullBackupS
 				return err
 =======
 			if level == backup.CalculateAll || level == backup.CalculateIncremental {
+=======
+
+			if level == CalculateAll || level == CalculateIncremental {
+>>>>>>> 44eefb26c (*: code format)
 				volSnapshots, err := getVolSnapshots(volumeId)
 				if err != nil {
 					return err

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -17,11 +17,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/dustin/go-humanize"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ebs"

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/dustin/go-humanize"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -147,16 +148,48 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (fullBackupS
 		volumeId := vid
 		// sort snapshots by timestamp
 		workerPool.ApplyOnErrorGroup(eg, func() error {
+<<<<<<< HEAD
 			snapSize, apiReq, err := calculateSnapshotSize(volumeId, snapshotId)
 			if err != nil {
 				return err
+=======
+			var snapSize uint64
+			if level == backup.CalculateFullSize || level == backup.CalculateFullSize {
+				snapSize, apiReq, err := calculateSnapshotSize(volumeId, snapshotId)
+				if err != nil {
+					return err
+				}
+				atomic.AddInt64(&fullBackupSize, int64(snapSize))
+				atomic.AddUint64(&apiReqCount, apiReq)
+>>>>>>> 33580d9dc (*: manual cp)
 			}
 			atomic.AddInt64(&fullBackupSize, int64(snapSize))
 			atomic.AddUint64(&apiReqCount, apiReq)
 
+<<<<<<< HEAD
 			volSnapshots, err := getVolSnapshots(volumeId)
 			if err != nil {
 				return err
+=======
+			if level == backup.CalculateAll || level == backup.CalculateIncremental {
+				volSnapshots, err := getVolSnapshots(volumeId)
+				if err != nil {
+					return err
+				}
+				prevSnapshotId, existed := getPrevSnapshotId(snapshotId, volSnapshots)
+				if !existed {
+					// if there is no previous snapshot, means it's the first snapshot, uses its full size as incremental size
+					atomic.AddInt64(&incrementalBackupSize, int64(snapSize))
+					return nil
+				}
+				klog.Infof("get previous snapshot %s of snapshot %s, volume %s", prevSnapshotId, snapshotId, volumeId)
+				incrementalSnapSize, incrementalApiReq, err := calculateChangedBlocksSize(volumeId, prevSnapshotId, snapshotId)
+				if err != nil {
+					return err
+				}
+				atomic.AddInt64(&incrementalBackupSize, int64(incrementalSnapSize))
+				atomic.AddUint64(&incrementalApiReqCount, incrementalApiReq)
+>>>>>>> 33580d9dc (*: manual cp)
 			}
 			prevSnapshotId, existed := getPrevSnapshotId(snapshotId, volSnapshots)
 			if !existed {
@@ -217,19 +250,31 @@ func calculateSnapshotSize(volumeId, snapshotId string) (uint64, uint64, error) 
 		}
 		nextToken = resp.NextToken
 	}
+<<<<<<< HEAD
 	klog.Infof("full snapshot size %s, num of ListSnapshotBlocks request %d, snapshot id %s, volume id %s",
 		humanize.Bytes(snapshotSize), numApiReq, snapshotId, volumeId)
+=======
+	klog.Infof("full backup snapshot size %d bytes, num of ListSnapshotBlocks request %d, snapshot id %s, volume id %s", humanize.Bytes(snapshotSize), numApiReq, snapshotId, volumeId)
+>>>>>>> 33580d9dc (*: manual cp)
 	return snapshotSize, numApiReq, nil
 }
 
 // calculateChangedBlocksSize calculates changed blocks total size in bytes between two snapshots with common ancestry.
+<<<<<<< HEAD
 func calculateChangedBlocksSize(volumeId, preSnapshotId, snapshotId string) (uint64, uint64, error) {
+=======
+func calculateChangedBlocksSize(volumeId, preSnapshotId string, snapshotId string) (uint64, uint64, error) {
+>>>>>>> 33580d9dc (*: manual cp)
 	var numBlocks int
 	var snapshotSize uint64
 	var numApiReq uint64
 
+<<<<<<< HEAD
 	klog.Infof("start to calculate incremental snapshot size for %s, base on prev snapshot %s, volume id %s",
 		snapshotId, preSnapshotId, volumeId)
+=======
+	klog.Infof("the calc snapshot size for %s, base on prev snapshot %s, volume id %s", snapshotId, preSnapshotId, volumeId)
+>>>>>>> 33580d9dc (*: manual cp)
 	ebsSession, err := util.NewEBSSession(util.CloudAPIConcurrency)
 	if err != nil {
 		klog.Errorf("new a ebs session failure.")
@@ -264,8 +309,12 @@ func calculateChangedBlocksSize(volumeId, preSnapshotId, snapshotId string) (uin
 		}
 		nextToken = resp.NextToken
 	}
+<<<<<<< HEAD
 	klog.Infof("incremental snapshot size %s, num of api ListChangedBlocks request %d, snapshot id %s, volume id %s",
 		humanize.Bytes(snapshotSize), numApiReq, snapshotId, volumeId)
+=======
+	klog.Infof("the total size of snapshot %d, num of api ListChangedBlocks request %d, snapshot id %s, volume id %s", humanize.Bytes(snapshotSize), numApiReq, snapshotId, volumeId)
+>>>>>>> 33580d9dc (*: manual cp)
 	return snapshotSize, numApiReq, nil
 }
 

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -22,11 +22,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dustin/go-humanize"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ebs"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/dustin/go-humanize"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/cmd/backup-manager/app/constants"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"

--- a/cmd/backup-manager/app/util/backup_size.go
+++ b/cmd/backup-manager/app/util/backup_size.go
@@ -159,7 +159,7 @@ func calcBackupSize(ctx context.Context, volumes map[string]string) (fullBackupS
 				return err
 =======
 			var snapSize uint64
-			if level == CalculateFullSize || level == CalculateFullSize {
+			if level == CalculateAll || level == CalculateFullSize {
 				snapSize, apiReq, err := calculateSnapshotSize(volumeId, snapshotId)
 				if err != nil {
 					return err

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -270,6 +270,18 @@ bool
 </tr>
 <tr>
 <td>
+<code>calcSizeLevel</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>federalVolumeBackupPhase</code></br>
 <em>
 <a href="#federalvolumebackupphase">
@@ -4032,6 +4044,18 @@ bool
 <td>
 <em>(Optional)</em>
 <p>LogStop indicates that will stop the log backup.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calcSizeLevel</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/federation-docs.md
+++ b/docs/api-references/federation-docs.md
@@ -695,6 +695,18 @@ string
 <p>PriorityClassName of Backup Job Pods</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>calcSizeLevel</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="volumebackupmemberstatus">VolumeBackupMemberStatus</h3>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -503,6 +503,9 @@ spec:
                 required:
                 - cluster
                 type: object
+              calcSizeLevel:
+                default: all
+                type: string
               cleanOption:
                 properties:
                   backoffEnabled:
@@ -2126,6 +2129,9 @@ spec:
                     required:
                     - cluster
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanOption:
                     properties:
                       backoffEnabled:
@@ -3553,6 +3559,9 @@ spec:
                     required:
                     - cluster
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanOption:
                     properties:
                       backoffEnabled:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
@@ -90,6 +90,9 @@ spec:
                       sendCredToTikv:
                         type: boolean
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanPolicy:
                     type: string
                   env:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
@@ -98,6 +98,9 @@ spec:
                           sendCredToTikv:
                             type: boolean
                         type: object
+                      calcSizeLevel:
+                        default: all
+                        type: string
                       cleanPolicy:
                         type: string
                       env:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -503,6 +503,9 @@ spec:
                 required:
                 - cluster
                 type: object
+              calcSizeLevel:
+                default: all
+                type: string
               cleanOption:
                 properties:
                   backoffEnabled:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -478,6 +478,9 @@ spec:
                     required:
                     - cluster
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanOption:
                     properties:
                       backoffEnabled:
@@ -1905,6 +1908,9 @@ spec:
                     required:
                     - cluster
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanOption:
                     properties:
                       backoffEnabled:

--- a/manifests/federation-crd.yaml
+++ b/manifests/federation-crd.yaml
@@ -90,6 +90,9 @@ spec:
                       sendCredToTikv:
                         type: boolean
                     type: object
+                  calcSizeLevel:
+                    default: all
+                    type: string
                   cleanPolicy:
                     type: string
                   env:
@@ -1143,6 +1146,9 @@ spec:
                           sendCredToTikv:
                             type: boolean
                         type: object
+                      calcSizeLevel:
+                        default: all
+                        type: string
                       cleanPolicy:
                         type: string
                       env:

--- a/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
@@ -320,6 +320,13 @@ func schema_apis_federation_pingcap_v1alpha1_VolumeBackupMemberSpec(ref common.R
 							Format:      "",
 						},
 					},
+					"calcSizeLevel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -113,6 +113,10 @@ type VolumeBackupMemberSpec struct {
 	CleanPolicy pingcapv1alpha1.CleanPolicyType `json:"cleanPolicy,omitempty"`
 	// PriorityClassName of Backup Job Pods
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup
+	// +optional
+	// +kubebuilder:default="all"
+	CalcSizeLevel string `json:"calcSizeLevel,omitempty"`
 }
 
 // BRConfig contains config for BR

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1067,6 +1067,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"calcSizeLevel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"federalVolumeBackupPhase": {
 						SchemaProps: spec.SchemaProps{
 							Description: "FederalVolumeBackupPhase indicates which phase to execute in federal volume backup",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1949,6 +1949,10 @@ type BackupSpec struct {
 	// LogStop indicates that will stop the log backup.
 	// +optional
 	LogStop bool `json:"logStop,omitempty"`
+	// CalcSizeLevel determines how to size calculation of snapshots for EBS volume snapshot backup
+	// +optional
+	// +kubebuilder:default="all"
+	CalcSizeLevel string `json:"calcSizeLevel,omitempty"`
 	// FederalVolumeBackupPhase indicates which phase to execute in federal volume backup
 	// +optional
 	FederalVolumeBackupPhase FederalVolumeBackupPhase `json:"federalVolumeBackupPhase,omitempty"`

--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -429,8 +429,9 @@ func TestGenerateBackupMetadata(t *testing.T) {
 					Annotations: make(map[string]string),
 				},
 				Spec: v1alpha1.BackupSpec{
-					Type: v1alpha1.BackupTypeFull,
-					Mode: v1alpha1.BackupModeVolumeSnapshot,
+					Type:          v1alpha1.BackupTypeFull,
+					Mode:          v1alpha1.BackupModeVolumeSnapshot,
+					CalcSizeLevel: "all",
 				},
 			},
 			wantSSNil: false,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Close #5201 
Close #5212 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
This pr introduced an option 'calcSizeLevel' in backup spec to claim if calculate backup snapshot size or not, and calculate which part of snapshot sizes. 

- 'all' (default) : calculate both full and incremental size; ''
- 'full' : calculate full size
-  'incremental': calculate incremental size
-  'disabled': skip size calculation

```yaml
apiVersion: pingcap.com/v1alpha1
kind: Backup
metadata:
  name: zm-dataplane-a
  namespace: backup-a
spec:
  backoffRetryPolicy:
    maxRetryTimes: 2
    minRetryDuration: 300s
    retryTimeout: 30m
  backupMode: volume-snapshot
  backupType: full
  br:
    cluster: db-a
    clusterNamespace: backup-a
    sendCredToTikv: false
  cleanPolicy: Delete
  calcSizeLevel: disabled | full | incremental | all
  resources: {}
  s3:
    bucket: wangle-ebs-test-us-west-2
    prefix: backup-20230704
    provider: aws
    region: us-west-2
  serviceAccount: tidb-backup-manager
```

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
