### PR TITLE
ebs br: backoff support for snapshots deletion

### DIFF
--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -129,7 +129,7 @@ func (bo *Options) deleteVolumeSnapshots(meta *bkutil.EBSBasedBRMeta) error {
 		return err
 	}
 	if err = ec2Session.DeleteSnapshots(newVolumeIDMap); err != nil {
-		klog.Errorf("delete snapshot failure.")
+		klog.Errorf("delete snapshots failure.")
 		return err
 	}
 

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -105,7 +105,7 @@ func (bo *Options) deleteSnapshotsAndBackupMeta(ctx context.Context, backup *v1a
 	}
 
 	//2. delete the snapshot
-	if err = bo.deleteVolumeSnapshots(metaInfo); err != nil {
+	if err = bo.deleteVolumeSnapshots(metaInfo, backup.Spec.CleanOption.SnapshotsDeleteRatio); err != nil {
 		klog.Errorf("delete volume snapshot failure, a mannual check or delete aciton require.")
 		return err
 	}
@@ -118,7 +118,7 @@ func (bo *Options) deleteSnapshotsAndBackupMeta(ctx context.Context, backup *v1a
 	return nil
 }
 
-func (bo *Options) deleteVolumeSnapshots(meta *bkutil.EBSBasedBRMeta) error {
+func (bo *Options) deleteVolumeSnapshots(meta *bkutil.EBSBasedBRMeta, deleteRatio float64) error {
 	newVolumeIDMap := make(map[string]string)
 	for i := range meta.TiKVComponent.Stores {
 		store := meta.TiKVComponent.Stores[i]
@@ -133,7 +133,7 @@ func (bo *Options) deleteVolumeSnapshots(meta *bkutil.EBSBasedBRMeta) error {
 		klog.Errorf("new a ec2 session failure.")
 		return err
 	}
-	if err = ec2Session.DeleteSnapshots(newVolumeIDMap); err != nil {
+	if err = ec2Session.DeleteSnapshots(newVolumeIDMap, deleteRatio); err != nil {
 		klog.Errorf("delete snapshots failure.")
 		return err
 	}

--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -86,8 +86,13 @@ func (bo *Options) deleteSnapshotsAndBackupMeta(ctx context.Context, backup *v1a
 	contents, err := os.ReadFile(metaFile)
 
 	if errors.Is(err, os.ErrNotExist) {
-		klog.Errorf("read metadata file %s failed, err: %s, a manual check or delete action required.", metaFile, err)
-		return err
+		if v1alpha1.IsBackupFailed(backup) {
+			klog.Warningf("read meta file %s not found from a failed backup, a manual check to snapshots might be needed.", metaFile)
+			return nil
+		} else {
+			klog.Errorf("read metadata file %s failed, err: %s, a manual check or delete action required.", metaFile, err)
+			return err
+		}
 	} else if err != nil { // will retry it
 		klog.Errorf("read metadata file %s failed, err: %s", metaFile, err)
 		return err

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -5061,6 +5061,17 @@ BatchDeleteOption
 </p>
 </td>
 </tr>
+<tr>
+<td>
+<code>snapshotsDeleteRatio</code></br>
+<em>
+float64
+</em>
+</td>
+<td>
+<p>SnapshotsDeleteRatio represents the number of snapshots deleted per second</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="cleanpolicytype">CleanPolicyType</h3>

--- a/docs/api-references/federation-docs.md
+++ b/docs/api-references/federation-docs.md
@@ -746,6 +746,17 @@ int
 <p>VolumeBackupInitJobMaxActiveSeconds represents the deadline (in seconds) of the vbk init job</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>snapshotsDeleteRatio</code></br>
+<em>
+float64
+</em>
+</td>
+<td>
+<p>SnapshotsDeleteRatio represents the number of snapshots deleted per second</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="volumebackupmemberstatus">VolumeBackupMemberStatus</h3>

--- a/docs/api-references/federation-docs.md
+++ b/docs/api-references/federation-docs.md
@@ -754,7 +754,7 @@ float64
 </em>
 </td>
 <td>
-<p>SnapshotsDeleteRatio represents the number of snapshots deleted per second</p>
+<p>SnapshotsDeleteRatio represents the number of snapshots deleted per second in every data plane</p>
 </td>
 </tr>
 </tbody>

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/tikv/pd v2.1.17+incompatible
 	go.etcd.io/etcd/client/v3 v3.5.9
-	go.uber.org/atomic v1.10.0
 	gocloud.dev v0.18.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/time v0.3.0
@@ -110,6 +109,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/tools v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
@@ -200,7 +200,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.uber.org/multierr v1.11.0
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1239,6 +1239,7 @@ spec:
                     format: int32
                     type: integer
                   snapshotsDeleteRatio:
+                    default: 1
                     type: number
                 type: object
               cleanPolicy:
@@ -3612,6 +3613,7 @@ spec:
                         format: int32
                         type: integer
                       snapshotsDeleteRatio:
+                        default: 1
                         type: number
                     type: object
                   cleanPolicy:
@@ -5789,6 +5791,7 @@ spec:
                         format: int32
                         type: integer
                       snapshotsDeleteRatio:
+                        default: 1
                         type: number
                     type: object
                   cleanPolicy:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1238,6 +1238,8 @@ spec:
                   routineConcurrency:
                     format: int32
                     type: integer
+                  snapshotsDeleteRatio:
+                    type: number
                 type: object
               cleanPolicy:
                 type: string
@@ -3609,6 +3611,8 @@ spec:
                       routineConcurrency:
                         format: int32
                         type: integer
+                      snapshotsDeleteRatio:
+                        type: number
                     type: object
                   cleanPolicy:
                     type: string
@@ -5784,6 +5788,8 @@ spec:
                       routineConcurrency:
                         format: int32
                         type: integer
+                      snapshotsDeleteRatio:
+                        type: number
                     type: object
                   cleanPolicy:
                     type: string

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
@@ -1681,6 +1681,9 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  snapshotsDeleteRatio:
+                    default: 1
+                    type: number
                   tolerations:
                     items:
                       properties:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
@@ -1689,6 +1689,9 @@ spec:
                         type: object
                       serviceAccount:
                         type: string
+                      snapshotsDeleteRatio:
+                        default: 1
+                        type: number
                       tolerations:
                         items:
                           properties:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -1239,6 +1239,7 @@ spec:
                     format: int32
                     type: integer
                   snapshotsDeleteRatio:
+                    default: 1
                     type: number
                 type: object
               cleanPolicy:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -1238,6 +1238,8 @@ spec:
                   routineConcurrency:
                     format: int32
                     type: integer
+                  snapshotsDeleteRatio:
+                    type: number
                 type: object
               cleanPolicy:
                 type: string

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -1214,6 +1214,7 @@ spec:
                         format: int32
                         type: integer
                       snapshotsDeleteRatio:
+                        default: 1
                         type: number
                     type: object
                   cleanPolicy:
@@ -3391,6 +3392,7 @@ spec:
                         format: int32
                         type: integer
                       snapshotsDeleteRatio:
+                        default: 1
                         type: number
                     type: object
                   cleanPolicy:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -1213,6 +1213,8 @@ spec:
                       routineConcurrency:
                         format: int32
                         type: integer
+                      snapshotsDeleteRatio:
+                        type: number
                     type: object
                   cleanPolicy:
                     type: string
@@ -3388,6 +3390,8 @@ spec:
                       routineConcurrency:
                         format: int32
                         type: integer
+                      snapshotsDeleteRatio:
+                        type: number
                     type: object
                   cleanPolicy:
                     type: string

--- a/manifests/federation-crd.yaml
+++ b/manifests/federation-crd.yaml
@@ -1681,6 +1681,9 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  snapshotsDeleteRatio:
+                    default: 1
+                    type: number
                   tolerations:
                     items:
                       properties:
@@ -3480,6 +3483,9 @@ spec:
                         type: object
                       serviceAccount:
                         type: string
+                      snapshotsDeleteRatio:
+                        default: 1
+                        type: number
                       tolerations:
                         items:
                           properties:

--- a/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
@@ -362,6 +362,13 @@ func schema_apis_federation_pingcap_v1alpha1_VolumeBackupMemberSpec(ref common.R
 							Format:      "int32",
 						},
 					},
+					"snapshotsDeleteRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SnapshotsDeleteRatio represents the number of snapshots deleted per second",
+							Type:        []string{"number"},
+							Format:      "double",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/openapi_generated.go
@@ -364,7 +364,7 @@ func schema_apis_federation_pingcap_v1alpha1_VolumeBackupMemberSpec(ref common.R
 					},
 					"snapshotsDeleteRatio": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SnapshotsDeleteRatio represents the number of snapshots deleted per second",
+							Description: "SnapshotsDeleteRatio represents the number of snapshots deleted per second in every data plane",
 							Type:        []string{"number"},
 							Format:      "double",
 						},

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -127,7 +127,7 @@ type VolumeBackupMemberSpec struct {
 	// +kubebuilder:default=600
 	VolumeBackupInitJobMaxActiveSeconds int `json:"volumeBackupInitJobMaxActiveSeconds,omitempty"`
 	// SnapshotsDeleteRatio represents the number of snapshots deleted per second
-	// +kubebuilder:default=1.0
+	// +kubebuilder:default=1
 	SnapshotsDeleteRatio float64 `json:"snapshotsDeleteRatio,omitempty"`
 }
 

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -126,6 +126,9 @@ type VolumeBackupMemberSpec struct {
 	// VolumeBackupInitJobMaxActiveSeconds represents the deadline (in seconds) of the vbk init job
 	// +kubebuilder:default=600
 	VolumeBackupInitJobMaxActiveSeconds int `json:"volumeBackupInitJobMaxActiveSeconds,omitempty"`
+	// SnapshotsDeleteRatio represents the number of snapshots deleted per second
+	// +kubebuilder:default=1.0
+	SnapshotsDeleteRatio float64 `json:"snapshotsDeleteRatio,omitempty"`
 }
 
 // BRConfig contains config for BR

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -126,7 +126,7 @@ type VolumeBackupMemberSpec struct {
 	// VolumeBackupInitJobMaxActiveSeconds represents the deadline (in seconds) of the vbk init job
 	// +kubebuilder:default=600
 	VolumeBackupInitJobMaxActiveSeconds int `json:"volumeBackupInitJobMaxActiveSeconds,omitempty"`
-	// SnapshotsDeleteRatio represents the number of snapshots deleted per second
+	// SnapshotsDeleteRatio represents the number of snapshots deleted per second in every data plane
 	// +kubebuilder:default=1
 	SnapshotsDeleteRatio float64 `json:"snapshotsDeleteRatio,omitempty"`
 }

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1498,6 +1498,13 @@ func schema_pkg_apis_pingcap_v1alpha1_CleanOption(ref common.ReferenceCallback) 
 							Format:      "int64",
 						},
 					},
+					"snapshotsDeleteRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SnapshotsDeleteRatio represents the number of snapshots deleted per second",
+							Type:        []string{"number"},
+							Format:      "double",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2015,6 +2015,7 @@ type CleanOption struct {
 	BatchDeleteOption `json:",inline"`
 
 	// SnapshotsDeleteRatio represents the number of snapshots deleted per second
+	// +kubebuilder:default=1
 	SnapshotsDeleteRatio float64 `json:"snapshotsDeleteRatio,omitempty"`
 }
 

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2013,6 +2013,9 @@ type CleanOption struct {
 	BackoffEnabled bool `json:"backoffEnabled,omitempty"`
 
 	BatchDeleteOption `json:",inline"`
+
+	// SnapshotsDeleteRatio represents the number of snapshots deleted per second
+	SnapshotsDeleteRatio float64 `json:"snapshotsDeleteRatio,omitempty"`
 }
 
 type Progress struct {

--- a/pkg/backup/snapshotter/snapshotter_aws.go
+++ b/pkg/backup/snapshotter/snapshotter_aws.go
@@ -30,6 +30,7 @@ const (
 	CloudAPIConcurrency = 8
 	PVCTagKey           = "CSIVolumeName"
 	PodTagKey           = "kubernetes.io/created-for/pvc/name"
+	PVAvailableStatus   = "Available"
 )
 
 // AWSSnapshotter is the snapshotter for creating snapshots from volumes (during a backup)
@@ -102,6 +103,10 @@ func (s *AWSSnapshotter) AddVolumeTags(pvs []*corev1.PersistentVolume) error {
 	resourcesTags := make(map[string]util.TagMap)
 
 	for _, pv := range pvs {
+		// Only tagging to available volumes
+		if pv.Status.Phase != PVAvailableStatus {
+			continue
+		}
 		podName := pv.GetAnnotations()[label.AnnPodNameKey]
 		pvcName := pv.GetName()
 		volId := pv.Spec.CSI.VolumeHandle

--- a/pkg/backup/snapshotter/snapshotter_aws.go
+++ b/pkg/backup/snapshotter/snapshotter_aws.go
@@ -30,7 +30,6 @@ const (
 	CloudAPIConcurrency = 8
 	PVCTagKey           = "CSIVolumeName"
 	PodTagKey           = "kubernetes.io/created-for/pvc/name"
-	PVAvailableStatus   = "Available"
 )
 
 // AWSSnapshotter is the snapshotter for creating snapshots from volumes (during a backup)
@@ -103,10 +102,6 @@ func (s *AWSSnapshotter) AddVolumeTags(pvs []*corev1.PersistentVolume) error {
 	resourcesTags := make(map[string]util.TagMap)
 
 	for _, pv := range pvs {
-		// Only tagging to available volumes
-		if pv.Status.Phase != PVAvailableStatus {
-			continue
-		}
 		podName := pv.GetAnnotations()[label.AnnPodNameKey]
 		pvcName := pv.GetName()
 		volId := pv.Spec.CSI.VolumeHandle

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -148,6 +148,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
 	lastFlowCheck := time.Now()
 	for volID := range snapIDMap {
 		snapID := snapIDMap[volID]
+		klog.Infof("deleting snapshot %s ", snapID)
 		// use exponential backoff, every retry duration is duration * factor ^ (used_step - 1)
 		backoff := wait.Backoff{
 			Duration: time.Second,
@@ -166,7 +167,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
 						return nil
 					}
 				}
-				klog.Warningf("snapshot %s failed, err: %s", snapID, err.Error())
+				klog.Warningf("delete snapshot %s failed, err: %s", snapID, err.Error())
 				return err
 			} else {
 				klog.Infof("snapshot %s is deleted", snapID)
@@ -193,8 +194,8 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
 		err := retry.OnError(backoff, isRetry, delSnapshots)
 		if err != nil {
 			klog.Errorf("failed to delete snapshot id=%s, error=%s", snapID, err.Error())
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -146,6 +146,7 @@ func NewEC2Session(concurrency uint) (*EC2Session, error) {
 func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
 	var deletedCnt int32
 	lastFlowCheck := time.Now()
+	klog.Infof("Start deleting snapshots, total is %d", len(snapIDMap))
 	for volID := range snapIDMap {
 		snapID := snapIDMap[volID]
 		klog.Infof("deleting snapshot %s ", snapID)

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -173,7 +173,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string, deleteRatio fl
 			} else {
 				klog.Infof("snapshot %s is deleted", snapID)
 				deletedCnt++
-				// Check flow every 10 deletions, we try to make no more than 1 deletion/second.
+				// Check flow every 10 deletions, we try to make no more than deleteRatio deletion/second.
 				if deletedCnt%SnapshotDeletionFlowControlInterval == 0 {
 					lastRoundDuration := time.Since(lastFlowCheck)
 					expectedET := time.Duration(SnapshotDeletionFlowControlInterval/deleteRatio) * time.Second

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -169,11 +169,14 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
 				klog.Warningf("snapshot %s failed, err: %s", snapID, err.Error())
 				return err
 			} else {
+				klog.Infof("snapshot %s is deleted", snapID)
 				deletedCnt++
 				// Check flow every 10 deletions, we try to make no more than 1 deletion/second.
 				if deletedCnt%SnapshotDeletionFlowControlInterval == 0 {
-					if time.Since(lastFlowCheck) < SnapshotDeletionFlowControlInterval*time.Second {
-						suspension := SnapshotDeletionFlowControlInterval*time.Second - time.Since(lastFlowCheck)
+					lastRoundDuration := time.Since(lastFlowCheck)
+					klog.Infof("deletion count is %d, last round costs %s", deletedCnt, lastRoundDuration)
+					if lastRoundDuration < SnapshotDeletionFlowControlInterval*time.Second {
+						suspension := SnapshotDeletionFlowControlInterval*time.Second - lastRoundDuration
 						klog.Infof("Snapshot deletion flow control for %s", suspension)
 						time.Sleep(suspension)
 					}

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -15,11 +15,11 @@ package util
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -356,7 +356,7 @@ func (bm *backupScheduleManager) backupGCByMaxBackups(vbs *v1alpha1.VolumeBackup
 	// In order to avoid throttling, we choose to do delete volumebackup one by one.
 	// Delete the oldest expired backup
 	if len(backupsList) > int(*vbs.Spec.MaxBackups) {
-		backup := backupsList[int(*vbs.Spec.MaxBackups)]
+		backup := backupsList[len(backupsList)-1]
 		if backup.DeletionTimestamp != nil {
 			klog.Infof("Deletion is ongoing for backup schedule %s/%s, backup %s", ns, bsName, backup.GetName())
 			return


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #5493 
Closes #5503

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
1. Provide backoff for snapshots deletion in data plane cleanup and provide a simple local flow control on snapshot deletion at no more than one per second. What's more a new option is provided to backup schedule CRD as `spec.template.snapshotsDeleteRatio`. It controls the expected ratio for snapshots deletion at individual data plane.
2. Let volumebackup succeed in the scenario where meta file is not created in some data plane.

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [X] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
When use the default ratio (1.0)
![img_v3_0271_b66dc4cf-0415-4b38-9265-22623de900fg](https://github.com/pingcap/tidb-operator/assets/97348524/93b117da-80ee-41e8-a44b-adadc48c1e3b)
When set to 0.5
![Uploading img_v3_0271_c8c34528-1455-4b95-8dc7-684b7ea9f48g.jpg…]()

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
