### PR TITLE
pdms: make pdms tls reusing pd tls

### DIFF
--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -499,10 +499,11 @@ func (m *pdMSMemberManager) getNewPDMSStatefulSet(tc *v1alpha1.TidbCluster, cm *
 		},
 	}
 	if tc.IsTLSClusterEnabled() {
+		// reuse the secret created for pd
 		vols = append(vols, corev1.Volume{
 			Name: "pd-tls", VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.ClusterTLSSecretName(tc.Name, label.PDMSLabel(curService)),
+					SecretName: util.ClusterTLSSecretName(tc.Name, label.PDLabelVal),
 				},
 			},
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

ref https://github.com/tikv/pd/issues/7519

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

need to update pd-server.json
```bash
$ cat pd-server.json
{
    "CN": "TiDB",
    "hosts": [
      "127.0.0.1",
      "::1",
      "basic-pd",
      "basic-pd.pingcap",
      "basic-pd.pingcap.svc",
      "basic-pd-peer",
      "basic-pd-peer.pingcap",
      "basic-pd-peer.pingcap.svc",
      "*.basic-pd-peer",
      "*.basic-pd-peer.pingcap",
      "*.basic-pd-peer.pingcap.svc",
      "basic-pdms-scheduling",
      "basic-pdms-scheduling.pingcap",
      "basic-pdms-scheduling.pingcap.svc",
      "basic-pdms-scheduling-peer",
      "basic-pdms-scheduling-peer.pingcap",
      "basic-pdms-scheduling-peer.pingcap.svc",
      "*.basic-pdms-scheduling-peer",
      "*.basic-pdms-scheduling-peer.pingcap",
      "*.basic-pdms-scheduling-peer.pingcap.svc",
      "basic-pdms-tso",
      "basic-pdms-tso.pingcap",
      "basic-pdms-tso.pingcap.svc",
      "basic-pdms-tso-peer",
      "basic-pdms-tso-peer.pingcap",
      "basic-pdms-tso-peer.pingcap.svc",
      "*.basic-pdms-tso-peer",
      "*.basic-pdms-tso-peer.pingcap",
      "*.basic-pdms-tso-peer.pingcap.svc"
    ],
    "key": {
        "algo": "ecdsa",
        "size": 256
    },
    "names": [
        {
            "C": "US",
            "L": "CA",
            "ST": "San Francisco"
        }
    ]
}

```

<img width="801" alt="image" src="https://github.com/pingcap/tidb-operator/assets/53859786/3cd21c0a-2bc5-4302-90ab-fb7ede4e257f">

<img width="752" alt="image" src="https://github.com/pingcap/tidb-operator/assets/53859786/6e2a5b2c-2180-49c7-9682-d89e5b41fe13">


### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
