### PR TITLE
add support for sha256 container image specifications

### DIFF
--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -2799,6 +2799,19 @@ func TestTiDBMemberManagerSetServerLabels(t *testing.T) {
 			setCount: 0,
 		},
 		{
+			name:        "sha256 version string",
+			tidbVersion: "d7f62aab6315b4378cbbfaaaaaaaaaaaaaaaa90ecaf7e0f22d2225304822ee2e",
+			members: []Member{
+				{
+					node: "node-1",
+				},
+				{
+					node: "node-2",
+				},
+			},
+			setCount: 2,
+		},
+		{
 			name: "skip unhealthy pods",
 			members: []Member{
 				{

--- a/pkg/util/cmpver/cmpver_test.go
+++ b/pkg/util/cmpver/cmpver_test.go
@@ -75,6 +75,7 @@ func genTestCases() []testcase {
 		{"latest-dev", Greater, "v5.3.1", true},
 		{"nightly-dev", Greater, "v5.3.1", true},
 		{"master-dev", Greater, "v5.3.1", true},
+		{"d7f62aab6315b4378cbbfaaaaaaaaaaaaaaaa90ecaf7e0f22d2225304822ee2e", Greater, "v5.3.1", true},
 		// GreaterOrEqual
 		{"v5.3.1", GreaterOrEqual, "v5.1.2", true},
 		{"5.3.1", GreaterOrEqual, "5.1.2", true},
@@ -90,6 +91,7 @@ func genTestCases() []testcase {
 		{"latest-dev", GreaterOrEqual, "v5.3.1", true},
 		{"nightly-dev", GreaterOrEqual, "v5.3.1", true},
 		{"master-dev", GreaterOrEqual, "v5.3.1", true},
+		{"d7f62aab6315b4378cbbfaaaaaaaaaaaaaaaa90ecaf7e0f22d2225304822ee2e", GreaterOrEqual, "v5.3.1", true},
 		// Less
 		{"v5.3.1", Less, "v5.1.2", false},
 		{"v5.1.2", Less, "v5.3.1", true},
@@ -104,6 +106,7 @@ func genTestCases() []testcase {
 		{"latest-dev", Less, "v5.3.1", false},
 		{"nightly-dev", Less, "v5.3.1", false},
 		{"master-dev", Less, "v5.3.1", false},
+		{"d7f62aab6315b4378cbbfaaaaaaaaaaaaaaaa90ecaf7e0f22d2225304822ee2e", Less, "v5.3.1", false},
 		// LessOrEqual
 		{"v5.3.1", LessOrEqual, "v5.1.2", false},
 		{"5.3.1", LessOrEqual, "5.1.2", false},
@@ -118,5 +121,6 @@ func genTestCases() []testcase {
 		{"latest-dev", LessOrEqual, "v5.3.1", false},
 		{"nightly-dev", LessOrEqual, "v5.3.1", false},
 		{"master-dev", LessOrEqual, "v5.3.1", false},
+		{"d7f62aab6315b4378cbbfaaaaaaaaaaaaaaaa90ecaf7e0f22d2225304822ee2e", LessOrEqual, "v5.3.1", false},
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
The operator doesn't work when the image spec includes a sha256 image reference. 

For security reasons, I much prefer to use the sha256 method of retrieving container images, rather then tags. Eg, we want to do `pingcap/tidb@sha256:deadbeef....` instead of `pingcap/tidb:v7.1.0`. However, this breaks the operator because the operator tests if it can set labels in https://github.com/pingcap/tidb-operator/blob/master/pkg/manager/member/tidb_member_manager.go#L1142 by checking if the version extracted from the container image spec is greater than `v6.3.0`. 

When I use the sha256 method of container image specification this code reports that we can't set labels and bails on all the code after that check.

This change makes it so that any valid sha256 is considered a greater version number then any other, similar to the logic for handling `latest` or `nightly`. 

### What is changed and how does it work?

The logic in the semantic version comparison is changed to support sha256 values. A value is consider a sha256 if `hex.DecodeString` returns no error and the length of the string is 64. 


### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [X] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [X] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->
There's a potential that people are using 6.3.0 or early with sha256 container image specs.

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
