### PR TITLE
Check wal only 1.5

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1626,6 +1626,17 @@ string
 <p>Additional volume mounts of component pod.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>tolerateSingleTiKVOutageOutage</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -14290,6 +14301,17 @@ string
 <td>
 <em>(Optional)</em>
 <p>Additional volume mounts of component pod.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerateSingleTiKVOutageOutage</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -17117,6 +17117,9 @@ spec:
                 - host
                 - secretName
                 type: object
+              tolerateSingleTiKVOutageOutage:
+                default: false
+                type: boolean
               tolerations:
                 items:
                   properties:

--- a/manifests/crd/v1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1/pingcap.com_restores.yaml
@@ -2755,6 +2755,9 @@ spec:
                 - host
                 - secretName
                 type: object
+              tolerateSingleTiKVOutageOutage:
+                default: false
+                type: boolean
               tolerations:
                 items:
                   properties:

--- a/manifests/crd/v1beta1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1beta1/pingcap.com_restores.yaml
@@ -2754,6 +2754,8 @@ spec:
               - host
               - secretName
               type: object
+            tolerateSingleTiKVOutageOutage:
+              type: boolean
             tolerations:
               items:
                 properties:

--- a/manifests/crd_v1beta1.yaml
+++ b/manifests/crd_v1beta1.yaml
@@ -17088,6 +17088,8 @@ spec:
               - host
               - secretName
               type: object
+            tolerateSingleTiKVOutageOutage:
+              type: boolean
             tolerations:
               items:
                 properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -7683,6 +7683,13 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 							},
 						},
 					},
+					"tolerateSingleTiKVOutageOutage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -902,8 +902,9 @@ func (tc *TidbCluster) TiKVIsAvailable() bool {
 	return true
 }
 
-func (tc *TidbCluster) AllTiKVsAreAvailable() bool {
-	if len(tc.Status.TiKV.Stores) != int(tc.Spec.TiKV.Replicas) {
+func (tc *TidbCluster) AllTiKVsAreAvailable(tolerateSingleTiKVOutage bool) bool {
+	if (!tolerateSingleTiKVOutage && len(tc.Status.TiKV.Stores) != int(tc.Spec.TiKV.Replicas)) ||
+		(tolerateSingleTiKVOutage && int(tc.Spec.TiKV.Replicas-1) != len(tc.Status.TiKV.Stores)) {
 		return false
 	}
 

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster_test.go
@@ -367,7 +367,7 @@ func TestAllTiKVsAreAvailable(t *testing.T) {
 
 		tc := newTidbCluster()
 		test.update(tc)
-		test.expectFn(g, tc.AllTiKVsAreAvailable())
+		test.expectFn(g, tc.AllTiKVsAreAvailable(false))
 	}
 	tests := []testcase{
 		{

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2565,6 +2565,8 @@ const (
 	RestoreWarmupStrategyHybrid RestoreWarmupStrategy = "hybrid"
 	// RestoreWarmupStrategyFsr warms up data volume by enabling Fast Snapshot Restore, other (e.g. WAL or Raft) will be warmed up via fio.
 	RestoreWarmupStrategyFsr RestoreWarmupStrategy = "fsr"
+	// RestoreWarmupStrategyCheckOnly warm up none data volumes and check wal consistency
+	RestoreWarmupStrategyCheckOnly RestoreWarmupStrategy = "check-wal-only"
 )
 
 // RestoreStatus represents the current status of a tidb cluster restore.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2528,6 +2528,9 @@ type RestoreSpec struct {
 	// Additional volume mounts of component pod.
 	// +optional
 	AdditionalVolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
+	// TolerateSingleTiKVOutage indicates whether to tolerate a single failure of a store without data loss
+	// +kubebuilder:default=false
+	TolerateSingleTiKVOutage bool `json:"tolerateSingleTiKVOutageOutage,omitempty"`
 }
 
 // FederalVolumeRestorePhase represents a phase to execute in federal volume restore


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

This PR provide restore capability to check wal corruption only and mitigate from a single TiKV outage.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
