### PR TITLE
pdms: randomly run pdms in e2e test

### DIFF
--- a/examples/basic/pd-micro-service-cluster.yaml
+++ b/examples/basic/pd-micro-service-cluster.yaml
@@ -17,8 +17,8 @@ spec:
     image: alpine:3.16.0
   pd:
     # TODO: use a stable version
-    baseImage: pingcap/pd
-    version: nightly
+    baseImage: hub-new.pingcap.net/orchestration/pd
+    version: v8.0.0
     maxFailoverCount: 0
     replicas: 1
     # if storageClassName is not set, the default Storage Class of the Kubernetes cluster will be used
@@ -29,16 +29,18 @@ spec:
     mode: "ms"
   pdms:
     - name: "tso"
-      baseImage: pingcap/pd
-      version: nightly
+      # TODO: use a stable version
+      baseImage: hub-new.pingcap.net/orchestration/pd
+      version: v8.0.0
       replicas: 2
     - name: "scheduling"
-      baseImage: pingcap/pd
-      version: nightly
+      # TODO: use a stable version
+      baseImage: hub-new.pingcap.net/orchestration/pd
+      version: v8.0.0
       replicas: 1
   tikv:
     baseImage: pingcap/tikv
-    version: v7.4.0
+    version: v7.5.0
     maxFailoverCount: 0
     # If only 1 TiKV is deployed, the TiKV region leader
     # cannot be transferred during upgrade, so we have
@@ -61,7 +63,7 @@ spec:
         max-open-files: 256
   tidb:
     baseImage: pingcap/tidb
-    version: v7.4.0
+    version: v7.5.0
     maxFailoverCount: 0
     replicas: 1
     service:

--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -187,6 +187,17 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 		}
 	}
 
+	// works that should be done to make the pd microservice current state match the desired state:
+	//   - create or update the pdms service
+	//   - create or update the pdms headless service
+	//   - create the pdms statefulset
+	//   - sync pdms cluster status from pdms to TidbCluster object
+	//   - upgrade the pdms cluster
+	//   - scale out/in the pdms cluster
+	if err := c.pdMSMemberManager.Sync(tc); err != nil {
+		return err
+	}
+
 	// works that should be done to make the pd cluster current state match the desired state:
 	//   - create or update the pd service
 	//   - create or update the pd headless service
@@ -200,17 +211,6 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 	//   - failover the pd cluster
 	if err := c.pdMemberManager.Sync(tc); err != nil {
 		metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "pd").Inc()
-		return err
-	}
-
-	// works that should be done to make the pd microservice current state match the desired state:
-	//   - create or update the pdms service
-	//   - create or update the pdms headless service
-	//   - create the pdms statefulset
-	//   - sync pdms cluster status from pdms to TidbCluster object
-	//   - upgrade the pdms cluster
-	//   - scale out/in the pdms cluster
-	if err := c.pdMSMemberManager.Sync(tc); err != nil {
 		return err
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -80,8 +80,8 @@ func (m *pdMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return nil
 	}
 
-	if tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS == nil ||
-		tc.Spec.PDMS != nil && tc.Spec.PD.Mode != "ms" {
+	if (tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS == nil) ||
+		(tc.Spec.PDMS != nil && tc.Spec.PD.Mode != "ms") {
 		klog.Infof("tidbcluster: [%s/%s]'s enable micro service failed, please check `PD.Mode` and `PDMS`", tc.GetNamespace(), tc.GetName())
 	}
 

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -80,8 +80,9 @@ func (m *pdMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return nil
 	}
 
-	if tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS == nil {
-		return fmt.Errorf("tidbcluster: [%s/%s]'s enable micro service but pdMS spec is nil, please check `PDMS`", tc.GetNamespace(), tc.GetName())
+	if tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS == nil ||
+		tc.Spec.PDMS != nil && tc.Spec.PD.Mode != "ms" {
+		klog.Infof("tidbcluster: [%s/%s]'s enable micro service failed, please check `PD.Mode` and `PDMS`", tc.GetNamespace(), tc.GetName())
 	}
 
 	// skip sync if pd is suspended

--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -66,7 +66,7 @@ func (m *pdMSMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	}
 	// remove all micro service components if PDMS is not enabled
 	// PDMS need to be enabled when PD.Mode is ms && PDMS is not nil
-	if tc.Spec.PDMS == nil || tc.Spec.PD != nil && tc.Spec.PD.Mode != "ms" {
+	if tc.Spec.PDMS == nil || (tc.Spec.PD != nil && tc.Spec.PD.Mode != "ms") {
 		for _, comp := range tc.Status.PDMS {
 			ns := tc.GetNamespace()
 			tcName := tc.GetName()

--- a/pkg/manager/member/startscript/v1/render_script.go
+++ b/pkg/manager/member/startscript/v1/render_script.go
@@ -74,7 +74,7 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 
 	pdStartSubScript := ``
 	mode := ""
-	if tc.Spec.PD.Mode == "ms" {
+	if tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS != nil {
 		mode = "api"
 	}
 	pdStartScriptTpl := template.Must(

--- a/pkg/manager/member/startscript/v2/pd_start_script.go
+++ b/pkg/manager/member/startscript/v2/pd_start_script.go
@@ -94,7 +94,7 @@ func RenderPDStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 		tc.Spec.StartScriptV2FeatureFlags, v1alpha1.StartScriptV2FeatureFlagWaitForDnsNameIpMatch)
 
 	mode := ""
-	if tc.Spec.PD.Mode == "ms" {
+	if tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS != nil {
 		mode = "api"
 	}
 	pdStartScriptTpl := template.Must(

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -111,17 +111,14 @@ func (m *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	if tc.Spec.PD != nil && !tc.PDIsAvailable() {
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], waiting for PD cluster running", ns, tcName)
 	}
-	// Need to wait for PDMS
-	if tc.Spec.PD != nil && tc.Spec.PD.Mode == "ms" && tc.Spec.PDMS == nil {
-		return controller.RequeueErrorf("TidbCluster: [%s/%s], please make sure pdms is not nil, "+
-			"then now waiting for PD's micro service running", ns, tcName)
-	}
 	// Check if all PD Micro Services are available
-	for _, pdms := range tc.Spec.PDMS {
-		_, err = controller.GetPDMSClient(m.deps.PDControl, tc, pdms.Name)
-		if err != nil {
-			return controller.RequeueErrorf("PDMS component %s for TidbCluster: [%s/%s], "+
-				"waiting for PD micro service cluster running, error: %v", pdms.Name, ns, tcName, err)
+	if tc.Spec.PDMS != nil && tc.Spec.PD != nil && tc.Spec.PD.Mode == "ms" {
+		for _, pdms := range tc.Spec.PDMS {
+			_, err = controller.GetPDMSClient(m.deps.PDControl, tc, pdms.Name)
+			if err != nil {
+				return controller.RequeueErrorf("PDMS component %s for TidbCluster: [%s/%s], "+
+					"waiting for PD micro service cluster running, error: %v", pdms.Name, ns, tcName, err)
+			}
 		}
 	}
 

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -112,7 +112,7 @@ func (m *tikvMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], waiting for PD cluster running", ns, tcName)
 	}
 	// Check if all PD Micro Services are available
-	if tc.Spec.PDMS != nil && tc.Spec.PD != nil && tc.Spec.PD.Mode == "ms" {
+	if tc.Spec.PDMS != nil && (tc.Spec.PD != nil && tc.Spec.PD.Mode == "ms") {
 		for _, pdms := range tc.Spec.PDMS {
 			_, err = controller.GetPDMSClient(m.deps.PDControl, tc, pdms.Name)
 			if err != nil {

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -683,6 +683,19 @@ func (oa *OperatorActions) memberCheckContextForTC(tc *v1alpha1.TidbCluster, com
 		expectedImage = tc.PDImage()
 		services = []string{controller.PDMemberName(name), controller.PDPeerMemberName(name)}
 		checkComponent = oa.isPDMembersReady
+	case v1alpha1.PDMSTSOMemberType, v1alpha1.PDMSSchedulingMemberType:
+		curService := component.String()
+		skip = true
+		for _, service := range tc.Spec.PDMS {
+			log.Logf("check pdms service ready, curService: %s, service.Name: %s", curService, service.Name)
+			if curService == service.Name {
+				skip = false
+				break
+			}
+		}
+		expectedImage = tc.PDImage()
+		services = []string{controller.PDMSMemberName(name, curService), controller.PDMSPeerMemberName(name, curService)}
+		checkComponent = oa.isPDMSMembersReady
 	case v1alpha1.TiDBMemberType:
 		skip = tc.Spec.TiDB == nil
 		expectedImage = tc.TiDBImage()
@@ -873,6 +886,36 @@ func (oa *OperatorActions) isPDMembersReady(tc *v1alpha1.TidbCluster, sts *v1.St
 		if !member.Health {
 			return fmt.Errorf("pd member(%s/%s) is not health", member.ID, member.Name)
 		}
+	}
+
+	return nil
+}
+
+func (oa *OperatorActions) isPDMSMembersReady(tc *v1alpha1.TidbCluster, sts *v1.StatefulSet) error {
+	curService := controller.PDMSTrimName(sts.Name)
+	if tc.Status.PDMS[curService] == nil || tc.Status.PDMS[curService].StatefulSet == nil {
+		return fmt.Errorf("sts in tc status is nil, pdms curService is %s", curService)
+	}
+
+	var replicas int32
+	for _, component := range tc.Spec.PDMS {
+		if strings.Contains(component.Name, curService) {
+			replicas = component.Replicas
+			break
+		}
+	}
+
+	if *sts.Spec.Replicas != replicas {
+		return fmt.Errorf("sts.spec.Replicas(%d) != %d, pdms curService is %s\", curService)",
+			*sts.Spec.Replicas, replicas, curService)
+	}
+	if sts.Status.ReadyReplicas != replicas {
+		return fmt.Errorf("sts.status.ReadyReplicas(%d) != %d, pdms curService is %s\", curService)",
+			sts.Status.ReadyReplicas, tc.Spec.PD.Replicas, curService)
+	}
+	if sts.Status.ReadyReplicas != sts.Status.Replicas {
+		return fmt.Errorf("sts.status.ReadyReplicas(%d) != sts.status.Replicas(%d), pdms curService is %s\", curService)",
+			sts.Status.ReadyReplicas, sts.Status.Replicas, curService)
 	}
 
 	return nil
@@ -1331,6 +1374,50 @@ func (oa *OperatorActions) WaitForTidbClusterReady(tc *v1alpha1.TidbCluster, tim
 
 		for _, component := range components {
 			if err := oa.IsMembersReady(local, component); err != nil {
+				checkErr = fmt.Errorf("%s members for tc %q are not ready: %v", component, tcID, err)
+				return false, nil
+			}
+		}
+
+		log.Logf("TidbCluster %q is ready", tcID)
+		return true, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = checkErr
+	}
+
+	return err
+}
+
+func (oa *OperatorActions) WaitForPDMSClusterReady(tc *v1alpha1.TidbCluster, timeout, pollInterval time.Duration) error {
+	if tc == nil {
+		return fmt.Errorf("tidbcluster is nil, cannot call WaitForTidbClusterReady")
+	}
+	var checkErr, err error
+	var local *v1alpha1.TidbCluster
+	tcID := fmt.Sprintf("%s/%s", tc.Namespace, tc.Name)
+	err = wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		if local, err = oa.cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Get(context.TODO(), tc.Name, metav1.GetOptions{}); err != nil {
+			checkErr = fmt.Errorf("failed to get TidbCluster: %q, %v", tcID, err)
+			return false, nil
+		}
+
+		components := []v1alpha1.MemberType{
+			v1alpha1.PDMSTSOMemberType,
+			v1alpha1.PDMSSchedulingMemberType,
+			v1alpha1.PDMemberType,
+			v1alpha1.TiKVMemberType,
+			v1alpha1.TiDBMemberType,
+			v1alpha1.TiDBMemberType,
+			v1alpha1.TiFlashMemberType,
+			v1alpha1.PumpMemberType,
+			v1alpha1.TiCDCMemberType,
+		}
+
+		for _, component := range components {
+			if err := oa.IsMembersReady(local, component); err != nil {
+				log.Logf("%s members for tc %q are not ready: %v", component, tcID, err)
 				checkErr = fmt.Errorf("%s members for tc %q are not ready: %v", component, tcID, err)
 				return false, nil
 			}

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	astsHelper "github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
 	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
+	"github.com/pingcap/errors"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -138,7 +139,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 
 	// basic deploy, scale out, scale in, change configuration tests
 	ginkgo.Context("[TiDBCluster: Basic]", func() {
-		versions := []string{utilimage.TiDBLatest}
+		versions := []string{utilimage.TiDBLatest, utilimage.PDMSImage}
 		versions = append(versions, utilimage.TiDBPreviousVersions...)
 		for _, version := range versions {
 			version := version
@@ -3219,7 +3220,6 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 		})
 	})
 
-
 	// basic deploy for pdms, scale out, scale in, change configuration tests
 	ginkgo.Context("[PDMSCluster: Basic]", func() {
 		versions := []string{utilimage.PDMSImage}
@@ -3272,7 +3272,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				})
 
 				ginkgo.It("should scale in tc successfully", func() {
-					ginkgo.By("Deploy a basic tc")
+					ginkgo.By("Deploy a basic tc with pdms")
 					tc := fixture.GetTidbCluster(ns, fmt.Sprintf("basic-%s", versionDashed), version)
 					tc = fixture.AddPDMSForTidbCluster(tc)
 					tc.Spec.TiKV.Replicas = 4
@@ -3302,7 +3302,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 				})
 
 				ginkgo.It("should change configurations successfully", func() {
-					ginkgo.By("Deploy a basic tc")
+					ginkgo.By("Deploy a basic tc with pdms")
 					tc := fixture.GetTidbCluster(ns, fmt.Sprintf("basic-%s", versionDashed), version)
 					tc = fixture.AddPDMSForTidbCluster(tc)
 					tc.Spec.TiDB.Replicas = 1
@@ -3350,10 +3350,105 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 					ginkgo.By("Check custom labels and annotations changed")
 					framework.ExpectNoError(checkCustomLabelAndAnn(tc, c, newValue, 10*time.Minute, 10*time.Second), "failed to check labels and annotations")
 				})
+
+				// move pd original mode to pdms mode
+				ginkgo.It("should transfer pd mode successfully", func() {
+					ginkgo.By("Deploy a basic tc")
+					tc := fixture.GetTidbCluster(ns, fmt.Sprintf("basic-%s", versionDashed), version)
+					tc.Spec.PD.Mode = ""
+					tc.Spec.PDMS = nil
+					_, err := cli.PingcapV1alpha1().TidbClusters(tc.Namespace).Create(context.TODO(), tc, metav1.CreateOptions{})
+					framework.ExpectNoError(err, "failed to create TidbCluster: %q", tc.Name)
+					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 30*time.Second)
+					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+					err = crdUtil.CheckDisasterTolerance(tc)
+					framework.ExpectNoError(err, "failed to check disaster tolerance for TidbCluster: %q", tc.Name)
+
+					ginkgo.By("transfer to pdms")
+					err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+						tc = fixture.AddPDMSForTidbCluster(tc)
+						return nil
+					})
+					framework.ExpectNoError(err, "failed to change pd mode of TidbCluster: %q", tc.Name)
+					err = oa.WaitForTidbClusterReady(tc, 10*time.Minute, 5*time.Second)
+					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+
+					ginkgo.By("transfer to original pd mode but not delete pdms")
+					err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+						tc.Spec.PD.Mode = ""
+						return nil
+					})
+					framework.ExpectNoError(err, "failed to change pd mode of TidbCluster: %q", tc.Name)
+					// wait for pdms deleted
+					checkAllPDMSStatus(stsGetter, ns, tc.Name, 0)
+					ginkgo.By("check pdms deleted successfully")
+					err = oa.WaitForTidbClusterReady(tc, 10*time.Minute, 5*time.Second)
+					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+
+					ginkgo.By("transfer to pdms")
+					err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+						tc = fixture.AddPDMSForTidbCluster(tc)
+						return nil
+					})
+					framework.ExpectNoError(err, "failed to change pd mode of TidbCluster: %q", tc.Name)
+					err = oa.WaitForTidbClusterReady(tc, 10*time.Minute, 5*time.Second)
+					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+
+					ginkgo.By("transfer to original pd mode and delete pdms")
+					err = controller.GuaranteedUpdate(genericCli, tc, func() error {
+						tc.Spec.PD.Mode = ""
+						tc.Spec.PDMS = nil
+						return nil
+					})
+					framework.ExpectNoError(err, "failed to change pd mode of TidbCluster: %q", tc.Name)
+					// wait for pdms deleted
+					checkAllPDMSStatus(stsGetter, ns, tc.Name, 0)
+					ginkgo.By("check pdms deleted successfully")
+					err = oa.WaitForTidbClusterReady(tc, 30*time.Minute, 5*time.Second)
+					framework.ExpectNoError(err, "failed to wait for TidbCluster ready: %q", tc.Name)
+				})
 			})
 		}
 	})
 })
+
+// checkAllPDMSStatus check there are onlineNum online pdms instance running now.
+func checkAllPDMSStatus(stsGetter typedappsv1.StatefulSetsGetter, ns string, tcName string, onlineNum int32) error {
+	var checkErr error
+	err := wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+
+		var onlines int32
+		for _, component := range []string{"tso", "scheduling"} {
+			pdSts, err := stsGetter.StatefulSets(ns).Get(context.TODO(), controller.PDMSMemberName(tcName, "tso"), metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return false, err
+			}
+
+			if err != nil {
+				setNotExist := errors.IsNotFound(err)
+				if !setNotExist && pdSts.Status.Replicas > 0 {
+					log.Logf("failed to check %d online pdms, onlines %d, component is %s", onlineNum, pdSts.Status.Replicas, component)
+					onlines++
+				}
+			} else if pdSts.Status.Replicas > 0 {
+				onlines++
+			}
+		}
+
+		if onlines == onlineNum {
+			return true, nil
+		}
+
+		checkErr = fmt.Errorf("failed to check %d online pdms", onlineNum)
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = checkErr
+	}
+
+	return err
+}
 
 // checkPumpStatus check there are onlineNum online pump instance running now.
 func checkPumpStatus(pcli versioned.Interface, ns string, name string, onlineNum int32) error {

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -55,7 +55,8 @@ const (
 	DMV2                          = TiDBLatest
 	TiDBNGMonitoringLatest        = TiDBLatest
 	HelperImage                   = "alpine:3.16.0"
-	PDMSImage                     = "nightly"
+	// TODO: replace this after we have `8.0.0` release
+	PDMSImage = "v7.6.0"
 )
 
 func ListImages() []string {

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -55,6 +55,7 @@ const (
 	DMV2                          = TiDBLatest
 	TiDBNGMonitoringLatest        = TiDBLatest
 	HelperImage                   = "alpine:3.16.0"
+	PDMSImage                     = "nightly"
 )
 
 func ListImages() []string {

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -791,25 +791,32 @@ const (
 )
 
 func AddPDMSForTidbCluster(tc *v1alpha1.TidbCluster) *v1alpha1.TidbCluster {
+	tc.Spec.PD.Mode = "ms"
 	if tc.Spec.PDMS != nil {
 		return tc
 	}
-	tc.Spec.PD.Mode = "ms"
+	pdmsImage := "hub-new.pingcap.net/orchestration/pd"
+	version := "v8.0.0"
+	// TODO: remove pd version when released pdms
+	tc.Spec.PD.BaseImage = "hub-new.pingcap.net/orchestration/pd"
+	tc.Spec.PD.Version = &version
 	tc.Spec.PDMS = []*v1alpha1.PDMSSpec{
 		{
 			Name: tsoService,
+			// TODO: replace pdms image when released pdms
+			BaseImage: &pdmsImage,
 			ComponentSpec: v1alpha1.ComponentSpec{
-				// TODO: specific version which supported pdms
-				Image: "pingcap/pd:nightly",
+				Version: &version,
 			},
 			Replicas:             2,
 			ResourceRequirements: WithStorage(BurstableSmall, "10Gi"),
 		},
 		{
 			Name: schedulingService,
+			// TODO: replace pdms image when released pdms
+			BaseImage: &pdmsImage,
 			ComponentSpec: v1alpha1.ComponentSpec{
-				// TODO: specific version which supported pdms
-				Image: "pingcap/pd:nightly",
+				Version: &version,
 			},
 			Replicas:             1,
 			ResourceRequirements: WithStorage(BurstableSmall, "10Gi"),

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -29,6 +29,7 @@ import (
 	tcconfig "github.com/pingcap/tidb-operator/pkg/apis/util/config"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	utilimage "github.com/pingcap/tidb-operator/tests/e2e/util/image"
+	"github.com/pingcap/tidb-operator/tests/third_party/k8s/log"
 )
 
 var (
@@ -194,6 +195,7 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 
 	random := rand.Intn(2)
 	if random != 0 && version == utilimage.PDMSImage {
+		log.Logf("[GetTidbCluster] tidbcluster's pd mode is micro-service in this situation, version: %s", version)
 		// 50% random in pdms mode
 		tc = AddPDMSForTidbCluster(tc)
 	}

--- a/tests/pkg/fixture/fixture.go
+++ b/tests/pkg/fixture/fixture.go
@@ -195,7 +195,8 @@ func GetTidbCluster(ns, name, version string) *v1alpha1.TidbCluster {
 
 	random := rand.Intn(2)
 	if random != 0 && version == utilimage.PDMSImage {
-		log.Logf("[GetTidbCluster] tidbcluster's pd mode is micro-service in this situation, version: %s", version)
+		log.Logf("[GetTidbCluster] tidbcluster's pd mode is micro-service in this situation, "+
+			"version: %s, tc name: %s, namespace: %s", version, name, ns)
 		// 50% random in pdms mode
 		tc = AddPDMSForTidbCluster(tc)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Ref https://github.com/tikv/pd/issues/7519


run e2e in local machine
<img width="1834" alt="image" src="https://github.com/pingcap/tidb-operator/assets/53859786/143894a2-8393-4101-8bc5-2f19c0f0d647">

test log in ci
https://ci.pingcap.net/blue/organizations/jenkins/tidb-operator-pull-e2e-kind/detail/tidb-operator-pull-e2e-kind/5325/pipeline/65
<img width="1770" alt="image" src="https://github.com/pingcap/tidb-operator/assets/53859786/74ca99cc-b39b-4a4d-b264-518c85d2c08d">



### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->


### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
