### PR TITLE
Fail restore if warmup fails only during `check-wal-only` strategy

### DIFF
--- a/pkg/backup/restore/restore_manager.go
+++ b/pkg/backup/restore/restore_manager.go
@@ -1298,7 +1298,7 @@ func (rm *restoreManager) waitWarmUpJobsFinished(r *v1alpha1.Restore) error {
 	for _, job := range jobs {
 		finished := false
 		for _, condition := range job.Status.Conditions {
-			if condition.Type == batchv1.JobFailed {
+			if condition.Type == batchv1.JobFailed && r.Spec.WarmupStrategy == v1alpha1.RestoreWarmupStrategyCheckOnly {
 				err := fmt.Errorf("warmup job %s/%s failed", job.Namespace, job.Name)
 				rm.statusUpdater.Update(r, &v1alpha1.RestoreCondition{
 					Type:    v1alpha1.RestoreFailed,
@@ -1308,7 +1308,8 @@ func (rm *restoreManager) waitWarmUpJobsFinished(r *v1alpha1.Restore) error {
 				}, nil)
 				return err
 			}
-			if condition.Type == batchv1.JobComplete {
+
+			if condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobFailed {
 				finished = true
 				continue
 			}

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -820,7 +820,7 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 		},
 	}
 
-	success_cases := []struct {
+	successCases := []struct {
 		name    string
 		restore *v1alpha1.Restore
 	}{

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -710,7 +710,7 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 	defer helper.Close()
 	deps := helper.Deps
 
-	error_cases := []struct {
+	errorCases := []struct {
 		name    string
 		restore *v1alpha1.Restore
 	}{

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -710,12 +710,12 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 	defer helper.Close()
 	deps := helper.Deps
 
-	cases := []struct {
+	error_cases := []struct {
 		name    string
 		restore *v1alpha1.Restore
 	}{
 		{
-			name: "restore-volume-warmup-sync",
+			name: "restore-volume-warmup-check-sync",
 			restore: &v1alpha1.Restore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-1",
@@ -727,6 +727,116 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 					BR: &v1alpha1.BRConfig{
 						ClusterNamespace: "ns-1",
 						Cluster:          "cluster-1",
+					},
+					Warmup:         v1alpha1.RestoreWarmupModeSync,
+					WarmupStrategy: v1alpha1.RestoreWarmupStrategyCheckOnly,
+					StorageProvider: v1alpha1.StorageProvider{
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.RestoreStatus{
+					Conditions: []v1alpha1.RestoreCondition{
+						{
+							Type:   v1alpha1.RestoreVolumeComplete,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   v1alpha1.RestoreWarmUpStarted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "restore-volume-warmup-check-async",
+			restore: &v1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-2",
+					Namespace: "ns-2",
+				},
+				Spec: v1alpha1.RestoreSpec{
+					Type: v1alpha1.BackupTypeFull,
+					Mode: v1alpha1.RestoreModeVolumeSnapshot,
+					BR: &v1alpha1.BRConfig{
+						ClusterNamespace: "ns-2",
+						Cluster:          "cluster-2",
+					},
+					Warmup:         v1alpha1.RestoreWarmupModeASync,
+					WarmupStrategy: v1alpha1.RestoreWarmupStrategyCheckOnly,
+					StorageProvider: v1alpha1.StorageProvider{
+						Local: &v1alpha1.LocalStorageProvider{
+							//	Prefix: "prefix",
+							Volume: corev1.Volume{
+								Name: "nfs",
+								VolumeSource: corev1.VolumeSource{
+									NFS: &corev1.NFSVolumeSource{
+										Server:   "fake-server",
+										Path:     "/tmp",
+										ReadOnly: true,
+									},
+								},
+							},
+							VolumeMount: corev1.VolumeMount{
+								Name:      "nfs",
+								MountPath: "/tmp",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.RestoreStatus{
+					Conditions: []v1alpha1.RestoreCondition{
+						{
+							Type:   v1alpha1.RestoreVolumeComplete,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   v1alpha1.RestoreWarmUpStarted,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   v1alpha1.RestoreTiKVComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	success_cases := []struct {
+		name    string
+		restore *v1alpha1.Restore
+	}{
+		{
+			name: "restore-volume-warmup-no-check-sync",
+			restore: &v1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-3",
+					Namespace: "ns-3",
+				},
+				Spec: v1alpha1.RestoreSpec{
+					Type: v1alpha1.BackupTypeFull,
+					Mode: v1alpha1.RestoreModeVolumeSnapshot,
+					BR: &v1alpha1.BRConfig{
+						ClusterNamespace: "ns-3",
+						Cluster:          "cluster-3",
 					},
 					Warmup: v1alpha1.RestoreWarmupModeSync,
 					StorageProvider: v1alpha1.StorageProvider{
@@ -764,18 +874,18 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 			},
 		},
 		{
-			name: "restore-volume-warmup-async",
+			name: "restore-volume-warmup-no-check-async",
 			restore: &v1alpha1.Restore{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-2",
-					Namespace: "ns-2",
+					Name:      "test-4",
+					Namespace: "ns-4",
 				},
 				Spec: v1alpha1.RestoreSpec{
 					Type: v1alpha1.BackupTypeFull,
 					Mode: v1alpha1.RestoreModeVolumeSnapshot,
 					BR: &v1alpha1.BRConfig{
-						ClusterNamespace: "ns-2",
-						Cluster:          "cluster-2",
+						ClusterNamespace: "ns-4",
+						Cluster:          "cluster-4",
 					},
 					Warmup: v1alpha1.RestoreWarmupModeASync,
 					StorageProvider: v1alpha1.StorageProvider{
@@ -831,7 +941,7 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 		g.Expect(err).To(Succeed())
 	}()
 
-	for _, tt := range cases {
+	for _, tt := range error_cases {
 		t.Run(tt.name, func(t *testing.T) {
 			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
 			helper.CreateRestore(tt.restore)
@@ -839,6 +949,17 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 			m := NewRestoreManager(deps)
 			err := m.Sync(tt.restore)
 			g.Expect(err).Should(MatchError(fmt.Sprintf("warmup job %s/warm-up failed", tt.restore.Namespace)))
+		})
+	}
+
+	for _, tt := range success_cases {
+		t.Run(tt.name, func(t *testing.T) {
+			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
+			helper.CreateRestore(tt.restore)
+			helper.createRestoreWarmupJobFailed(tt.restore)
+			m := NewRestoreManager(deps)
+			err := m.Sync(tt.restore)
+			g.Expect(err).Should(BeNil())
 		})
 	}
 }

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -941,7 +941,7 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 		g.Expect(err).To(Succeed())
 	}()
 
-	for _, tt := range error_cases {
+	for _, tt := range errorCases {
 		t.Run(tt.name, func(t *testing.T) {
 			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
 			helper.CreateRestore(tt.restore)
@@ -952,7 +952,7 @@ func TestFailWarmupBRRestoreByEBS(t *testing.T) {
 		})
 	}
 
-	for _, tt := range success_cases {
+	for _, tt := range successCases {
 		t.Run(tt.name, func(t *testing.T) {
 			helper.CreateTC(tt.restore.Spec.BR.ClusterNamespace, tt.restore.Spec.BR.Cluster, true, true)
 			helper.CreateRestore(tt.restore)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

#5569 updates volume-snapshot restore process to fail the entire restore if any warmup job failed. We use this to quickly check the viability of restores and terminate restore processing early if a corruption is detected.

#5572 updates volume-snapshot restore process to enable recovery from a corruption in a single TiKV through manual cluster operations. We use this in a full restore in case we encounter a corruption during this process.

These features are in conflict w/ each other. If we want to perform a full restore and use single TiKV recovery in the event of corruption, we cannot fail the restore during warmup and instead need to complete warmup stage and progress to restarting TiKVs. If we only want to check the viability of a restore, we are ok w/ failing the restore and not progressing to any further steps. Thus, we gate this failure behavior only behind the `check-wal-only` strategy.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Gate restore failure on warmup failure only for `check-wal-only` warmup strategy.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
