### PR TITLE
ebs br: allow new backup come in once snapshots generation is done

### DIFF
--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -199,6 +199,8 @@ const (
 	VolumeBackupInvalid VolumeBackupConditionType = "Invalid"
 	// VolumeBackupRunning means the VolumeBackup is running
 	VolumeBackupRunning VolumeBackupConditionType = "Running"
+	// VolumeBackupSnapshotsComplete means snapshots generation is complete in data plane
+	VolumeBackupSnapshotsComplete VolumeBackupConditionType = "SnapshotsComplete"
 	// VolumeBackupComplete means all the backups in data plane are complete and the VolumeBackup is complete
 	VolumeBackupComplete VolumeBackupConditionType = "Complete"
 	// VolumeBackupFailed means one of backup in data plane is failed and the VolumeBackup is failed

--- a/pkg/apis/federation/pingcap/v1alpha1/volume_backup.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/volume_backup.go
@@ -103,6 +103,12 @@ func IsVolumeBackupComplete(volumeBackup *VolumeBackup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsVolumeBackupSnapshotsComplete returns true if snapshots generation is complete
+func IsVolumeBackupSnapshotsComplete(volumeBackup *VolumeBackup) bool {
+	_, condition := GetVolumeBackupCondition(&volumeBackup.Status, VolumeBackupSnapshotsComplete)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsVolumeBackupFailed returns true if VolumeBackup is failed
 func IsVolumeBackupFailed(volumeBackup *VolumeBackup) bool {
 	_, condition := GetVolumeBackupCondition(&volumeBackup.Status, VolumeBackupFailed)

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -243,6 +243,15 @@ func IsVolumeBackupInitializeFailed(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsVolumeBackupSnapshotsComplete returns true if volume backup has complete snapshots generation
+func IsVolumeBackupSnapshotsComplete(backup *Backup) bool {
+	if backup.Spec.Mode != BackupModeVolumeSnapshot {
+		return false
+	}
+	_, condition := GetBackupCondition(&backup.Status, VolumeBackupSnapshotsComplete)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsVolumeBackupComplete returns true if volume backup is complete
 func IsVolumeBackupComplete(backup *Backup) bool {
 	if backup.Spec.Mode != BackupModeVolumeSnapshot {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2130,8 +2130,10 @@ const (
 	VolumeBackupInitialized BackupConditionType = "VolumeBackupInitialized"
 	// VolumeBackupInitializeFailed means the volume backup initialize job failed
 	VolumeBackupInitializeFailed BackupConditionType = "VolumeBackupInitializeFailed"
-	// VolumeBackupComplete means the volume backup has taken volume snapshots successfully
+	// VolumeBackupComplete means the volume backup is complete successfully
 	VolumeBackupComplete BackupConditionType = "VolumeBackupComplete"
+	// VolumeBackupSnapshotsComplete means the volume backup has taken volume snapshots successfully
+	VolumeBackupSnapshotsComplete BackupConditionType = "VolumeBackupSnapshotsComplete"
 	// VolumeBackupFailed means the volume backup take volume snapshots failed
 	VolumeBackupFailed BackupConditionType = "VolumeBackupFailed"
 )

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -205,7 +205,7 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 		return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
 	}
 
-	if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
+	if v1alpha1.IsVolumeBackupSnapshotsComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) || v1alpha1.IsVolumeBackupComplete(backup) {
 		return nil
 	}
 	// skip this sync round of the backup schedule and waiting the last backup.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Close #5276 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

This PR introduced a new status type `VolumeBackupSnapshotComplete` for backup CR of both data plane and federation plane. Once backup CR has complete EBS snapshot generation, its status can be switch to the new status type. And when CRs in all data planes arrive to the status type, whole volume backup in control plane switches to the new status type. 
If the status type of the volume backup arrives to `VolumeBackupSnapshotComplete` ,  a new volume can come in and be scheduled instead of waiting for current backup CR is complete.(when backup size calculation is done also)

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
Schedule denser ebs snpshot backups and verify those job running has interleaves.
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
