### PR TITLE
backup: support multiple schedules

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -53,6 +53,9 @@ const (
 	// BackupScheduleLabelKey is backup schedule key
 	BackupScheduleLabelKey string = "tidb.pingcap.com/backup-schedule"
 
+	// BackupScheduleGroupLabelKey is backup schedule group key
+	BackupScheduleGroupLabelKey string = "tidb.pingcap.com/backup-schedule-group"
+
 	// BackupLabelKey is backup key
 	BackupLabelKey string = "tidb.pingcap.com/backup"
 
@@ -286,7 +289,7 @@ func NewRestore() Label {
 	}
 }
 
-// NewBackupSchedule initialize a new Label for backups of bakcup schedule
+// NewBackupSchedule initialize a new Label for backups of backup schedule
 func NewBackupSchedule() Label {
 	return Label{
 		NameLabelKey:      BackupScheduleJobLabelVal,
@@ -320,6 +323,12 @@ func NewGroup() Label {
 	return Label{
 		NameLabelKey:      "tidb-cluster-group",
 		ManagedByLabelKey: TiDBOperator,
+	}
+}
+
+func NewBackupScheduleGroup(val string) Label {
+	return Label{
+		BackupScheduleGroupLabelKey: val,
 	}
 }
 

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -15,6 +15,7 @@ package backupschedule
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"path"
 	"sort"
 	"strings"
@@ -115,12 +116,20 @@ func (bm *backupScheduleManager) canPerformNextBackup(bs *v1alpha1.BackupSchedul
 	ns := bs.GetNamespace()
 	bsName := bs.GetName()
 
+<<<<<<< HEAD
 	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(nil)
+=======
+	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(labels.Everything())
+>>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
 	if err != nil {
 		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
 	}
 
 	for _, bsMember := range bss {
+<<<<<<< HEAD
+=======
+		// The check is not safe in fact since we don't have strict serialization
+>>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
 		backup, err := bm.deps.BackupLister.Backups(ns).Get(bsMember.Status.LastBackup)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -115,20 +115,28 @@ func (bm *backupScheduleManager) canPerformNextBackup(bs *v1alpha1.BackupSchedul
 	ns := bs.GetNamespace()
 	bsName := bs.GetName()
 
-	backup, err := bm.deps.BackupLister.Backups(ns).Get(bs.Status.LastBackup)
+	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(nil)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, bs.Status.LastBackup, err)
+		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
 	}
 
-	if v1alpha1.IsBackupComplete(backup) || (v1alpha1.IsBackupScheduled(backup) && v1alpha1.IsBackupFailed(backup)) {
-		return nil
+	for _, bsMember := range bss {
+		backup, err := bm.deps.BackupLister.Backups(ns).Get(bsMember.Status.LastBackup)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, bsMember.Status.LastBackup, err)
+		}
+
+		if v1alpha1.IsBackupComplete(backup) || (v1alpha1.IsBackupScheduled(backup) && v1alpha1.IsBackupFailed(backup)) {
+			continue
+		}
+		// skip this sync round of the backup schedule and waiting the last backup.
+		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, bsMember.Status.LastBackup)
 	}
-	// If the last backup is in a failed state, but it is not scheduled yet,
-	// skip this sync round of the backup schedule and waiting the last backup.
-	return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, bs.Status.LastBackup)
+
+	return nil
 }
 
 func (bm *backupScheduleManager) performLogBackupIfNeeded(bs *v1alpha1.BackupSchedule) error {

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -115,13 +115,6 @@ func (bm *backupScheduleManager) canPerformNextBackup(bs *v1alpha1.BackupSchedul
 	ns := bs.GetNamespace()
 	bsName := bs.GetName()
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(nil)
-=======
-	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(labels.Everything())
->>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
-=======
 	// If this backup schedule has specified label of backup schedule group, then we need to check the last backup of the group.
 	// Otherwise, check its own last backup.
 	bsGroupName := bs.GetLabels()[label.BackupScheduleGroupLabelKey]
@@ -150,16 +143,12 @@ func (bm *backupScheduleManager) canPerformNextBackup(bs *v1alpha1.BackupSchedul
 	}
 
 	bss, err := bm.deps.BackupScheduleLister.BackupSchedules(ns).List(selector)
->>>>>>> aeeaf1be6 (backup: use label to identify the backup schedule group)
 	if err != nil {
 		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
 	}
 
 	for _, bsMember := range bss {
-<<<<<<< HEAD
-=======
 		// The check is not safe in fact since we don't have strict serialization
->>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
 		backup, err := bm.deps.BackupLister.Backups(ns).Get(bsMember.Status.LastBackup)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -194,19 +194,28 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 	ns := vbs.GetNamespace()
 	bsName := vbs.GetName()
 
-	backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbs.Status.LastBackup)
+	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(nil)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
+		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
 	}
 
-	if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
-		return nil
+	for _, vbsMember := range vbss {
+		backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbsMember.Status.LastBackup)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
+		}
+
+		if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
+			continue
+		}
+		// skip this sync round of the backup schedule and waiting the last backup.
+		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbsMember.Status.LastBackup)
 	}
-	// skip this sync round of the backup schedule and waiting the last backup.
-	return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbs.Status.LastBackup)
+
+	return nil
 }
 
 func (bm *backupScheduleManager) backupGC(vbs *v1alpha1.VolumeBackupSchedule) {

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -194,13 +194,6 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 	ns := vbs.GetNamespace()
 	bsName := vbs.GetName()
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(nil)
-=======
-	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(labels.Everything())
->>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
-=======
 	// If this backup schedule has specified label of backup schedule group, then we need to check the last backup of the group.
 	// Otherwise, check its own last backup.
 	bsGroupName := vbs.GetLabels()[label.BackupScheduleGroupLabelKey]
@@ -224,37 +217,12 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 	// Check the last backup of the group
 	backupScheduleGroupLabels := label.NewBackupScheduleGroup(bsGroupName)
 	selector, err := backupScheduleGroupLabels.Selector()
->>>>>>> aeeaf1be6 (backup: use label to identify the backup schedule group)
 	if err != nil {
 		return fmt.Errorf("generate backup schedule group %s label selector failed, err: %v", bsGroupName, err)
 	}
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-	for _, vbsMember := range vbss {
-		backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbsMember.Status.LastBackup)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
-			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
-		}
-
-		if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
-			continue
-		}
-		// skip this sync round of the backup schedule and waiting the last backup.
-		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbsMember.Status.LastBackup)
-	}
-
-=======
-	if len(vbs.Spec.BackupTemplate.Clusters) == 0 {
-		return fmt.Errorf("invalid backup schedule %s/%s, no tc cluser specified", ns, bsName)
-=======
 	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(selector)
 	if err != nil {
 		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
->>>>>>> aeeaf1be6 (backup: use label to identify the backup schedule group)
 	}
 
 	for _, vbsMember := range vbss {
@@ -274,7 +242,6 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbsMember.Status.LastBackup)
 	}
 
->>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
 	return nil
 }
 

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager.go
@@ -15,7 +15,6 @@ package backupschedule
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"path"
 	"sort"
 	"time"
@@ -196,14 +195,41 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 	bsName := vbs.GetName()
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(nil)
 =======
 	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(labels.Everything())
 >>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)
-	if err != nil {
-		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
+=======
+	// If this backup schedule has specified label of backup schedule group, then we need to check the last backup of the group.
+	// Otherwise, check its own last backup.
+	bsGroupName := vbs.GetLabels()[label.BackupScheduleGroupLabelKey]
+
+	if bsGroupName == "" {
+		backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbs.Status.LastBackup)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
+		}
+
+		if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
+			return nil
+		}
+		// skip this sync round of the backup schedule and waiting the last backup.
+		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbs.Status.LastBackup)
 	}
 
+	// Check the last backup of the group
+	backupScheduleGroupLabels := label.NewBackupScheduleGroup(bsGroupName)
+	selector, err := backupScheduleGroupLabels.Selector()
+>>>>>>> aeeaf1be6 (backup: use label to identify the backup schedule group)
+	if err != nil {
+		return fmt.Errorf("generate backup schedule group %s label selector failed, err: %v", bsGroupName, err)
+	}
+
+<<<<<<< HEAD
 <<<<<<< HEAD
 	for _, vbsMember := range vbss {
 		backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbsMember.Status.LastBackup)
@@ -224,34 +250,28 @@ func (bm *backupScheduleManager) canPerformNextBackup(vbs *v1alpha1.VolumeBackup
 =======
 	if len(vbs.Spec.BackupTemplate.Clusters) == 0 {
 		return fmt.Errorf("invalid backup schedule %s/%s, no tc cluser specified", ns, bsName)
+=======
+	vbss, err := bm.deps.VolumeBackupScheduleLister.VolumeBackupSchedules(ns).List(selector)
+	if err != nil {
+		return fmt.Errorf("backup schedule %s/%s, list backup schedules failed, err: %v", ns, bsName, err)
+>>>>>>> aeeaf1be6 (backup: use label to identify the backup schedule group)
 	}
 
 	for _, vbsMember := range vbss {
-		needCheck := false
-		// only check the backup schedule that operates against the same tc cluster
-		for _, cluster := range vbsMember.Spec.BackupTemplate.Clusters {
-			if cluster.TCName == vbs.Spec.BackupTemplate.Clusters[0].TCName {
-				needCheck = true
-				break
-			}
-		}
-
-		if needCheck {
-			// The check is not safe in fact since we don't have strict serialization
-			backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbsMember.Status.LastBackup)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					continue
-				}
-				return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
-			}
-
-			if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
+		// The check is not safe in fact since we don't have strict serialization
+		backup, err := bm.deps.VolumeBackupLister.VolumeBackups(ns).Get(vbsMember.Status.LastBackup)
+		if err != nil {
+			if errors.IsNotFound(err) {
 				continue
 			}
-			// skip this sync round of the backup schedule and waiting the last backup.
-			return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbsMember.Status.LastBackup)
+			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, vbs.Status.LastBackup, err)
 		}
+
+		if v1alpha1.IsVolumeBackupComplete(backup) || v1alpha1.IsVolumeBackupFailed(backup) {
+			continue
+		}
+		// skip this sync round of the backup schedule and waiting the last backup.
+		return controller.RequeueErrorf("backup schedule %s/%s, the last backup %s is still running", ns, bsName, vbsMember.Status.LastBackup)
 	}
 
 >>>>>>> 2fc5598f4 (backup: support multiple multiple schedules)

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
@@ -133,6 +133,140 @@ func TestManager(t *testing.T) {
 	helper.checkBacklist(bs.Namespace, 8)
 }
 
+func TestMultiSchedules(t *testing.T) {
+	g := NewGomegaWithT(t)
+	helper := newHelper(t)
+	defer helper.close()
+	deps := helper.deps
+	m := NewBackupScheduleManager(deps).(*backupScheduleManager)
+	var err error
+	bs1 := &v1alpha1.VolumeBackupSchedule{}
+	bs1.Namespace = "ns"
+	bs1.Name = "bsname1"
+	bs1.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs1.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs1.Status.LastBackup = "bs1_backupname"
+
+	bk1 := &v1alpha1.VolumeBackup{}
+	bk1.Namespace = bs1.Namespace
+	bk1.Name = bs1.Status.LastBackup
+	bk1.Status.Conditions = append(bk1.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk1)
+	err = m.canPerformNextBackup(bs1)
+	g.Expect(err).Should(BeNil())
+
+	// create another schedule, without the special label
+	bs2 := &v1alpha1.VolumeBackupSchedule{}
+	bs2.Namespace = "ns"
+	bs2.Name = "bsname2"
+	bs2.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs2.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs2.Status.LastBackup = "bs2_backupname"
+
+	// test backup complete
+	bk2 := &v1alpha1.VolumeBackup{}
+	bk2.Namespace = bs2.Namespace
+	bk2.Name = bs2.Status.LastBackup
+	bk2.Status.Conditions = append(bk2.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk2)
+	err = m.canPerformNextBackup(bs2)
+	g.Expect(err).Should(BeNil())
+	helper.deleteBackup(bk1)
+	helper.deleteBackup(bk2)
+
+	// make 2 schedules in the same group, but neither has active backup
+	bs11 := &v1alpha1.VolumeBackupSchedule{}
+	bs11.Namespace = "ns"
+	bs11.Name = "bsname11"
+	bs11.Labels = label.NewBackupScheduleGroup("group1")
+	bs11.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs11.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs11.Status.LastBackup = "bs11_backupname"
+
+	bk11 := &v1alpha1.VolumeBackup{}
+	bk11.Namespace = bs11.Namespace
+	bk11.Name = bs11.Status.LastBackup
+	bk11.Status.Conditions = append(bk11.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk11)
+	err = m.canPerformNextBackup(bs11)
+	g.Expect(err).Should(BeNil())
+
+	// create another schedule
+	bs12 := &v1alpha1.VolumeBackupSchedule{}
+	bs12.Namespace = "ns"
+	bs12.Name = "bsname12"
+	bs12.Labels = label.NewBackupScheduleGroup("group1")
+	bs12.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs12.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs12.Status.LastBackup = "bs12_backupname"
+
+	// test backup complete
+	bk12 := &v1alpha1.VolumeBackup{}
+	bk12.Namespace = bs12.Namespace
+	bk12.Name = bs12.Status.LastBackup
+	bk12.Status.Conditions = append(bk12.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk12)
+	err = m.canPerformNextBackup(bs12)
+	g.Expect(err).Should(BeNil())
+	helper.deleteBackup(bk11)
+	helper.deleteBackup(bk12)
+
+	// make 2 schedules in the same group, has conflicting backup
+	bs21 := &v1alpha1.VolumeBackupSchedule{}
+	bs21.Namespace = "ns"
+	bs21.Name = "bsname21"
+	bs21.Labels = label.NewBackupScheduleGroup("group2")
+	bs21.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs21.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs21.Status.LastBackup = "bs21_backupname"
+
+	bk21 := &v1alpha1.VolumeBackup{}
+	bk21.Namespace = bs21.Namespace
+	bk21.Name = bs21.Status.LastBackup
+	bk21.Status.Conditions = append(bk21.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupRunning,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk21)
+	err = m.canPerformNextBackup(bs21)
+	g.Expect(err).Should(BeNil())
+
+	// create another schedule
+	bs22 := &v1alpha1.VolumeBackupSchedule{}
+	bs22.Namespace = "ns"
+	bs22.Name = "bsname22"
+	bs22.Labels = label.NewBackupScheduleGroup("group2")
+	bs22.Spec.BackupTemplate.Template.BR = &v1alpha1.BRConfig{}
+	bs22.Spec.BackupTemplate.Template.S3 = &pingcapv1alpha1.S3StorageProvider{}
+	bs22.Status.LastBackup = "bs22_backupname"
+
+	// test backup complete
+	bk22 := &v1alpha1.VolumeBackup{}
+	bk22.Namespace = bs22.Namespace
+	bk22.Name = bs22.Status.LastBackup
+	bk22.Status.Conditions = append(bk22.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk22)
+	err = m.canPerformNextBackup(bs22)
+	g.Expect(err).Should(BeNil())
+	helper.deleteBackup(bk21)
+	helper.deleteBackup(bk22)
+}
+
 func TestGetLastScheduledTime(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Close #5632 

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
In order to support multiple active schedulers, we need to co-ordinate the scheduling to make sure there is only one active backup within the same namespace.
A new label is introduced in this PR, whose key is `tidb.pingcap.com/backup-schedule-group`.  Backup schedule CRD can be assigned such a label, and the value is not empty,  if it's in a multiple schedule group, otherwise, the schedule is independent.  At backup schedule check time, all schedules in the same group need to be checked.

Here is a sample volume backup schedule CRD with the label specified `tidb.pingcap.com/backup-schedule-group: ebs-backup-schedule-group1`.

``` shell
apiVersion: federation.pingcap.com/v1alpha1
kind: VolumeBackupSchedule
metadata:
  name: sche-rolling
  namespace: bc-fed-admin
  labels:
    tidb.pingcap.com/backup-schedule-group: ebs-backup-schedule-group1
spec:
  backupTemplate:
    clusters:
    - k8sClusterName: dataplane-a
      tcName: restore1-a
      tcNamespace: backup-a
    - k8sClusterName: dataplane-b
      tcName: restore1-b
      tcNamespace: backup-b
    - k8sClusterName: dataplane-c
      tcName: restore1-c
      tcNamespace: backup-c
    template:
      br:
        sendCredToTikv: false
      calcSizeLevel: disabled
      cleanPolicy: Delete
      resources: {}
      s3:
        bucket: wangle-ebs-test-us-west-2
        prefix: zm-rolling
        provider: aws
        region: us-west-2
      serviceAccount: tidb-backup-manager
      snapshotsDeleteRatio: 1
      toolImage: gcr.io/pingcap-public/zhongming/qa/br:240401173528
      volumeBackupInitJobMaxActiveSeconds: 1200
  maxReservedTime: 10m
  pause: true
  schedule: '*/10 * * * *'
```

This PR also provides the similar support to snapshot (non-EBS snapshot) backup schedule.

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
