### PR TITLE
Fix issue when using VolumeReplace feature that may mark wrong PD member ID labels.

### DIFF
--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -336,6 +336,9 @@ func (c *PodController) syncPDPodForReplaceVolume(ctx context.Context, pod *core
 		if targetMemberName == "" {
 			return reconcile.Result{}, fmt.Errorf("could not find an alternate pd member to transfer leadership to")
 		}
+		if !tc.PDAllMembersReady() {
+			return reconcile.Result{Requeue: true}, fmt.Errorf("not all PDs ready before leader transfer")
+		}
 		klog.Infof("Transferring PD Leader from %s to %s", pod.Name, targetMemberName)
 		pdClient.TransferPDLeader(targetMemberName)
 		// Wait for leader transfer.

--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -185,16 +185,6 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 		}
 	}
 
-	// syncing the labels from Pod to PVC and PV, these labels include:
-	//   - label.StoreIDLabelKey
-	//   - label.MemberIDLabelKey
-	//   - label.NamespaceLabelKey
-	// Note this sync is called twice, once here and once after all the member syncs. The call here won't block on
-	// error to avoid potential deadlock with dependency on member manager. However, the next call will return if error.
-	// This also updates the TiKV pod annotation for label.AnnTiKVNoActiveStoreSince if store is missing. So we
-	// sometimes depend on this to be run before tikv member manager which will wait on this.
-	c.metaManager.Sync(tc) // Silently ignore error.
-
 	// works that should be done to make the pd cluster current state match the desired state:
 	//   - create or update the pd service
 	//   - create or update the pd headless service
@@ -285,7 +275,6 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 	//   - label.StoreIDLabelKey
 	//   - label.MemberIDLabelKey
 	//   - label.NamespaceLabelKey
-	// Note: This is second run, where errors should block, see also previous run above.
 	if err := c.metaManager.Sync(tc); err != nil {
 		metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "meta").Inc()
 		return err

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -191,7 +191,7 @@ func (s *tikvScaler) scaleInOne(tc *v1alpha1.TidbCluster, skipPreCheck bool, upT
 	// update it once here (to avoid a dependency on metaManager to sync it first instead)
 	pod, err = s.deps.PodControl.UpdateMetaInfo(tc, pod)
 	if err != nil {
-		klog.Errorf("tikvScaler.ScaleIn: failed to update pod MetaInfo for %s", podName)
+		klog.Errorf("tikvScaler.ScaleIn: failed to update pod MetaInfo for, pod %s, cluster %s/%s", podName, ns, tcName)
 		return deletedUpStore, nil
 	}
 

--- a/pkg/manager/member/tikv_scaler.go
+++ b/pkg/manager/member/tikv_scaler.go
@@ -187,6 +187,14 @@ func (s *tikvScaler) scaleInOne(tc *v1alpha1.TidbCluster, skipPreCheck bool, upT
 		return deletedUpStore, fmt.Errorf("tikvScaler.ScaleIn: failed to pass up stores check , pod %s, cluster %s/%s", podName, ns, tcName)
 	}
 
+	// Below code depends on tikv StoreIDLabelKey & AnnTiKVNoActiveStoreSince to be correctly updated, so manually
+	// update it once here (to avoid a dependency on metaManager to sync it first instead)
+	pod, err = s.deps.PodControl.UpdateMetaInfo(tc, pod)
+	if err != nil {
+		klog.Errorf("tikvScaler.ScaleIn: failed to update pod MetaInfo for %s", podName)
+		return deletedUpStore, nil
+	}
+
 	// call PD API to delete the store of the TiKV Pod to be scaled in
 	for _, store := range tc.Status.TiKV.Stores {
 		if store.PodName == podName {

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -2050,11 +2050,17 @@ func TestTiKVScalerScaleInSimultaneouslyExtra(t *testing.T) {
 	}
 }
 
+// Reuse podCtlMock from ticdc_scaler_test
+func (p *podCtlMock) UpdateMetaInfo(tc *v1alpha1.TidbCluster, pod *corev1.Pod) (*corev1.Pod, error) {
+	return pod, nil
+}
+
 func newFakeTiKVScaler(resyncDuration ...time.Duration) (*tikvScaler, *pdapi.FakePDControl, cache.Indexer, cache.Indexer, *controller.FakePVCControl) {
 	fakeDeps := controller.NewFakeDependencies()
 	if len(resyncDuration) > 0 {
 		fakeDeps.CLIConfig.ResyncDuration = resyncDuration[0]
 	}
+	fakeDeps.PodControl = &podCtlMock{} // So that UpdateMetaInfo is no-op instead of changing labels.
 	pvcIndexer := fakeDeps.KubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer().GetIndexer()
 	podIndexer := fakeDeps.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 	pdControl := fakeDeps.PDControl.(*pdapi.FakePDControl)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Fix an issue Introduced in https://github.com/pingcap/tidb-operator/pull/5150 by running metaManager.Sync() once before the member syncs status.

Specifically in rare cases (AFAIK only when using volume replace) there can be a race condition.
`controller/pod_control.go` can run right after a pd member is deleted + pod is deleted + new pod comes back all before pd member manager has had a chance to run it's `syncTidbClusterStatus` function
This leaves `tc.Status.PD.Members` in an old state without removing the member that was deleted.
This can cause controller/pod_control.go to run with an out of date stale tc.Status.PD.Members and use the wrong member id to apply as pod label for PD.
Consequently causing more bugs when that pd pod is restarted (leader eviction missed), or disk replaced (pvc deleted without deleting pd member), or scaled in (without deleting pd member), etc.

I believe this race condition can only trigger with disk replace as it is rare for pd member delete + pod delete + new pod with same name to happen quickly in any other case. The deletion today happens in `tidbcluster/pod_control.go` which runs in a separate thread than member managers/metamanager/`controller/pod_control.go`, hence the race conditions.

### What is changed and how does it work?

Revert the extra metamanager.Sync() introduced in https://github.com/pingcap/tidb-operator/pull/5150 to go back to old behavior with only one run
Instead run UpdateMetaInfo for the specific pod being scaled in by tikv_scaler which is the only dependency that was needed/introduced. Since scaler will run only after tikv's `syncTidbClusterStatus` , updating the labels now is safe.

Some extra changes to improve safety:
 * Add error messages when pod_control detects mismatched store/member labels on pod. No action taken, but will help debug bad state.
 * In disk replace for PD, check all PD's are available before triggering pd leader transfer (avoid leader transfer to bad PD)

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix an issue where VolumeReplacement feature on PD can cause stale PD member labels resulting in potential PD members left without cleanup or PD restarts without leader eviction.
```
