### PR TITLE
retry evict leader when upgrading TiKV if needed

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -40,6 +40,7 @@ const (
 	// defaultEvictLeaderTimeout is the timeout limit of evict leader
 	defaultEvictLeaderTimeout            = 1500 * time.Minute
 	defaultWaitLeaderTransferBackTimeout = 400 * time.Second
+	RetryEvictLeaderInterval             = 10 * time.Minute
 	// defaultTiCDCGracefulShutdownTimeout is the timeout limit of graceful
 	// shutdown a TiCDC pod.
 	defaultTiCDCGracefulShutdownTimeout = 10 * time.Minute

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -423,7 +423,7 @@ func (u *tikvUpgrader) retryEvictLeaderIfNeeded(tc *v1alpha1.TidbCluster, storeI
 	}
 
 	// retry evict leader
-	klog.Infof("retryEvictLeaderIfNecessary: retry evict leader for store %d of %s/%s", storeID, tc.Namespace, pod.GetName())
+	klog.Infof("retryEvictLeaderIfNeeded: retry evict leader for store %d of %s/%s", storeID, tc.Namespace, pod.GetName())
 	// call `beginEvictLeader` to reset the `annoKeyEvictLeaderBeginTime` annotation
 	return u.beginEvictLeader(tc, storeID, pod)
 }

--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -230,6 +230,15 @@ func (u *tikvUpgrader) evictLeaderBeforeUpgrade(tc *v1alpha1.TidbCluster, upgrad
 			klog.Infof("%s: evict leader timeout with threshold %v, so ready to upgrade", logPrefix, evictLeaderTimeout)
 			return true, nil
 		}
+
+		// in some cases, even `evicting`` is true, the evict-leader-scheduler may still not be created or existing in PD.
+		// so we try to check and retry if the scheduler is not created yet.
+		if time.Now().After(evictLeaderBeginTime.Add(v1alpha1.RetryEvictLeaderInterval)) {
+			err := u.retryEvictLeaderIfNeeded(tc, storeID, upgradePod)
+			if err != nil {
+				return false, err
+			}
+		}
 	}
 
 	leaderCount, err := u.deps.TiKVControl.GetTiKVPodClient(tc.Namespace, tc.Name,
@@ -401,6 +410,22 @@ func (u *tikvUpgrader) endEvictLeader(tc *v1alpha1.TidbCluster, storeID uint64, 
 	}
 
 	return nil
+}
+
+func (u *tikvUpgrader) retryEvictLeaderIfNeeded(tc *v1alpha1.TidbCluster, storeID uint64, pod *corev1.Pod) error {
+	schedulers, err := controller.GetPDClient(u.deps.PDControl, tc).GetEvictLeaderSchedulersForStores(storeID)
+	if err != nil {
+		return fmt.Errorf("get scheduler for store %d failed: %v", storeID, err)
+	}
+	if len(schedulers) > 0 && len(schedulers[storeID]) > 0 {
+		// scheduler already created, no need to retry
+		return nil
+	}
+
+	// retry evict leader
+	klog.Infof("retryEvictLeaderIfNecessary: retry evict leader for store %d of %s/%s", storeID, tc.Namespace, pod.GetName())
+	// call `beginEvictLeader` to reset the `annoKeyEvictLeaderBeginTime` annotation
+	return u.beginEvictLeader(tc, storeID, pod)
 }
 
 // endEvictLeaderForAllStore end evict leader for all stores of a tc

--- a/tests/e2e/tidbcluster/across-kubernetes.go
+++ b/tests/e2e/tidbcluster/across-kubernetes.go
@@ -509,7 +509,7 @@ var _ = ginkgo.Describe("[Across Kubernetes]", func() {
 			framework.ExpectNoError(err, "deleting sts of tikv for %q", tcName1)
 
 			ginkgo.By("Waiting for tikv pod to be unavailable")
-			err = utiltc.WaitForTCCondition(cli, tc1.Namespace, tc1.Name, time.Minute*5, time.Second*10,
+			err = utiltc.WaitForTCCondition(cli, tc1.Namespace, tc1.Name, time.Minute*5, time.Second,
 				func(tc *v1alpha1.TidbCluster) (bool, error) {
 					down := true
 					for _, store := range tc.Status.TiKV.Stores {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

close #5614

In some cases when upgrading TiKV, the evict-leader-scheduler may not be added or missing in PD, but the `evictLeaderBeginTime` annotation of the TiKV pod is added. As TiDB Operator will not call PD API to add evict-leader-scheduler again, then the upgrade operation is blocked.

In this PR, we check whether the evict-leader-scheduler exists if a timeout (10m) is reached, and try to add evict-leader-again if it's missing.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  1. hack TiDB Operator code to remove the `controller.GetPDClient(u.deps.PDControl, tc).BeginEvictLeader(storeID)` call in `beginEvictLeader`
  2. upgrade TiKV
  3. check whether the upgrade operation is blocked (`wait for evictition to complete`), and check the `evictLeaderBeginTime` annotation existing
  4. revert the hack in step.1 and re-deploy TiDB-Operator
  5. wait about 10m
  6. check `evictLeaderBeginTime` is updated to the new time
  7. check upgrade operation is continue and completed later
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
