### PR TITLE
always save checkpoint to the warmup folder

### DIFF
--- a/cmd/ebs-warmup/main.go
+++ b/cmd/ebs-warmup/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"math"
 	"os"
 	"os/signal"
@@ -38,6 +39,8 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
 	config := filereader.Config{
@@ -60,5 +63,7 @@ func main() {
 		signal.Stop(ch)
 		cancel()
 	}()
-	rd.RunAndClose(ctx)
+	if err := rd.RunAndClose(ctx); err != nil {
+		klog.ErrorS(err, "Failed to warmup. The checkpoint maybe stored.")
+	}
 }

--- a/images/ebs-warmup/warmup-steps.sh
+++ b/images/ebs-warmup/warmup-steps.sh
@@ -34,6 +34,12 @@ Supported flags:
 EOF
 }
 
+warmup_by_file() {
+    checkpoint=.com.pingcap.tidb.operator.ebs.warmup.checkpoint
+    /warmup --type=whole --files="$1" -P256 --direct --checkpoint.at="$1/$checkpoint"
+}
+
+
 # The trap command is to make sure the sidecars are terminated when the jobs are finished
 cleanup() {
     if [ ! -d "/tmp/pod" ]; then
@@ -74,7 +80,7 @@ while [ $# -gt 0 ]; do
                             --thread=1 --filename=/dev/"$device" &
                     fi
                     ;;
-                fs) /warmup --type=whole --files="$1" -P256 --direct &
+                fs) warmup_by_file "$1" &
                     ;;
                 *) die "internal error: unsupported operation $1; forgot to call --block or --fs?"
                     ;;


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Fixed #5506.

### What is changed and how does it work?

The checkpoint file is stored at the work directory where the `warmup` binary runs. 
This PR changes the `warmup_step` script, make it always set checkpoint to the directory to be warmed up. 
(Also notice that, it is impossible to pass a glob pattern to `warmup_step` anymore.)

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->



### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fixed a bug that may cause the warmup checkpoint is unavailable.
```
