### PR TITLE
chart: do not deploy tidb-scheduler by default

### DIFF
--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -152,7 +152,7 @@ controllerManager:
   # kubeClientBurst: 10
 
 scheduler:
-  create: true
+  create: false
   # With rbac.create=false, the user is responsible for creating this account
   # With rbac.create=true, this service account will be created
   # Also see rbac.create and clusterScoped

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -205,7 +205,7 @@ func GetDMCluster(ns, name, version string) *v1alpha1.DMCluster {
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			PVReclaimPolicy: &deletePVP,
 			// SchedulerName:   "tidb-scheduler",
-			Timezone:        "Asia/Shanghai",
+			Timezone: "Asia/Shanghai",
 			Labels: map[string]string{
 				ClusterCustomKey: "value",
 			},

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -112,8 +112,8 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 			Helper: &v1alpha1.HelperSpec{
 				Image: pointer.StringPtr(utilimage.HelperImage),
 			},
-			SchedulerName: "tidb-scheduler",
-			Timezone:      "Asia/Shanghai",
+			// SchedulerName: "tidb-scheduler", // use the default k8s scheduler now
+			Timezone: "Asia/Shanghai",
 			Labels: map[string]string{
 				ClusterCustomKey: "value",
 			},
@@ -204,7 +204,7 @@ func GetDMCluster(ns, name, version string) *v1alpha1.DMCluster {
 			Version:         version,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			PVReclaimPolicy: &deletePVP,
-			SchedulerName:   "tidb-scheduler",
+			// SchedulerName:   "tidb-scheduler",
 			Timezone:        "Asia/Shanghai",
 			Labels: map[string]string{
 				ClusterCustomKey: "value",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

for k8s > v1.19, we often don't need to deploy tidb-scheduler. ref https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-scheduler

and some users became confused when deploying tidb-scheduler (e.g #5462), so we disable it by default from v1.6.


### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
