### PR TITLE
Skip corruption check on last WAL

### DIFF
--- a/images/ebs-warmup/warmup-steps.sh
+++ b/images/ebs-warmup/warmup-steps.sh
@@ -89,11 +89,11 @@ while [ $# -gt 0 ]; do
                     ;;
             esac
             echo "also trying to verify the sst files in $1"
-            if find "$1" -iname '??????.LOG' -print0  | xargs -0 -I% sh -c 'echo -n "%: " >&2; /tikv-ctl ldb dump_wal --walfile=%; echo >&2' 2>&1 >/dev/null | grep "Corruption"; then
+            if find "$1" -iname '[0-9]*.LOG' -size +0c -print0 | sort -z | head -z -n -1 | xargs -0 -I% sh -c 'echo -n "%: " >&2; /tikv-ctl ldb dump_wal --walfile=%; echo >&2' 2>&1 >/dev/null | grep "Corruption"; then
                 echo "There are some files corrupted!"
                 echo $bg_works | xargs kill || true
                 wait || true
-                echo "HINT: All files in the dir, if the last one corrupted, you may ignore it:"
+                echo "Current WALs:"
                 find . -iname '??????.LOG' -print | sort
                 exit 1
             fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

During EBS snapshot warmup, only check WALs up to the last one for corruption. We expect some corruptions in the last WAL due to race between fsync and EBS snapshot, and we can recover from these scenarios.

Also updates WAL log file pattern since logs can contain variable length log nos.
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->

Executed warmup w/ these changes and observe warmup progress normally w/out checking the last WAL

- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
