### PR TITLE
Support br-federation-manager managing resources in specific-namespace tidb clusters

### DIFF
--- a/charts/br-federation/templates/controller-manager-deployment.yaml
+++ b/charts/br-federation/templates/controller-manager-deployment.yaml
@@ -60,6 +60,7 @@ spec:
         command:
           - /usr/local/bin/br-federation-manager
           - -v={{ .Values.brFederationManager.logLevel }}
+          - -cluster-scoped={{ .Values.clusterScoped }}
           {{- if .Values.brFederationManager.workers }}
           - -workers={{ .Values.brFederationManager.workers | default 5 }}
           {{- end }}

--- a/charts/br-federation/templates/controller-manager-rbac.yaml
+++ b/charts/br-federation/templates/controller-manager-rbac.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: br-federation-manager
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+{{- if .Values.clusterScoped }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -55,4 +56,50 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}:br-federation-manager
   apiGroup: rbac.authorization.k8s.io
+{{- else }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}:br-federation-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: br-federation-manager
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "events"]
+  verbs: ["create", "get", "list", "watch", "update", "delete"]
+- apiGroups: ["federation.pingcap.com"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}:br-federation-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "chart.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: br-federation-manager
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+subjects:
+- kind: ServiceAccount
+  {{- if eq .Values.appendReleaseSuffix true}}
+  name: {{ .Values.brFederationManager.serviceAccount }}-{{ .Release.Name }}
+  {{- else }}
+  name: {{ .Values.brFederationManager.serviceAccount }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}:br-federation-manager
+  namespace: {{ .Release.Namespace }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/br-federation/templates/controller-manager-rbac.yaml
+++ b/charts/br-federation/templates/controller-manager-rbac.yaml
@@ -99,7 +99,6 @@ subjects:
 roleRef:
   kind: Role
   name: {{ .Release.Name }}:br-federation-manager
-  namespace: {{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/charts/br-federation/values.yaml
+++ b/charts/br-federation/values.yaml
@@ -1,5 +1,9 @@
 # Default values for br-federation
 
+# clusterScoped is whether federation-manager should manage kubernetes cluster wide
+# Also see rbac.create and brFederationManager.serviceAccount.
+clusterScoped: true
+
 rbac:
   create: true
 
@@ -16,7 +20,7 @@ brFederationManager:
   create: true
   # With rbac.create=false, the user is responsible for creating this account
   # With rbac.create=true, this service account will be created
-  # Also see rbac.create
+  # Also see rbac.create and clusterScoped
   serviceAccount: br-federation-manager
 
   # Secret name of the kubeconfig for the federation Kubernetes clusters

--- a/cmd/br-federation-manager/main.go
+++ b/cmd/br-federation-manager/main.go
@@ -119,7 +119,7 @@ func main() {
 		klog.Fatalf("failed to init federation kube clients: %v", err)
 	}
 
-	deps := controller.NewBrFedDependencies(cliCfg, cli, kubeCli, genericCli, fedClients)
+	deps := controller.NewBrFedDependencies(ns, cliCfg, cli, kubeCli, genericCli, fedClients)
 
 	onStarted := func(ctx context.Context) {
 		// Define some nested types to simplify the codebase

--- a/pkg/controller/br_fed_config.go
+++ b/pkg/controller/br_fed_config.go
@@ -29,6 +29,9 @@ type BrFedCLIConfig struct {
 	// Larger number = more responsive management, but more CPU
 	// (and network) load
 	Workers int
+	// Controls whether operator should manage kubernetes cluster
+	// wide TiDB clusters
+	ClusterScoped bool
 
 	LeaseDuration time.Duration
 	RenewDeadline time.Duration
@@ -49,6 +52,7 @@ type BrFedCLIConfig struct {
 func DefaultBrFedCLIConfig() *BrFedCLIConfig {
 	return &BrFedCLIConfig{
 		Workers:        5,
+		ClusterScoped:  true,
 		LeaseDuration:  15 * time.Second,
 		RenewDeadline:  10 * time.Second,
 		RetryPeriod:    2 * time.Second,
@@ -64,6 +68,7 @@ func (c *BrFedCLIConfig) AddFlag(_ *flag.FlagSet) {
 	flag.BoolVar(&c.PrintVersion, "V", false, "Show version and quit")
 	flag.BoolVar(&c.PrintVersion, "version", false, "Show version and quit")
 	flag.IntVar(&c.Workers, "workers", c.Workers, "The number of workers that are allowed to sync concurrently. Larger number = more responsive management, but more CPU (and network) load")
+	flag.BoolVar(&c.ClusterScoped, "cluster-scoped", c.ClusterScoped, "Whether br-federation-manager should manage kubernetes cluster-wide resources")
 	flag.DurationVar(&c.ResyncDuration, "resync-duration", c.ResyncDuration, "Resync time of informer")
 
 	// see https://pkg.go.dev/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig for the config


### PR DESCRIPTION
### What problem does this PR solve?

Our infra setup deploys a given TiDB cluster across multiple k8s clusters, so we use federation to manage br resources across these k8s clusters. Additionally, we deploy multiple of these TiDB clusters in a single k8s cluster across different namespaces -- for ease of deployment/upgrade and least-access, we want to deploy the br-federation-manager control plane independently for each of these TiDB clusters to manage volume backups/restores in separate namespaces.

### What is changed and how does it work?

This PR applies two sets of changes that enable br-federation-manager (bfm) to run in a namespace-scoped way.

1. Support `clusterScoped` in helm charts. When `clusterScoped=false`, charts generate manifests for `Role`s and `RoleBinding`s in the specified namespace rather than `ClusterRole`s and `ClusterRoleBinding`s.
2. Support `clusterScoped` in the bfm executable. When `-cluster-scoped=false`, the manager will listen to changes in br resources only within the specified namespace rather than cluster-wide.

I modeled these changes after how `clusterScoped` is used in the controller-manager [helm charts](https://github.com/pingcap/tidb-operator/blob/8b83a3fbc3d8b028443231fb38e7d031f05a0341/charts/br-federation/templates/controller-manager-rbac.yaml) and [executable](https://github.com/pingcap/tidb-operator/blob/8b83a3fbc3d8b028443231fb38e7d031f05a0341/pkg/controller/dependences.go#L394-L397).

These changes only affect how the control-plane access resources in its namespace and does not affect how bfm manages data-plane resources in other k8s clusters using provided kubeconfig. Managing data-plane resources continues to be done through `.spec.clusters.tcNamespace` in the federation CRDs.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

Manual testing to set up bfm in a namespace-scoped way on a control plane cluster and validate it attempts to reconcile namespaced br resources and does not attempt to reconcile br resources in other namespaces.

1. Set up a Kubernetes cluster for testing.
2. Apply CRDs

```
cd $TIDB_OPERATOR_REPO
kubectl create -f manifests/crd.yaml
kubectl apply -f manifests/federation-crd.yaml
```

3. Set up two namespaces, one for the bfm control-plane and one other (representing other namespaces for other tidb clusters)

```
apiVersion: v1
kind: Namespace
metadata:
  name: cluster1
---
apiVersion: v1
kind: Namespace
metadata:
  name: cluster2
```

4. Set up bfm kubeconfig following directions [here](https://github.com/pingcap/docs-tidb-operator/blob/master/en/deploy-br-federation.md). This can be mocked as we won't be testing managing data-plane resources

5. Build image and install namespace-scoped bfm

```
cd $TIDB_OPERATOR_REPO
make build
cd images/br-federation-manager
docker build -t {bfm-image} .

cd $TIDB_OPERATOR_REPO
helm install --namespace cluster1 br-federation-manager charts/br-federation --set image={bfm-image} --set clusterScoped=false
```

6. Create an empty backup in `cluster1` namespace control plane. 

```
apiVersion: federation.pingcap.com/v1alpha1
kind: VolumeBackup
metadata:
  name: basic-volumebackup
spec: {}
```

7. Validate that deployment attempts to reconcile this backup.

```
...
2023-11-21T16:32:34.313084051Z I1121 16:32:34.312972       1 fed_volume_backup_controller.go:176] VolumeBackup object cluster1/cluster1-volumebackup enqueue
2023-11-21T16:32:34.410123093Z I1121 16:32:34.410044       1 backup_manager.go:53] sync VolumeBackup cluster1/cluster1-volumebackup
2023-11-21T16:32:34.410132551Z I1121 16:32:34.410078       1 backup_manager.go:120] VolumeBackup cluster1/cluster1-volumebackup set status running
2023-11-21T16:32:34.410134801Z I1121 16:32:34.410090       1 fed_volume_backup_controller.go:126] Finished syncing VolumeBackup "cluster1/cluster1-volumebackup" (78.25µs)
...
```

8. Repeat validation for `VolumeRestore` and `VolumeBackupSchedule`

9. Create br resources in other namespace.

```
apiVersion: federation.pingcap.com/v1alpha1
kind: VolumeBackup
metadata:
  name: cluster2-volumebackup
  namespace: cluster2
spec: {}
---
apiVersion: federation.pingcap.com/v1alpha1
kind: VolumeRestore
metadata:
  name: cluster2-volumerestore
  namespace: cluster2
spec: {}
```

10. Validate that bfm does not register those changes and does not attempt to reconcile those resources.

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
