### PR TITLE
ebs br: add resilience to single TiKV crash

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1626,6 +1626,17 @@ string
 <p>Additional volume mounts of component pod.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>tolerateSingleTiKVOutageOutage</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -14755,6 +14766,17 @@ string
 <td>
 <em>(Optional)</em>
 <p>Additional volume mounts of component pod.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerateSingleTiKVOutageOutage</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1628,7 +1628,7 @@ string
 </tr>
 <tr>
 <td>
-<code>tolerateSingleTiKVOutageOutage</code></br>
+<code>tolerateSingleTiKVOutage</code></br>
 <em>
 bool
 </em>
@@ -14770,7 +14770,7 @@ string
 </tr>
 <tr>
 <td>
-<code>tolerateSingleTiKVOutageOutage</code></br>
+<code>tolerateSingleTiKVOutage</code></br>
 <em>
 bool
 </em>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -18671,6 +18671,9 @@ spec:
                 - host
                 - secretName
                 type: object
+              tolerateSingleTiKVOutageOutage:
+                default: false
+                type: boolean
               tolerations:
                 items:
                   properties:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -18671,7 +18671,7 @@ spec:
                 - host
                 - secretName
                 type: object
-              tolerateSingleTiKVOutageOutage:
+              tolerateSingleTiKVOutage:
                 default: false
                 type: boolean
               tolerations:

--- a/manifests/crd/v1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1/pingcap.com_restores.yaml
@@ -2933,7 +2933,7 @@ spec:
                 - host
                 - secretName
                 type: object
-              tolerateSingleTiKVOutageOutage:
+              tolerateSingleTiKVOutage:
                 default: false
                 type: boolean
               tolerations:

--- a/manifests/crd/v1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1/pingcap.com_restores.yaml
@@ -2933,6 +2933,9 @@ spec:
                 - host
                 - secretName
                 type: object
+              tolerateSingleTiKVOutageOutage:
+                default: false
+                type: boolean
               tolerations:
                 items:
                   properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -8369,7 +8369,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 							},
 						},
 					},
-					"tolerateSingleTiKVOutageOutage": {
+					"tolerateSingleTiKVOutage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss",
 							Type:        []string{"boolean"},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -8369,6 +8369,13 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 							},
 						},
 					},
+					"tolerateSingleTiKVOutageOutage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -971,8 +971,9 @@ func (tc *TidbCluster) TiKVIsAvailable() bool {
 	return true
 }
 
-func (tc *TidbCluster) AllTiKVsAreAvailable() bool {
-	if len(tc.Status.TiKV.Stores) != int(tc.Spec.TiKV.Replicas) {
+func (tc *TidbCluster) AllTiKVsAreAvailable(tolerateSingleTiKVOutage bool) bool {
+	if (!tolerateSingleTiKVOutage && len(tc.Status.TiKV.Stores) != int(tc.Spec.TiKV.Replicas)) ||
+		(tolerateSingleTiKVOutage && int(tc.Spec.TiKV.Replicas-1) != len(tc.Status.TiKV.Stores)) {
 		return false
 	}
 

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
@@ -367,7 +367,7 @@ func TestAllTiKVsAreAvailable(t *testing.T) {
 
 		tc := newTidbCluster()
 		test.update(tc)
-		test.expectFn(g, tc.AllTiKVsAreAvailable())
+		test.expectFn(g, tc.AllTiKVsAreAvailable(false))
 	}
 	tests := []testcase{
 		{

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2688,6 +2688,9 @@ type RestoreSpec struct {
 	// Additional volume mounts of component pod.
 	// +optional
 	AdditionalVolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
+	// TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss
+	// +kubebuilder:default=false
+	TolerateSingleTiKVOutage bool `json:"tolerateSingleTiKVOutageOutage,omitempty"`
 }
 
 // FederalVolumeRestorePhase represents a phase to execute in federal volume restore

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2690,7 +2690,7 @@ type RestoreSpec struct {
 	AdditionalVolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
 	// TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss
 	// +kubebuilder:default=false
-	TolerateSingleTiKVOutage bool `json:"tolerateSingleTiKVOutageOutage,omitempty"`
+	TolerateSingleTiKVOutage bool `json:"tolerateSingleTiKVOutage,omitempty"`
 }
 
 // FederalVolumeRestorePhase represents a phase to execute in federal volume restore

--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -399,8 +399,7 @@ func (rm *restoreManager) checkTiFlashAndTiKVReplicasFromBackupMeta(r *v1alpha1.
 		metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV.Replicas == 0 {
 		klog.Errorf("backup source tc has no tikv nodes")
 		return fmt.Errorf("backup source tc has no tivk nodes")
-	} else if tc.Spec.TiKV.Replicas != metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV.Replicas ||
-		(r.Spec.TolerateSingleTiKVOutage && metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV.Replicas-1 == tc.Spec.TiKV.Replicas) {
+	} else if tc.Spec.TiKV.Replicas != metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV.Replicas {
 		klog.Errorf("mismatch tikv replicas, tc has %d, while backup has %d", tc.Spec.TiKV.Replicas, metaInfo.KubernetesMeta.TiDBCluster.Spec.TiKV)
 		return fmt.Errorf("tikv replica mismatch")
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

This PR provides the resilience to a single TiKV crash due to wal corruption at restore

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
 Add a new attribute `spec.tolerateSingleTiKVOutage` to restore CR. When it's set to true, restore to the tc can tolerate a single TiKV outage due to wal log corruption issue.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
