### PR TITLE
fix anno check and bump operator to v1.6.0-alpha.8

### DIFF
--- a/charts/br-federation/values.yaml
+++ b/charts/br-federation/values.yaml
@@ -6,7 +6,7 @@ rbac:
 # timezone is the default system timzone
 timezone: UTC
 
-image: pingcap/br-federation-manager:v1.6.0-alpha.7
+image: pingcap/br-federation-manager:v1.6.0-alpha.8
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 

--- a/charts/tidb-cluster/values.yaml
+++ b/charts/tidb-cluster/values.yaml
@@ -38,7 +38,7 @@ services:
     type: ClusterIP
 
 discovery:
-  image: pingcap/tidb-operator:v1.6.0-alpha.7
+  image: pingcap/tidb-operator:v1.6.0-alpha.8
   imagePullPolicy: IfNotPresent
   resources:
     limits:

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -12,12 +12,12 @@ rbac:
 timezone: UTC
 
 # operatorImage is TiDB Operator image
-operatorImage: pingcap/tidb-operator:v1.6.0-alpha.7
+operatorImage: pingcap/tidb-operator:v1.6.0-alpha.8
 imagePullPolicy: IfNotPresent
 # imagePullSecrets: []
 
 # tidbBackupManagerImage is tidb backup manager image
-tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.6.0-alpha.7
+tidbBackupManagerImage: pingcap/tidb-backup-manager:v1.6.0-alpha.8
 
 #
 # Enable or disable tidb-operator features:

--- a/deploy/aliyun/variables.tf
+++ b/deploy/aliyun/variables.tf
@@ -10,7 +10,7 @@ variable "bastion_cpu_core_count" {
 
 variable "operator_version" {
   type    = string
-  default = "v1.6.0-alpha.7"
+  default = "v1.6.0-alpha.8"
 }
 
 variable "operator_helm_values" {

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -19,7 +19,7 @@ variable "eks_version" {
 
 variable "operator_version" {
   description = "TiDB operator version"
-  default     = "v1.6.0-alpha.7"
+  default     = "v1.6.0-alpha.8"
 }
 
 variable "operator_values" {

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -28,7 +28,7 @@ variable "tidb_version" {
 }
 
 variable "tidb_operator_version" {
-  default = "v1.6.0-alpha.7"
+  default = "v1.6.0-alpha.8"
 }
 
 variable "tidb_operator_chart_version" {

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/pingcap/advanced-statefulset/client v1.17.1-0.20230830071059-cfaedeea6cb3
 	github.com/pingcap/errors v0.11.4
 	github.com/pingcap/kvproto v0.0.0-20200927054727-1290113160f0
-	github.com/pingcap/tidb-operator/pkg/apis v1.6.0-alpha.7
-	github.com/pingcap/tidb-operator/pkg/client v1.6.0-alpha.7
+	github.com/pingcap/tidb-operator/pkg/apis v1.6.0-alpha.8
+	github.com/pingcap/tidb-operator/pkg/client v1.6.0-alpha.8
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.28.0

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -22,8 +22,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # parameters
-OPERATOR_OLD="v1\.6\.0-alpha.6"
-OPERATOR_NEW="v1\.6\.0-alpha.7"
+OPERATOR_OLD="v1\.6\.0-alpha.7"
+OPERATOR_NEW="v1\.6\.0-alpha.8"
 TIDB_OLD="v6\.1\.0"
 TIDB_NEW="v6\.5\.0"
 DM_OLD="v6.1.0"

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -3,7 +3,7 @@ module github.com/pingcap/tidb-operator/pkg/client
 go 1.19
 
 require (
-	github.com/pingcap/tidb-operator/pkg/apis v1.6.0-alpha.7
+	github.com/pingcap/tidb-operator/pkg/apis v1.6.0-alpha.8
 	k8s.io/apimachinery v0.23.17
 	k8s.io/client-go v0.23.17
 )

--- a/pkg/manager/utils/statefulset.go
+++ b/pkg/manager/utils/statefulset.go
@@ -117,7 +117,7 @@ func UpdateStatefulSet(setCtl controller.StatefulSetControlInterface, object run
 
 	// Check if an upgrade is needed.
 	// If not, early return.
-	stsEqual, podTemplateEqual := util.StatefulSetEqual(*newSet, *oldSet)
+	stsEqual, podTemplateCheckedAndNotEqual := util.StatefulSetEqual(*newSet, *oldSet)
 	if stsEqual && !isOrphan {
 		return nil
 	}
@@ -155,11 +155,11 @@ func UpdateStatefulSet(setCtl controller.StatefulSetControlInterface, object run
 		return err
 	}
 
-	// this should be done after SetStatefulSetLastAppliedConfigAnnotation,
-	// then this volumeMode set by defaults won't be stored in the annotation
-	if podTemplateEqual {
-		// if the pod template is not equal,
+	if !podTemplateCheckedAndNotEqual {
+		// if the pod template is check and not equal, it means the pod template is changed
 		// there is no need to hack the volume mode as it can be updated in this round
+		// this should be done after SetStatefulSetLastAppliedConfigAnnotation,
+		// then this volumeMode set by defaults won't be stored in the annotation
 		hackEphemeralVolumeMode(oldSet, &set)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

in #5273, we hacked the volume mode if the pod template is equal. but if the annotation of the asts is changed, we didn't hacked it. when scaling a replica with `delete-slots` used, then the remain pods restarted unexcepted.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - scaling in TiDB created with v1.5.0-alpha.8 and v1.6.0-alpha.6
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
