### PR TITLE
do not delete chaos-mesh namespace

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -90,6 +90,7 @@ func setupSuite(c kubernetes.Interface, extClient versioned.Interface, apiExtCli
 			metav1.NamespaceDefault,
 			metav1.NamespacePublic,
 			v1.NamespaceNodeLease,
+			"chaos-testing", // used by chaos-mesh
 		}
 		if framework.TestContext.Provider == "kind" {
 			// kind local path provisioner namespace since 0.7.0


### PR DESCRIPTION
chaos testing hasn't been working for a long time, so we disable this Action now and may enable it again (and make it work) later.

- the chaos YAML has `pingcap` namespace, but this namespace will be cleaned in https://github.com/pingcap/tidb-operator/blob/27e71c73f50152da6222322650c4f6de405d1165/tests/e2e/e2e.go#L87-L115
- the ginkgo focus for chaos mesh is `Restarter` (https://github.com/pingcap/tidb-operator/blob/27e71c73f50152da6222322650c4f6de405d1165/.github/workflows/chaos.yaml#L60C52-L60C61), but this case has been removed in #3296
