### PR TITLE
fix: minreadyseconds for last TiKV

### DIFF
--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -87,7 +87,7 @@ func (u *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, new
 
 	tc, _ := meta.(*v1alpha1.TidbCluster)
 
-	// upgrade tikv without evicting leader when only one tikv is exist
+	// upgrade tikv without evicting leader when only one tikv exists
 	// NOTE: If `TiKVStatus.Synced`` is false, it's acceptable to use old record about peer stores
 	if *oldSet.Spec.Replicas < 2 && len(tc.Status.TiKV.PeerStores) == 0 {
 		klog.Infof("TiKV statefulset replicas are less than 2, skip evicting region leader for tc %s/%s", ns, tcName)
@@ -115,16 +115,7 @@ func (u *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, new
 		return nil
 	}
 
-	minReadySeconds := 0
-	s, ok := tc.Annotations[annoKeyTiKVMinReadySeconds]
-	if ok {
-		i, err := strconv.Atoi(s)
-		if err != nil {
-			klog.Warningf("tidbcluster: [%s/%s] annotation %s should be an integer: %v", ns, tcName, annoKeyTiKVMinReadySeconds, err)
-		} else {
-			minReadySeconds = i
-		}
-	}
+	minReadySeconds := getMinReadySeconds(tc)
 
 	mngerutils.SetUpgradePartition(newSet, *oldSet.Spec.UpdateStrategy.RollingUpdate.Partition)
 	podOrdinals := helper.GetPodOrdinals(*oldSet.Spec.Replicas, oldSet).List()
@@ -147,13 +138,8 @@ func (u *tikvUpgrader) Upgrade(meta metav1.Object, oldSet *apps.StatefulSet, new
 
 		if revision == status.StatefulSet.UpdateRevision {
 
-			if !k8s.IsPodAvailable(pod, int32(minReadySeconds), metav1.Now()) {
-				readyCond := k8s.GetPodReadyCondition(pod.Status)
-				if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
-					return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded tikv pod: [%s] is not ready", ns, tcName, podName)
-
-				}
-				return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded tikv pod: [%s] is not available, last transition time is %v", ns, tcName, podName, readyCond.LastTransitionTime)
+			if err := isPodAvailable(pod, minReadySeconds, tc); err != nil {
+				return err
 			}
 			if store.State != v1alpha1.TiKVStateUp {
 				return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded tikv pod: [%s] is not all ready", ns, tcName, podName)
@@ -458,7 +444,50 @@ func endEvictLeaderForAllStore(deps *controller.Dependencies, tc *v1alpha1.TidbC
 	return nil
 }
 
+func getMinReadySeconds(tc *v1alpha1.TidbCluster) int {
+	minReadySeconds := 0
+	s, ok := tc.Annotations[annoKeyTiKVMinReadySeconds]
+	if ok {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			klog.Warningf("tidbcluster: [%s/%s] annotation %s should be an integer: %v", tc.Namespace, tc.Name, annoKeyTiKVMinReadySeconds, err)
+		} else {
+			minReadySeconds = i
+		}
+	}
+	return minReadySeconds
+}
+
+func isPodAvailable(pod *corev1.Pod, minReadySeconds int, tc *v1alpha1.TidbCluster) error {
+	ns := tc.GetNamespace()
+	tcName := tc.GetName()
+	podName := pod.GetName()
+	if !k8s.IsPodAvailable(pod, int32(minReadySeconds), metav1.Now()) {
+		readyCond := k8s.GetPodReadyCondition(pod.Status)
+		if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
+			return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded tikv pod: [%s] is not ready", ns, tcName, podName)
+
+		}
+		return controller.RequeueErrorf("tidbcluster: [%s/%s]'s upgraded tikv pod: [%s] is not available, last transition time is %v", ns, tcName, podName, readyCond.LastTransitionTime)
+	}
+	return nil
+}
+
 func endEvictLeader(deps *controller.Dependencies, tc *v1alpha1.TidbCluster, ordinal int32) error {
+	ns := tc.GetNamespace()
+	tcName := tc.GetName()
+	podName := TikvPodName(tcName, ordinal)
+
+	minReadySeconds := getMinReadySeconds(tc)
+
+	pod, err := deps.PodLister.Pods(ns).Get(podName)
+	if err != nil {
+		return fmt.Errorf("endEvictLeader: failed to get pods %s for cluster %s/%s, error: %s", podName, ns, tcName, err)
+	}
+	if err := isPodAvailable(pod, minReadySeconds, tc); err != nil {
+		return err
+	}
+
 	store := getStoreByOrdinal(tc.GetName(), tc.Status.TiKV, ordinal)
 	if store == nil {
 		klog.Errorf("endEvictLeader: no store found for TiKV ordinal %v of %s/%s", ordinal, tc.Namespace, tc.Name)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.
For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Closes #5501 


### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Check whether the last TiKV pod is available before end evict leader.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->
1. Modify the basic tidb-cluster, set `replicas` for TiKV to `2`, and add annotation `tidb.pingcap.com/tikv-min-ready-seconds: "300"`.
2. Deploy the operator and the modified basic tidb-cluster.
3. Once all things ready, trigger an upgrade for TiKV.

```
I0207 05:57:42.942954       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s upgraded tikv pod: [basic-tikv-1] is not available, last transition time is 2024-02-07 05:57:42 +0000 UTC, requeuing
...
I0207 06:02:38.460404       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s upgraded tikv pod: [basic-tikv-1] is not available, last transition time is 2024-02-07 05:57:42 +0000 UTC, requeuing
I0207 06:03:08.473673       1 pdapi.go:588] call DELETE method: http://basic-pd.default:2379/pd/api/v1/schedulers/evict-leader-scheduler-1 success
I0207 06:03:08.481605       1 tikv_upgrader.go:515] endEvictLeaderbyStoreID: end evict leader for store: 1 of default/basic successfully
I0207 06:03:08.482320       1 tikv_upgrader.go:386] endEvictLeader: end evict leader: 1, default/basic-tikv-1 successfully
I0207 06:03:08.497112       1 pod_control.go:90] Pod: [default/basic-tikv-1] updated successfully, : [default/basic]
...
I0207 06:03:14.588726       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s upgraded tikv pod: [basic-tikv-0] is not ready, requeuing
...
I0207 06:07:38.453695       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s upgraded tikv pod: [basic-tikv-0] is not available, last transition time is 2024-02-07 06:03:15 +0000 UTC, requeuing
I0207 06:08:08.466089       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s upgraded tikv pod: [basic-tikv-0] is not available, last transition time is 2024-02-07 06:03:15 +0000 UTC, requeuing
I0207 06:08:38.464321       1 pdapi.go:588] call DELETE method: http://basic-pd.default:2379/pd/api/v1/schedulers/evict-leader-scheduler-2 success
I0207 06:08:38.467645       1 tikv_upgrader.go:515] endEvictLeaderbyStoreID: end evict leader for store: 2 of default/basic successfully
I0207 06:08:38.468944       1 tikv_upgrader.go:425] tikv: no evict leader scheduler exists for default/basic
```


### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
