### PR TITLE
br: fix redundant pvc and pv in metadata

### DIFF
--- a/pkg/backup/snapshotter/snapshotter_test.go
+++ b/pkg/backup/snapshotter/snapshotter_test.go
@@ -15,7 +15,6 @@ package snapshotter
 
 import (
 	"encoding/json"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -2352,42 +2351,4 @@ func TestCommitPVsAndPVCsToK8S(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, tc.pvcCount, len(pvcs))
 	}
-}
-
-func TestCSB(t *testing.T) {
-	csb := new(CloudSnapBackup)
-	content, err := os.ReadFile("/Users/wangle/Downloads/restoremeta (1).txt")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if err := json.Unmarshal(content, csb); err != nil {
-		t.Error("unmarshal csb", err)
-		return
-	}
-
-	pvMap := make(map[string]*corev1.PersistentVolume, len(csb.Kubernetes.PVs))
-	pvNameMap := make(map[string]struct{}, len(csb.Kubernetes.PVs))
-	for _, pv := range csb.Kubernetes.PVs {
-		pvMap[pv.Name] = pv
-		pvNameMap[pv.Name] = struct{}{}
-	}
-
-	pvcMap := make(map[string]*corev1.PersistentVolumeClaim, len(csb.Kubernetes.PVCs))
-	for _, pvc := range csb.Kubernetes.PVCs {
-		pvcMap[pvc.Name] = pvc
-		delete(pvNameMap, pvc.Spec.VolumeName)
-	}
-
-	for pvName, _ := range pvNameMap {
-		remainedPV := pvMap[pvName]
-		t.Log("remained pv", remainedPV)
-		pvc := pvcMap[remainedPV.Spec.ClaimRef.Name]
-		t.Log("pvc", pvc)
-		pv := pvMap[pvc.Spec.VolumeName]
-		t.Log("pv", pv)
-	}
-
-	t.Log("pvc", len(csb.Kubernetes.PVCs), "pv", len(csb.Kubernetes.PVs))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Fix the bug that if there are redundant pvc or pv of backup tidb cluster, the backup can succeed but the restore can fail.

The redundant pvc or pv means:

- redundant pvc: there are labels in the pvc indicating that the pvc belongs to the backup tidb cluster but there is no tikv pod using it
- redundant pv: there are labels in the pv indicating that the pv belongs to the backup tidb cluster but there is no tikv pvc using it.

Closes #5459 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

At first we retrieve all the pvcs and pvs that may belong to the backup tidb cluster. Then we filter pvc by the tikv pod and filter pv by the pvc.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
