### PR TITLE
opt: keep ports config for TiFlash 7.1.0+ to avoid restarting

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -140,6 +140,11 @@ const (
 	// when TiDB cluster is restored from volume snapshot based backup.
 	AnnTiKVVolumesReadyKey = "tidb.pingcap.com/tikv-volumes-ready"
 
+	// AnnoTiFlash710KeepPortsKey is the annotation key to indicate whether the TiFlash v7.1.0+ keeps ports to avoid restart.
+	// ports: tcp_port, http_port, tcp_port_secure and https_port.
+	// NOTE: this annotation should only be used for existing TiFlash v7.1.0+ clusters with ports config items.
+	AnnoTiFlash710KeepPortsKey = "tidb.pingcap.com/tiflash-710-keep-port"
+
 	// PDLabelVal is PD label value
 	PDLabelVal string = "pd"
 	// TiDBLabelVal is TiDB label value

--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -143,7 +143,7 @@ const (
 	// AnnoTiFlash710KeepPortsKey is the annotation key to indicate whether the TiFlash v7.1.0+ keeps ports to avoid restart.
 	// ports: tcp_port, http_port, tcp_port_secure and https_port.
 	// NOTE: this annotation should only be used for existing TiFlash v7.1.0+ clusters with ports config items.
-	AnnoTiFlash710KeepPortsKey = "tidb.pingcap.com/tiflash-710-keep-port"
+	AnnoTiFlash710KeepPortsKey = "tidb.pingcap.com/tiflash-710-keep-ports"
 
 	// PDLabelVal is PD label value
 	PDLabelVal string = "pd"

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -1132,6 +1132,11 @@ func (tc *TidbCluster) SkipTLSWhenConnectTiDB() bool {
 	return ok
 }
 
+func (tc *TidbCluster) KeepTiFlash710Ports() bool {
+	_, ok := tc.Annotations[label.AnnoTiFlash710KeepPortsKey]
+	return ok
+}
+
 // TODO: We Should better do not specified the default value ourself if user not specified the item.
 func (tc *TidbCluster) TiCDCTimezone() string {
 	if tc.Spec.TiCDC != nil && tc.Spec.TiCDC.Config != nil {

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -164,7 +164,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("tmp_path", "/data0/tmp")
 
 		// port
-		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
+		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok || tc.KeepTiFlash710Ports() {
 			common.SetIfNil("tcp_port", int64(v1alpha1.DefaultTiFlashTcpPort))
 			common.SetIfNil("http_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 		}
@@ -229,7 +229,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.Set("security.ca_path", path.Join(tiflashCertPath, corev1.ServiceAccountRootCAKey))
 		common.Set("security.cert_path", path.Join(tiflashCertPath, corev1.TLSCertKey))
 		common.Set("security.key_path", path.Join(tiflashCertPath, corev1.TLSPrivateKeyKey))
-		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok {
+		if ok, err := tiflashEqualOrGreaterThanV710.Check(version); err == nil && !ok || tc.KeepTiFlash710Ports() {
 			common.SetIfNil("tcp_port_secure", int64(v1alpha1.DefaultTiFlashTcpPort))
 			common.SetIfNil("https_port", int64(v1alpha1.DefaultTiFlashHttpPort))
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

in #5075, we removed tcp and http ports for tiflash >= 7.1.0.

In this PR, add a `tidb.pingcap.com/tiflash-710-keep-ports` annotation to avoid restarting when upgrading TiDB Operator for existing TiFlash (>= 7.1.0)

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - deploy operator without #5075
  - create a >=v7.1.0 cluster with TiFlash
  - add annotation `tidb.pingcap.com/tiflash-710-keep-ports`  in tc
  - upgrade operator to this PR version
  - observe no TiFlash upgrade
  - remove the annotation
  - observe TiFlash upgrade
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
