### PR TITLE
Add trap to create a path when BR container exit

### DIFF
--- a/images/ebs-warmup/warmup-steps.sh
+++ b/images/ebs-warmup/warmup-steps.sh
@@ -34,6 +34,13 @@ Supported flags:
 EOF
 }
 
+# The trap command is to make sure the sidecars are terminated when the jobs are finished
+cleanup() {
+    touch /tmp/pod/main-terminated
+}
+
+trap cleanup EXIT
+
 operation=none
 while [ $# -gt 0 ]; do
     case $1 in

--- a/images/tidb-backup-manager/e2e-entrypoint.sh
+++ b/images/tidb-backup-manager/e2e-entrypoint.sh
@@ -15,6 +15,13 @@
 
 set -e
 
+# The trap command is to make sure the sidecars are terminated when the jobs are finished
+cleanup() {
+    touch /tmp/pod/main-terminated
+}
+
+trap cleanup EXIT
+
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/google-credentials.json
 echo "Create rclone.conf file."
 cat <<EOF > /tmp/rclone.conf

--- a/images/tidb-backup-manager/entrypoint.sh
+++ b/images/tidb-backup-manager/entrypoint.sh
@@ -15,6 +15,13 @@
 
 set -e
 
+# The trap command is to make sure the sidecars are terminated when the jobs are finished
+cleanup() {
+    touch /tmp/pod/main-terminated
+}
+
+trap cleanup EXIT
+
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/google-credentials.json
 echo "Create rclone.conf file."
 cat <<EOF > /tmp/rclone.conf


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
close Add an ISSUE LINK WITH SUMMARY if exists.
For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #5430

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Create a path when the main container exits, the sidecar can check the path once it shows up it can exit. 
### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
