### PR TITLE
fix: append cluster domain for PD/TiKV/TiDB/etcd URL; prefer PD address for TiFlash/TiCDC

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/validation/validation.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation.go
@@ -197,8 +197,8 @@ func validatePDAddresses(arrayOfAddresses []string, fldPath *field.Path) field.E
 		example := " PD address format example: http://{ADDRESS}:{PORT}"
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(idxPath, address, err.Error()+example))
-		} else if u.Scheme != "http" {
-			allErrs = append(allErrs, field.Invalid(idxPath, address, "Support 'http' scheme only."+example))
+		} else if u.Scheme != "http" && u.Scheme != "https" {
+			allErrs = append(allErrs, field.Invalid(idxPath, address, "Support 'http'/'https' scheme only."+example))
 		}
 	}
 	return allErrs

--- a/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/pingcap/v1alpha1/validation/validation_test.go
@@ -688,6 +688,13 @@ func TestValidatePDAddresses(t *testing.T) {
 			"http://test-pd-0.test-pd-peer.default.svc:2380",
 			"http://test:2379",
 		},
+		{
+			"https://1.2.3.4:2379",
+		},
+		{
+			"http://1.2.3.4:2380",
+			"https://1.2.3.4:2379",
+		},
 	}
 
 	for _, c := range successCases {
@@ -698,13 +705,6 @@ func TestValidatePDAddresses(t *testing.T) {
 	}
 
 	errorCases := [][]string{
-		{
-			"https://1.2.3.4:2379",
-		},
-		{
-			"http://1.2.3.4:2380",
-			"https://1.2.3.4:2379",
-		},
 		{
 			"test-pd-0.test-pd-peer.default.svc:2380",
 		},

--- a/pkg/backup/backup/backup_tracker.go
+++ b/pkg/backup/backup/backup_tracker.go
@@ -199,7 +199,8 @@ func (bt *backupTracker) refreshLogBackupCheckpointTs(ns, name string) {
 func (bt *backupTracker) doRefreshLogBackupCheckpointTs(backup *v1alpha1.Backup, dep *trackDepends) {
 	ns := backup.Namespace
 	name := backup.Name
-	etcdCli, err := bt.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(dep.tc.Namespace), dep.tc.Name, dep.tc.IsTLSClusterEnabled())
+	etcdCli, err := bt.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(dep.tc.Namespace), dep.tc.Name,
+		dep.tc.IsTLSClusterEnabled(), pdapi.ClusterRef(dep.tc.Spec.ClusterDomain))
 	if err != nil {
 		klog.Errorf("get log backup %s/%s pd cli error %v", ns, name, err)
 		return

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -27,12 +27,14 @@ func getPDClientFromService(pdControl pdapi.PDControlInterface, tc *v1alpha1.Tid
 			pdapi.UseHeadlessService(tc.Spec.AcrossK8s),
 		)
 	}
-	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled())
+	// cluster domain may be empty
+	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain))
 }
 
 // getPDClientFromService gets the pd client from the TidbCluster
 func getPDMSClientFromService(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster, serviceName string) pdapi.PDMSClient {
-	return pdControl.GetPDMSClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), serviceName, tc.IsTLSClusterEnabled())
+	return pdControl.GetPDMSClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), serviceName,
+		tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain))
 }
 
 // GetPDClient tries to return an available PDClient

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -83,6 +83,9 @@ func NewFakePDClient(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster) *
 	if tc.Spec.Cluster != nil {
 		pdControl.SetPDClientWithClusterDomain(pdapi.Namespace(tc.Spec.Cluster.Namespace), tc.Spec.Cluster.Name, tc.Spec.Cluster.ClusterDomain, pdClient)
 	}
+	if tc.Spec.ClusterDomain != "" {
+		pdControl.SetPDClientWithClusterDomain(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.Spec.ClusterDomain, pdClient)
+	}
 	pdControl.SetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), pdClient)
 
 	return pdClient

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -149,7 +149,11 @@ func (c *defaultTiDBControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32)
 	scheme := tc.Scheme()
 	hostName := fmt.Sprintf("%s-%d", TiDBMemberName(tcName), ordinal)
 
-	return fmt.Sprintf("%s://%s.%s.%s:%d", scheme, hostName, TiDBPeerMemberName(tcName), ns, v1alpha1.DefaultTiDBStatusPort)
+	baseURL := fmt.Sprintf("%s://%s.%s.%s:%d", scheme, hostName, TiDBPeerMemberName(tcName), ns, v1alpha1.DefaultTiDBStatusPort)
+	if tc.Spec.ClusterDomain != "" {
+		baseURL = fmt.Sprintf("%s://%s.%s.%s.svc.%s:%d", scheme, hostName, TiDBPeerMemberName(tcName), ns, tc.Spec.ClusterDomain, v1alpha1.DefaultTiDBStatusPort)
+	}
+	return baseURL
 }
 
 // FakeTiDBControl is a fake implementation of TiDBControlInterface.

--- a/pkg/controller/tidbcluster/pod_control.go
+++ b/pkg/controller/tidbcluster/pod_control.go
@@ -437,7 +437,7 @@ func (c *PodController) syncTiKVPodForEviction(ctx context.Context, pod *corev1.
 		// delete pod after eviction finished if needed
 		if value == v1alpha1.EvictLeaderValueDeletePod {
 			tlsEnabled := tc.IsTLSClusterEnabled()
-			kvClient := c.deps.TiKVControl.GetTiKVPodClient(tc.Namespace, tc.Name, pod.Name, tlsEnabled)
+			kvClient := c.deps.TiKVControl.GetTiKVPodClient(tc.Namespace, tc.Name, pod.Name, tc.Spec.ClusterDomain, tlsEnabled)
 			leaderCount, err := kvClient.GetLeaderCount()
 			if err != nil {
 				return reconcile.Result{}, perrors.Annotatef(err, "failed to get leader count for pod %s/%s", pod.Namespace, pod.Name)

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -127,8 +127,8 @@ func (d *tidbDiscovery) Discover(advertisePeerUrl string) (string, error) {
 	var pdClients []pdapi.PDClient
 
 	if tc.Spec.PD != nil {
-		// connect to pd of current cluster
-		pdClients = append(pdClients, d.pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled()))
+		// connect to pd of current cluster, `ClusterDomain` may be empty
+		pdClients = append(pdClients, d.pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain)))
 	}
 
 	if tc.Heterogeneous() {

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -167,7 +167,8 @@ func buildBinlogClient(tc *v1alpha1.TidbCluster, control pdapi.PDControlInterfac
 			pdapi.ClusterRef(tc.Spec.Cluster.ClusterDomain),
 		)
 	} else {
-		endpoints, tlsConfig, err = control.GetEndpoints(pdapi.Namespace(tc.Namespace), tc.Name, tc.IsTLSClusterEnabled())
+		endpoints, tlsConfig, err = control.GetEndpoints(pdapi.Namespace(tc.Namespace), tc.Name,
+			tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain))
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/manager/member/tidbcluster_status_manager.go
+++ b/pkg/manager/member/tidbcluster_status_manager.go
@@ -111,7 +111,8 @@ func (m *TidbClusterStatusManager) syncTiDBInfoKey(tc *v1alpha1.TidbCluster) err
 			pdapi.UseHeadlessService(tc.Spec.AcrossK8s),
 		)
 	} else {
-		pdEtcdClient, err = m.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name, tc.IsTLSClusterEnabled())
+		pdEtcdClient, err = m.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name,
+			tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain))
 	}
 	if err != nil {
 		return err

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -210,7 +210,7 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 
 		preferPDAddressesOverDiscovery := slices.Contains(
 			tc.Spec.StartScriptV2FeatureFlags, v1alpha1.StartScriptV2FeatureFlagPreferPDAddressesOverDiscovery)
-		if preferPDAddressesOverDiscovery {
+		if preferPDAddressesOverDiscovery && tc.Spec.StartScriptVersion == v1alpha1.StartScriptV2 {
 			pdAddr = strings.Join(tc.Spec.PDAddresses, ",")
 		}
 		common.SetIfNil("raft.pd_addr", pdAddr)

--- a/pkg/manager/member/tiflash_util.go
+++ b/pkg/manager/member/tiflash_util.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
@@ -205,6 +206,12 @@ func getTiFlashConfigV2(tc *v1alpha1.TidbCluster) *v1alpha1.TiFlashConfigWraper 
 		} else if tc.Heterogeneous() && tc.WithoutLocalPD() {
 			pdAddr = fmt.Sprintf("%s.%s.svc%s:%d", controller.PDMemberName(ref.Name), ref.Namespace,
 				controller.FormatClusterDomain(ref.ClusterDomain), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
+		}
+
+		preferPDAddressesOverDiscovery := slices.Contains(
+			tc.Spec.StartScriptV2FeatureFlags, v1alpha1.StartScriptV2FeatureFlagPreferPDAddressesOverDiscovery)
+		if preferPDAddressesOverDiscovery {
+			pdAddr = strings.Join(tc.Spec.PDAddresses, ",")
 		}
 		common.SetIfNil("raft.pd_addr", pdAddr)
 

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1541,6 +1541,43 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 					status-addr = "0.0.0.0:20292"`,
 			},
 			{
+				name: "config is with PreferPDAddressesOverDiscovery",
+				setTC: func(tc *v1alpha1.TidbCluster) {
+					tc.Spec.TiFlash.Config = nil
+					tc.Spec.StartScriptV2FeatureFlags = []v1alpha1.StartScriptV2FeatureFlag{v1alpha1.StartScriptV2FeatureFlagPreferPDAddressesOverDiscovery}
+					tc.Spec.PDAddresses = []string{"test-pd.another-ns.svc:2379"}
+				},
+				expectCommonCfg: `
+					tmp_path = "/data0/tmp"
+					[flash]
+					  service_addr = "0.0.0.0:3930"
+					  tidb_status_addr = "test-tidb.default.svc:10080"
+					  [flash.flash_cluster]
+						log = "/data0/logs/flash_cluster_manager.log"
+					  [flash.proxy]
+						addr = "0.0.0.0:20170"
+						advertise-addr = "test-tiflash-POD_NUM.test-tiflash-peer.default.svc:20170"
+						config = "/data0/proxy.toml"
+						data-dir = "/data0/proxy"
+					[logger]
+					  errorlog = "/data0/logs/error.log"
+					  log = "/data0/logs/server.log"
+					[raft]
+					  pd_addr = "test-pd.another-ns.svc:2379"
+					[storage]
+					  [storage.main]
+						dir = ["/data0/db"]
+					  [storage.raft]
+						dir = ["/data0/kvstore"]`,
+				expectProxyCfg: `
+					log-level = "info"
+
+					[server]
+					advertise-status-addr = "test-tiflash-POD_NUM.test-tiflash-peer.default.svc:20292"
+					engine-addr = "test-tiflash-POD_NUM.test-tiflash-peer.default.svc:3930"
+					status-addr = "0.0.0.0:20292"`,
+			},
+			{
 				name: "config is nil and cluster enable tls",
 				setTC: func(tc *v1alpha1.TidbCluster) {
 					tc.Spec.TiFlash.Config = nil

--- a/pkg/manager/member/tiflash_util_test.go
+++ b/pkg/manager/member/tiflash_util_test.go
@@ -1544,6 +1544,7 @@ func TestTestGetTiFlashConfig(t *testing.T) {
 				name: "config is with PreferPDAddressesOverDiscovery",
 				setTC: func(tc *v1alpha1.TidbCluster) {
 					tc.Spec.TiFlash.Config = nil
+					tc.Spec.StartScriptVersion = v1alpha1.StartScriptV2
 					tc.Spec.StartScriptV2FeatureFlags = []v1alpha1.StartScriptV2FeatureFlag{v1alpha1.StartScriptV2FeatureFlagPreferPDAddressesOverDiscovery}
 					tc.Spec.PDAddresses = []string{"test-pd.another-ns.svc:2379"}
 				},

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -232,7 +232,8 @@ func (u *tikvUpgrader) evictLeaderBeforeUpgrade(tc *v1alpha1.TidbCluster, upgrad
 		}
 	}
 
-	leaderCount, err := u.deps.TiKVControl.GetTiKVPodClient(tc.Namespace, tc.Name, upgradePod.Name, tc.IsTLSClusterEnabled()).GetLeaderCount()
+	leaderCount, err := u.deps.TiKVControl.GetTiKVPodClient(tc.Namespace, tc.Name,
+		upgradePod.Name, tc.Spec.ClusterDomain, tc.IsTLSClusterEnabled()).GetLeaderCount()
 	if err != nil {
 		klog.Warningf("%s: failed to get leader count, error: %v", logPrefix, err)
 		return false, nil

--- a/pkg/monitor/monitor/monitor_manager.go
+++ b/pkg/monitor/monitor/monitor_manager.go
@@ -749,7 +749,8 @@ func (m *MonitorManager) syncDashboardMetricStorage(tc *v1alpha1.TidbCluster, tm
 	if tc.Spec.PD == nil || tc.ComponentIsSuspending(v1alpha1.PDMemberType) {
 		return nil
 	}
-	pdEtcdClient, err := m.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name, tc.IsTLSClusterEnabled())
+	pdEtcdClient, err := m.deps.PDControl.GetPDEtcdClient(pdapi.Namespace(tc.Namespace), tc.Name,
+		tc.IsTLSClusterEnabled(), pdapi.ClusterRef(tc.Spec.ClusterDomain))
 
 	if err != nil {
 		return err

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -38,6 +38,7 @@ type Namespace string
 type Option func(c *clientConfig)
 
 // ClusterRef sets the cluster domain of TC, it is used when generating the client address from TC.
+// the cluster domain may be another K8s's cluster domain, or a local custom cluster domain.
 func ClusterRef(clusterDomain string) Option {
 	return func(c *clientConfig) {
 		c.clusterDomain = clusterDomain


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

ref #5375

before this PR, TiDB Operator may not append the cluster domain (for local K8s) in the URL when creating clients.

this often works well, but if TLS enabled and the cert can only be issued for the cluster domain, the clients may not work as #5375

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

- append cluster domain for PD/TiKV/TiDB/etcd clients
- add preferred PD address support for TiFlash/TiCDC, which introduced in #5400

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  1. modify CoreDNS config with `mydomain.internal` cluster domain support
  2. add certs for components
    ```yaml
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-pd-cluster-secret
        namespace: tls
      spec:
        secretName: basic-pd-cluster-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - server auth
          - client auth
        dnsNames:
        - "basic-pd.tls.svc.mydomain.internal"
        - "basic-pd-peer.tls.svc.mydomain.internal"
        - "*.basic-pd-peer.tls.svc.mydomain.internal"
        ipAddresses:
        - 127.0.0.1
        - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-tikv-cluster-secret
        namespace: tls
      spec:
        secretName: basic-tikv-cluster-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - server auth
          - client auth
        dnsNames:
        - "basic-tikv.tls.svc.mydomain.internal"
        - "basic-tikv-peer.tls.svc.mydomain.internal"
        - "*.basic-tikv-peer.tls.svc.mydomain.internal"
        ipAddresses:
        - 127.0.0.1
        - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-tidb-cluster-secret
        namespace: tls
      spec:
        secretName: basic-tidb-cluster-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - server auth
          - client auth
        dnsNames:
        - "basic-tidb.tls.svc.mydomain.internal"
        - "basic-tidb-peer.tls.svc.mydomain.internal"
        - "*.basic-tidb-peer.tls.svc.mydomain.internal"
        ipAddresses:
        - 127.0.0.1
        - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-cluster-client-secret
        namespace: tls
      spec:
        secretName: basic-cluster-client-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - client auth
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-ticdc-cluster-secret
        namespace: tls
      spec:
        secretName: basic-ticdc-cluster-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - server auth
          - client auth
        dnsNames:
        - "basic-ticdc.tls.svc.mydomain.internal"
        - "basic-ticdc-peer.tls.svc.mydomain.internal"
        - "*.basic-ticdc-peer.tls.svc.mydomain.internal"
        ipAddresses:
        - 127.0.0.1
        - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-tiflash-cluster-secret
        namespace: tls
      spec:
        secretName: basic-tiflash-cluster-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB"
        usages:
          - server auth
          - client auth
        dnsNames:
        - "basic-tiflash.tls.svc.mydomain.internal"
        - "basic-tiflash-peer.tls.svc.mydomain.internal"
        - "*.basic-tiflash-peer.tls.svc.mydomain.internal"
        ipAddresses:
        - 127.0.0.1
        - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-tidb-server-secret
        namespace: tls
      spec:
        secretName: basic-tidb-server-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB Server"
        usages:
          - server auth
        dnsNames:
          - "basic-tidb.tls.svc.mydomain.internal"
          - "*.basic-tidb.tls.svc.mydomain.internal"
          - "*.basic-tidb-peer.tls.svc.mydomain.internal"
        ipAddresses:
          - 127.0.0.1
          - ::1
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
      ---
      apiVersion: cert-manager.io/v1
      kind: Certificate
      metadata:
        name: basic-tidb-client-secret
        namespace: tls
      spec:
        secretName: basic-tidb-client-secret
        duration: 8760h # 365d
        renewBefore: 360h # 15d
        subject:
          organizations:
          - PingCAP
        commonName: "TiDB Client"
        usages:
          - client auth
        issuerRef:
          name: basic-tidb-issuer
          kind: Issuer
          group: cert-manager.io
    ```
  3. deploy TidbCluster with TLS enabled
    ```yaml
    apiVersion: pingcap.com/v1alpha1
    kind: TidbCluster
    metadata:
      name: basic
      namespace: tls
    spec:
      clusterDomain: mydomain.internal
      startScriptVersion: v2
      startScriptV2FeatureFlags:
      - PreferPDAddressesOverDiscovery
      pdAddresses:
        - https://basic-pd.tls.svc.mydomain.internal:2379
      tlsCluster:
        enabled: true
      version: v7.1.1
      timezone: UTC
      pvReclaimPolicy: Delete
      enableDynamicConfiguration: true
      configUpdateStrategy: RollingUpdate
      discovery: {}
      helper:
        image: alpine:3.16.0
      pd:
        baseImage: pingcap/pd
        maxFailoverCount: 0
        replicas: 3
        requests:
          storage: "1Gi"
        config:
         security:
           cert-allowed-cn:
             - TiDB
      tikv:
        baseImage: pingcap/tikv
        maxFailoverCount: 0
        evictLeaderTimeout: 1m
        replicas: 3
        requests:
          storage: "1Gi"
        config:
          security:
            cert-allowed-cn:
              - TiDB
          storage:
            reserve-space: "0MB"
          rocksdb:
            max-open-files: 256
          raftdb:
            max-open-files: 256
      tidb:
        baseImage: pingcap/tidb
        maxFailoverCount: 0
        replicas: 2
        service:
          type: ClusterIP
        tlsClient:
          enabled: true
        config:
         security:
           cluster-verify-cn:
             - TiDB
      tiflash:
        baseImage: pingcap/tiflash
        maxFailoverCount: 0
        replicas: 1
        storageClaims:
        - resources:
            requests:
              storage: 1Gi
          storageClassName: standard
      ticdc:
        baseImage: pingcap/ticdc
        replicas: 1
        config: {}
      tiproxy:
        baseImage: pingcap/tiproxy
        version: v0.2.0
        replicas: 1
        config: {}
    ```
  4. check TidbCluster and Pods ready, check components logs
  5. upgrade TidbCluster and check works well
  6. scale components of TidbCluster and check works well
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
