### PR TITLE
pdms: fix tls config is nil

### DIFF
--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -713,6 +713,9 @@ func (m *pdMSMemberManager) getNewPDMSStatefulSet(tc *v1alpha1.TidbCluster, cm *
 }
 
 func (m *pdMSMemberManager) getPDMSConfigMap(tc *v1alpha1.TidbCluster, curSpec *v1alpha1.PDMSSpec) (*corev1.ConfigMap, error) {
+	if curSpec.Config == nil {
+		curSpec.Config = v1alpha1.NewPDConfig()
+	}
 	config := curSpec.Config.DeepCopy() // use copy to not update tc spec
 
 	curService := curSpec.Name

--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -713,10 +713,12 @@ func (m *pdMSMemberManager) getNewPDMSStatefulSet(tc *v1alpha1.TidbCluster, cm *
 }
 
 func (m *pdMSMemberManager) getPDMSConfigMap(tc *v1alpha1.TidbCluster, curSpec *v1alpha1.PDMSSpec) (*corev1.ConfigMap, error) {
-	if curSpec.Config == nil {
-		curSpec.Config = v1alpha1.NewPDConfig()
+	var config *v1alpha1.PDConfigWraper
+	if curSpec.Config != nil {
+		config = curSpec.Config.DeepCopy() // use copy to not update tc spec
+	} else {
+		config = v1alpha1.NewPDConfig()
 	}
-	config := curSpec.Config.DeepCopy() // use copy to not update tc spec
 
 	curService := curSpec.Name
 	// override CA if tls enabled


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Ref https://github.com/tikv/pd/issues/7519
-->

    Ref https://github.com/tikv/pd/issues/7519

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

fix config panic when enable tls

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
