### PR TITLE
pdms: rename pdms-`service` to `service`

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -158,9 +158,9 @@ const (
 	// PDLabelVal is PD label value
 	PDLabelVal string = "pd"
 	// PDMSTSOLabelVal is pd microservice tso member type
-	PDMSTSOLabelVal string = "pdms-tso"
+	PDMSTSOLabelVal string = "tso"
 	// PDMSSchedulingLabelVal is pd microservice scheduling member type
-	PDMSSchedulingLabelVal string = "pdms-scheduling"
+	PDMSSchedulingLabelVal string = "scheduling"
 	// TiDBLabelVal is TiDB label value
 	TiDBLabelVal string = "tidb"
 	// TiKVLabelVal is TiKV label value

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -71,9 +71,9 @@ const (
 	// PDMemberType is pd member type
 	PDMemberType MemberType = "pd"
 	// PDMSTSOMemberType is pd microservice tso member type
-	PDMSTSOMemberType MemberType = "pdms-tso"
+	PDMSTSOMemberType MemberType = "tso"
 	// PDMSSchedulingMemberType is pd microservice scheduling member type
-	PDMSSchedulingMemberType MemberType = "pdms-scheduling"
+	PDMSSchedulingMemberType MemberType = "scheduling"
 	// TiDBMemberType is tidb member type
 	TiDBMemberType MemberType = "tidb"
 	// TiKVMemberType is tikv member type

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -313,12 +313,12 @@ func PDPeerMemberName(clusterName string) string {
 
 // PDMSMemberName returns pd microservice member name
 func PDMSMemberName(clusterName string, serviceName string) string {
-	return fmt.Sprintf("%s-pdms-%s", clusterName, serviceName)
+	return fmt.Sprintf("%s-%s", clusterName, serviceName)
 }
 
 // PDMSPeerMemberName returns pd microservice peer service name
 func PDMSPeerMemberName(clusterName string, serviceName string) string {
-	return fmt.Sprintf("%s-pdms-%s-peer", clusterName, serviceName)
+	return fmt.Sprintf("%s-%s-peer", clusterName, serviceName)
 }
 
 // PDMSTrimName returns last `-` separated string for `PDMSMemberName`

--- a/pkg/manager/member/pd_ms_member_manager_test.go
+++ b/pkg/manager/member/pd_ms_member_manager_test.go
@@ -428,13 +428,13 @@ func TestGetNewPDMSHeadlessServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso-peer",
+					Name:      "foo-tso-peer",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "peer",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -472,7 +472,7 @@ func TestGetNewPDMSHeadlessServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 					PublishNotReadyAddresses: true,
 				},
@@ -593,15 +593,15 @@ func TestGetNewPDMSSetForTidbCluster(t *testing.T) {
 				},
 				{
 					Name:  "PEER_SERVICE_NAME",
-					Value: "tc-pdms-tso-peer",
+					Value: "tc-tso-peer",
 				},
 				{
 					Name:  "SERVICE_NAME",
-					Value: "tc-pdms-tso",
+					Value: "tc-tso",
 				},
 				{
 					Name:  "SET_NAME",
-					Value: "tc-pdms-tso",
+					Value: "tc-tso",
 				},
 				{
 					Name: "TZ",
@@ -612,7 +612,7 @@ func TestGetNewPDMSSetForTidbCluster(t *testing.T) {
 				},
 				{
 					Name:  "HEADLESS_SERVICE_NAME",
-					Value: "tc-pdms-tso-peer",
+					Value: "tc-tso-peer",
 				},
 				{
 					Name: "PDMS_SESSION_SECRET",
@@ -1097,13 +1097,13 @@ func TestGetPDMSConfigMap(t *testing.T) {
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1164,13 +1164,13 @@ func TestGetPDMSConfigMap(t *testing.T) {
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1222,13 +1222,13 @@ func TestGetPDMSConfigMap(t *testing.T) {
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1294,13 +1294,13 @@ func TestGetPDMSConfigMap(t *testing.T) {
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1392,13 +1392,13 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "end-user",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1430,7 +1430,7 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 				},
 			},
@@ -1468,13 +1468,13 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "end-user",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1507,7 +1507,7 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 				},
 			},
@@ -1545,13 +1545,13 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "end-user",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1584,7 +1584,7 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 				},
 			},
@@ -1623,13 +1623,13 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "end-user",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1662,7 +1662,7 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 				},
 			},
@@ -1703,13 +1703,13 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 			},
 			expected: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-pdms-tso",
+					Name:      "foo-tso",
 					Namespace: "ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 						"app.kubernetes.io/used-by":    "end-user",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1742,7 +1742,7 @@ func TestGetNewPdMSServiceForTidbCluster(t *testing.T) {
 						"app.kubernetes.io/name":       "tidb-cluster",
 						"app.kubernetes.io/managed-by": "tidb-operator",
 						"app.kubernetes.io/instance":   "foo",
-						"app.kubernetes.io/component":  "pdms-tso",
+						"app.kubernetes.io/component":  "tso",
 					},
 				},
 			},

--- a/pkg/manager/volumes/selector_test.go
+++ b/pkg/manager/volumes/selector_test.go
@@ -42,14 +42,14 @@ func TestNewSelector(t *testing.T) {
 			instance: "aaa",
 			mt:       v1alpha1.PDMSTSOMemberType,
 
-			expected: "app.kubernetes.io/component=pdms-tso,app.kubernetes.io/instance=aaa,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/name=tidb-cluster",
+			expected: "app.kubernetes.io/component=tso,app.kubernetes.io/instance=aaa,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/name=tidb-cluster",
 		},
 		{
 			desc:     "selector for scheduling",
 			instance: "aaa",
 			mt:       v1alpha1.PDMSSchedulingMemberType,
 
-			expected: "app.kubernetes.io/component=pdms-scheduling,app.kubernetes.io/instance=aaa,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/name=tidb-cluster",
+			expected: "app.kubernetes.io/component=scheduling,app.kubernetes.io/instance=aaa,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/name=tidb-cluster",
 		},
 		{
 			desc:     "selector for tidb",

--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -45,8 +45,8 @@ var (
 	tikvPattern           = "tikv"
 	tiproxyPattern        = "tiproxy"
 	pdPattern             = "pd"
-	pdmsTSOPattern        = "pdms-tso"
-	pdmsSchedulingPattern = "pdms-scheduling"
+	pdmsTSOPattern        = "tso"
+	pdmsSchedulingPattern = "scheduling"
 	tidbPattern           = "tidb"
 	addressPattern        = "(.+);(.+);(.+);(.+)"
 	tiflashPattern        = "tiflash"
@@ -94,8 +94,8 @@ type ClusterRegexInfo struct {
 func newPrometheusConfig(cmodel *MonitorConfigModel) yaml.MapSlice {
 	var scrapeJobs []yaml.MapSlice
 	scrapeJobs = append(scrapeJobs, scrapeJob("pd", pdPattern, cmodel, buildAddressRelabelConfigByComponent("pd"))...)
-	scrapeJobs = append(scrapeJobs, scrapeJob("pdms-tso", pdmsTSOPattern, cmodel, buildAddressRelabelConfigByComponent("pdms-tso"))...)
-	scrapeJobs = append(scrapeJobs, scrapeJob("pdms-scheduling", pdmsSchedulingPattern, cmodel, buildAddressRelabelConfigByComponent("pdms-scheduling"))...)
+	scrapeJobs = append(scrapeJobs, scrapeJob("tso", pdmsTSOPattern, cmodel, buildAddressRelabelConfigByComponent("tso"))...)
+	scrapeJobs = append(scrapeJobs, scrapeJob("scheduling", pdmsSchedulingPattern, cmodel, buildAddressRelabelConfigByComponent("scheduling"))...)
 	scrapeJobs = append(scrapeJobs, scrapeJob("tidb", tidbPattern, cmodel, buildAddressRelabelConfigByComponent("tidb"))...)
 	scrapeJobs = append(scrapeJobs, scrapeJob("tikv", tikvPattern, cmodel, buildAddressRelabelConfigByComponent("tikv"))...)
 	scrapeJobs = append(scrapeJobs, scrapeJob("tiproxy", tiproxyPattern, cmodel, buildAddressRelabelConfigByComponent("tiproxy"))...)
@@ -139,7 +139,7 @@ func buildAddressRelabelConfigByComponent(kind string) yaml.MapSlice {
 	}
 
 	switch strings.ToLower(kind) {
-	case "pd", "pdms-scheduling", "pdms-tso":
+	case "pd", "scheduling", "tso":
 		return f()
 	case "tidb":
 		return f()

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -150,7 +150,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-tso
+- job_name: ns1-target-tso
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -178,10 +178,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-tso
+    regex: tso
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-tso-peer.$3:$4
+    replacement: $1.$2-tso-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name
@@ -223,7 +223,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-scheduling
+- job_name: ns1-target-scheduling
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -251,10 +251,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-scheduling
+    regex: scheduling
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-scheduling-peer.$3:$4
+    replacement: $1.$2-scheduling-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name
@@ -1267,7 +1267,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-tso
+- job_name: ns1-target-tso
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -1295,10 +1295,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-tso
+    regex: tso
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-tso-peer.$3:$4
+    replacement: $1.$2-tso-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name
@@ -1340,7 +1340,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-scheduling
+- job_name: ns1-target-scheduling
   honor_labels: true
   scrape_interval: 15s
   scheme: http
@@ -1368,10 +1368,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-scheduling
+    regex: scheduling
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-scheduling-peer.$3:$4
+    replacement: $1.$2-scheduling-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name
@@ -2382,7 +2382,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-tso
+- job_name: ns1-target-tso
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -2412,10 +2412,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-tso
+    regex: tso
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-tso-peer.$3:$4
+    replacement: $1.$2-tso-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name
@@ -2457,7 +2457,7 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-- job_name: ns1-target-pdms-scheduling
+- job_name: ns1-target-scheduling
   honor_labels: true
   scrape_interval: 15s
   scheme: https
@@ -2487,10 +2487,10 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_component
     action: keep
-    regex: pdms-scheduling
+    regex: scheduling
   - action: replace
     regex: (.+);(.+);(.+);(.+)
-    replacement: $1.$2-pdms-scheduling-peer.$3:$4
+    replacement: $1.$2-scheduling-peer.$3:$4
     target_label: __address__
     source_labels:
     - __meta_kubernetes_pod_name

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -302,7 +302,7 @@ func genEtcdClientKey(namespace Namespace, clusterName string, clusterDomain str
 func genClientUrl(namespace Namespace, clusterName, scheme, clusterDomain, serviceName string, headlessSvc bool) string {
 	svc := "pd"
 	if serviceName != "" && checkServiceName(serviceName) {
-		svc = fmt.Sprintf("pdms-%s", serviceName)
+		svc = serviceName
 	}
 	if headlessSvc {
 		svc = fmt.Sprintf("%s-peer", svc)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

ref https://github.com/tikv/pd/issues/7519

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

rename `pdms-tso` to `tso`

before 
![img_v3_028g_22577ee4-3961-45b0-bd59-c596c0175ccg](https://github.com/pingcap/tidb-operator/assets/53859786/0e86e6fe-438e-4e81-a36f-69d978178c1e)

after
<img width="674" alt="image" src="https://github.com/pingcap/tidb-operator/assets/53859786/edcc7776-dd9a-4c4e-afd2-79eb88f32bfa">


### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
