### PR TITLE
Adding delve to launch controller manager in local kind execution environment

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -58,6 +58,9 @@ spec:
           periodSeconds: 10
           failureThreshold: 10
         command:
+          - "/bin/sh"
+          - "-c"
+          - "$GOPATH/bin/dlv --listen=:2345 --continue --headless=true --accept-multiclient --api-version=2 exec /usr/local/bin/tidb-controller-manager --"
           - /usr/local/bin/tidb-controller-manager
           {{- if .Values.tidbBackupManagerImage }}
           - -tidb-backup-manager-image={{ .Values.tidbBackupManagerImage }}

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -2,6 +2,11 @@ FROM pingcap/pingcap-base:v1
 
 ARG TARGETARCH
 RUN dnf install -y tzdata bind-utils && dnf clean all
+RUN dnf install -y golang git
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+ENV GOPATH=/root/go
+
 ADD bin/${TARGETARCH}/tidb-scheduler /usr/local/bin/tidb-scheduler
 ADD bin/${TARGETARCH}/tidb-discovery /usr/local/bin/tidb-discovery
 ADD bin/${TARGETARCH}/tidb-controller-manager /usr/local/bin/tidb-controller-manager


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
This PR runs the controller-manager binary through delve, which will listen on port 2345. This facilitates the debugging of the operator within kubernetes, as well as exploring the source code for newcomers.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->


### Code changes

Changes the command within the local deployment helm template to run the controller manager through dlv, and installs delve through go install .

- [ ] Has Go code change
- [X] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

How to test:

- ./hack/local-up-operator.sh
- kubectl port-foward $CONTROLLER_MANAGER_POD_NAME 2345:2345
- create a go remote config within goland (or anything similar in other ides), and connect to localhost:2345
- set a breakpoint on package/controller/tidbcluster/tidbcluster_control.go (I did it on the first line for the UpdateTidbCluster function)
- kubectl apply -f example/multi-cluster/tidb-cluster-1.yaml
- watch the breakpoint pop

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
