### PR TITLE
br: modify time complete of restore status

### DIFF
--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -291,7 +291,6 @@ func (rm *Manager) performRestore(ctx context.Context, restore *v1alpha1.Restore
 			restoreType = v1alpha1.RestoreVolumeComplete
 		} else {
 			restoreType = v1alpha1.RestoreDataComplete
-			allFinished = true
 		}
 	default:
 		ts, err := util.GetCommitTsFromBRMetaData(ctx, restore.Spec.StorageProvider)
@@ -314,8 +313,10 @@ func (rm *Manager) performRestore(ctx context.Context, restore *v1alpha1.Restore
 	}
 
 	updateStatus := &controller.RestoreUpdateStatus{
-		TimeStarted: &metav1.Time{Time: started},
-		CommitTs:    commitTS,
+		CommitTs: commitTS,
+	}
+	if restore.Status.TimeStarted.Unix() <= 0 {
+		updateStatus.TimeStarted = &metav1.Time{Time: started}
 	}
 	if allFinished {
 		updateStatus.TimeCompleted = &metav1.Time{Time: time.Now()}

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -489,10 +489,13 @@ func (rm *restoreManager) volumeSnapshotRestore(r *v1alpha1.Restore, tc *v1alpha
 		}
 
 		// restore TidbCluster completed
+		newStatus := &controller.RestoreUpdateStatus{
+			TimeCompleted: &metav1.Time{Time: time.Now()},
+		}
 		if err := rm.statusUpdater.Update(r, &v1alpha1.RestoreCondition{
 			Type:   v1alpha1.RestoreComplete,
 			Status: corev1.ConditionTrue,
-		}, nil); err != nil {
+		}, newStatus); err != nil {
 			return "UpdateRestoreCompleteFailed", err
 		}
 		return "", nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Make sure time complete is valid for restore with volume-snapshot mode.

Closes #5239 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Before this change, the timeStarted and timeCompleted in restore status is the time of data restore phase. We change timeStarted to start time of volume restore phase and timeCompleted to the time of restore complete.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

![image](https://github.com/pingcap/tidb-operator/assets/13897016/a0f942b5-ea02-48f3-b8f8-ac23de14731d)


- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
