### PR TITLE
support run tiflash pod with ConfigMap mounted in tiflash container

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -104,10 +104,10 @@ const (
 	AnnTiCDCGracefulShutdownBeginTime = "tidb.pingcap.com/ticdc-graceful-shutdown-begin-time"
 	// AnnStsLastSyncTimestamp is sts annotation key to indicate the last timestamp the operator sync the sts
 	AnnStsLastSyncTimestamp = "tidb.pingcap.com/sync-timestamp"
-	// AnnTiflashDisableInitContainer is pod annotation key to indicate whether disabling init container for tiflash
-	// with it enabled, the tiflash container will directly read config from files mounted by ConfigMap and that enables
-	// tiflash support hot-reload config
-	AnnTiflashDisableInitContainer = "tidb.pingcap.com/tiflash-disable-init-container"
+	// AnnTiflashMountCMInTiflashContainer is tiflash pod annotation key to indicate whether directly mount ConfigMap
+	// in tiflash container instead of init container for tiflash. With it annotated, the tiflash container will directly
+	// read config from files mounted by ConfigMap and that enables tiflash support hot-reload config.
+	AnnTiflashMountCMInTiflashContainer = "tiflash.tidb.pingcap.com/mount-cm-in-tiflash-container"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only
 	AnnPVCScaleInTime = "tidb.pingcap.com/scale-in-time"

--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -104,7 +104,9 @@ const (
 	AnnTiCDCGracefulShutdownBeginTime = "tidb.pingcap.com/ticdc-graceful-shutdown-begin-time"
 	// AnnStsLastSyncTimestamp is sts annotation key to indicate the last timestamp the operator sync the sts
 	AnnStsLastSyncTimestamp = "tidb.pingcap.com/sync-timestamp"
-	// AnnTiflashDisableInitContainer is pod annotation key to indicate whether disabling init container
+	// AnnTiflashDisableInitContainer is pod annotation key to indicate whether disabling init container for tiflash
+	// with it enabled, the tiflash container will directly read config from files mounted by ConfigMap and that enables
+	// tiflash support hot-reload config
 	AnnTiflashDisableInitContainer = "tidb.pingcap.com/tiflash-disable-init-container"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only

--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -104,6 +104,8 @@ const (
 	AnnTiCDCGracefulShutdownBeginTime = "tidb.pingcap.com/ticdc-graceful-shutdown-begin-time"
 	// AnnStsLastSyncTimestamp is sts annotation key to indicate the last timestamp the operator sync the sts
 	AnnStsLastSyncTimestamp = "tidb.pingcap.com/sync-timestamp"
+	// AnnTiflashDisableInitContainer is pod annotation key to indicate whether disabling init container
+	AnnTiflashDisableInitContainer = "tidb.pingcap.com/tiflash-disable-init-container"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only
 	AnnPVCScaleInTime = "tidb.pingcap.com/scale-in-time"

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -1158,6 +1158,10 @@ func (tiflash *TiFlashSpec) GetScaleOutParallelism() int {
 	return int(*(tiflash.ScalePolicy.ScaleOutParallelism))
 }
 
+func (tiflash *TiFlashSpec) IsInitScriptDisabled() bool {
+	return tiflash.Annotations[label.AnnTiflashDisableInitContainer] == "true"
+}
+
 func (tidbSvc *TiDBServiceSpec) ShouldExposeStatus() bool {
 	exposeStatus := tidbSvc.ExposeStatus
 	if exposeStatus == nil {

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -1158,8 +1158,8 @@ func (tiflash *TiFlashSpec) GetScaleOutParallelism() int {
 	return int(*(tiflash.ScalePolicy.ScaleOutParallelism))
 }
 
-func (tiflash *TiFlashSpec) IsInitScriptDisabled() bool {
-	return tiflash.Annotations[label.AnnTiflashDisableInitContainer] == "true"
+func (tiflash *TiFlashSpec) DoesMountCMInTiflashContainer() bool {
+	return tiflash.Annotations[label.AnnTiflashMountCMInTiflashContainer] == "true"
 }
 
 func (tidbSvc *TiDBServiceSpec) ShouldExposeStatus() bool {

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -261,11 +261,7 @@ func RenderTiFlashStartScriptWithStartArgs(tc *v1alpha1.TidbCluster) (string, er
 		model.PDAddress = fmt.Sprintf("%s://%s:%d", tc.Scheme(), controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 	}
 
-	listenHost := "0.0.0.0"
-	if tc.Spec.PreferIPv6 {
-		listenHost = "[::]"
-	}
-	model.Addr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort)
+	model.Addr = fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:%d", controller.FormatClusterDomain(tc.Spec.ClusterDomain), v1alpha1.DefaultTiFlashFlashPort)
 
 	return renderTemplateFunc(tiflashStartScriptTpl, model)
 }

--- a/pkg/manager/member/startscript/v1/template.go
+++ b/pkg/manager/member/startscript/v1/template.go
@@ -742,3 +742,61 @@ type DMWorkerStartScriptModel struct {
 func RenderDMWorkerStartScript(model *DMWorkerStartScriptModel) (string, error) {
 	return renderTemplateFunc(dmWorkerStartScriptTpl, model)
 }
+
+var tiflashStartScriptTplText = `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+	echo "entering debug mode."
+	tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr={{ .AdvertiseAddr }} \{{if .EnableAdvertiseStatusAddr }}
+--flash.proxy.advertise-status-addr={{ .AdvertiseStatusAddr }} \{{end}}
+--flash.service_addr={{ .Addr }}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`
+
+var tiflashStartScriptTpl = template.Must(template.New("tiflash-start-script").Parse(tiflashStartScriptTplText))
+
+type TiflashStartScriptModel struct {
+	CommonModel
+
+	AdvertiseAddr             string
+	EnableAdvertiseStatusAddr bool
+	AdvertiseStatusAddr       string
+	Addr                      string
+}

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1688,6 +1688,339 @@ func TestRenderTiFlashStartScript(t *testing.T) {
 	}
 }
 
+func TestRenderTiFlashStartScriptWithStartArgs(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	type testcase struct {
+		name string
+
+		modifyTC     func(tc *v1alpha1.TidbCluster)
+		expectScript string
+	}
+
+	cases := []testcase{
+		{
+			name:     "basic",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {},
+			expectScript: `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
+
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "enable AdvertiseAddr",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				enable := true
+				tc.Spec.EnableDynamicConfiguration = &enable
+			},
+			expectScript: `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
+
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.proxy.advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20292 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "across k8s",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.ClusterDomain = "cluster.local"
+				tc.Spec.AcrossK8s = true
+			},
+			expectScript: `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
+pd_url="http://${CLUSTER_NAME}-pd:2379"
+encoded_domain_url=$(echo $pd_url | base64 | tr "\n" " " | sed "s/ //g")
+discovery_url="${CLUSTER_NAME}-discovery.${NAMESPACE}:10261"
+
+until result=$(wget -qO- -T 3 http://${discovery_url}/verify/${encoded_domain_url} 2>/dev/null); do
+echo "waiting for the verification of PD endpoints ..."
+sleep $((RANDOM % 5))
+done
+PD_ADDRESS=${result}
+
+
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "across k8s with tls enabled",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.ClusterDomain = "cluster.local"
+				tc.Spec.AcrossK8s = true
+				tc.Spec.TLSCluster = &v1alpha1.TLSCluster{Enabled: true}
+			},
+			expectScript: `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="https://${CLUSTER_NAME}-pd:2379"
+pd_url="https://${CLUSTER_NAME}-pd:2379"
+encoded_domain_url=$(echo $pd_url | base64 | tr "\n" " " | sed "s/ //g")
+discovery_url="${CLUSTER_NAME}-discovery.${NAMESPACE}:10261"
+
+until result=$(wget -qO- -T 3 http://${discovery_url}/verify/${encoded_domain_url} 2>/dev/null); do
+echo "waiting for the verification of PD endpoints ..."
+sleep $((RANDOM % 5))
+done
+PD_ADDRESS=${result}
+
+
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "basic with ipv6",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.PreferIPv6 = true
+			},
+			expectScript: `#!/bin/sh
+
+# This script is used to start tiflash containers in kubernetes cluster
+
+# Use DownwardAPIVolumeFiles to store informations of the cluster:
+# https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+#
+#   runmode="normal/debug"
+#
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
+
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.service_addr=[::]:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Logf("test case: %s", c.name)
+
+			tc := &v1alpha1.TidbCluster{
+				Spec: v1alpha1.TidbClusterSpec{
+					TiFlash: &v1alpha1.TiFlashSpec{},
+				},
+			}
+			tc.Name = "start-script-test"
+			tc.Namespace = "start-script-test-ns"
+
+			if c.modifyTC != nil {
+				c.modifyTC(tc)
+			}
+
+			script, err := RenderTiFlashStartScriptWithStartArgs(tc)
+			g.Expect(err).Should(gomega.Succeed())
+			if diff := cmp.Diff(c.expectScript, script); diff != "" {
+				t.Errorf("unexpected (-want, +got): %s", diff)
+				t.Logf("got: %s", script)
+			}
+			g.Expect(validateScript(script)).Should(gomega.Succeed())
+		})
+	}
+}
+
 func TestRenderTiFlashInitScript(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/manager/member/startscript/v1/template_test.go
+++ b/pkg/manager/member/startscript/v1/template_test.go
@@ -1737,7 +1737,7 @@ PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -1793,7 +1793,7 @@ ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
 --flash.proxy.advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20292 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -1858,7 +1858,7 @@ PD_ADDRESS=${result}
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -1924,7 +1924,7 @@ PD_ADDRESS=${result}
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -1978,7 +1978,7 @@ PD_ADDRESS="http://${CLUSTER_NAME}-pd:2379"
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
---flash.service_addr=[::]:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 

--- a/pkg/manager/member/startscript/v2/tiflash_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiflash_start_script.go
@@ -86,11 +86,7 @@ func RenderTiFlashStartScriptWithStartArgs(tc *v1alpha1.TidbCluster) (string, er
 		}
 	}
 
-	listenHost := "0.0.0.0"
-	if tc.Spec.PreferIPv6 {
-		listenHost = "[::]"
-	}
-	m.Addr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort)
+	m.Addr = fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:%d", controller.FormatClusterDomain(tc.Spec.ClusterDomain), v1alpha1.DefaultTiFlashFlashPort)
 
 	return renderTemplateFunc(tiflashStartScriptWithStartArgsTpl, m)
 }

--- a/pkg/manager/member/startscript/v2/tiflash_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiflash_start_script.go
@@ -14,9 +14,11 @@
 package v2
 
 import (
+	"fmt"
 	"text/template"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
 )
 
 // TiFlashStartScriptModel contain fields for rendering TiFlash start script
@@ -26,11 +28,46 @@ type TiFlashStartScriptModel struct {
 
 // RenderTiFlashStartScript renders TiFlash start script from TidbCluster
 func RenderTiFlashStartScript(tc *v1alpha1.TidbCluster) (string, error) {
+	if tc.Spec.TiFlash.IsInitScriptDisabled() {
+		return RenderTiFlashStartScriptWithStartArgs(tc)
+	}
+
 	m := &TiFlashStartScriptModel{}
 
 	m.ExtraArgs = ""
 
 	return renderTemplateFunc(tiflashStartScriptTpl, m)
+}
+
+// TiFlashStartScriptWithStartArgsModel is an alternative of TiFlashStartScriptModel that enable tiflash pod run without
+// initContainer
+type TiFlashStartScriptWithStartArgsModel struct {
+	AdvertiseAddr             string
+	EnableAdvertiseStatusAddr bool
+	AdvertiseStatusAddr       string
+	Addr                      string
+	ExtraArgs                 string
+}
+
+func RenderTiFlashStartScriptWithStartArgs(tc *v1alpha1.TidbCluster) (string, error) {
+	model := &TiFlashStartScriptWithStartArgsModel{
+		AdvertiseAddr:             fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:%d", controller.FormatClusterDomain(tc.Spec.ClusterDomain), v1alpha1.DefaultTiFlashProxyPort),
+		EnableAdvertiseStatusAddr: false,
+		ExtraArgs:                 "",
+	}
+	// only the tiflash learner supports dynamic configuration
+	if tc.Spec.EnableDynamicConfiguration != nil && *tc.Spec.EnableDynamicConfiguration {
+		model.AdvertiseStatusAddr = fmt.Sprintf("${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc%s:%d", controller.FormatClusterDomain(tc.Spec.ClusterDomain), v1alpha1.DefaultTiFlashProxyStatusPort)
+		model.EnableAdvertiseStatusAddr = true
+	}
+
+	listenHost := "0.0.0.0"
+	if tc.Spec.PreferIPv6 {
+		listenHost = "[::]"
+	}
+	model.Addr = fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort)
+
+	return renderTemplateFunc(tiflashStartScriptWithStartArgsTpl, model)
 }
 
 const (
@@ -50,10 +87,40 @@ echo "starting tiflash-server ..."
 echo "/tiflash/tiflash ${ARGS}"
 exec /tiflash/tiflash server ${ARGS}
 `
+	// tiflashStartScriptWithStartArgs is the new way to launch tiflash, that enable tiflash pod run without init container.
+	tiflashStartScriptWithStartArgs = `
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr={{ .AdvertiseAddr }} \{{if .EnableAdvertiseStatusAddr }}
+--flash.proxy.advertise-status-addr={{ .AdvertiseStatusAddr }} \{{end}}
+--flash.service_addr={{ .Addr }}
+"
+
+{{- if .ExtraArgs }}
+ARGS="${ARGS} {{ .ExtraArgs }}"
+{{- end }}
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`
 )
 
 var tiflashStartScriptTpl = template.Must(
 	template.Must(
 		template.New("tiflash-start-script").Parse(tiflashStartSubScript),
 	).Parse(componentCommonScript + tiflashStartScript),
+)
+
+var tiflashStartScriptWithStartArgsTpl = template.Must(
+	template.Must(
+		template.New("tiflash-start-script-with-start-args").Parse(tiflashStartSubScript),
+	).Parse(componentCommonScript + tiflashStartScriptWithStartArgs),
 )

--- a/pkg/manager/member/startscript/v2/tiflash_start_script_test.go
+++ b/pkg/manager/member/startscript/v2/tiflash_start_script_test.go
@@ -87,3 +87,282 @@ exec /tiflash/tiflash server ${ARGS}
 		g.Expect(validateScript(script)).Should(gomega.Succeed())
 	}
 }
+
+func TestRenderTiFlashStartScriptWithStartArgs(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	type testcase struct {
+		name string
+
+		modifyTC     func(tc *v1alpha1.TidbCluster)
+		expectScript string
+	}
+
+	cases := []testcase{
+		{
+			name:     "basic",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="start-script-test-pd:2379"
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "enable AdvertiseAddr",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				enable := true
+				tc.Spec.EnableDynamicConfiguration = &enable
+			},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="start-script-test-pd:2379"
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.proxy.advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20292 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "across k8s",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.ClusterDomain = "cluster.local"
+				tc.Spec.AcrossK8s = true
+			},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="${result}"
+pd_url=start-script-test-pd:2379
+encoded_domain_url=$(echo $pd_url | base64 | tr "\n" " " | sed "s/ //g")
+discovery_url=start-script-test-discovery.start-script-test-ns:10261
+until result=$(wget -qO- -T 3 http://${discovery_url}/verify/${encoded_domain_url} 2>/dev/null | sed 's/http:\/\///g' | sed 's/https:\/\///g'); do
+    echo "waiting for the verification of PD endpoints ..."
+    sleep $((RANDOM % 5))
+done
+PD_ADDRESS=${result}
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "across k8s with tls enabled",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.ClusterDomain = "cluster.local"
+				tc.Spec.AcrossK8s = true
+				tc.Spec.TLSCluster = &v1alpha1.TLSCluster{Enabled: true}
+			},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="${result}"
+pd_url=start-script-test-pd:2379
+encoded_domain_url=$(echo $pd_url | base64 | tr "\n" " " | sed "s/ //g")
+discovery_url=start-script-test-discovery.start-script-test-ns:10261
+until result=$(wget -qO- -T 3 http://${discovery_url}/verify/${encoded_domain_url} 2>/dev/null | sed 's/http:\/\///g' | sed 's/https:\/\///g'); do
+    echo "waiting for the verification of PD endpoints ..."
+    sleep $((RANDOM % 5))
+done
+PD_ADDRESS=${result}
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
+--flash.service_addr=0.0.0.0:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+		{
+			name: "basic with ipv6",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.PreferIPv6 = true
+			},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+# Use HOSTNAME if POD_NAME is unset for backward compatibility.
+POD_NAME=${POD_NAME:-$HOSTNAME}
+PD_ADDRESS="start-script-test-pd:2379"
+ARGS="server --config-file /etc/tiflash/config_templ.toml \
+-- \
+--flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
+--flash.service_addr=[::]:3930 \
+--raft.pd_addr=${PD_ADDRESS}
+"
+
+if [ ! -z "${STORE_LABELS:-}" ]; then
+  LABELS=" --labels ${STORE_LABELS} "
+  ARGS="${ARGS}${LABELS}"
+fi
+
+echo "starting tiflash-server ..."
+echo "/tiflash/tiflash ${ARGS}"
+exec /tiflash/tiflash ${ARGS}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Logf("test case: %s", c.name)
+
+			tc := &v1alpha1.TidbCluster{
+				Spec: v1alpha1.TidbClusterSpec{
+					TiFlash: &v1alpha1.TiFlashSpec{},
+				},
+			}
+			tc.Name = "start-script-test"
+			tc.Namespace = "start-script-test-ns"
+
+			if c.modifyTC != nil {
+				c.modifyTC(tc)
+			}
+
+			script, err := RenderTiFlashStartScriptWithStartArgs(tc)
+			g.Expect(err).Should(gomega.Succeed())
+			if diff := cmp.Diff(c.expectScript, script); diff != "" {
+				t.Errorf("unexpected (-want, +got): %s", diff)
+				t.Logf("got: %s", script)
+			}
+			g.Expect(validateScript(script)).Should(gomega.Succeed())
+		})
+	}
+}

--- a/pkg/manager/member/startscript/v2/tiflash_start_script_test.go
+++ b/pkg/manager/member/startscript/v2/tiflash_start_script_test.go
@@ -127,7 +127,7 @@ PD_ADDRESS="start-script-test-pd:2379"
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -173,7 +173,7 @@ ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
 --flash.proxy.advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20292 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -226,7 +226,7 @@ PD_ADDRESS=${result}
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -280,7 +280,7 @@ PD_ADDRESS=${result}
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:20170 \
---flash.service_addr=0.0.0.0:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 
@@ -324,7 +324,7 @@ PD_ADDRESS="start-script-test-pd:2379"
 ARGS="server --config-file /etc/tiflash/config_templ.toml \
 -- \
 --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
---flash.service_addr=[::]:3930 \
+--flash.service_addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:3930 \
 --raft.pd_addr=${PD_ADDRESS}
 "
 

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -403,7 +403,8 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 			Name: tiflashCertVolumeName, ReadOnly: true, MountPath: tiflashCertPath,
 		})
 	}
-	// mount config ConfigMap into tiflash container if the init container is disabled
+	// with initContainerDisabled enabled, the tiflash container should directly read config from `/etc/tiflash/xxx.toml` mounted from ConfigMap
+	// rather than `/data0/xxx.toml` created by initContainer.
 	if initContainerDisabled {
 		volMounts = append(volMounts, corev1.VolumeMount{
 			Name: "config", ReadOnly: true, MountPath: "/etc/tiflash",
@@ -470,6 +471,8 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 		podSecurityContext.Sysctls = []corev1.Sysctl{}
 	}
 
+	// the work of initContainer is substituted by new start scripts which moves the configuration items depending on running env
+	// to command args.
 	if !initContainerDisabled {
 		// Append init container for config files initialization
 		initVolMounts := []corev1.VolumeMount{

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -373,6 +373,7 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 	tcName := tc.GetName()
 	baseTiFlashSpec := tc.BaseTiFlashSpec()
 	spec := tc.Spec.TiFlash
+	initContainerDisabled := spec.IsInitScriptDisabled()
 
 	tiflashConfigMap := controller.MemberConfigMapName(tc, v1alpha1.TiFlashMemberType)
 	if cm != nil {
@@ -400,6 +401,12 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 	if tc.IsTLSClusterEnabled() {
 		volMounts = append(volMounts, corev1.VolumeMount{
 			Name: tiflashCertVolumeName, ReadOnly: true, MountPath: tiflashCertPath,
+		})
+	}
+	// mount config ConfigMap into tiflash container if the init container is disabled
+	if initContainerDisabled {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name: "config", ReadOnly: true, MountPath: "/etc/tiflash",
 		})
 	}
 
@@ -463,43 +470,45 @@ func getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*apps.St
 		podSecurityContext.Sysctls = []corev1.Sysctl{}
 	}
 
-	// Append init container for config files initialization
-	initVolMounts := []corev1.VolumeMount{
-		{Name: "data0", MountPath: "/data0"},
-		{Name: "config", ReadOnly: true, MountPath: "/etc/tiflash"},
-	}
-	initEnv := []corev1.EnvVar{
-		{
-			Name: "POD_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
+	if !initContainerDisabled {
+		// Append init container for config files initialization
+		initVolMounts := []corev1.VolumeMount{
+			{Name: "data0", MountPath: "/data0"},
+			{Name: "config", ReadOnly: true, MountPath: "/etc/tiflash"},
+		}
+		initEnv := []corev1.EnvVar{
+			{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	// NOTE: the config content should respect the init script
-	initScript, err := startscript.RenderTiFlashInitScript(tc)
-	if err != nil {
-		return nil, fmt.Errorf("render start-script for tc %s/%s failed: %v", tc.Namespace, tc.Name, err)
-	}
+		// NOTE: the config content should respect the init script
+		initScript, err := startscript.RenderTiFlashInitScript(tc)
+		if err != nil {
+			return nil, fmt.Errorf("render start-script for tc %s/%s failed: %v", tc.Namespace, tc.Name, err)
+		}
 
-	initializer := corev1.Container{
-		Name:  "init",
-		Image: tc.HelperImage(),
-		Command: []string{
-			"sh",
-			"-c",
-			initScript,
-		},
-		Env:          initEnv,
-		VolumeMounts: initVolMounts,
+		initializer := corev1.Container{
+			Name:  "init",
+			Image: tc.HelperImage(),
+			Command: []string{
+				"sh",
+				"-c",
+				initScript,
+			},
+			Env:          initEnv,
+			VolumeMounts: initVolMounts,
+		}
+		if spec.Initializer != nil {
+			initializer.Resources = controller.ContainerResource(spec.Initializer.ResourceRequirements)
+		}
+		initContainers = append(initContainers, initializer)
 	}
-	if spec.Initializer != nil {
-		initializer.Resources = controller.ContainerResource(spec.Initializer.ResourceRequirements)
-	}
-	initContainers = append(initContainers, initializer)
 
 	stsLabels := labelTiFlash(tc)
 	setName := controller.TiFlashMemberName(tcName)

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -187,7 +187,9 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 			}
 		}
 		common.SetIfNil("flash.tidb_status_addr", tidbStatusAddr)
-		common.SetIfNil("flash.service_addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort))
+		if !mountCMInTiflashContainer {
+			common.SetIfNil("flash.service_addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort))
+		}
 		common.SetIfNil("flash.flash_cluster.log", defaultClusterLog)
 		common.SetIfNil("flash.proxy.addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyPort))
 		if !mountCMInTiflashContainer {

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -215,6 +215,9 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 			pdAddr = fmt.Sprintf("%s.%s.svc%s:%d", controller.PDMemberName(ref.Name), ref.Namespace,
 				controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
 		}
+		// tiflash require at least one configuration item in ["raft"] config group, otherwise
+		// tiflash with version less than v7.1.0 may encounter schema sync problems. So we keep this item
+		// even if this item is configured via command line args.
 		common.SetIfNil("raft.pd_addr", pdAddr)
 
 		if listenHost == listenHostForIPv6 {

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -198,7 +198,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		if !mountCMInTiflashContainer {
 			common.SetIfNil("flash.proxy.config", "/data0/proxy.toml")
 		} else {
-			common.SetIfNil("flash.proxy.config", "/etc/proxy_templ.toml")
+			common.SetIfNil("flash.proxy.config", "/etc/tiflash/proxy_templ.toml")
 		}
 
 		// logger

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -195,7 +195,11 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 				controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyPort))
 		}
 		common.SetIfNil("flash.proxy.data-dir", "/data0/proxy")
-		common.SetIfNil("flash.proxy.config", "/data0/proxy.toml")
+		if !mountCMInTiflashContainer {
+			common.SetIfNil("flash.proxy.config", "/data0/proxy.toml")
+		} else {
+			common.SetIfNil("flash.proxy.config", "/etc/proxy_templ.toml")
+		}
 
 		// logger
 		common.SetIfNil("logger.errorlog", defaultErrorLog)

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -129,7 +129,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 	if config.Proxy == nil {
 		config.Proxy = v1alpha1.NewTiFlashProxyConfig()
 	}
-	initContainerDisabled := tc.Spec.TiFlash.IsInitScriptDisabled()
+	mountCMInTiflashContainer := tc.Spec.TiFlash.DoesMountCMInTiflashContainer()
 	common := config.Common
 	proxy := config.Proxy
 
@@ -190,7 +190,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		common.SetIfNil("flash.service_addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashFlashPort))
 		common.SetIfNil("flash.flash_cluster.log", defaultClusterLog)
 		common.SetIfNil("flash.proxy.addr", fmt.Sprintf("%s:%d", listenHost, v1alpha1.DefaultTiFlashProxyPort))
-		if !initContainerDisabled {
+		if !mountCMInTiflashContainer {
 			common.SetIfNil("flash.proxy.advertise-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name),
 				controller.TiFlashPeerMemberName(name), ns, controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashProxyPort))
 		}
@@ -220,7 +220,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 	// proxy
 	{
 		proxy.SetIfNil("log-level", "info")
-		if !initContainerDisabled {
+		if !mountCMInTiflashContainer {
 			proxy.SetIfNil("server.engine-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns,
 				controller.FormatClusterDomain(clusterDomain), v1alpha1.DefaultTiFlashFlashPort))
 			proxy.SetIfNil("server.advertise-status-addr", fmt.Sprintf("%s-POD_NUM.%s.%s.svc%s:%d", controller.TiFlashMemberName(name), controller.TiFlashPeerMemberName(name), ns,

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1602,7 +1602,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 						log = "/data0/logs/flash_cluster_manager.log"
 					  [flash.proxy]
 						addr = "0.0.0.0:20170"
-						config = "/etc/proxy_templ.toml"
+						config = "/etc/tiflash/proxy_templ.toml"
 						data-dir = "/data0/proxy"
 					[logger]
 					  errorlog = "/data0/logs/error.log"

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1596,7 +1596,6 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				expectCommonCfg: `
 					tmp_path = "/data0/tmp"
 					[flash]
-					  service_addr = "0.0.0.0:3930"
 					  tidb_status_addr = "test-tidb.default.svc:10080"
 					  [flash.flash_cluster]
 						log = "/data0/logs/flash_cluster_manager.log"

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -3198,14 +3198,15 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	})
 
-	ginkgo.Describe("[Feature]: Mount ConfigMap in tiflash container", func() {
-		ginkgo.It("deploy tidb cluster with random password", func() {
+	ginkgo.Describe("Mount ConfigMap in tiflash container", func() {
+		ginkgo.It("deploy tidb cluster", func() {
 			ginkgo.By("Deploy initial tc")
 			tc := fixture.GetTidbCluster(ns, "mount-cm-in-tiflash-container", utilimage.TiDBLatest)
+			fixture.AddTiFlashForTidbCluster(tc)
 			tc.Spec.PD.Replicas = 1
 			tc.Spec.TiKV.Replicas = 1
 			tc.Spec.TiDB.Replicas = 1
-			tc.Spec.TiFlash.Replicas = 1
+			tc.Spec.TiFlash.Replicas = 2
 			if tc.Spec.TiFlash.Annotations == nil {
 				tc.Spec.TiFlash.Annotations = map[string]string{}
 			}

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -3197,6 +3197,27 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		}
 
 	})
+
+	ginkgo.Describe("[Feature]: Mount ConfigMap in tiflash container", func() {
+		ginkgo.It("deploy tidb cluster with random password", func() {
+			ginkgo.By("Deploy initial tc")
+			tc := fixture.GetTidbCluster(ns, "mount-cm-in-tiflash-container", utilimage.TiDBLatest)
+			tc.Spec.PD.Replicas = 1
+			tc.Spec.TiKV.Replicas = 1
+			tc.Spec.TiDB.Replicas = 1
+			tc.Spec.TiFlash.Replicas = 1
+			if tc.Spec.TiFlash.Annotations == nil {
+				tc.Spec.TiFlash.Annotations = map[string]string{}
+			}
+			tc.Spec.TiFlash.Annotations[label.AnnTiflashMountCMInTiflashContainer] = "true"
+
+			tc, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(context.TODO(), tc, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Expected create tidbcluster")
+			err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
+			framework.ExpectNoError(err, "Expected get tidbcluster")
+		})
+	})
+
 })
 
 // checkPumpStatus check there are onlineNum online pump instance running now.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

Add an annotation `tiflash.tidb.pingcap.com/mount-cm-in-tiflash-container` to tc.spec.tiflash.annotations to supports run tiflash pod without init container and directly mount ConfigMap in tiflash container.  This change enable tiflash supports config hot-reload when the tc.spec.configUpdateStrategy is set to InPlace.

### What is changed and how does it work?
When this annotation is annotated, the tiflash container will directly mount config ConfigMap and use new start script to launch tiflash without the initContainer did ever that use sed to modify ConfigMap and then generate a new config files into /data0 directory. 


### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

#### Test steps
* create a TC with tiflash enabled
* edit TC to add `tiflash.tidb.pingcap.com/mount-cm-in-tiflash-container: "true"` into tc.spec.tiflash.annotations
* old tiflash pod will be terminated and new tiflash pod without initContainer, will be created
* modify the ConfigMap used by the tiflash pod to change `config_templ.toml:logger.level` to "debug" and add `config_templ.toml:logger.count = 11`
* watch log of tiflash pod, some logs like 'Loading config ' should be logged

#### Diffs of key resources
* the diffs of tiflash pod 
```diff
diff old.txt new.txt -I 'kube-api-access'
13c13,26
<     - /tiflash/tiflash server --config-file /data0/config.toml
---
>     - |
>       #!/bin/sh
>
>       # This script is used to start tiflash containers in kubernetes cluster
>
>       # Use DownwardAPIVolumeFiles to store informations of the cluster:
>       # https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
>       #
>       #   runmode="normal/debug"
>       #
>
>       set -uo pipefail
>
>       ANNOTATIONS="/etc/podinfo/annotations"
>
>       if [[ ! -f "${ANNOTATIONS}" ]]
>       then
>           echo "${ANNOTATIONS} does't exist, exiting."
>           exit 1
>       fi
>       source ${ANNOTATIONS} 2>/dev/null
>
>       runmode=${runmode:-normal}
>       if [[ X${runmode} == Xdebug ]]
>       then
>           echo "entering debug mode."
>           tail -f /dev/null
>       fi
>
>       # Use HOSTNAME if POD_NAME is unset for backward compatibility.
>       POD_NAME=${POD_NAME:-$HOSTNAME}
>       PD_ADDRESS="https://${CLUSTER_NAME}-pd:2379"
>
>       ARGS="server --config-file /etc/tiflash/config_templ.toml \
>       -- \
>       --flash.proxy.advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20170 \
>       --flash.proxy.advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20292 \
>       --flash.service_addr=0.0.0.0:3930 \
>       --raft.pd_addr=${PD_ADDRESS}
>       "
>
>       if [ ! -z "${STORE_LABELS:-}" ]; then
>         LABELS=" --labels ${STORE_LABELS} "
>         ARGS="${ARGS}${LABELS}"
>       fi
>
>       echo "starting tiflash-server ..."
>       echo "/tiflash/tiflash ${ARGS}"
>       exec /tiflash/tiflash ${ARGS}
79a128,130
>     - mountPath: /etc/tiflash
>       name: config
>       readOnly: true
153,181c204
<   initContainers:
<   - command:
<     - sh
<     - -c
<     - set -ex;ordinal=`echo ${POD_NAME} | awk -F- '{print $NF}'`;sed s/POD_NUM/${ordinal}/g
<       /etc/tiflash/config_templ.toml > /data0/config.toml;sed s/POD_NUM/${ordinal}/g
<       /etc/tiflash/proxy_templ.toml > /data0/proxy.toml
<     env:
<     - name: POD_NAME
<       valueFrom:
<         fieldRef:
<           apiVersion: v1
<           fieldPath: metadata.name
<     image: 385595570414.dkr.ecr.us-west-2.amazonaws.com/third-party/busybox:1.34.1
<     imagePullPolicy: IfNotPresent
<     name: init
<     resources: {}
<     terminationMessagePath: /dev/termination-log
<     terminationMessagePolicy: File
<     volumeMounts:
<     - mountPath: /data0
<       name: data0
<     - mountPath: /etc/tiflash
<       name: config
<       readOnly: true
<     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
<       name: kube-api-access-dwb6m
<       readOnly: true
```
* the diffs of ConfigMap
```diff
<         advertise-addr = "db-tiflash-POD_NUM.db-tiflash-peer.tidb9527.svc:20170"
<         config = "/data0/proxy.toml"
---
>         config = "/etc/proxy_templ.toml"
55,56d53
<       advertise-status-addr = "db-tiflash-POD_NUM.db-tiflash-peer.tidb9527.svc:20292"
<       engine-addr = "db-tiflash-POD_NUM.db-tiflash-peer.tidb9527.svc:3930"
```
* diffs between command line of tiflash container
```diff
<   /tiflash/tiflash server --config-file /data0/config.toml
---
>   /tiflash/tiflash server --config-file /etc/tiflash/config_templ.toml -- --flash.proxy.advertise-addr=db-tiflash-0.db-tiflash-peer.tidb9527.svc:20170 --flash.proxy.advertise-status-addr=db-tiflash-0.db-tiflash-peer.tidb9527.svc:20292 --flash.service_addr=0.0.0.0:3930 --raft.pd_addr=https://db-pd:2379
```
### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
