### PR TITLE
fix some E2E cases for across k8s

### DIFF
--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -35,6 +35,7 @@ import (
 	utiltidb "github.com/pingcap/tidb-operator/tests/e2e/util/tidb"
 	utiltc "github.com/pingcap/tidb-operator/tests/e2e/util/tidbcluster"
 	"github.com/pingcap/tidb-operator/tests/pkg/fixture"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
@@ -238,11 +239,36 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc1, 10*time.Minute, 10*time.Second)
 
 			ginkgo.By("Update cluster domain of cluster-1")
+			timeBeforeUpdate := metav1.Now()
 			err := controller.GuaranteedUpdate(genericCli, tc1, func() error {
 				tc1.Spec.ClusterDomain = defaultClusterDomain
 				return nil
 			})
 			framework.ExpectNoError(err, "failed to update cluster domain of cluster-1 %s/%s", tc1.Namespace, tc1.Name)
+
+			ginkgo.By("Wait for updating cluster domain of cluster-1")
+			// the PD pod should be restarted after updating cluster domain
+			err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+				pdPods, err := c.CoreV1().Pods(tc1.Namespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"app.kubernetes.io/component": "pd",
+						"app.kubernetes.io/instance":  tc1.Name,
+					}).String(),
+				})
+				if err != nil {
+					return false, err
+				}
+				if len(pdPods.Items) == 0 {
+					return false, nil
+				}
+				log.Logf("time before update: %v, pd pod creation time: %v", timeBeforeUpdate, pdPods.Items[0].CreationTimestamp)
+				if pdPods.Items[0].CreationTimestamp.Before(&timeBeforeUpdate) {
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "failed to wait for updating cluster domain of cluster-1 %s/%s", tc1.Namespace, tc1.Name)
+
 			err = oa.WaitForTidbClusterReady(tc1, 25*time.Minute, 30*time.Second)
 			framework.ExpectNoError(err, "failed to wait for cluster-1 ready: %s/%s", tc1.Namespace, tc1.Name)
 

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -746,14 +746,34 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 				framework.ExpectNoError(err, "failed to get tc %s/%s", ns, tcName)
 
 				ginkgo.By("Update tc to use start script v2")
+				timeBeforeUpdate := metav1.Now()
 				err = controller.GuaranteedUpdate(genericCli, tc, func() error {
 					tc.Spec.StartScriptVersion = v1alpha1.StartScriptV2
 					return nil
 				})
 				framework.ExpectNoError(err, "failed to start script version to v2")
 
-				ginkgo.By(fmt.Sprintf("Wait for phase is %q", v1alpha1.UpgradePhase))
-				utiltc.MustWaitForComponentPhase(cli, tc, v1alpha1.PDMemberType, v1alpha1.UpgradePhase, 3*time.Minute, time.Second*3)
+				ginkgo.By("Wait for PD to be recreated") // MustWaitForComponentPhase may not observe the UpgradePhase
+				err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+					pdPods, err := c.CoreV1().Pods(tc.Namespace).List(context.TODO(), metav1.ListOptions{
+						LabelSelector: labels.SelectorFromSet(map[string]string{
+							"app.kubernetes.io/component": "pd",
+							"app.kubernetes.io/instance":  tc.Name,
+						}).String(),
+					})
+					if err != nil {
+						return false, err
+					}
+					if len(pdPods.Items) == 0 {
+						return false, nil
+					}
+					log.Logf("time before update: %v, pd pod creation time: %v", timeBeforeUpdate, pdPods.Items[0].CreationTimestamp)
+					if pdPods.Items[0].CreationTimestamp.Before(&timeBeforeUpdate) {
+						return false, nil
+					}
+					return true, nil
+				})
+				framework.ExpectNoError(err, "failed to wait for pd pod of tc %s/%s to be recreated", ns, tcName)
 
 				ginkgo.By("Wait for cluster is ready")
 				err = oa.WaitForTidbClusterReady(tc, 25*time.Minute, 10*time.Second)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
