### PR TITLE
ebs br: check status of global nodes before doing data recovery

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -531,6 +531,17 @@ func (tc *TidbCluster) PDAllMembersReady() bool {
 	return true
 }
 
+// PDAllPeerMembersReady return whether all peer members of PD are ready.
+func (tc *TidbCluster) PDAllPeerMembersReady() bool {
+
+	for _, member := range tc.Status.PD.PeerMembers {
+		if !member.Health {
+			return false
+		}
+	}
+	return true
+}
+
 func (tc *TidbCluster) PDAutoFailovering() bool {
 	if len(tc.Status.PD.FailureMembers) == 0 {
 		return false
@@ -900,6 +911,16 @@ func (tc *TidbCluster) AllTiKVsAreAvailable() bool {
 	}
 
 	for _, store := range tc.Status.TiKV.Stores {
+		if store.State != TiKVStateUp {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (tc *TidbCluster) AllPeerTiKVsAreAvailable() bool {
+	for _, store := range tc.Status.TiKV.PeerStores {
 		if store.State != TiKVStateUp {
 			return false
 		}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -131,12 +131,12 @@ func (rm *restoreManager) syncRestoreJob(restore *v1alpha1.Restore) error {
 			}, nil)
 			return err
 		}
-		if !tc.PDAllMembersReady() {
+		if !tc.PDAllMembersReady() || !tc.PDAllPeerMembersReady() {
 			return controller.RequeueErrorf("restore %s/%s: waiting for all PD members are ready in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
 		}
 
 		if v1alpha1.IsRestoreVolumeComplete(restore) && !v1alpha1.IsRestoreTiKVComplete(restore) {
-			if !tc.AllTiKVsAreAvailable() {
+			if !tc.AllTiKVsAreAvailable() || !tc.AllPeerTiKVsAreAvailable() {
 				return controller.RequeueErrorf("restore %s/%s: waiting for all TiKVs are available in tidbcluster %s/%s", ns, name, tc.Namespace, tc.Name)
 			} else {
 				sel, err := label.New().Instance(tc.Name).TiKV().Selector()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #5242 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

For TiDB cluster deployed across K8S, there could be more than one TC Clusters.  EBS data restore should start until all TiKV Nodes and PD nodes are ready.

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
