### PR TITLE
Fix issue in VolumeReplace feature that may conflict with TiKV eviction annotation.

### DIFF
--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -240,11 +240,11 @@ func (c *PodController) getPDClient(tc *v1alpha1.TidbCluster) pdapi.PDClient {
 }
 
 func (c *PodController) syncPDPod(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
-	result, err := c.syncPDPodForLeaderTransfer(ctx, pod, tc)
+	result, err := c.syncPDPodForReplaceVolume(ctx, pod, tc)
 	if err != nil || result.Requeue || result.RequeueAfter > 0 {
 		return result, err
 	}
-	return c.syncPDPodForReplaceVolume(ctx, pod, tc)
+	return c.syncPDPodForLeaderTransfer(ctx, pod, tc)
 }
 
 func (c *PodController) syncPDPodForLeaderTransfer(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
@@ -363,11 +363,11 @@ func (c *PodController) syncPDPodForReplaceVolume(ctx context.Context, pod *core
 }
 
 func (c *PodController) syncTiKVPod(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
-	result, err := c.syncTiKVPodForEviction(ctx, pod, tc)
+	result, err := c.syncTiKVPodForReplaceVolume(ctx, pod, tc)
 	if err != nil || result.Requeue || result.RequeueAfter > 0 {
 		return result, err
 	}
-	return c.syncTiKVPodForReplaceVolume(ctx, pod, tc)
+	return c.syncTiKVPodForEviction(ctx, pod, tc)
 }
 
 func (c *PodController) syncTiKVPodForEviction(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
@@ -568,11 +568,11 @@ func (c *PodController) syncTiKVPodForReplaceVolume(ctx context.Context, pod *co
 }
 
 func (c *PodController) syncTiDBPod(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {
-	result, err := c.syncTiDBPodForGracefulShutdown(ctx, pod, tc)
+	result, err := c.syncTiDBPodForReplaceVolume(ctx, pod, tc)
 	if err != nil || result.Requeue || result.RequeueAfter > 0 {
 		return result, err
 	}
-	return c.syncTiDBPodForReplaceVolume(ctx, pod, tc)
+	return c.syncTiDBPodForGracefulShutdown(ctx, pod, tc)
 }
 
 func (c *PodController) syncTiDBPodForGracefulShutdown(ctx context.Context, pod *corev1.Pod, tc *v1alpha1.TidbCluster) (reconcile.Result, error) {

--- a/pkg/manager/volumes/pvc_modifier.go
+++ b/pkg/manager/volumes/pvc_modifier.go
@@ -105,7 +105,7 @@ func (p *pvcModifier) tryToRecreateSTS(ctx *componentVolumeContext) error {
 	// Modifier does not support new volumes, trigger error if so and return.
 	isSynced, err := p.utils.IsStatefulSetSynced(ctx, ctx.sts)
 	if err != nil {
-		return fmt.Errorf("change in number of volumes is not supported without VolumeReplacing feature. Reconciliation is blocked due to : %s", err.Error())
+		return fmt.Errorf("change in number of volumes is not supported. For pd, tikv, tidb supported with VolumeReplacing feature. Reconciliation is blocked due to : %s", err.Error())
 	}
 	if isSynced {
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Fixes a small issue that can occur when using Volume Replacement feature added in https://github.com/pingcap/tidb-operator/pull/5150

While a disk replacement is ongoing, if we apply a `tidb.pingcap.com/evict-leader="none"` annotation to the tikv at the same time. It can result in a deadlock.
* replacement feature will delete store and eventually store becomes tombstone.
* However since eviction code runs first, it will error forever saying cannot find store for this tikv, and get stuck permanently.

The place where it gets stuck is when calling `member.TiKVStoreIDFromStatus` here: https://github.com/pingcap/tidb-operator/blob/master/pkg/controller/tidbcluster/pod_control.go#L421C26-L421C47

Since store is tombstone this will fail forever, and will prevent replacement code from continuing to fix it.

<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
Replacement takes precedence over eviction in `pod_control.go`, that way deadlock can be prevented. 

Also slightly clarify error message when unsupported change is made, clarifying which components are supported in Volume Replace feature.
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes
Need to cherry pick for 1.5 branch 
- [] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix an issue where VolumeReplacement feature can conflict with TiKV eviction annotation when replacing disk simultaneously
```
