### PR TITLE
http-service: fix get prometheus config panic

### DIFF
--- a/cmd/http-service/server/cluster.go
+++ b/cmd/http-service/server/cluster.go
@@ -523,6 +523,7 @@ func (s *ClusterServer) GetCluster(ctx context.Context, req *api.GetClusterReq) 
 		// for TidbMonitor, we don't return error if previous TiDBCluster exists
 		if apierrors.IsNotFound(err) {
 			logger.Warn("TidbMonitor not found", zap.Error(err))
+			tm = nil // set emtpy TidbMonitor to nil
 		} else {
 			logger.Error("Get TidbMonitor failed", zap.Error(err))
 		}

--- a/cmd/http-service/server/cluster.go
+++ b/cmd/http-service/server/cluster.go
@@ -523,7 +523,7 @@ func (s *ClusterServer) GetCluster(ctx context.Context, req *api.GetClusterReq) 
 		// for TidbMonitor, we don't return error if previous TiDBCluster exists
 		if apierrors.IsNotFound(err) {
 			logger.Warn("TidbMonitor not found", zap.Error(err))
-			tm = nil // set emtpy TidbMonitor to nil
+			tm = nil // set empty TidbMonitor to nil
 		} else {
 			logger.Error("Get TidbMonitor failed", zap.Error(err))
 		}

--- a/cmd/http-service/server/cluster.go
+++ b/cmd/http-service/server/cluster.go
@@ -664,9 +664,11 @@ func convertToClusterInfo(logger *zap.Logger, kubeCli kubernetes.Interface, tc *
 
 	if tm != nil {
 		info.Prometheus = &api.PrometheusStatus{
-			Version:        tm.Spec.Prometheus.MonitorContainer.Version,
-			Resource:       reConvertResourceRequirements(tm.Spec.Prometheus.MonitorContainer.ResourceRequirements),
-			CommandOptions: tm.Spec.Prometheus.Config.CommandOptions,
+			Version:  tm.Spec.Prometheus.MonitorContainer.Version,
+			Resource: reConvertResourceRequirements(tm.Spec.Prometheus.MonitorContainer.ResourceRequirements),
+		}
+		if tm.Spec.Prometheus.Config != nil {
+			info.Prometheus.CommandOptions = tm.Spec.Prometheus.Config.CommandOptions
 		}
 		if tm.Spec.Grafana != nil {
 			info.Grafana = &api.GrafanaStatus{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

```
[2023/10/19 10:17:14.916 +00:00] [WARN] [cluster.go:525] ["TidbMonitor not found"] [request=GetCluster] [k8sID=] [clusterID=tidb-clsuter-002] [error="[tidbmonitors.pingcap.com](http://tidbmonitors.pingcap.com/) \"tidb-monitor\" not found"]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1208754]
goroutine 123 [running]:
[github.com/pingcap/tidb-operator/http-service/server.convertToClusterInfo](http://github.com/pingcap/tidb-operator/http-service/server.convertToClusterInfo)(0x1a41e40?, {0x1a6db78, 0x4000221080}, 0x4000d4c000, 0x4000e93b00)
/home/sean/code/src/[github.com/pingcap/tidb-operator/cmd/http-service/server/cluster.go:669](http://github.com/pingcap/tidb-operator/cmd/http-service/server/cluster.go:669) +0x1644
[github.com/pingcap/tidb-operator/http-service/server.(*ClusterServer).GetCluster](http://github.com/pingcap/tidb-operator/http-service/server.(*ClusterServer).GetCluster)(0x400000e158, {0x1a56c98, 0x4000c15230}, 0x4000696e40)
/home/sean/code/src/[github.com/pingcap/tidb-operator/cmd/http-service/server/cluster.go:531](http://github.com/pingcap/tidb-operator/cmd/http-service/server/cluster.go:531) +0x9a8
[github.com/pingcap/tidb-operator/http-service/pbgen/api._Cluster_GetCluster_Handler](http://github.com/pingcap/tidb-operator/http-service/pbgen/api._Cluster_GetCluster_Handler)({0x142dd40?, 0x400000e158}, {0x1a56c98, 0x4000c15230}, 0x400051ec40, 0x0)
/home/sean/code/src/[github.com/pingcap/tidb-operator/cmd/http-service/pbgen/api/service_grpc.pb.go:116](http://github.com/pingcap/tidb-operator/cmd/http-service/pbgen/api/service_grpc.pb.go:116) +0x16c
[google.golang.org/grpc.(*Server).processUnaryRPC](http://google.golang.org/grpc.(*Server).processUnaryRPC)(0x40004fe000, {0x1a5c440, 0x40005829c0}, 0x400035ac60, 0x4000ae4510, 0x27a1018, 0x0)
/home/sean/code/go/pkg/mod/[google.golang.org/grpc@v1.58.1/server.go:1376](http://google.golang.org/grpc@v1.58.1/server.go:1376) +0xbb0
[google.golang.org/grpc.(*Server).handleStream](http://google.golang.org/grpc.(*Server).handleStream)(0x40004fe000, {0x1a5c440, 0x40005829c0}, 0x400035ac60, 0x0)
/home/sean/code/go/pkg/mod/[google.golang.org/grpc@v1.58.1/server.go:1753](http://google.golang.org/grpc@v1.58.1/server.go:1753) +0x840
[google.golang.org/grpc.(*Server).serveStreams.func1.1()](http://google.golang.org/grpc.(*Server).serveStreams.func1.1())
/home/sean/code/go/pkg/mod/[google.golang.org/grpc@v1.58.1/server.go:998](http://google.golang.org/grpc@v1.58.1/server.go:998) +0x84
created by [google.golang.org/grpc.(*Server).serveStreams.func1](http://google.golang.org/grpc.(*Server).serveStreams.func1)
/home/sean/code/go/pkg/mod/[google.golang.org/grpc@v1.58.1/server.go:996](http://google.golang.org/grpc@v1.58.1/server.go:996) +0x170


******** The connection failed. Unsupported, interrupted or timed out. ********
```

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
