### PR TITLE
pdms: remove shutdown component and add test for scaler&upgrader

### DIFF
--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -723,14 +723,6 @@ func (m *pdMSMemberManager) getNewPDMSStatefulSet(tc *v1alpha1.TidbCluster, cm *
 	}
 	// default in nil
 	if curSpec.StorageVolumes != nil {
-		storageRequest, err := controller.ParseStorageRequest(curSpec.Requests)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse storage request for PD, tidbcluster %s/%s, error: %v", tc.Namespace, tc.Name, err)
-		}
-		dataVolumeName := string(v1alpha1.GetStorageVolumeName("", v1alpha1.PDMSMemberType(curService)))
-		pdMSSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
-			util.VolumeClaimTemplate(storageRequest, dataVolumeName, tc.Spec.PD.StorageClassName),
-		}
 		pdMSSet.Spec.VolumeClaimTemplates = append(pdMSSet.Spec.VolumeClaimTemplates, additionalPVCs...)
 	}
 

--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -65,7 +65,7 @@ func (m *pdMSMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 
 	// Need to start PD API
 	if tc.Spec.PD == nil {
-		klog.Infof("PD Micro Service is enabled, but PD is not enabled or not in `ms` mode, skip syncing PD Micro Service")
+		klog.Infof("PD Micro Service is enabled, but PD is not enabled, skip syncing PD Micro Service")
 		return nil
 	}
 	if tc.Spec.PD.Mode != "ms" {
@@ -89,7 +89,7 @@ func (m *pdMSMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 			}
 			mngerutils.UpdateStatefulSetWithPrecheck(m.deps, tc, "FailedUpdatePDMSSTS", newPDMSSet, oldPDMSSet)
 		}
-		klog.Infof("PD Micro Service is enabled, but PD is not enabled or not in `ms` mode, skip syncing PD Micro Service")
+		klog.Infof("PD Micro Service is enabled, but PD is not in `ms` mode, skip syncing PD Micro Service")
 		return nil
 	}
 

--- a/pkg/manager/member/pd_ms_scaler.go
+++ b/pkg/manager/member/pd_ms_scaler.go
@@ -56,7 +56,6 @@ func (s *pdMSScaler) ScaleOut(meta metav1.Object, oldSet *apps.StatefulSet, newS
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 	serviceName := controller.PDMSTrimName(oldSet.Name)
-	println("scaleOne", serviceName)
 
 	klog.Infof("scaling out PDMS component %s for cluster [%s/%s] statefulset, ordinal: %d (replicas: %d, delete slots: %v)", serviceName, oldSet.Namespace, tcName, ordinal, replicas, deleteSlots.List())
 	if !tc.Status.PDMS[serviceName].Synced {

--- a/pkg/manager/member/pd_ms_scaler_test.go
+++ b/pkg/manager/member/pd_ms_scaler_test.go
@@ -1,0 +1,181 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestPDMSScaler(t *testing.T) {
+	g := NewGomegaWithT(t)
+	type testcase struct {
+		name        string
+		hasSynced   bool
+		errExpectFn func(*GomegaWithT, error)
+		changed     bool
+		scaleIn     bool
+	}
+
+	testFn := func(test testcase, t *testing.T) {
+		tc := newTidbClusterForPDMSScaler()
+
+		if test.hasSynced {
+			tc.Status.PDMS[tsoService].Synced = true
+		} else {
+			tc.Status.PDMS[tsoService].Synced = false
+		}
+
+		// default replicas is 5
+		oldSet := newStatefulSetForPDMSScale()
+		oldSet.Name = fmt.Sprintf("%s-pdms-%s", tc.Name, tsoService)
+		newSet := oldSet.DeepCopy()
+
+		scaler := newFakePDMSScaler()
+		if test.scaleIn {
+			newSet.Spec.Replicas = pointer.Int32Ptr(3)
+			err := scaler.ScaleIn(tc, oldSet, newSet)
+			test.errExpectFn(g, err)
+			if test.changed {
+				g.Expect(int(*newSet.Spec.Replicas)).To(Equal(4))
+			} else {
+				g.Expect(int(*newSet.Spec.Replicas)).To(Equal(5))
+			}
+		} else {
+			newSet.Spec.Replicas = pointer.Int32Ptr(7)
+			err := scaler.ScaleOut(tc, oldSet, newSet)
+			test.errExpectFn(g, err)
+			if test.changed {
+				g.Expect(int(*newSet.Spec.Replicas)).To(Equal(6))
+			} else {
+				g.Expect(int(*newSet.Spec.Replicas)).To(Equal(5))
+			}
+		}
+	}
+
+	tests := []testcase{
+		{
+			name:        "scaleIn normal",
+			scaleIn:     true,
+			hasSynced:   true,
+			errExpectFn: errExpectNil,
+			changed:     true,
+		},
+		{
+			name:        "scaleIn pdms is upgrading",
+			scaleIn:     true,
+			hasSynced:   false,
+			errExpectFn: errExpectNotNil,
+			changed:     false,
+		},
+		{
+			name:        "scaleOut normal",
+			scaleIn:     false,
+			hasSynced:   true,
+			errExpectFn: errExpectNil,
+			changed:     true,
+		},
+		{
+			name:        "scaleOut pdms is upgrading",
+			scaleIn:     false,
+			hasSynced:   false,
+			errExpectFn: errExpectNotNil,
+			changed:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFn(tt, t)
+		})
+	}
+}
+
+func newTidbClusterForPDMSScaler() *v1alpha1.TidbCluster {
+	return &v1alpha1.TidbCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TidbCluster",
+			APIVersion: "pingcap.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: v1alpha1.TidbClusterSpec{
+			PD: &v1alpha1.PDSpec{
+				ComponentSpec: v1alpha1.ComponentSpec{
+					Image: "pingcap/pd:v7.3.0",
+				},
+				Replicas:         1,
+				StorageClassName: pointer.StringPtr("my-storage-class"),
+				Mode:             "ms",
+			},
+			PDMS: []*v1alpha1.PDMSSpec{
+				{
+					Name: tsoService,
+					ComponentSpec: v1alpha1.ComponentSpec{
+						Image: "pd-test-image",
+					},
+					Replicas:         3,
+					StorageClassName: pointer.StringPtr("my-storage-class"),
+				},
+			},
+		},
+		Status: v1alpha1.TidbClusterStatus{
+			PDMS: map[string]*v1alpha1.PDMSStatus{
+				tsoService: {
+					Phase: v1alpha1.NormalPhase,
+					StatefulSet: &apps.StatefulSetStatus{
+						CurrentRevision: "1",
+						UpdateRevision:  "2",
+						ReadyReplicas:   3,
+						Replicas:        3,
+						CurrentReplicas: 2,
+						UpdatedReplicas: 1,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newFakePDMSScaler(resyncDuration ...time.Duration) *pdMSScaler {
+	fakeDeps := controller.NewFakeDependencies()
+	if len(resyncDuration) > 0 {
+		fakeDeps.CLIConfig.ResyncDuration = resyncDuration[0]
+	}
+	return &pdMSScaler{generalScaler{deps: fakeDeps}}
+}
+
+func newStatefulSetForPDMSScale() *apps.StatefulSet {
+	set := &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scaler",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: apps.StatefulSetSpec{
+			Replicas: pointer.Int32Ptr(5),
+		},
+	}
+	return set
+}

--- a/pkg/manager/member/pd_ms_upgrader_test.go
+++ b/pkg/manager/member/pd_ms_upgrader_test.go
@@ -1,0 +1,370 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/label"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	mngerutils "github.com/pingcap/tidb-operator/pkg/manager/utils"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	podinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+const tsoService = "tso"
+
+func TestPDMSUpgraderUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name         string
+		changeFn     func(*v1alpha1.TidbCluster)
+		changePods   func(pods []*corev1.Pod)
+		changeOldSet func(set *apps.StatefulSet)
+		errExpectFn  func(*GomegaWithT, error)
+		expectFn     func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet)
+	}
+
+	testFn := func(test *testcase) {
+		t.Log(test.name)
+		upgrader, podInformer := newPDMSUpgrader()
+		tc := newTidbClusterForPDMSUpgrader()
+
+		if test.changeFn != nil {
+			test.changeFn(tc)
+		}
+
+		pods := getPDMSPods()
+		if test.changePods != nil {
+			test.changePods(pods)
+		}
+		for i := range pods {
+			podInformer.Informer().GetIndexer().Add(pods[i])
+		}
+
+		newSet := newStatefulSetForPDMSUpgrader()
+		oldSet := newSet.DeepCopy()
+		if test.changeOldSet != nil {
+			test.changeOldSet(oldSet)
+		}
+		mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)
+
+		newSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(3)
+
+		err := upgrader.Upgrade(tc, oldSet, newSet)
+		test.errExpectFn(g, err)
+		test.expectFn(g, tc, newSet)
+	}
+
+	tests := []testcase{
+		{
+			name: "normal upgrade",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods:   nil,
+			changeOldSet: nil,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
+			},
+		},
+		{
+			name: "normal upgrade with notReady pod",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods: func(pods []*corev1.Pod) {
+				for _, pod := range pods {
+					pod.Status = *new(corev1.PodStatus)
+				}
+			},
+			changeOldSet: nil,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(2)))
+			},
+		},
+		{
+			name: "modify oldSet update strategy to OnDelete",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods: nil,
+			changeOldSet: func(set *apps.StatefulSet) {
+				set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+					Type: apps.OnDeleteStatefulSetStrategyType,
+				}
+			},
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy).To(Equal(apps.StatefulSetUpdateStrategy{Type: apps.OnDeleteStatefulSetStrategyType}))
+			},
+		},
+		{
+			name: "set oldSet's RollingUpdate strategy to nil",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods: nil,
+			changeOldSet: func(set *apps.StatefulSet) {
+				set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+				}
+			},
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy).To(Equal(apps.StatefulSetUpdateStrategy{Type: apps.RollingUpdateStatefulSetStrategyType}))
+			},
+		},
+		{
+			name: "newSet template changed",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods: nil,
+			changeOldSet: func(set *apps.StatefulSet) {
+				set.Spec.Template.Spec.Containers[0].Image = "pd-test-image:old"
+			},
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
+			},
+		},
+		{
+			name: "pdms scaling",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+				tc.Status.PDMS[tsoService].Phase = v1alpha1.ScalePhase
+			},
+			changePods: nil,
+			changeOldSet: func(set *apps.StatefulSet) {
+				set.Spec.Template.Spec.Containers[0].Image = "pd-test-image:old"
+			},
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.ScalePhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
+			},
+		},
+		{
+			name: "pdms sync failed",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = false
+			},
+			changePods: nil,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(3)))
+			},
+		},
+
+		{
+			name: "ignore pd peers health if annotation is not set",
+			changeFn: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.PDMS[tsoService].Synced = true
+			},
+			changePods:   nil,
+			changeOldSet: nil,
+			errExpectFn: func(g *GomegaWithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+			expectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster, newSet *apps.StatefulSet) {
+				g.Expect(tc.Status.PDMS[tsoService].Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
+			},
+		},
+	}
+
+	for i := range tests {
+		testFn(&tests[i])
+	}
+
+}
+
+func newPDMSUpgrader() (Upgrader, podinformers.PodInformer) {
+	fakeDeps := controller.NewFakeDependencies()
+	pdMSUpgrader := &pdMSUpgrader{deps: fakeDeps}
+	podInformer := fakeDeps.KubeInformerFactory.Core().V1().Pods()
+	return pdMSUpgrader, podInformer
+}
+
+func newStatefulSetForPDMSUpgrader() *apps.StatefulSet {
+	return &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.PDMSMemberName(upgradeTcName, tsoService),
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: apps.StatefulSetSpec{
+			Replicas: pointer.Int32Ptr(3),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "pd",
+							Image: "pd-test-image",
+						},
+					},
+				},
+			},
+			UpdateStrategy: apps.StatefulSetUpdateStrategy{
+				Type:          apps.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: pointer.Int32Ptr(2)},
+			},
+		},
+		Status: apps.StatefulSetStatus{
+			CurrentRevision: "1",
+			UpdateRevision:  "2",
+			ReadyReplicas:   3,
+			Replicas:        3,
+			CurrentReplicas: 2,
+			UpdatedReplicas: 1,
+		},
+	}
+}
+
+func newTidbClusterForPDMSUpgrader() *v1alpha1.TidbCluster {
+	podName0 := PDMSPodName(upgradeTcName, 0, tsoService)
+	podName1 := PDMSPodName(upgradeTcName, 1, tsoService)
+	podName2 := PDMSPodName(upgradeTcName, 2, tsoService)
+	return &v1alpha1.TidbCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TidbCluster",
+			APIVersion: "pingcap.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      upgradeTcName,
+			Namespace: corev1.NamespaceDefault,
+			UID:       upgradeTcName,
+			Labels:    label.New().Instance(upgradeInstanceName),
+		},
+		Spec: v1alpha1.TidbClusterSpec{
+			PD: &v1alpha1.PDSpec{
+				ComponentSpec: v1alpha1.ComponentSpec{
+					Image: "pingcap/pd:v7.3.0",
+				},
+				Replicas:         1,
+				StorageClassName: pointer.StringPtr("my-storage-class"),
+				Mode:             "ms",
+			},
+			PDMS: []*v1alpha1.PDMSSpec{
+				{
+					Name: tsoService,
+					ComponentSpec: v1alpha1.ComponentSpec{
+						Image: "pd-test-image",
+					},
+					Replicas:         3,
+					StorageClassName: pointer.StringPtr("my-storage-class"),
+				},
+			},
+		},
+		Status: v1alpha1.TidbClusterStatus{
+			PDMS: map[string]*v1alpha1.PDMSStatus{
+				tsoService: {
+					Phase: v1alpha1.NormalPhase,
+					StatefulSet: &apps.StatefulSetStatus{
+						CurrentRevision: "1",
+						UpdateRevision:  "2",
+						ReadyReplicas:   3,
+						Replicas:        3,
+						CurrentReplicas: 2,
+						UpdatedReplicas: 1,
+					},
+					Members: []string{podName0, podName1, podName2},
+				},
+			},
+		},
+	}
+}
+
+func getPDMSPods() []*corev1.Pod {
+	lc := label.New().Instance(upgradeInstanceName).PDMS(tsoService).Labels()
+	lc[apps.ControllerRevisionHashLabelKey] = "1"
+	lu := label.New().Instance(upgradeInstanceName).PDMS(tsoService).Labels()
+	lu[apps.ControllerRevisionHashLabelKey] = "2"
+	pods := []*corev1.Pod{
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PDMSPodName(upgradeTcName, 0, tsoService),
+				Namespace: corev1.NamespaceDefault,
+				Labels:    lc,
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue},
+				},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PDMSPodName(upgradeTcName, 1, tsoService),
+				Namespace: corev1.NamespaceDefault,
+				Labels:    lc,
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue},
+				},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PDMSPodName(upgradeTcName, 2, tsoService),
+				Namespace: corev1.NamespaceDefault,
+				Labels:    lu,
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue},
+				},
+			},
+		},
+	}
+	return pods
+}

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -66,7 +66,7 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			})
 		}
 
-		pods := getPods()
+		pods := getPDPods()
 		if test.changePods != nil {
 			test.changePods(pods)
 		}
@@ -539,7 +539,7 @@ func newTidbClusterForPDUpgrader() *v1alpha1.TidbCluster {
 	}
 }
 
-func getPods() []*corev1.Pod {
+func getPDPods() []*corev1.Pod {
 	lc := label.New().Instance(upgradeInstanceName).PD().Labels()
 	lc[apps.ControllerRevisionHashLabelKey] = "1"
 	lu := label.New().Instance(upgradeInstanceName).PD().Labels()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #5553 (issue number)
-->

Fix the bug that modifing tso config did not take effect

Closes #5553, related https://github.com/tikv/pd/issues/7519

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->


### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
