### PR TITLE
Add `advertise-addr` arg to tiproxy start script

### DIFF
--- a/pkg/manager/member/startscript/v2/tiproxy_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script.go
@@ -44,7 +44,7 @@ func RenderTiProxyStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 const (
 	tiproxyStartScript = `
 TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
-sed -i s/TIPROXY_ADVERTISE_ADDR/{{ .AdvertiseAddr }}/g /etc/proxy/config.toml
+sed -i s/TIPROXY_ADVERTISE_ADDR/{{ .AdvertiseAddr }}/g /etc/proxy/proxy.toml
 
 ARGS="--config=/etc/proxy/proxy.toml"
 echo "starting: tiproxy ${ARGS}"

--- a/pkg/manager/member/startscript/v2/tiproxy_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script.go
@@ -40,13 +40,15 @@ func RenderTiProxyStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 }
 
 // Old TiProxy versions don't support advertise-addr.
-// Passing unknown args will fail but passing unknown config won't fail.
+// We can't add advertise-addr to the config file because the file is read-only.
 const (
 	tiproxyStartScript = `
 TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
-sed -i s/TIPROXY_ADVERTISE_ADDR/{{ .AdvertiseAddr }}/g /etc/proxy/proxy.toml
-
 ARGS="--config=/etc/proxy/proxy.toml"
+if [[ $(/bin/tiproxy --help) == *advertise-addr* ]]; then
+  ARGS="${ARGS} --advertise-addr={{ .AdvertiseAddr }}"
+fi
+
 echo "starting: tiproxy ${ARGS}"
 exec /bin/tiproxy ${ARGS}
 `

--- a/pkg/manager/member/startscript/v2/tiproxy_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script.go
@@ -45,7 +45,6 @@ const (
 	tiproxyStartScript = `
 TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--config=/etc/proxy/proxy.toml"
-echo {{ .AdvertiseAddr }}
 if [[ "$(/bin/tiproxy --help)" == *"advertise-addr"* ]]; then
   ARGS="${ARGS} --advertise-addr={{ .AdvertiseAddr }}"
 fi

--- a/pkg/manager/member/startscript/v2/tiproxy_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script.go
@@ -31,7 +31,7 @@ func RenderTiProxyStartScript(tc *v1alpha1.TidbCluster) (string, error) {
 	m := &TiProxyStartScriptModel{}
 	tcName := tc.Name
 	tcNS := tc.Namespace
-	peerServiceName := controller.TiDBPeerMemberName(tcName)
+	peerServiceName := controller.TiProxyPeerMemberName(tcName)
 	m.AdvertiseAddr = fmt.Sprintf("${TIPROXY_POD_NAME}.%s.%s.svc", peerServiceName, tcNS)
 	if tc.Spec.ClusterDomain != "" {
 		m.AdvertiseAddr = m.AdvertiseAddr + "." + tc.Spec.ClusterDomain
@@ -45,6 +45,7 @@ const (
 	tiproxyStartScript = `
 TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--config=/etc/proxy/proxy.toml"
+echo {{ .AdvertiseAddr }}
 if [[ $(/bin/tiproxy --help) == *advertise-addr* ]]; then
   ARGS="${ARGS} --advertise-addr={{ .AdvertiseAddr }}"
 fi

--- a/pkg/manager/member/startscript/v2/tiproxy_start_script.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script.go
@@ -46,7 +46,7 @@ const (
 TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--config=/etc/proxy/proxy.toml"
 echo {{ .AdvertiseAddr }}
-if [[ $(/bin/tiproxy --help) == *advertise-addr* ]]; then
+if [[ "$(/bin/tiproxy --help)" == *"advertise-addr"* ]]; then
   ARGS="${ARGS} --advertise-addr={{ .AdvertiseAddr }}"
 fi
 

--- a/pkg/manager/member/startscript/v2/tiproxy_start_script_test.go
+++ b/pkg/manager/member/startscript/v2/tiproxy_start_script_test.go
@@ -1,0 +1,130 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega"
+)
+
+func TestRenderTiProxyStartScript(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	type testcase struct {
+		name string
+
+		modifyTC     func(tc *v1alpha1.TidbCluster)
+		expectScript string
+	}
+
+	cases := []testcase{
+		{
+			name:     "basic",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
+ARGS="--config=/etc/proxy/proxy.toml"
+if [[ "$(/bin/tiproxy --help)" == *"advertise-addr"* ]]; then
+  ARGS="${ARGS} --advertise-addr=${TIPROXY_POD_NAME}.start-script-test-tiproxy-peer.start-script-test-ns.svc"
+fi
+
+echo "starting: tiproxy ${ARGS}"
+exec /bin/tiproxy ${ARGS}
+`,
+		},
+		{
+			name: "set cluster domain",
+			modifyTC: func(tc *v1alpha1.TidbCluster) {
+				tc.Spec.ClusterDomain = "cluster.local"
+				tc.Spec.AcrossK8s = false
+			},
+			expectScript: `#!/bin/sh
+
+set -uo pipefail
+
+ANNOTATIONS="/etc/podinfo/annotations"
+if [[ ! -f "${ANNOTATIONS}" ]]
+then
+    echo "${ANNOTATIONS} does't exist, exiting."
+    exit 1
+fi
+source ${ANNOTATIONS} 2>/dev/null
+
+runmode=${runmode:-normal}
+if [[ X${runmode} == Xdebug ]]
+then
+    echo "entering debug mode."
+    tail -f /dev/null
+fi
+
+TIPROXY_POD_NAME=${POD_NAME:-$HOSTNAME}
+ARGS="--config=/etc/proxy/proxy.toml"
+if [[ "$(/bin/tiproxy --help)" == *"advertise-addr"* ]]; then
+  ARGS="${ARGS} --advertise-addr=${TIPROXY_POD_NAME}.start-script-test-tiproxy-peer.start-script-test-ns.svc.cluster.local"
+fi
+
+echo "starting: tiproxy ${ARGS}"
+exec /bin/tiproxy ${ARGS}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Logf("test case: %s", c.name)
+
+		tc := &v1alpha1.TidbCluster{
+			Spec: v1alpha1.TidbClusterSpec{
+				TiKV: &v1alpha1.TiKVSpec{},
+			},
+		}
+		tc.Name = "start-script-test"
+		tc.Namespace = "start-script-test-ns"
+		tc.Spec.AcrossK8s = false
+		tc.Spec.ClusterDomain = ""
+		tc.Spec.TLSCluster = &v1alpha1.TLSCluster{Enabled: false}
+
+		if c.modifyTC != nil {
+			c.modifyTC(tc)
+		}
+
+		script, err := RenderTiProxyStartScript(tc)
+		g.Expect(err).Should(gomega.Succeed())
+		if diff := cmp.Diff(c.expectScript, script); diff != "" {
+			t.Errorf("unexpected (-want, +got): %s", diff)
+		}
+		g.Expect(validateScript(script)).Should(gomega.Succeed())
+	}
+}

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -125,9 +125,6 @@ func (m *tiproxyMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *apps
 	if cfgWrapper.Get("proxy.require-backend-tls") == nil {
 		cfgWrapper.Set("proxy.require-backend-tls", false)
 	}
-	if cfgWrapper.Get("proxy.advertise-addr") == nil {
-		cfgWrapper.Set("proxy.advertise-addr", "TIPROXY_ADVERTISE_ADDR")
-	}
 
 	tlsCluster := tc.IsTLSClusterEnabled()
 	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -107,7 +107,7 @@ func (m *tiproxyMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *apps
 	PDAddr := fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Name), v1alpha1.DefaultPDClientPort)
 	// TODO: support it
 	if tc.AcrossK8s() {
-		return nil, fmt.Errorf("across k8s is not supported for")
+		return nil, fmt.Errorf("across k8s is not supported")
 	}
 	if tc.Heterogeneous() && tc.WithoutLocalPD() {
 		PDAddr = fmt.Sprintf("%s:%d", controller.PDMemberName(tc.Spec.Cluster.Name), v1alpha1.DefaultPDClientPort) // use pd of reference cluster
@@ -124,6 +124,9 @@ func (m *tiproxyMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *apps
 	cfgWrapper.Set("proxy.pd-addrs", PDAddr)
 	if cfgWrapper.Get("proxy.require-backend-tls") == nil {
 		cfgWrapper.Set("proxy.require-backend-tls", false)
+	}
+	if cfgWrapper.Get("proxy.advertise-addr") == nil {
+		cfgWrapper.Set("proxy.advertise-addr", "TIPROXY_ADVERTISE_ADDR")
 	}
 
 	tlsCluster := tc.IsTLSClusterEnabled()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fix the bug that TiDB connects to TiProxy with IP but the SAN in TiProxy certificate is DNS.
Closes https://github.com/pingcap/tiproxy/issues/494

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Add an `advertise-addr` arg to TiProxy so that TiDB connects to TiProxy by DNS.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

In the TiProxy container logs:
```
starting: tiproxy --config=/etc/proxy/proxy.toml --advertise-addr=basic-tiproxy-0.basic-tiproxy-peer.tidb-cluster.svc
```

Query the TiProxy config:
```
curl http://127.1:3080/api/admin/config/ | grep advertise
advertise-addr = 'basic-tiproxy-0.basic-tiproxy-peer.tidb-cluster.svc'
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
- Pass argument `advertise-addr` to TiProxy binary.
```
