### PR TITLE
Fail restore if any warmup job failed for volume-snapshot restores

### DIFF
--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -1276,7 +1276,16 @@ func (rm *restoreManager) waitWarmUpJobsFinished(r *v1alpha1.Restore) error {
 	for _, job := range jobs {
 		jobFinished := false
 		for _, condition := range job.Status.Conditions {
-			if condition.Type == batchv1.JobFailed || condition.Type == batchv1.JobComplete {
+			if condition.Type == batchv1.JobFailed {
+				err := fmt.Errorf("warmup job %s/%s failed", job.Namespace, job.Name)
+				rm.statusUpdater.Update(r, &v1alpha1.RestoreCondition{
+					Type:   v1alpha1.RestoreFailed,
+					Status: corev1.ConditionTrue,
+					Reason: condition.Reason,
+					Message: err.Error(),
+				}, nil)
+				return err
+			} else if condition.Type == batchv1.JobComplete {
 				jobFinished = true
 			}
 		}
@@ -1284,7 +1293,7 @@ func (rm *restoreManager) waitWarmUpJobsFinished(r *v1alpha1.Restore) error {
 			if isWarmUpAsync(r) {
 				return nil
 			}
-			return fmt.Errorf("wait warmup job %s/%s finished", job.Namespace, job.Name)
+			return fmt.Errorf("waiting for warmup job %s/%s to finish", job.Namespace, job.Name)
 		}
 	}
 

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -1279,9 +1279,9 @@ func (rm *restoreManager) waitWarmUpJobsFinished(r *v1alpha1.Restore) error {
 			if condition.Type == batchv1.JobFailed {
 				err := fmt.Errorf("warmup job %s/%s failed", job.Namespace, job.Name)
 				rm.statusUpdater.Update(r, &v1alpha1.RestoreCondition{
-					Type:   v1alpha1.RestoreFailed,
-					Status: corev1.ConditionTrue,
-					Reason: condition.Reason,
+					Type:    v1alpha1.RestoreFailed,
+					Status:  corev1.ConditionTrue,
+					Reason:  condition.Reason,
 					Message: err.Error(),
 				}, nil)
 				return err

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -1159,7 +1159,7 @@ func (rm *restoreManager) makeSyncWarmUpJob(r *v1alpha1.Restore, tc *v1alpha1.Ti
 		},
 		Spec: batchv1.JobSpec{
 			Template:     *warmUpPod,
-			BackoffLimit: pointer.Int32Ptr(4),
+			BackoffLimit: pointer.Int32Ptr(1),
 		},
 	}
 	return warmUpJob, nil
@@ -1253,7 +1253,7 @@ func (rm *restoreManager) makeAsyncWarmUpJob(r *v1alpha1.Restore, tikvPod *corev
 		},
 		Spec: batchv1.JobSpec{
 			Template:     *warmUpPod,
-			BackoffLimit: pointer.Int32Ptr(4),
+			BackoffLimit: pointer.Int32Ptr(1),
 		},
 	}
 	return warmUpJob, nil

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -818,8 +818,6 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 		},
 	}
 
-	// Verify invalid tc with mismatch tikv replicas
-	//generate the restore meta in local nfs, with 3 volumes for each tikv
 	err := os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
 	g.Expect(err).To(Succeed())
 

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -823,7 +823,6 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 	err := os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
 	g.Expect(err).To(Succeed())
 
-	//generate the backup meta in local nfs, tiflash check need backupmeta to validation
 	err = os.WriteFile("/tmp/backupmeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
 	g.Expect(err).To(Succeed())
 	defer func() {

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -63,7 +63,7 @@ func (h *helper) createRestoreWarmupJobFailed(restore *v1alpha1.Restore) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "warm-up",
 			Namespace: restore.Namespace,
-			Labels: label.NewRestore().RestoreWarmUpJob().Restore(restore.Name),
+			Labels:    label.NewRestore().RestoreWarmUpJob().Restore(restore.Name),
 		},
 		Status: batchv1.JobStatus{
 			CompletionTime: &metav1.Time{},
@@ -750,13 +750,13 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.RestoreStatus{
-					Conditions: []v1alpha1.RestoreCondition {
+					Conditions: []v1alpha1.RestoreCondition{
 						{
-							Type: v1alpha1.RestoreVolumeComplete,
+							Type:   v1alpha1.RestoreVolumeComplete,
 							Status: corev1.ConditionTrue,
 						},
 						{
-							Type: v1alpha1.RestoreWarmUpStarted,
+							Type:   v1alpha1.RestoreWarmUpStarted,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -799,17 +799,17 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.RestoreStatus{
-					Conditions: []v1alpha1.RestoreCondition {
+					Conditions: []v1alpha1.RestoreCondition{
 						{
-							Type: v1alpha1.RestoreVolumeComplete,
+							Type:   v1alpha1.RestoreVolumeComplete,
 							Status: corev1.ConditionTrue,
 						},
 						{
-							Type: v1alpha1.RestoreWarmUpStarted,
+							Type:   v1alpha1.RestoreWarmUpStarted,
 							Status: corev1.ConditionTrue,
 						},
 						{
-							Type: v1alpha1.RestoreTiKVComplete,
+							Type:   v1alpha1.RestoreTiKVComplete,
 							Status: corev1.ConditionTrue,
 						},
 					},

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
+	"github.com/pingcap/tidb-operator/pkg/apis/label"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/backup/constants"
 	"github.com/pingcap/tidb-operator/pkg/backup/testutils"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -50,6 +52,34 @@ func (h *helper) createRestore(restore *v1alpha1.Restore) {
 	g.Expect(err).Should(BeNil())
 	g.Eventually(func() error {
 		_, err := h.Deps.RestoreLister.Restores(restore.Namespace).Get(restore.Name)
+		return err
+	}, time.Second*10).Should(BeNil())
+}
+
+func (h *helper) createRestoreWarmupJobFailed(restore *v1alpha1.Restore) {
+	g := NewGomegaWithT(h.T)
+	deps := h.Deps
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-up",
+			Namespace: restore.Namespace,
+			Labels: label.NewRestore().RestoreWarmUpJob().Restore(restore.Name),
+		},
+		Status: batchv1.JobStatus{
+			CompletionTime: &metav1.Time{},
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	_, err := deps.KubeClientset.BatchV1().Jobs(restore.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+	g.Expect(err).Should(BeNil())
+
+	g.Eventually(func() error {
+		_, err := deps.JobLister.Jobs(job.GetNamespace()).Get(job.GetName())
 		return err
 	}, time.Second*10).Should(BeNil())
 }
@@ -672,6 +702,148 @@ func TestVolumeNumMismatchBRRestoreByEBS(t *testing.T) {
 		err := m.Sync(cases[0].restore)
 		g.Expect(err).Should(MatchError("additional volumes mismatched"))
 	})
+}
+
+func TestFailWarmupBRRestoreByEBS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.Close()
+	deps := helper.Deps
+
+	cases := []struct {
+		name    string
+		restore *v1alpha1.Restore
+	}{
+		{
+			name: "restore-volume-warmup-sync",
+			restore: &v1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-1",
+					Namespace: "ns-1",
+				},
+				Spec: v1alpha1.RestoreSpec{
+					Type: v1alpha1.BackupTypeFull,
+					Mode: v1alpha1.RestoreModeVolumeSnapshot,
+					BR: &v1alpha1.BRConfig{
+						ClusterNamespace: "ns-1",
+						Cluster:          "cluster-1",
+					},
+					Warmup: v1alpha1.RestoreWarmupModeSync,
+					StorageProvider: v1alpha1.StorageProvider{
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.RestoreStatus{
+					Conditions: []v1alpha1.RestoreCondition {
+						{
+							Type: v1alpha1.RestoreVolumeComplete,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type: v1alpha1.RestoreWarmUpStarted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "restore-volume-warmup-async",
+			restore: &v1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-2",
+					Namespace: "ns-2",
+				},
+				Spec: v1alpha1.RestoreSpec{
+					Type: v1alpha1.BackupTypeFull,
+					Mode: v1alpha1.RestoreModeVolumeSnapshot,
+					BR: &v1alpha1.BRConfig{
+						ClusterNamespace: "ns-2",
+						Cluster:          "cluster-2",
+					},
+					Warmup: v1alpha1.RestoreWarmupModeASync,
+					StorageProvider: v1alpha1.StorageProvider{
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.RestoreStatus{
+					Conditions: []v1alpha1.RestoreCondition {
+						{
+							Type: v1alpha1.RestoreVolumeComplete,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type: v1alpha1.RestoreWarmUpStarted,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type: v1alpha1.RestoreTiKVComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Verify invalid tc with mismatch tikv replicas
+	//generate the restore meta in local nfs, with 3 volumes for each tikv
+	err := os.WriteFile("/tmp/restoremeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+
+	//generate the backup meta in local nfs, tiflash check need backupmeta to validation
+	err = os.WriteFile("/tmp/backupmeta", []byte(testutils.ConstructRestoreMetaStr()), 0644) //nolint:gosec
+	g.Expect(err).To(Succeed())
+	defer func() {
+		err = os.Remove("/tmp/restoremeta")
+		g.Expect(err).To(Succeed())
+
+		err = os.Remove("/tmp/backupmeta")
+		g.Expect(err).To(Succeed())
+	}()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
+			helper.CreateRestore(tt.restore)
+			helper.createRestoreWarmupJobFailed(tt.restore)
+			m := NewRestoreManager(deps)
+			err := m.Sync(tt.restore)
+			g.Expect(err).Should(MatchError(fmt.Sprintf("warmup job %s/warm-up failed", tt.restore.Namespace)))
+		})
+	}
 }
 
 func TestGenerateWarmUpArgs(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

Currently restore only checks if all warmup jobs completed (success or fail) before continuing w/ later steps of restore. Instead, if any warmup jobs fail, we should fail the restore.

Observed behavior:

* Failed warmup job conditions:

```yaml
...
conditions:
  - lastProbeTime: "2024-03-10T21:05:24Z"
    lastTransitionTime: "2024-03-10T21:05:24Z"
    message: Job has reached the specified backoff limit
    reason: BackoffLimitExceeded
    status: "True"
    type: Failed
failed: 5
ready: 0
startTime: "2024-03-10T20:53:09Z"
uncountedTerminatedPods: {}
```

* Results in `WarmUpComplete` in restore

```yaml
commitTs: "448239596192667254"
conditions:
  - lastTransitionTime: "2024-03-10T20:51:49Z"
    status: "True"
    type: Scheduled
  - lastTransitionTime: "2024-03-10T20:51:57Z"
    status: "True"
    type: Running
  - lastTransitionTime: "2024-03-10T20:52:11Z"
    status: "True"
    type: VolumeComplete
  - lastTransitionTime: "2024-03-10T20:52:57Z"
    status: "True"
    type: WarmUpStarted
  - lastTransitionTime: "2024-03-10T22:02:49Z"
    status: "True"
    type: WarmUpComplete
phase: WarmUpComplete
progresses:
  - lastTransitionTime: "2024-03-10T20:52:11Z"
    progress: 100
    step: Volume Restore
timeCompleted: null
timeStarted: "2024-03-10T20:51:57Z"
```

### What is changed and how does it work?

When any warmup jobs fail, fail the entire restore. Verified this in a testing workload by artificially causing warmup to fail and observing `Restore` (and consequently, `VolumeRestore`) put into `Failed` state

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
