### PR TITLE
fips: adjust version suffix (#5512)

### DIFF
--- a/pkg/fips/fips.go
+++ b/pkg/fips/fips.go
@@ -19,10 +19,4 @@ package fips
 import (
 	// Restricts all TLS configuration to FIPS-approved settings
 	_ "crypto/tls/fipsonly"
-
-	"github.com/pingcap/tidb-operator/pkg/version"
 )
-
-func init() {
-	version.SetVersionSuffix("-fips")
-}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,11 +28,6 @@ var (
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
-// SetVersionSuffix sets version suffix.
-func SetVersionSuffix(suffix string) {
-	gitVersion += suffix
-}
-
 // PrintVersionInfo show version info to Stdout
 func PrintVersionInfo() {
 	fmt.Printf("TiDB Operator Version: %#v\n", Get())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Adjust version suffix, so that it does not display double fips suffixes (`v1.5.1-fips-fips`) for tags end with `fips`.

Ref #5396

### Code changes

- [x] Has Go code change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

```
➜ git tag v1.5.1-fips                             

➜ make                                            
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:32Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/tidb-operator/bin/amd64/tidb-controller-manager cmd/controller-manager/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:38Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/tidb-operator/bin/amd64/tidb-scheduler cmd/scheduler/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:41Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/tidb-operator/bin/amd64/tidb-discovery cmd/discovery/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:45Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/tidb-operator/bin/amd64/tidb-admission-webhook cmd/admission-webhook/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:50Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/tidb-backup-manager/bin/amd64/tidb-backup-manager cmd/backup-manager/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X 'github.com/pingcap/tidb-operator/pkg/version.buildDate=2024-01-12T06:57:55Z' -X 'github.com/pingcap/tidb-operator/pkg/version.gitCommit=ea9d440b225831e85d3eababbb1a69df868ceb95' -X 'github.com/pingcap/tidb-operator/pkg/version.gitTreeState=clean' -X 'github.com/pingcap/tidb-operator/pkg/version.gitVersion=v1.5.1-fips'' -o images/br-federation-manager/bin/amd64/br-federation-manager ./cmd/br-federation-manager

➜ images/tidb-operator/bin/amd64/tidb-controller-manager -V
TiDB Operator Version: version.Info{GitVersion:"v1.5.1-fips", GitCommit:"ea9d440b225831e85d3eababbb1a69df868ceb95", GitTreeState:"clean", BuildDate:"2024-01-12T06:57:32Z", GoVersion:"go1.21.1", Compiler:"gc", Platform:"linux/amd64"}
```


### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
