### PR TITLE
tiproxy: no need for volume

### DIFF
--- a/pkg/manager/volumes/vol_compare_utils.go
+++ b/pkg/manager/volumes/vol_compare_utils.go
@@ -223,13 +223,6 @@ func (u *volCompareUtils) GetDesiredVolumes(tc *v1alpha1.TidbCluster, mt v1alpha
 	switch mt {
 	case v1alpha1.TiProxyMemberType:
 		defaultScName = tc.Spec.TiProxy.StorageClassName
-		d := DesiredVolume{
-			Name:             v1alpha1.GetStorageVolumeName("", mt),
-			Size:             getStorageSize(tc.Spec.TiProxy.Requests),
-			StorageClassName: defaultScName,
-		}
-		desiredVolumes = append(desiredVolumes, d)
-
 		storageVolumes = tc.Spec.TiProxy.StorageVolumes
 	case v1alpha1.PDMemberType:
 		defaultScName = tc.Spec.PD.StorageClassName


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

Tiproxy needs no volume, remove warning:

```
Reconciliation is blocked due to : unsupported change in number of volumes 0 -> 1 for cluster tidb1379661944646195934/db:tiproxy, requeuing
```

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
