### PR TITLE
Fix issue in VolumeReplace feature that may block replacement when combined with an annotation change

### DIFF
--- a/pkg/manager/volumes/pvc_replacer.go
+++ b/pkg/manager/volumes/pvc_replacer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
-	"github.com/pingcap/tidb-operator/pkg/manager/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errutil "k8s.io/apimachinery/pkg/util/errors"
@@ -141,9 +140,6 @@ func (p *pvcReplacer) tryToRecreateSTS(ctx *componentVolumeContext) error {
 	isSynced, _ := p.utils.IsStatefulSetSynced(ctx, ctx.sts)
 	if isSynced {
 		return nil
-	}
-	if utils.StatefulSetIsUpgrading(ctx.sts) {
-		return fmt.Errorf("component sts %s/%s is upgrading", ctx.sts.Namespace, ctx.sts.Name)
 	}
 
 	orphan := metav1.DeletePropagationOrphan


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Fix an issue with Volume Replacement feature that can cause it to be blocked when user requests a metadata / annotation change, clubbed with a disk replacement.


### What is changed and how does it work?
Remove check in pvc_replacer that checks if sts is upgrading before recreating sts.

If a disk change is clubbed with pod spec changes (but not metadata changes), it gets reverted here: https://github.com/pingcap/tidb-operator/blob/6de4871569b4e556436b35ba87cad753c3c72b62/pkg/manager/member/tikv_member_manager.go#L276
So the statefulset would not show any changes (and would not fail upgrade check, so issue doesn't happen).

However metadata changes like (annotation change), do not get reverted, and will be applied to the sts, but since volume replace marks the update strategy to be OnDelete : https://github.com/pingcap/tidb-operator/blob/6de4871569b4e556436b35ba87cad753c3c72b62/pkg/manager/member/tikv_member_manager.go#L691
The annotation won't be applied, and will be stuck.

Further pvc_replacer will be stuck forever on this check (which is removed in this PR)

The check itself is unnecessary since, before the code reaches here we are already in volume replace mode, which means sts should have OnDelete strategy and sts updates will only be performed by pvc_replacer clubbed with disk replace.

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix an issue where VolumeReplacement feature can get stuck when a disk change is clubbed with a metadata(annotation) change
```
