### PR TITLE
chart: set leader-elect-resource-lock when deploying asts controller

### DIFF
--- a/charts/tidb-operator/templates/advanced-statefulset-deployment.yaml
+++ b/charts/tidb-operator/templates/advanced-statefulset-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         - --leader-elect
         - --leader-elect-resource-name=advanced-statefulset-controller
         - --leader-elect-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.advancedStatefulset.resourceLock }}
+        - --leader-elect-resource-lock={{ .Values.advancedStatefulset.resourceLock }}
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/charts/tidb-operator/templates/advanced-statefulset-rbac.yaml
+++ b/charts/tidb-operator/templates/advanced-statefulset-rbac.yaml
@@ -81,6 +81,12 @@ rules:
   - 'endpoints'
   verbs:
   - '*'
+- apiGroups:
+  - 'coordination.k8s.io'
+  resources:
+  - 'leases'
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -202,6 +202,9 @@ scheduler:
 #   kubectl apply -f manifests/advanced-statefulset-crd.v1.yaml
 advancedStatefulset:
   create: false
+  ## resourceLock indicates the type of resource object that will be used for locking during leader election.
+  ## If using "endpoints" before and want to migrate to "leases", you should migrate to "endpointsleases" first.
+  resourceLock: "endpointsleases"
   image: pingcap/advanced-statefulset:v0.4.0
   imagePullPolicy: IfNotPresent
   serviceAccount: advanced-statefulset-controller

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -204,7 +204,7 @@ advancedStatefulset:
   create: false
   ## resourceLock indicates the type of resource object that will be used for locking during leader election.
   ## If using "endpoints" before and want to migrate to "leases", you should migrate to "endpointsleases" first.
-  resourceLock: "endpointsleases"
+  resourceLock: "leases"
   image: pingcap/advanced-statefulset:v0.4.0
   imagePullPolicy: IfNotPresent
   serviceAccount: advanced-statefulset-controller

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -204,7 +204,7 @@ advancedStatefulset:
   create: false
   ## resourceLock indicates the type of resource object that will be used for locking during leader election.
   ## If using "endpoints" before and want to migrate to "leases", you should migrate to "endpointsleases" first.
-  resourceLock: "leases"
+  resourceLock: "endpointsleases"
   image: pingcap/advanced-statefulset:v0.4.0
   imagePullPolicy: IfNotPresent
   serviceAccount: advanced-statefulset-controller

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -204,7 +204,7 @@ advancedStatefulset:
   create: false
   ## resourceLock indicates the type of resource object that will be used for locking during leader election.
   ## If using "endpoints" before and want to migrate to "leases", you should migrate to "endpointsleases" first.
-  resourceLock: "endpointsleases"
+  # resourceLock: "leases"
   image: pingcap/advanced-statefulset:v0.4.0
   imagePullPolicy: IfNotPresent
   serviceAccount: advanced-statefulset-controller


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

ref:

- https://github.com/kubernetes/kubernetes/pull/106852
- https://github.com/pingcap/advanced-statefulset/pull/104

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
    see log of advanced-statefulset deploy with this chart `--set advancedStatefulset.resourceLock=leases`
    ```
    I1207 08:24:39.220976       1 flags.go:33] FLAG: --add-dir-header="false"
    I1207 08:24:39.221003       1 flags.go:33] FLAG: --alsologtostderr="false"
    I1207 08:24:39.221007       1 flags.go:33] FLAG: --controller-start-interval="0s"
    I1207 08:24:39.221012       1 flags.go:33] FLAG: --help="false"
    I1207 08:24:39.221016       1 flags.go:33] FLAG: --kube-api-burst="30"
    I1207 08:24:39.221020       1 flags.go:33] FLAG: --kube-api-content-type="application/vnd.kubernetes.protobuf"
    I1207 08:24:39.221024       1 flags.go:33] FLAG: --kube-api-qps="20"
    I1207 08:24:39.221028       1 flags.go:33] FLAG: --kubeconfig=""
    I1207 08:24:39.221031       1 flags.go:33] FLAG: --leader-elect="true"
    I1207 08:24:39.221033       1 flags.go:33] FLAG: --leader-elect-lease-duration="15s"
    I1207 08:24:39.221036       1 flags.go:33] FLAG: --leader-elect-renew-deadline="10s"
    I1207 08:24:39.221038       1 flags.go:33] FLAG: --leader-elect-resource-lock="leases"
    I1207 08:24:39.221041       1 flags.go:33] FLAG: --leader-elect-resource-name="advanced-statefulset-controller"
    I1207 08:24:39.221043       1 flags.go:33] FLAG: --leader-elect-resource-namespace="tidb-admin"
    ```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
