### PR TITLE
br: backup manifests related to tidb cluster in EBS backup

### DIFF
--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -836,7 +836,7 @@ func (bm *backupManager) backupManifests(b *v1alpha1.Backup, tc *v1alpha1.TidbCl
 	}
 
 	for _, manifest := range manifests {
-		if err := bm.saveManifest(b, manifest, externalStorage); err != nil {
+		if err := bm.saveManifest(b, manifest.DeepCopyObject(), externalStorage); err != nil {
 			return err
 		}
 	}
@@ -844,19 +844,23 @@ func (bm *backupManager) backupManifests(b *v1alpha1.Backup, tc *v1alpha1.TidbCl
 }
 
 func (bm *backupManager) saveManifest(b *v1alpha1.Backup, manifest runtime.Object, externalStorage *backuputil.StorageBackend) error {
-	metadataAccessor := meta.NewAccessor()
-	namespace, err := metadataAccessor.Namespace(manifest)
+	if manifest.GetObjectKind().GroupVersionKind().Empty() {
+		gvk, err := controller.InferObjectKind(manifest)
+		if err != nil {
+			return err
+		}
+		manifest.GetObjectKind().SetGroupVersionKind(gvk)
+	}
+	kind := manifest.GetObjectKind().GroupVersionKind().Kind
+	metadataAccessor, err := meta.Accessor(manifest)
 	if err != nil {
 		return err
 	}
-	name, err := metadataAccessor.Name(manifest)
-	if err != nil {
-		return err
-	}
-	kind, err := metadataAccessor.Kind(manifest)
-	if err != nil {
-		return err
-	}
+	namespace := metadataAccessor.GetNamespace()
+	name := metadataAccessor.GetName()
+	// remove managedFields because it is used for k8s internal housekeeping, and we don't need them in backup
+	metadataAccessor.SetManagedFields(nil)
+	klog.Infof("%s/%s get manifest meta, kind: %s, namespace: %s, name: %s", b.Namespace, b.Name, kind, namespace, name)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
@@ -870,7 +874,7 @@ func (bm *backupManager) saveManifest(b *v1alpha1.Backup, manifest runtime.Objec
 		return nil
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
 	printer := printers.YAMLPrinter{}
 	if err := printer.PrintObj(manifest, buf); err != nil {
 		return err

--- a/pkg/backup/backup/backup_manifests.go
+++ b/pkg/backup/backup/backup_manifests.go
@@ -14,21 +14,28 @@
 package backup
 
 import (
-	pingcapv1alpha1 "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 )
 
 type ManifestFetcher interface {
-	ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error)
+	ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error)
 }
 
 type TiDBDashboardFetcher struct {
 	lister listers.TidbDashboardLister
 }
 
-func (f *TiDBDashboardFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+func NewTiDBDashboardFetcher(lister listers.TidbDashboardLister) *TiDBDashboardFetcher {
+	return &TiDBDashboardFetcher{
+		lister: lister,
+	}
+}
+
+func (f *TiDBDashboardFetcher) ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error) {
 	emptySelector := labels.NewSelector()
 	dashboards, err := f.lister.List(emptySelector)
 	if err != nil {
@@ -43,6 +50,8 @@ func (f *TiDBDashboardFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (object
 				namespace = dashboard.Namespace
 			}
 			if name == tc.Name && namespace == tc.Namespace {
+				klog.Infof("TiDBDashboard %s/%s matches tc %s/%s",
+					dashboard.Namespace, dashboard.Name, tc.Namespace, tc.Name)
 				objects = append(objects, dashboard)
 				break
 			}
@@ -55,7 +64,13 @@ type TiDBMonitorFetcher struct {
 	lister listers.TidbMonitorLister
 }
 
-func (f *TiDBMonitorFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+func NewTiDBMonitorFetcher(lister listers.TidbMonitorLister) *TiDBMonitorFetcher {
+	return &TiDBMonitorFetcher{
+		lister: lister,
+	}
+}
+
+func (f *TiDBMonitorFetcher) ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error) {
 	emptySelector := labels.NewSelector()
 	monitors, err := f.lister.List(emptySelector)
 	if err != nil {
@@ -70,6 +85,8 @@ func (f *TiDBMonitorFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects 
 				namespace = monitor.Namespace
 			}
 			if name == tc.Name && namespace == tc.Namespace {
+				klog.Infof("TidbMonitor %s/%s matches tc %s/%s",
+					monitor.Namespace, monitor.Name, tc.Namespace, tc.Name)
 				objects = append(objects, monitor)
 				break
 			}
@@ -82,7 +99,13 @@ type TiDBClusterAutoScalerFetcher struct {
 	lister listers.TidbClusterAutoScalerLister
 }
 
-func (f *TiDBClusterAutoScalerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+func NewTiDBClusterAutoScalerFetcher(lister listers.TidbClusterAutoScalerLister) *TiDBClusterAutoScalerFetcher {
+	return &TiDBClusterAutoScalerFetcher{
+		lister: lister,
+	}
+}
+
+func (f *TiDBClusterAutoScalerFetcher) ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error) {
 	emptySelector := labels.NewSelector()
 	autoScalers, err := f.lister.List(emptySelector)
 	if err != nil {
@@ -96,6 +119,8 @@ func (f *TiDBClusterAutoScalerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster)
 			namespace = autoScaler.Namespace
 		}
 		if name == tc.Name && namespace == tc.Namespace {
+			klog.Infof("TiDBClusterAutoScaler %s/%s matches tc %s/%s",
+				autoScaler.Namespace, autoScaler.Name, tc.Namespace, tc.Name)
 			objects = append(objects, autoScaler)
 		}
 	}
@@ -106,7 +131,13 @@ type TiDBInitializerFetcher struct {
 	lister listers.TidbInitializerLister
 }
 
-func (f *TiDBInitializerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+func NewTiDBInitializerFetcher(lister listers.TidbInitializerLister) *TiDBInitializerFetcher {
+	return &TiDBInitializerFetcher{
+		lister: lister,
+	}
+}
+
+func (f *TiDBInitializerFetcher) ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error) {
 	emptySelector := labels.NewSelector()
 	initializers, err := f.lister.List(emptySelector)
 	if err != nil {
@@ -120,6 +151,8 @@ func (f *TiDBInitializerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (obje
 			namespace = initializer.Namespace
 		}
 		if name == tc.Name && namespace == tc.Namespace {
+			klog.Infof("TiDBInitializer %s/%s matches tc %s/%s",
+				initializer.Namespace, initializer.Name, tc.Namespace, tc.Name)
 			objects = append(objects, initializer)
 		}
 	}
@@ -130,7 +163,13 @@ type TiDBNgMonitoringFetcher struct {
 	lister listers.TidbNGMonitoringLister
 }
 
-func (f *TiDBNgMonitoringFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+func NewTiDBNgMonitoringFetcher(lister listers.TidbNGMonitoringLister) *TiDBNgMonitoringFetcher {
+	return &TiDBNgMonitoringFetcher{
+		lister: lister,
+	}
+}
+
+func (f *TiDBNgMonitoringFetcher) ListByTC(tc *v1alpha1.TidbCluster) (objects []runtime.Object, err error) {
 	emptySelector := labels.NewSelector()
 	monitorings, err := f.lister.List(emptySelector)
 	if err != nil {
@@ -145,6 +184,8 @@ func (f *TiDBNgMonitoringFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (obj
 				namespace = monitoring.Namespace
 			}
 			if name == tc.Name && namespace == tc.Namespace {
+				klog.Infof("TidbNGMonitoring %s/%s matches tc %s/%s",
+					monitoring.Namespace, monitoring.Name, tc.Namespace, tc.Name)
 				objects = append(objects, monitoring)
 				break
 			}

--- a/pkg/backup/backup/backup_manifests.go
+++ b/pkg/backup/backup/backup_manifests.go
@@ -29,7 +29,7 @@ type TiDBDashboardFetcher struct {
 	lister listers.TidbDashboardLister
 }
 
-func NewTiDBDashboardFetcher(lister listers.TidbDashboardLister) *TiDBDashboardFetcher {
+func NewTiDBDashboardFetcher(lister listers.TidbDashboardLister) ManifestFetcher {
 	return &TiDBDashboardFetcher{
 		lister: lister,
 	}
@@ -64,7 +64,7 @@ type TiDBMonitorFetcher struct {
 	lister listers.TidbMonitorLister
 }
 
-func NewTiDBMonitorFetcher(lister listers.TidbMonitorLister) *TiDBMonitorFetcher {
+func NewTiDBMonitorFetcher(lister listers.TidbMonitorLister) ManifestFetcher {
 	return &TiDBMonitorFetcher{
 		lister: lister,
 	}
@@ -99,7 +99,7 @@ type TiDBClusterAutoScalerFetcher struct {
 	lister listers.TidbClusterAutoScalerLister
 }
 
-func NewTiDBClusterAutoScalerFetcher(lister listers.TidbClusterAutoScalerLister) *TiDBClusterAutoScalerFetcher {
+func NewTiDBClusterAutoScalerFetcher(lister listers.TidbClusterAutoScalerLister) ManifestFetcher {
 	return &TiDBClusterAutoScalerFetcher{
 		lister: lister,
 	}
@@ -131,7 +131,7 @@ type TiDBInitializerFetcher struct {
 	lister listers.TidbInitializerLister
 }
 
-func NewTiDBInitializerFetcher(lister listers.TidbInitializerLister) *TiDBInitializerFetcher {
+func NewTiDBInitializerFetcher(lister listers.TidbInitializerLister) ManifestFetcher {
 	return &TiDBInitializerFetcher{
 		lister: lister,
 	}
@@ -163,7 +163,7 @@ type TiDBNgMonitoringFetcher struct {
 	lister listers.TidbNGMonitoringLister
 }
 
-func NewTiDBNgMonitoringFetcher(lister listers.TidbNGMonitoringLister) *TiDBNgMonitoringFetcher {
+func NewTiDBNgMonitoringFetcher(lister listers.TidbNGMonitoringLister) ManifestFetcher {
 	return &TiDBNgMonitoringFetcher{
 		lister: lister,
 	}

--- a/pkg/backup/backup/backup_manifests.go
+++ b/pkg/backup/backup/backup_manifests.go
@@ -1,0 +1,154 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	pingcapv1alpha1 "github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	listers "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ManifestFetcher interface {
+	ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error)
+}
+
+type TiDBDashboardFetcher struct {
+	lister listers.TidbDashboardLister
+}
+
+func (f *TiDBDashboardFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+	emptySelector := labels.NewSelector()
+	dashboards, err := f.lister.List(emptySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dashboard := range dashboards {
+		for _, cluster := range dashboard.Spec.Clusters {
+			name := cluster.Name
+			namespace := cluster.Namespace
+			if namespace == "" {
+				namespace = dashboard.Namespace
+			}
+			if name == tc.Name && namespace == tc.Namespace {
+				objects = append(objects, dashboard)
+				break
+			}
+		}
+	}
+	return
+}
+
+type TiDBMonitorFetcher struct {
+	lister listers.TidbMonitorLister
+}
+
+func (f *TiDBMonitorFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+	emptySelector := labels.NewSelector()
+	monitors, err := f.lister.List(emptySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, monitor := range monitors {
+		for _, cluster := range monitor.Spec.Clusters {
+			name := cluster.Name
+			namespace := cluster.Namespace
+			if namespace == "" {
+				namespace = monitor.Namespace
+			}
+			if name == tc.Name && namespace == tc.Namespace {
+				objects = append(objects, monitor)
+				break
+			}
+		}
+	}
+	return
+}
+
+type TiDBClusterAutoScalerFetcher struct {
+	lister listers.TidbClusterAutoScalerLister
+}
+
+func (f *TiDBClusterAutoScalerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+	emptySelector := labels.NewSelector()
+	autoScalers, err := f.lister.List(emptySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, autoScaler := range autoScalers {
+		name := autoScaler.Spec.Cluster.Name
+		namespace := autoScaler.Spec.Cluster.Namespace
+		if namespace == "" {
+			namespace = autoScaler.Namespace
+		}
+		if name == tc.Name && namespace == tc.Namespace {
+			objects = append(objects, autoScaler)
+		}
+	}
+	return
+}
+
+type TiDBInitializerFetcher struct {
+	lister listers.TidbInitializerLister
+}
+
+func (f *TiDBInitializerFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+	emptySelector := labels.NewSelector()
+	initializers, err := f.lister.List(emptySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, initializer := range initializers {
+		name := initializer.Spec.Clusters.Name
+		namespace := initializer.Spec.Clusters.Namespace
+		if namespace == "" {
+			namespace = initializer.Namespace
+		}
+		if name == tc.Name && namespace == tc.Namespace {
+			objects = append(objects, initializer)
+		}
+	}
+	return
+}
+
+type TiDBNgMonitoringFetcher struct {
+	lister listers.TidbNGMonitoringLister
+}
+
+func (f *TiDBNgMonitoringFetcher) ListByTC(tc *pingcapv1alpha1.TidbCluster) (objects []runtime.Object, err error) {
+	emptySelector := labels.NewSelector()
+	monitorings, err := f.lister.List(emptySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, monitoring := range monitorings {
+		for _, cluster := range monitoring.Spec.Clusters {
+			name := cluster.Name
+			namespace := cluster.Namespace
+			if namespace == "" {
+				namespace = monitoring.Namespace
+			}
+			if name == tc.Name && namespace == tc.Namespace {
+				objects = append(objects, monitoring)
+				break
+			}
+		}
+	}
+	return
+}

--- a/pkg/backup/backup/backup_manifests_test.go
+++ b/pkg/backup/backup/backup_manifests_test.go
@@ -1,0 +1,478 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	listers_v1alpha1 "github.com/pingcap/tidb-operator/pkg/client/listers/pingcap/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type fakeIndexer struct {
+	cache.Indexer
+	listResults []interface{}
+}
+
+func (f *fakeIndexer) List() []interface{} {
+	return f.listResults
+}
+
+func TestTiDBDashboardFetcher(t *testing.T) {
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "tc-1",
+		},
+	}
+	dashboards := []*v1alpha1.TidbDashboard{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-1",
+			},
+			Spec: v1alpha1.TidbDashboardSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-2",
+				Name:      "d-2",
+			},
+			Spec: v1alpha1.TidbDashboardSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-3",
+			},
+			Spec: v1alpha1.TidbDashboardSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-4",
+			},
+			Spec: v1alpha1.TidbDashboardSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-2",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-5",
+			},
+			Spec: v1alpha1.TidbDashboardSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-2",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+	}
+	expectedResults := []*v1alpha1.TidbDashboard{dashboards[0], dashboards[2]}
+	g := gomega.NewGomegaWithT(t)
+
+	listResults := make([]interface{}, 0, len(dashboards))
+	for _, d := range dashboards {
+		listResults = append(listResults, d)
+	}
+	lister := listers_v1alpha1.NewTidbDashboardLister(&fakeIndexer{
+		listResults: listResults,
+	})
+	fetcher := NewTiDBDashboardFetcher(lister)
+	results, err := fetcher.ListByTC(tc)
+	g.Expect(err, gomega.BeNil())
+	g.Expect(results, gomega.Equal(expectedResults))
+}
+
+func TestTiDBMonitorFetcher(t *testing.T) {
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "tc-1",
+		},
+	}
+	monitors := []*v1alpha1.TidbMonitor{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-1",
+			},
+			Spec: v1alpha1.TidbMonitorSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-2",
+				Name:      "d-2",
+			},
+			Spec: v1alpha1.TidbMonitorSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-3",
+			},
+			Spec: v1alpha1.TidbMonitorSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-4",
+			},
+			Spec: v1alpha1.TidbMonitorSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-2",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-5",
+			},
+			Spec: v1alpha1.TidbMonitorSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-2",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+	}
+	expectedResults := []*v1alpha1.TidbMonitor{monitors[0], monitors[2]}
+	g := gomega.NewGomegaWithT(t)
+
+	listResults := make([]interface{}, 0, len(monitors))
+	for _, m := range monitors {
+		listResults = append(listResults, m)
+	}
+	lister := listers_v1alpha1.NewTidbMonitorLister(&fakeIndexer{
+		listResults: listResults,
+	})
+	fetcher := NewTiDBMonitorFetcher(lister)
+	results, err := fetcher.ListByTC(tc)
+	g.Expect(err, gomega.BeNil())
+	g.Expect(results, gomega.Equal(expectedResults))
+}
+
+func TestTiDBClusterAutoScalerFetcher(t *testing.T) {
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "tc-1",
+		},
+	}
+	autoScalers := []*v1alpha1.TidbClusterAutoScaler{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-1",
+			},
+			Spec: v1alpha1.TidbClusterAutoScalerSpec{
+				Cluster: v1alpha1.TidbClusterRef{
+					Name: "tc-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-2",
+				Name:      "d-2",
+			},
+			Spec: v1alpha1.TidbClusterAutoScalerSpec{
+				Cluster: v1alpha1.TidbClusterRef{
+					Name: "tc-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-3",
+			},
+			Spec: v1alpha1.TidbClusterAutoScalerSpec{
+				Cluster: v1alpha1.TidbClusterRef{
+					Name:      "tc-1",
+					Namespace: "ns-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-4",
+			},
+			Spec: v1alpha1.TidbClusterAutoScalerSpec{
+				Cluster: v1alpha1.TidbClusterRef{
+					Name:      "tc-1",
+					Namespace: "ns-2",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-5",
+			},
+			Spec: v1alpha1.TidbClusterAutoScalerSpec{
+				Cluster: v1alpha1.TidbClusterRef{
+					Name:      "tc-2",
+					Namespace: "ns-1",
+				},
+			},
+		},
+	}
+	expectedResults := []*v1alpha1.TidbClusterAutoScaler{autoScalers[0], autoScalers[2]}
+	g := gomega.NewGomegaWithT(t)
+
+	listResults := make([]interface{}, 0, len(autoScalers))
+	for _, a := range autoScalers {
+		listResults = append(listResults, a)
+	}
+	lister := listers_v1alpha1.NewTidbClusterAutoScalerLister(&fakeIndexer{
+		listResults: listResults,
+	})
+	fetcher := NewTiDBClusterAutoScalerFetcher(lister)
+	results, err := fetcher.ListByTC(tc)
+	g.Expect(err, gomega.BeNil())
+	g.Expect(results, gomega.Equal(expectedResults))
+}
+
+func TestTiDBInitializerFetcher(t *testing.T) {
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "tc-1",
+		},
+	}
+	initializers := []*v1alpha1.TidbInitializer{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-1",
+			},
+			Spec: v1alpha1.TidbInitializerSpec{
+				Clusters: v1alpha1.TidbClusterRef{
+					Name: "tc-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-2",
+				Name:      "d-2",
+			},
+			Spec: v1alpha1.TidbInitializerSpec{
+				Clusters: v1alpha1.TidbClusterRef{
+					Name: "tc-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-3",
+			},
+			Spec: v1alpha1.TidbInitializerSpec{
+				Clusters: v1alpha1.TidbClusterRef{
+					Name:      "tc-1",
+					Namespace: "ns-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-4",
+			},
+			Spec: v1alpha1.TidbInitializerSpec{
+				Clusters: v1alpha1.TidbClusterRef{
+					Name:      "tc-1",
+					Namespace: "ns-2",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-5",
+			},
+			Spec: v1alpha1.TidbInitializerSpec{
+				Clusters: v1alpha1.TidbClusterRef{
+					Name:      "tc-2",
+					Namespace: "ns-1",
+				},
+			},
+		},
+	}
+	expectedResults := []*v1alpha1.TidbInitializer{initializers[0], initializers[2]}
+	g := gomega.NewGomegaWithT(t)
+
+	listResults := make([]interface{}, 0, len(initializers))
+	for _, a := range initializers {
+		listResults = append(listResults, a)
+	}
+	lister := listers_v1alpha1.NewTidbInitializerLister(&fakeIndexer{
+		listResults: listResults,
+	})
+	fetcher := NewTiDBInitializerFetcher(lister)
+	results, err := fetcher.ListByTC(tc)
+	g.Expect(err, gomega.BeNil())
+	g.Expect(results, gomega.Equal(expectedResults))
+}
+
+func TestTiDBNgMonitoringFetcher(t *testing.T) {
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "tc-1",
+		},
+	}
+	monitorings := []*v1alpha1.TidbNGMonitoring{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-1",
+			},
+			Spec: v1alpha1.TidbNGMonitoringSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-2",
+				Name:      "d-2",
+			},
+			Spec: v1alpha1.TidbNGMonitoringSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name: "tc-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-3",
+			},
+			Spec: v1alpha1.TidbNGMonitoringSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-4",
+			},
+			Spec: v1alpha1.TidbNGMonitoringSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-1",
+						Namespace: "ns-2",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns-1",
+				Name:      "d-5",
+			},
+			Spec: v1alpha1.TidbNGMonitoringSpec{
+				Clusters: []v1alpha1.TidbClusterRef{
+					{
+						Name:      "tc-2",
+						Namespace: "ns-1",
+					},
+				},
+			},
+		},
+	}
+	expectedResults := []*v1alpha1.TidbNGMonitoring{monitorings[0], monitorings[2]}
+	g := gomega.NewGomegaWithT(t)
+
+	listResults := make([]interface{}, 0, len(monitorings))
+	for _, m := range monitorings {
+		listResults = append(listResults, m)
+	}
+	lister := listers_v1alpha1.NewTidbNGMonitoringLister(&fakeIndexer{
+		listResults: listResults,
+	})
+	fetcher := NewTiDBNgMonitoringFetcher(lister)
+	results, err := fetcher.ListByTC(tc)
+	g.Expect(err, gomega.BeNil())
+	g.Expect(results, gomega.Equal(expectedResults))
+}

--- a/pkg/backup/constants/constants.go
+++ b/pkg/backup/constants/constants.go
@@ -100,6 +100,7 @@ const (
 	ClusterBackupMeta  = "clustermeta"
 	ClusterRestoreMeta = "restoremeta"
 	MetaFile           = "backupmeta"
+	ClusterManifests   = "manifests"
 
 	// AWSRegionEnv is the aws region environment variable
 	AWSRegionEnv = "AWS_REGION"

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -649,7 +649,7 @@ func InferObjectKind(obj runtime.Object) (schema.GroupVersionKind, error) {
 		return schema.GroupVersionKind{}, err
 	}
 	if len(gvks) != 1 {
-		return schema.GroupVersionKind{}, fmt.Errorf("Object %v has ambigious GVK", obj)
+		return schema.GroupVersionKind{}, fmt.Errorf("object %v has ambiguous GVK", obj)
 	}
 	return gvks[0], nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

backup manifests related to tidb cluster in EBS backup

Closes #5116 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

retrieve the objects of `TidbMonitor`, `TidbDashboard`, `TidbClusterAutoScaler`, `TidbInitializer`, `TidbNgMonitoring`, filter them by check if their `Cluster` is equal to `tc`. Then upload them with `tc` to the remote storage. The storage path of the manifests `{backup-path}/manifests/{namespace}/{kind}/{name}.yaml`

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support backup manifests related to tidb cluster in EBS backup
```
