### PR TITLE
allow porting labels when initiating backup/restore member

### DIFF
--- a/pkg/fedvolumebackup/backup/backup_manager.go
+++ b/pkg/fedvolumebackup/backup/backup_manager.go
@@ -209,7 +209,7 @@ func (bm *backupManager) listAllBackupMembers(ctx context.Context, volumeBackup 
 func (bm *backupManager) initializeVolumeBackup(ctx context.Context, volumeBackup *v1alpha1.VolumeBackup) error {
 	initializeMember := volumeBackup.Spec.Clusters[0]
 	kubeClient := bm.deps.FedClientset[initializeMember.K8sClusterName]
-	backupMember := bm.buildBackupMember(volumeBackup.Name, &initializeMember, &volumeBackup.Spec.Template, volumeBackup.Annotations, true)
+	backupMember := bm.buildBackupMember(volumeBackup.Name, &initializeMember, &volumeBackup.Spec.Template, volumeBackup.Annotations, volumeBackup.Labels, true)
 	backupMember, err := kubeClient.PingcapV1alpha1().Backups(backupMember.Namespace).Create(ctx, backupMember, metav1.CreateOptions{})
 	if err != nil {
 		return controller.RequeueErrorf("create initialize backup member %s to cluster %s error: %s", backupMember.Name, initializeMember.K8sClusterName, err.Error())
@@ -266,7 +266,7 @@ func (bm *backupManager) executeVolumeBackup(ctx context.Context, volumeBackup *
 		}
 
 		kubeClient := bm.deps.FedClientset[memberCluster.K8sClusterName]
-		backupMember := bm.buildBackupMember(volumeBackup.Name, &memberCluster, &volumeBackup.Spec.Template, volumeBackup.Annotations, false)
+		backupMember := bm.buildBackupMember(volumeBackup.Name, &memberCluster, &volumeBackup.Spec.Template, volumeBackup.Annotations, volumeBackup.Labels, false)
 		if _, err := kubeClient.PingcapV1alpha1().Backups(memberCluster.TCNamespace).Create(ctx, backupMember, metav1.CreateOptions{}); err != nil {
 			return false, controller.RequeueErrorf("create backup member %s to cluster %s error: %s", backupMember.Name, memberCluster.K8sClusterName, err.Error())
 		}
@@ -394,12 +394,13 @@ func (bm *backupManager) updateVolumeBackupMembersToStatus(volumeBackupStatus *v
 	}
 }
 
-func (bm *backupManager) buildBackupMember(volumeBackupName string, clusterMember *v1alpha1.VolumeBackupMemberCluster, backupTemplate *v1alpha1.VolumeBackupMemberSpec, annotations map[string]string, initialize bool) *pingcapv1alpha1.Backup {
+func (bm *backupManager) buildBackupMember(volumeBackupName string, clusterMember *v1alpha1.VolumeBackupMemberCluster, backupTemplate *v1alpha1.VolumeBackupMemberSpec, annotations map[string]string, labels map[string]string, initialize bool) *pingcapv1alpha1.Backup {
 	backupMember := &pingcapv1alpha1.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        bm.generateBackupMemberName(volumeBackupName, clusterMember.K8sClusterName),
 			Namespace:   clusterMember.TCNamespace,
 			Annotations: annotations,
+			Labels:      labels,
 		},
 		Spec: pingcapv1alpha1.BackupSpec{
 			Mode:                     pingcapv1alpha1.BackupModeVolumeSnapshot,

--- a/pkg/fedvolumebackup/restore/restore_manager.go
+++ b/pkg/fedvolumebackup/restore/restore_manager.go
@@ -210,7 +210,7 @@ func (rm *restoreManager) executeRestoreVolumePhase(ctx context.Context, volumeR
 		}
 
 		kubeClient := rm.deps.FedClientset[k8sClusterName]
-		restoreMember := rm.buildRestoreMember(volumeRestore.Name, &memberCluster, &volumeRestore.Spec.Template, volumeRestore.Annotations)
+		restoreMember := rm.buildRestoreMember(volumeRestore.Name, &memberCluster, &volumeRestore.Spec.Template, volumeRestore.Annotations, volumeRestore.Labels)
 		if _, err := kubeClient.PingcapV1alpha1().Restores(memberCluster.TCNamespace).Create(ctx, restoreMember, metav1.CreateOptions{}); err != nil {
 			return false, fmt.Errorf("create restore member %s to cluster %s error: %s", restoreMember.Name, k8sClusterName, err.Error())
 		}
@@ -477,7 +477,7 @@ func (rm *restoreManager) skipVolumeRestore(volumeRestore *v1alpha1.VolumeRestor
 	return v1alpha1.IsVolumeRestoreComplete(volumeRestore) || v1alpha1.IsVolumeRestoreFailed(volumeRestore)
 }
 
-func (rm *restoreManager) buildRestoreMember(volumeRestoreName string, memberCluster *v1alpha1.VolumeRestoreMemberCluster, template *v1alpha1.VolumeRestoreMemberSpec, annotations map[string]string) *pingcapv1alpha1.Restore {
+func (rm *restoreManager) buildRestoreMember(volumeRestoreName string, memberCluster *v1alpha1.VolumeRestoreMemberCluster, template *v1alpha1.VolumeRestoreMemberSpec, annotations map[string]string, labels map[string]string) *pingcapv1alpha1.Restore {
 	restoreMember := &pingcapv1alpha1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        rm.generateRestoreMemberName(volumeRestoreName, memberCluster.K8sClusterName),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
iam role cannot be used during backup process
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change
allow porting labels when initiating backup/restore member
### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
Reviewers: @WangLe1321 @BornChanger 