### PR TITLE
Modify backup path to add root folder 

### DIFF
--- a/pkg/fedvolumebackup/backup/backup_manager.go
+++ b/pkg/fedvolumebackup/backup/backup_manager.go
@@ -418,7 +418,7 @@ func (bm *backupManager) buildBackupMember(volumeBackupName string, clusterMembe
 			CalcSizeLevel:            backupTemplate.CalcSizeLevel,
 		},
 	}
-	backupMember.Spec.S3.Prefix = fmt.Sprintf("%s-%s", backupMember.Spec.S3.Prefix, clusterMember.K8sClusterName)
+	backupMember.Spec.S3.Prefix = fmt.Sprintf("%s/%s", backupMember.Spec.S3.Prefix, clusterMember.K8sClusterName)
 	if initialize {
 		backupMember.Spec.FederalVolumeBackupPhase = pingcapv1alpha1.FederalVolumeBackupInitialize
 	}

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -157,7 +157,7 @@ func buildBackup(vbs *v1alpha1.VolumeBackupSchedule, timestamp time.Time) *v1alp
 	}
 
 	if backupSpec.Template.S3 != nil {
-		backupSpec.Template.S3.Prefix = path.Join(backupSpec.Template.S3.Prefix, "-"+timestamp.UTC().Format(pingcapv1alpha1.BackupNameTimeFormat))
+		backupSpec.Template.S3.Prefix = path.Join(backupSpec.Template.S3.Prefix, timestamp.UTC().Format(pingcapv1alpha1.BackupNameTimeFormat))
 	} else {
 		klog.Errorf("Information on S3 missing in template")
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
currently ebs backup for multi az cluster will create backup path 
s3://{bucket_name}/prefix-k8s-cluster. so backups for each k8s cluster don't have a root folder.  

for volumebackupschedule, we saw external storage backup path folder name starting with hyphen
shared-iam/sched1/-2023-08-10t23-10-00-m-tidb-test-d-ea1-us/
shared-iam/sched1/-2023-08-10t23-10-00-m-tidb-test-e-ea1-us/
shared-iam/sched1/-2023-08-10t23-10-00-m-tidb-test-f-ea1-us/
### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

Adding a new level of folder in backup path. 
e.g.
volumeBackup vb1 creates folder 
s3://{bucket_name}/{backup_namespace}/vb1-k8s-cluster1, 
s3://{bucket_name}/{backup_namespace}/vb1-k8s-cluster2 and 
s3://{bucket_name}/{backup_namespace}/vb1-k8s-cluster3.
 
backup path after this change will be like
s3://{bucket_name}/{backup_namespace}/vb1/k8s-cluster1, 
s3://{bucket_name}/{backup_namespace}/vb1/k8s-cluster2, 
s3://{bucket_name}/{backup_namespace}/vb1/k8s-cluster3

for volumebackupschedule, this code change will remove the hyphen
### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
Reviewers: @WangLe1321 @BornChanger 