### PR TITLE
ebs br: resume gc and scheduler when volume snapshots created

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -278,7 +278,12 @@ func (bo *Options) brCommandRunWithLogCallback(ctx context.Context, fullArgs []s
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute br command failed, args: %s, err: %v", bo, fullArgs, err)
 	}
-	go backupUtil.GracefullyShutDownSubProcess(ctx, cmd)
+
+	// only the initialization command of volume snapshot backup use gracefully shutting down
+	// because it should resume gc and pd scheduler immediately
+	if bo.Mode == string(v1alpha1.BackupModeVolumeSnapshot) && bo.Initialize {
+		go backupUtil.GracefullyShutDownSubProcess(ctx, cmd)
+	}
 
 	var errMsg string
 	stdErrCh := make(chan []byte, 1)

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -264,7 +264,7 @@ func (bo *Options) brCommandRunWithLogCallback(ctx context.Context, fullArgs []s
 	}
 	klog.Infof("Running br command with args: %v", fullArgs)
 	bin := filepath.Join(util.BRBinPath, "br")
-	cmd := exec.CommandContext(ctx, bin, fullArgs...)
+	cmd := exec.Command(bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -120,7 +120,7 @@ func (ro *Options) restoreData(
 	fullArgs = append(fullArgs, args...)
 	klog.Infof("Running br command with args: %v", fullArgs)
 	bin := path.Join(util.BRBinPath, "br")
-	cmd := exec.CommandContext(ctx, bin, fullArgs...)
+	cmd := exec.Command(bin, fullArgs...)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -134,7 +134,6 @@ func (ro *Options) restoreData(
 	if err != nil {
 		return fmt.Errorf("cluster %s, execute br command failed, args: %s, err: %v", ro, fullArgs, err)
 	}
-	go backupUtil.GracefullyShutDownSubProcess(ctx, cmd)
 
 	var (
 		progressWg     sync.WaitGroup

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -526,12 +526,12 @@ func ReadAllStdErrToChannel(stdErr io.Reader, errMsgCh chan []byte) {
 // the caller should wait the process of cmd to shut down
 func GracefullyShutDownSubProcess(ctx context.Context, cmd *exec.Cmd) {
 	<-ctx.Done()
+	klog.Errorf("context done, err: %s. start to shut down sub process gracefully", ctx.Err().Error())
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		klog.Errorf("send SIGTERM to sub process error: %s", err.Error())
 	} else {
-		klog.Infof("context done, gracefully shut down sub process")
+		klog.Infof("send SIGTERM to sub process successfully")
 	}
-	klog.Error(ctx.Err().Error())
 }
 
 const (

--- a/cmd/backup-manager/app/util/util.go
+++ b/cmd/backup-manager/app/util/util.go
@@ -16,8 +16,10 @@ package util
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path"
 	"path/filepath"
@@ -508,6 +510,28 @@ func ParseRestoreProgress(line string) (step, progress string) {
 	}
 	step, progress = matchs[1], matchs[2]
 	return
+}
+
+// ReadAllStdErrToChannel read the stdErr and send the output to channel
+func ReadAllStdErrToChannel(stdErr io.Reader, errMsgCh chan []byte) {
+	errMsg, err := io.ReadAll(stdErr)
+	if err != nil {
+		klog.Errorf("read stderr error: %s", err.Error())
+	}
+	errMsgCh <- errMsg
+	close(errMsgCh)
+}
+
+// GracefullyShutDownSubProcess just send SIGTERM to the process of cmd when context done
+// the caller should wait the process of cmd to shut down
+func GracefullyShutDownSubProcess(ctx context.Context, cmd *exec.Cmd) {
+	<-ctx.Done()
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		klog.Errorf("send SIGTERM to sub process error: %s", err.Error())
+	} else {
+		klog.Infof("context done, gracefully shut down sub process")
+	}
+	klog.Error(ctx.Err().Error())
 }
 
 const (

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -296,6 +296,18 @@ FederalVolumeBackupPhase
 </tr>
 <tr>
 <td>
+<code>resumeGcSchedule</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResumeGcSchedule indicates whether resume gc and pd scheduler for EBS volume snapshot backup</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>dumpling</code></br>
 <em>
 <a href="#dumplingconfig">
@@ -4096,6 +4108,18 @@ FederalVolumeBackupPhase
 <td>
 <em>(Optional)</em>
 <p>FederalVolumeBackupPhase indicates which phase to execute in federal volume backup</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resumeGcSchedule</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResumeGcSchedule indicates whether resume gc and pd scheduler for EBS volume snapshot backup</p>
 </td>
 </tr>
 <tr>

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -96,8 +96,14 @@ esac
 # save the PID of the sub process
 pid=$!
 
+terminate_subprocesses() {
+    echo "get SIGTERM, send it to sub process $pid"
+    kill -15 $pid # -15 is SIGTERM
+    wait $pid
+}
+
 # Trap the SIGTERM signal and forward it to the main process
-trap "echo 'get SIGTERM, propagate it to sub process'; kill -SIGTERM $pid" SIGTERM
+trap 'terminate_subprocesses' SIGTERM
 
 # Wait for the sub process to complete
 wait $pid

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -63,41 +63,41 @@ case "$1" in
     backup)
         shift 1
         echo "$BACKUP_BIN backup $@"
-        $EXEC_COMMAND $BACKUP_BIN backup "$@"
+        $EXEC_COMMAND $BACKUP_BIN backup "$@" &
         ;;
     export)
         shift 1
         echo "$BACKUP_BIN export $@"
-        $EXEC_COMMAND $BACKUP_BIN export "$@"
+        $EXEC_COMMAND $BACKUP_BIN export "$@" &
         ;;
     restore)
         shift 1
         echo "$BACKUP_BIN restore $@"
-        $EXEC_COMMAND $BACKUP_BIN restore "$@"
+        $EXEC_COMMAND $BACKUP_BIN restore "$@" &
         ;;
     import)
         shift 1
         echo "$BACKUP_BIN import $@"
-        $EXEC_COMMAND $BACKUP_BIN import "$@"
+        $EXEC_COMMAND $BACKUP_BIN import "$@" &
         ;;
     clean)
         shift 1
         echo "$BACKUP_BIN clean $@"
-        $EXEC_COMMAND $BACKUP_BIN clean "$@"
+        $EXEC_COMMAND $BACKUP_BIN clean "$@" &
         ;;
     *)
         echo "Usage: $0 {backup|restore|clean}"
         echo "Now runs your command."
         echo "$@"
 
-        exec "$@"
+        exec "$@" &
 esac
 
-# save the PID of the main process
+# save the PID of the sub process
 pid=$!
 
 # Trap the SIGTERM signal and forward it to the main process
-trap 'kill -SIGTERM $pid; wait $pid' SIGTERM
+trap "echo 'get SIGTERM, propagate it to sub process'; kill -SIGTERM $pid" SIGTERM
 
-# Wait for the main process to complete
+# Wait for the sub process to complete
 wait $pid

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -58,52 +58,50 @@ else
 	EXEC_COMMAND="/usr/local/bin/shush exec --"
 fi
 
+terminate_subprocesses() {
+    echo "get SIGTERM, send it to sub process $1"
+    kill -15 $1 # -15 is SIGTERM
+    wait $1
+}
+
 # exec command
 case "$1" in
     backup)
         shift 1
         echo "$BACKUP_BIN backup $@"
         $EXEC_COMMAND $BACKUP_BIN backup "$@" &
+
+        # save the PID of the sub process
+        pid=$!
+        # Trap the SIGTERM signal and forward it to the main process
+        trap 'terminate_subprocesses $pid' SIGTERM
+        # Wait for the sub process to complete
+        wait $pid
         ;;
     export)
         shift 1
         echo "$BACKUP_BIN export $@"
-        $EXEC_COMMAND $BACKUP_BIN export "$@" &
+        $EXEC_COMMAND $BACKUP_BIN export "$@"
         ;;
     restore)
         shift 1
         echo "$BACKUP_BIN restore $@"
-        $EXEC_COMMAND $BACKUP_BIN restore "$@" &
+        $EXEC_COMMAND $BACKUP_BIN restore "$@"
         ;;
     import)
         shift 1
         echo "$BACKUP_BIN import $@"
-        $EXEC_COMMAND $BACKUP_BIN import "$@" &
+        $EXEC_COMMAND $BACKUP_BIN import "$@"
         ;;
     clean)
         shift 1
         echo "$BACKUP_BIN clean $@"
-        $EXEC_COMMAND $BACKUP_BIN clean "$@" &
+        $EXEC_COMMAND $BACKUP_BIN clean "$@"
         ;;
     *)
         echo "Usage: $0 {backup|restore|clean}"
         echo "Now runs your command."
         echo "$@"
 
-        exec "$@" &
+        exec "$@"
 esac
-
-# save the PID of the sub process
-pid=$!
-
-terminate_subprocesses() {
-    echo "get SIGTERM, send it to sub process $pid"
-    kill -15 $pid # -15 is SIGTERM
-    wait $pid
-}
-
-# Trap the SIGTERM signal and forward it to the main process
-trap 'terminate_subprocesses' SIGTERM
-
-# Wait for the sub process to complete
-wait $pid

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -92,3 +92,12 @@ case "$1" in
 
         exec "$@"
 esac
+
+# save the PID of the main process
+pid=$!
+
+# Trap the SIGTERM signal and forward it to the main process
+trap 'kill -SIGTERM $pid; wait $pid' SIGTERM
+
+# Wait for the main process to complete
+wait $pid

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1442,6 +1442,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              resumeGcSchedule:
+                type: boolean
               s3:
                 properties:
                   acl:
@@ -3068,6 +3070,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  resumeGcSchedule:
+                    type: boolean
                   s3:
                     properties:
                       acl:
@@ -4498,6 +4502,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  resumeGcSchedule:
+                    type: boolean
                   s3:
                     properties:
                       acl:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -1442,6 +1442,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              resumeGcSchedule:
+                type: boolean
               s3:
                 properties:
                   acl:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -1417,6 +1417,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  resumeGcSchedule:
+                    type: boolean
                   s3:
                     properties:
                       acl:
@@ -2847,6 +2849,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  resumeGcSchedule:
+                    type: boolean
                   s3:
                     properties:
                       acl:

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -199,6 +199,8 @@ const (
 	VolumeBackupInvalid VolumeBackupConditionType = "Invalid"
 	// VolumeBackupRunning means the VolumeBackup is running
 	VolumeBackupRunning VolumeBackupConditionType = "Running"
+	// VolumeBackupSnapshotsCreated means the all the volume snapshots have created, and we have safely resumed GC and PD scheduler
+	VolumeBackupSnapshotsCreated VolumeBackupConditionType = "SnapshotsCreated"
 	// VolumeBackupComplete means all the backups in data plane are complete and the VolumeBackup is complete
 	VolumeBackupComplete VolumeBackupConditionType = "Complete"
 	// VolumeBackupFailed means one of backup in data plane is failed and the VolumeBackup is failed

--- a/pkg/apis/federation/pingcap/v1alpha1/volume_backup.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/volume_backup.go
@@ -97,6 +97,12 @@ func IsVolumeBackupRunning(volumeBackup *VolumeBackup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsVolumeBackupSnapshotsCreated returns true if VolumeBackup's snapshots are all created
+func IsVolumeBackupSnapshotsCreated(volumeBackup *VolumeBackup) bool {
+	_, condition := GetVolumeBackupCondition(&volumeBackup.Status, VolumeBackupSnapshotsCreated)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsVolumeBackupComplete returns true if VolumeBackup is complete
 func IsVolumeBackupComplete(volumeBackup *VolumeBackup) bool {
 	_, condition := GetVolumeBackupCondition(&volumeBackup.Status, VolumeBackupComplete)

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -243,6 +243,22 @@ func IsVolumeBackupInitializeFailed(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+func IsVolumeBackupSnapshotsCreated(backup *Backup) bool {
+	if backup.Spec.Mode != BackupModeVolumeSnapshot {
+		return false
+	}
+	_, condition := GetBackupCondition(&backup.Status, VolumeBackupSnapshotsCreated)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+func IsVolumeBackupInitializeComplete(backup *Backup) bool {
+	if backup.Spec.Mode != BackupModeVolumeSnapshot {
+		return false
+	}
+	_, condition := GetBackupCondition(&backup.Status, VolumeBackupInitializeComplete)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsVolumeBackupComplete returns true if volume backup is complete
 func IsVolumeBackupComplete(backup *Backup) bool {
 	if backup.Spec.Mode != BackupModeVolumeSnapshot {

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1084,6 +1084,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"resumeGcSchedule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResumeGcSchedule indicates whether resume gc and pd scheduler for EBS volume snapshot backup",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"dumpling": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DumplingConfig is the configs for dumpling",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1970,6 +1970,9 @@ type BackupSpec struct {
 	// FederalVolumeBackupPhase indicates which phase to execute in federal volume backup
 	// +optional
 	FederalVolumeBackupPhase FederalVolumeBackupPhase `json:"federalVolumeBackupPhase,omitempty"`
+	// ResumeGcSchedule indicates whether resume gc and pd scheduler for EBS volume snapshot backup
+	// +optional
+	ResumeGcSchedule bool `json:"resumeGcSchedule,omitempty"`
 	// DumplingConfig is the configs for dumpling
 	Dumpling *DumplingConfig `json:"dumpling,omitempty"`
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
@@ -2126,10 +2129,14 @@ const (
 	BackupStopped BackupConditionType = "Stopped"
 	// BackupRestart means the backup was restarted, now just support snapshot backup
 	BackupRestart BackupConditionType = "Restart"
-	// VolumeBackupInitialized means the volume backup has stopped GC and PD schedule
+	// VolumeBackupInitialized means the volume backup has stopped GC and PD scheduler
 	VolumeBackupInitialized BackupConditionType = "VolumeBackupInitialized"
 	// VolumeBackupInitializeFailed means the volume backup initialize job failed
 	VolumeBackupInitializeFailed BackupConditionType = "VolumeBackupInitializeFailed"
+	// VolumeBackupSnapshotsCreated means the local volume snapshots created, and they won't be changed
+	VolumeBackupSnapshotsCreated BackupConditionType = "VolumeBackupSnapshotsCreated"
+	// VolumeBackupInitializeComplete means the volume backup has safely resumed GC and PD scheduler
+	VolumeBackupInitializeComplete BackupConditionType = "VolumeBackupInitializeComplete"
 	// VolumeBackupComplete means the volume backup has taken volume snapshots successfully
 	VolumeBackupComplete BackupConditionType = "VolumeBackupComplete"
 	// VolumeBackupFailed means the volume backup take volume snapshots failed


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

1. resume gc and pd scheduler when all the volume snapshots are created
Closes #5256

2. send `SIGTERM` to the BR process when tidb-backup-manager receives `SIGTERM`
3. read stderr async in case that the pipe of stderr is full and blocks the BR process
Closes #5281 
4. The EBS backup task may cause the import task to fail 
Closes #5282 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

**data plane:**
1. check if the `backupmeta` file is existed when the backup enter `execute` phase. if it is existed, modify backup status `VolumeBackupSnapshotsCreated`

**control plane:**
2. if all the backups in data plane has status `VolumeBackupSnapshotsCreated`, modify `resumeGcSchedule` field `true` in the backup that is responsible to pause gc and pd schduler.

**data plane:**
3. if `resumeGcSchedule` field is `true`, delete the initialize pod and modify backup status `VolumeBackupInitializeComplete`

**control plane:**
5. if the backup with `resumeGcSchedule: true` has status `VolumeBackupInitializeComplete`, modify volume backup status `SnapshotsCreated`. It means all the volume snapshots are created and gc and pd schedulers are resumed.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
