### PR TITLE
Make warmup failure/skip on corruption configurable

### DIFF
--- a/images/ebs-warmup/warmup-steps.sh
+++ b/images/ebs-warmup/warmup-steps.sh
@@ -76,6 +76,9 @@ while [ $# -gt 0 ]; do
             ;;
         --debug) set -x
             ;;
+        --exit-on-corruption)
+            # already parsed above, skip handling here
+            ;;
         -*)
             die "unsupported flag $1"
             ;;

--- a/images/ebs-warmup/warmup-steps.sh
+++ b/images/ebs-warmup/warmup-steps.sh
@@ -105,7 +105,7 @@ while [ $# -gt 0 ]; do
             if find "$1" -iname '[0-9]*.LOG' -size +0c -print0 | sort -z | head -z -n -1 | xargs -0 -I% sh -c 'echo -n "%: " >&2; /tikv-ctl ldb dump_wal --walfile=%; echo >&2' 2>&1 >/dev/null | grep "Corruption"; then
                 echo "There are some files corrupted!"
                 echo "Current WALs:"
-                find . -iname '??????.LOG' -print | sort
+                find . -iname '[0-9]*.LOG' -print | sort
 
                 if [ "$exit_on_corruption" = true ]; then
                     echo $bg_works | xargs kill || true

--- a/pkg/backup/restore/restore_manager_test.go
+++ b/pkg/backup/restore/restore_manager_test.go
@@ -876,6 +876,11 @@ func TestGenerateWarmUpArgs(t *testing.T) {
 			expected: []string{"--fs", constants.TiKVDataVolumeMountPath, "--block", "/logs"},
 		},
 		{
+			name:     "check-wal-only",
+			strategy: v1alpha1.RestoreWarmupStrategyCheckOnly,
+			expected: []string{"--exit-on-corruption", "--block", "/logs"},
+		},
+		{
 			name:     "unknown strategy",
 			strategy: "unknown",
 			errMsg:   `unknown warmup strategy "unknown"`,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Currently warmup script exits w/ error when it encounters corruption. Similar to #5621, this behavior makes sense for checking viability of backups, but conflicts w/ desire to perform a full restore and recover.

When we perform a full restore, if restore encounters corruption, warmup will fail and will cancel the actual warmup of the volumes. Desired behavior is to log the corruption but continue the warmup operation, so that, when complete, if there is only a single corrupt TiKV, we can attempt to recover using functionality added in #5585.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Change updates warmup script to only exit/cancel warmup when encountering corruption when explicitly enabled. This is only enabled for `check-wal-only` strategy. Otherwise, we only log the corruption but continue with normal warmup.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
