### PR TITLE
Do not error in pvc_modifier, when a manual TiKV eviction is requested.

### DIFF
--- a/pkg/manager/volumes/pvc_modifier.go
+++ b/pkg/manager/volumes/pvc_modifier.go
@@ -302,9 +302,8 @@ func (p *pvcModifier) endEvictLeader(tc *v1alpha1.TidbCluster, pod *corev1.Pod) 
 		if _, err := p.deps.KubeClientset.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("delete leader eviction annotation to pod %s/%s failed: %s", pod.Namespace, pod.Name, err)
 		}
-	}
-
-	if !isLeaderEvictionFinished(tc, pod) {
+		// Return an error once after deleting annotation, to give pod_control a chance to stop the eviction.
+		// (but do not block / re-check in case the eviction here maybe manually requested by user via annotation)
 		return fmt.Errorf("wait for leader eviction of %s/%s finished", pod.Namespace, pod.Name)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
pvc_modifier keeps throwing errors even if a manual TiKV region leader eviction is requested by annotating the pod per the documentation here:
https://docs.pingcap.com/tidb-in-kubernetes/stable/maintain-a-kubernetes-node#evict-tikv-region-leader

This happens even if no volume modification is actually requested.

<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
Do not keep checking if eviction has ended during pvc_modifier sync.
If an annotation does exist for resize, delete it and throw an error once alone to give pod_control.go a chance to stop the eviction. But do not block forever until it is removed as this may have been requested by user manually and should not throw errors.
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix spurious errors from pvc_modifier when manual TiKV eviction is requested by user annotation
```
