### PR TITLE
br: add metrics for volume backup

### DIFF
--- a/cmd/backup-manager/app/clean/manager.go
+++ b/cmd/backup-manager/app/clean/manager.go
@@ -101,7 +101,7 @@ func (bm *Manager) performCleanBackup(ctx context.Context, backup *v1alpha1.Back
 		errs = append(errs, err)
 		klog.Errorf("clean cluster %s backup %s failed, err: %s", bm, backup.Status.BackupPath, err)
 		uerr := bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{
-			Type:    v1alpha1.BackupFailed,
+			Type:    v1alpha1.BackupCleanFailed,
 			Status:  corev1.ConditionTrue,
 			Reason:  "CleanBackupDataFailed",
 			Message: err.Error(),

--- a/pkg/apis/federation/pingcap/v1alpha1/types.go
+++ b/pkg/apis/federation/pingcap/v1alpha1/types.go
@@ -219,6 +219,8 @@ const (
 	VolumeBackupFailed VolumeBackupConditionType = "Failed"
 	// VolumeBackupCleaned means all the resources about VolumeBackup have cleaned
 	VolumeBackupCleaned VolumeBackupConditionType = "Cleaned"
+	// VolumeBackupCleanFailed means one of backup cleanup in data plane is failed
+	VolumeBackupCleanFailed VolumeBackupConditionType = "CleanFailed"
 )
 
 // +genclient

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -294,6 +294,12 @@ func IsBackupClean(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsBackupCleanFailed returns true if a Backup has failed to clean up
+func IsBackupCleanFailed(backup *Backup) bool {
+	_, condition := GetBackupCondition(&backup.Status, BackupCleanFailed)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsCleanCandidate returns true if a Backup should be added to clean candidate according to cleanPolicy
 func IsCleanCandidate(backup *Backup) bool {
 	switch backup.Spec.CleanPolicy {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2253,6 +2253,8 @@ const (
 	BackupFailed BackupConditionType = "Failed"
 	// BackupRetryTheFailed means this failure can be retried
 	BackupRetryTheFailed BackupConditionType = "RetryFailed"
+	// BackupCleanFailed means the clean job has failed
+	BackupCleanFailed BackupConditionType = "CleanFailed"
 	// BackupInvalid means invalid backup CR
 	BackupInvalid BackupConditionType = "Invalid"
 	// BackupPrepare means the backup prepare backup process

--- a/pkg/controller/fedvolumebackup/fed_volume_backup_control.go
+++ b/pkg/controller/fedvolumebackup/fed_volume_backup_control.go
@@ -16,6 +16,7 @@ package fedvolumebackup
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -123,6 +124,10 @@ func (c *defaultBackupControl) updateVolumeBackupMetrics(volumeBackup *v1alpha1.
 	fedmetrics.FedVolumeBackupStatusCounterVec.WithLabelValues(ns, tcName, status).Inc()
 	fedmetrics.FedVolumeBackupTotalTimeCounterVec.WithLabelValues(ns, tcName).
 		Add(volumeBackup.Status.TimeCompleted.Sub(volumeBackup.Status.TimeStarted.Time).Seconds())
+	if volumeBackup.Status.BackupSize > 0 {
+		fedmetrics.FedVolumeBackupTotalSizeCounterVec.WithLabelValues(ns, tcName).Add(
+			float64(volumeBackup.Status.BackupSize) / math.Pow(1024, 3))
+	}
 }
 
 func (c *defaultBackupControl) updateVolumeBackupCleanupMetrics(volumeBackup *v1alpha1.VolumeBackup) {

--- a/pkg/controller/fedvolumebackup/fed_volume_backup_control.go
+++ b/pkg/controller/fedvolumebackup/fed_volume_backup_control.go
@@ -29,8 +29,8 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/client/federation/clientset/versioned"
 	informers "github.com/pingcap/tidb-operator/pkg/client/federation/informers/externalversions/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
-	"github.com/pingcap/tidb-operator/pkg/fedmetrics"
 	"github.com/pingcap/tidb-operator/pkg/fedvolumebackup"
+	"github.com/pingcap/tidb-operator/pkg/metrics"
 	"github.com/pingcap/tidb-operator/pkg/third_party/k8s"
 )
 
@@ -121,11 +121,11 @@ func (c *defaultBackupControl) updateVolumeBackupMetrics(volumeBackup *v1alpha1.
 	ns := volumeBackup.Namespace
 	tcName := volumeBackup.GetCombinedTCName()
 	status := string(volumeBackup.Status.Phase)
-	fedmetrics.FedVolumeBackupStatusCounterVec.WithLabelValues(ns, tcName, status).Inc()
-	fedmetrics.FedVolumeBackupTotalTimeCounterVec.WithLabelValues(ns, tcName).
+	metrics.FedVolumeBackupStatusCounterVec.WithLabelValues(ns, tcName, status).Inc()
+	metrics.FedVolumeBackupTotalTimeCounterVec.WithLabelValues(ns, tcName).
 		Add(volumeBackup.Status.TimeCompleted.Sub(volumeBackup.Status.TimeStarted.Time).Seconds())
 	if volumeBackup.Status.BackupSize > 0 {
-		fedmetrics.FedVolumeBackupTotalSizeCounterVec.WithLabelValues(ns, tcName).Add(
+		metrics.FedVolumeBackupTotalSizeCounterVec.WithLabelValues(ns, tcName).Add(
 			float64(volumeBackup.Status.BackupSize) / math.Pow(1024, 3))
 	}
 }
@@ -134,9 +134,9 @@ func (c *defaultBackupControl) updateVolumeBackupCleanupMetrics(volumeBackup *v1
 	ns := volumeBackup.Namespace
 	tcName := volumeBackup.GetCombinedTCName()
 	status := string(volumeBackup.Status.Phase)
-	fedmetrics.FedVolumeBackupCleanupStatusCounterVec.WithLabelValues(ns, tcName, status).Inc()
-	fedmetrics.FedVolumeBackupCleanupTotalTimeCounterVec.WithLabelValues(ns, tcName).
-		Add(time.Now().Sub(volumeBackup.DeletionTimestamp.Time).Seconds())
+	metrics.FedVolumeBackupCleanupStatusCounterVec.WithLabelValues(ns, tcName, status).Inc()
+	metrics.FedVolumeBackupCleanupTotalTimeCounterVec.WithLabelValues(ns, tcName).
+		Add(time.Since(volumeBackup.DeletionTimestamp.Time).Seconds())
 }
 
 // addProtectionFinalizer will be called when the VolumeBackup CR is created

--- a/pkg/fedmetrics/metrics.go
+++ b/pkg/fedmetrics/metrics.go
@@ -1,3 +1,16 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fedmetrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/fedmetrics/metrics.go
+++ b/pkg/fedmetrics/metrics.go
@@ -1,0 +1,41 @@
+package fedmetrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	LabelNamespace = "namespace"
+	LabelTC        = "tc"
+	LabelStatus    = "status"
+)
+
+var (
+	FedVolumeBackupStatusCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "fed",
+		Subsystem: "volume_backup",
+		Name:      "status",
+	}, []string{LabelNamespace, LabelTC, LabelStatus})
+	FedVolumeBackupTotalTimeCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "fed",
+		Subsystem: "volume_backup",
+		Name:      "total_time_sec",
+	}, []string{LabelNamespace, LabelTC})
+	FedVolumeBackupCleanupStatusCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "fed",
+		Subsystem: "volume_backup_cleanup",
+		Name:      "status",
+	}, []string{LabelNamespace, LabelTC, LabelStatus})
+	FedVolumeBackupCleanupTotalTimeCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "fed",
+		Subsystem: "volume_backup_cleanup",
+		Name:      "total_time_sec",
+	}, []string{LabelNamespace, LabelTC})
+)
+
+func init() {
+	prometheus.MustRegister(
+		FedVolumeBackupStatusCounterVec,
+		FedVolumeBackupTotalTimeCounterVec,
+		FedVolumeBackupCleanupStatusCounterVec,
+		FedVolumeBackupCleanupTotalTimeCounterVec,
+	)
+}

--- a/pkg/fedmetrics/metrics.go
+++ b/pkg/fedmetrics/metrics.go
@@ -19,6 +19,11 @@ var (
 		Subsystem: "volume_backup",
 		Name:      "total_time_sec",
 	}, []string{LabelNamespace, LabelTC})
+	FedVolumeBackupTotalSizeCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "fed",
+		Subsystem: "volume_backup",
+		Name:      "size_gb",
+	}, []string{LabelNamespace, LabelTC})
 	FedVolumeBackupCleanupStatusCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "fed",
 		Subsystem: "volume_backup_cleanup",
@@ -35,6 +40,7 @@ func init() {
 	prometheus.MustRegister(
 		FedVolumeBackupStatusCounterVec,
 		FedVolumeBackupTotalTimeCounterVec,
+		FedVolumeBackupTotalSizeCounterVec,
 		FedVolumeBackupCleanupStatusCounterVec,
 		FedVolumeBackupCleanupTotalTimeCounterVec,
 	)

--- a/pkg/metrics/brfederation.go
+++ b/pkg/metrics/brfederation.go
@@ -34,7 +34,7 @@ var (
 	FedVolumeBackupTotalSizeCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "fed",
 		Subsystem: "volume_backup",
-		Name:      "size_gb",
+		Name:      "total_size_gb",
 	}, []string{LabelNamespace, LabelTC})
 	FedVolumeBackupCleanupStatusCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "fed",

--- a/pkg/metrics/brfederation.go
+++ b/pkg/metrics/brfederation.go
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fedmetrics
+package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
 const (
-	LabelNamespace = "namespace"
-	LabelTC        = "tc"
-	LabelStatus    = "status"
+	LabelTC     = "tc"
+	LabelStatus = "status"
 )
 
 var (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Add metrics for br federation manager

Closes #5533

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Add metrics about volume backup status, volume backup total time, volume backup total size, volume backup cleanup status and volume backup cleanup total time.

For volume backup cleanup, there is no status to indicate cleanup failed. So I also add a `CleanFailed` status to backup and volume backup. If backup cleanup is failed, the backup CR will become `CleanFailed` status. If one of backup cleanup in data plane is failed, the volume backup CR will become `CleanFailed` status.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

![image](https://github.com/pingcap/tidb-operator/assets/13897016/fb0d879f-9837-4451-8e9d-dc6a33b4fa17)

![image](https://github.com/pingcap/tidb-operator/assets/13897016/d023cb03-1ca0-4a89-9855-dda461f1f403)

![image](https://github.com/pingcap/tidb-operator/assets/13897016/b1bbfcca-4073-4650-b8bb-d022677c2165)


### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
