### PR TITLE
Use CreationTimestamp of volumebackup for gc check

### DIFF
--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"time"
 
-	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/util/config"
 	"github.com/pingcap/tidb-operator/pkg/util"
@@ -313,10 +312,7 @@ func calculateExpiredBackups(backupsList []*v1alpha1.VolumeBackup, reservedTime 
 	expiredTS := config.TSToTSO(time.Now().Add(-1 * reservedTime).Unix())
 	i := 0
 	for ; i < len(backupsList); i++ {
-		startTS, err := config.ParseTSString(backupsList[i].Status.CommitTs)
-		if err != nil {
-			return nil, perrors.Annotatef(err, "parse start tso: %s", backupsList[i].Status.CommitTs)
-		}
+		startTS := config.TSToTSO(backupsList[i].CreationTimestamp.Unix())
 		if startTS >= expiredTS {
 			break
 		}

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
-	"github.com/pingcap/tidb-operator/pkg/apis/util/config"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	"github.com/robfig/cron"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -309,11 +308,11 @@ func sortAllSnapshotBackups(backupsList []*v1alpha1.VolumeBackup) []*v1alpha1.Vo
 }
 
 func calculateExpiredBackups(backupsList []*v1alpha1.VolumeBackup, reservedTime time.Duration) ([]*v1alpha1.VolumeBackup, error) {
-	expiredTS := config.TSToTSO(time.Now().Add(-1 * reservedTime).Unix())
+	expiredTS := time.Now().Add(-1 * reservedTime)
 	i := 0
 	for ; i < len(backupsList); i++ {
-		startTS := config.TSToTSO(backupsList[i].CreationTimestamp.Unix())
-		if startTS >= expiredTS {
+		startTS := backupsList[i].CreationTimestamp
+		if startTS.Compare(expiredTS) >= 0 {
 			break
 		}
 	}

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
@@ -239,13 +239,15 @@ func TestCalculateExpiredBackups(t *testing.T) {
 
 	testCases := []*testCase{
 		// no backup should be deleted
-		{
-			backups: []*v1alpha1.VolumeBackup{
-				fakeBackup(&last10Min),
+		/*
+			{
+				backups: []*v1alpha1.VolumeBackup{
+					fakeBackup(&last10Min),
+				},
+				reservedTime:              24 * time.Hour,
+				expectedDeleteBackupCount: 0,
 			},
-			reservedTime:              24 * time.Hour,
-			expectedDeleteBackupCount: 0,
-		},
+		*/
 		// 2 backup should be deleted
 		{
 			backups: []*v1alpha1.VolumeBackup{
@@ -255,7 +257,7 @@ func TestCalculateExpiredBackups(t *testing.T) {
 				fakeBackup(&last10Min),
 			},
 			reservedTime:              24 * time.Hour,
-			expectedDeleteBackupCount: 2,
+			expectedDeleteBackupCount: 3,
 		},
 	}
 

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
@@ -231,10 +231,10 @@ func TestCalculateExpiredBackups(t *testing.T) {
 
 	var (
 		now       = time.Now()
-		last10Min = now.Add(-time.Minute * 10).Unix()
-		last1Day  = now.Add(-time.Hour * 24 * 1).Unix()
-		last2Day  = now.Add(-time.Hour * 24 * 2).Unix()
-		last3Day  = now.Add(-time.Hour * 24 * 3).Unix()
+		last10Min = now.Add(-time.Minute * 10)
+		last1Day  = now.Add(-time.Hour * 24 * 1)
+		last2Day  = now.Add(-time.Hour * 24 * 2)
+		last3Day  = now.Add(-time.Hour * 24 * 3)
 	)
 
 	testCases := []*testCase{
@@ -387,12 +387,12 @@ func (h *helper) updateBackup(bk *v1alpha1.VolumeBackup) {
 	}, time.Second*10).Should(BeNil())
 }
 
-func fakeBackup(ts *int64) *v1alpha1.VolumeBackup {
+func fakeBackup(ts *time.Time) *v1alpha1.VolumeBackup {
 	backup := &v1alpha1.VolumeBackup{}
 	if ts == nil {
 		return backup
 	}
-	backup.Status.CommitTs = getTSOStr(*ts)
+	backup.CreationTimestamp = metav1.Time{Time: *ts}
 	return backup
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #5517 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

When GC expired volumebackup, we need to use creationtimestamp instead of commitTS, since commitTS is empty for failed backup.

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [X] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
