### PR TITLE
br: clean volumes when restore volume failed

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -137,7 +137,7 @@ func IsRestoreVolumeFailed(restore *Restore) bool {
 		!IsRestoreVolumeComplete(restore)
 }
 
-// IsCleanVolumeComplete returns true if a Restore for volume is Failed
+// IsCleanVolumeComplete returns true if restored volumes are cleaned
 func IsCleanVolumeComplete(restore *Restore) bool {
 	_, condition := GetRestoreCondition(&restore.Status, CleanVolumeComplete)
 	return condition != nil && condition.Status == corev1.ConditionTrue

--- a/pkg/apis/pingcap/v1alpha1/restore.go
+++ b/pkg/apis/pingcap/v1alpha1/restore.go
@@ -130,6 +130,19 @@ func IsRestoreVolumeComplete(restore *Restore) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// IsRestoreVolumeFailed returns true if a Restore for volume is Failed
+func IsRestoreVolumeFailed(restore *Restore) bool {
+	return restore.Spec.Mode == RestoreModeVolumeSnapshot &&
+		IsRestoreFailed(restore) &&
+		!IsRestoreVolumeComplete(restore)
+}
+
+// IsCleanVolumeComplete returns true if a Restore for volume is Failed
+func IsCleanVolumeComplete(restore *Restore) bool {
+	_, condition := GetRestoreCondition(&restore.Status, CleanVolumeComplete)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
 // IsRestoreWarmUpStarted returns true if all the warmup jobs has successfully started
 func IsRestoreWarmUpStarted(restore *Restore) bool {
 	_, condition := GetRestoreCondition(&restore.Status, RestoreWarmUpStarted)

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2563,6 +2563,8 @@ const (
 	// RestoreVolumeComplete means the Restore has successfully executed part-1 and the
 	// backup volumes have been rebuilded from the corresponding snapshot
 	RestoreVolumeComplete RestoreConditionType = "VolumeComplete"
+	// CleanVolumeComplete means volumes are cleaned successfully if restore volume failed
+	CleanVolumeComplete RestoreConditionType = "CleanVolumeComplete"
 	// RestoreWarmUpStarted means the Restore has successfully started warm up pods to
 	// initialize volumes restored from snapshots
 	RestoreWarmUpStarted RestoreConditionType = "WarmUpStarted"

--- a/pkg/backup/snapshotter/snapshotter.go
+++ b/pkg/backup/snapshotter/snapshotter.go
@@ -59,6 +59,8 @@ type Snapshotter interface {
 
 	// AddVolumeTags add operator related tags to volumes
 	AddVolumeTags(pvs []*corev1.PersistentVolume) error
+
+	CleanVolumes(r *v1alpha1.Restore, csb *CloudSnapBackup) error
 }
 
 type BaseSnapshotter struct {
@@ -181,6 +183,18 @@ func (s *BaseSnapshotter) prepareRestoreMetadata(r *v1alpha1.Restore, csb *Cloud
 	}
 
 	return "", nil
+}
+
+func (s *BaseSnapshotter) getRestoreVolumeIDs(csb *CloudSnapBackup) []string {
+	volumeIDs := make([]string, 0)
+	for _, store := range csb.TiKV.Stores {
+		for _, volume := range store.Volumes {
+			if volume.RestoreVolumeID != "" {
+				volumeIDs = append(volumeIDs, volume.RestoreVolumeID)
+			}
+		}
+	}
+	return volumeIDs
 }
 
 func checkCloudSnapBackup(b *CloudSnapBackup) (string, error) {

--- a/pkg/backup/snapshotter/snapshotter_aws.go
+++ b/pkg/backup/snapshotter/snapshotter_aws.go
@@ -150,3 +150,19 @@ func (s *AWSSnapshotter) ResetPvAvailableZone(r *v1alpha1.Restore, pv *corev1.Pe
 		}
 	}
 }
+
+func (s *AWSSnapshotter) CleanVolumes(r *v1alpha1.Restore, csb *CloudSnapBackup) error {
+	if !v1alpha1.IsRestoreVolumeFailed(r) {
+		return errors.New("can't clean volumes if not restore volume failed")
+	}
+
+	volumeIDs := s.getRestoreVolumeIDs(csb)
+	ec2Session, err := util.NewEC2Session(util.CloudAPIConcurrency)
+	if err != nil {
+		return fmt.Errorf("new ec2 session error: %w", err)
+	}
+	if err := ec2Session.DeleteVolumes(volumeIDs); err != nil {
+		return fmt.Errorf("delete volumes error: %w", err)
+	}
+	return nil
+}

--- a/pkg/backup/snapshotter/snapshotter_gcp.go
+++ b/pkg/backup/snapshotter/snapshotter_gcp.go
@@ -107,3 +107,8 @@ func (s *GCPSnapshotter) AddVolumeTags(pvs []*corev1.PersistentVolume) error {
 	// TODO implement it if support to restore snapshots to another az on GCP
 	return nil
 }
+
+func (s *GCPSnapshotter) CleanVolumes(r *v1alpha1.Restore, csb *CloudSnapBackup) error {
+	// TODO implement it if support to restore snapshots on GCP
+	return nil
+}

--- a/pkg/backup/snapshotter/snapshotter_none.go
+++ b/pkg/backup/snapshotter/snapshotter_none.go
@@ -48,3 +48,7 @@ func (s *NoneSnapshotter) AddVolumeTags(pvs []*corev1.PersistentVolume) error {
 	// TODO implement it if support to restore snapshots to another az on GCP
 	return nil
 }
+
+func (s *NoneSnapshotter) CleanVolumes(r *v1alpha1.Restore, csb *CloudSnapBackup) error {
+	return nil
+}

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -16,6 +16,7 @@ package util
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -164,7 +165,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string, deleteRatio fl
 			if err != nil {
 				if aErr, ok := err.(awserr.Error); ok {
 					if aErr.Code() == "InvalidSnapshot.NotFound" {
-						klog.Warningf("snapshot %s not found", snapID, err.Error())
+						klog.Warningf("snapshot %s not found, aws err: %s", snapID, err.Error())
 						return nil
 					}
 				}
@@ -202,6 +203,65 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string, deleteRatio fl
 	}
 
 	return nil
+}
+
+func (e *EC2Session) DeleteVolumes(volumeIDs []string) error {
+	volumes, err := e.ListValidVolumes(volumeIDs)
+	if err != nil {
+		return errors.Annotate(err, "list volumes error")
+	}
+
+	eg, _ := errgroup.WithContext(context.Background())
+	workerPool := NewWorkerPool(e.concurrency, "delete volumes")
+	for _, volume := range volumes {
+		volumeID := *volume.VolumeId
+		workerPool.ApplyOnErrorGroup(eg, func() error {
+			if _, err := e.EC2.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: aws.String(volumeID)}); err != nil {
+				if errors.IsNotFound(err) || strings.Contains(err.Error(), "NotFound") {
+					klog.Warningf(
+						"volume %s is not found, aws err: %s, skip deleting it", volumeID, err.Error())
+					return nil
+				}
+				return errors.Annotatef(err, "delete volume %s error", volumeID)
+			}
+			klog.Infof("volume %s is deleted", volumeID)
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *EC2Session) ListValidVolumes(volumeIDs []string) ([]*ec2.Volume, error) {
+	volumeIDPtrs := make([]*string, len(volumeIDs))
+	for i, volumeID := range volumeIDs {
+		volumeIDPtrs[i] = aws.String(volumeID)
+	}
+
+	volumes := make([]*ec2.Volume, 0, len(volumeIDs))
+	var nextToken *string
+	for {
+		volumesOutput, err := e.EC2.DescribeVolumes(&ec2.DescribeVolumesInput{
+			VolumeIds: volumeIDPtrs,
+			// MaxResults is up to 500
+			MaxResults: aws.Int64(int64(len(volumeIDPtrs))),
+			NextToken:  nextToken,
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "describe volumes error")
+		}
+
+		volumes = append(volumes, volumesOutput.Volumes...)
+		if volumesOutput.NextToken == nil {
+			break
+		}
+
+		nextToken = volumesOutput.NextToken
+	}
+	return volumes, nil
 }
 
 func (e *EC2Session) AddTags(resourcesTags map[string]TagMap) error {

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -245,7 +245,12 @@ func (e *EC2Session) ListValidVolumes(volumeIDs []string) ([]*ec2.Volume, error)
 	var nextToken *string
 	for {
 		volumesOutput, err := e.EC2.DescribeVolumes(&ec2.DescribeVolumesInput{
-			VolumeIds: volumeIDPtrs,
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("volume-id"),
+					Values: volumeIDPtrs,
+				},
+			},
 			NextToken: nextToken,
 		})
 		if err != nil {

--- a/pkg/backup/util/aws_ebs.go
+++ b/pkg/backup/util/aws_ebs.go
@@ -246,9 +246,7 @@ func (e *EC2Session) ListValidVolumes(volumeIDs []string) ([]*ec2.Volume, error)
 	for {
 		volumesOutput, err := e.EC2.DescribeVolumes(&ec2.DescribeVolumesInput{
 			VolumeIds: volumeIDPtrs,
-			// MaxResults is up to 500
-			MaxResults: aws.Int64(int64(len(volumeIDPtrs))),
-			NextToken:  nextToken,
+			NextToken: nextToken,
 		})
 		if err != nil {
 			return nil, errors.Annotate(err, "describe volumes error")

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -170,6 +170,12 @@ func (c *Controller) updateRestore(cur interface{}) {
 		return
 	}
 
+	if v1alpha1.IsRestoreVolumeFailed(newRestore) && !v1alpha1.IsCleanVolumeComplete(newRestore) {
+		// restore volume failed, need to clean created volumes
+		c.enqueueRestore(newRestore)
+		return
+	}
+
 	if v1alpha1.IsRestoreFailed(newRestore) {
 		klog.V(4).Infof("restore %s/%s is Failed, skipping.", ns, name)
 		return


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Add cleaning volumes function when restore volume failed. Then we can avoid volume leak

Closes #5638

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

manual test steps:

1. create a cluster
2. create a volume backup
3. create a restore cluster
4. create a volume restore using the volume backup in step 2. in this step, restore volume is successful and the tikv pods are started
5. edit the restore CR, modify its status from `VolumeComplete` to `Failed` to mock restore volume failed scenario
6. edit the tc CR, remove the annotation `tidb.pingcap.com/tikv-volumes-ready` to block tikv creation, then delete the tikv statefulset to detach the EBS volumes
7. wait for the volumes detached and deleted by tidb-operator

![image](https://github.com/pingcap/tidb-operator/assets/13897016/8ad04479-863d-479d-8282-e0a90001af94)

![image](https://github.com/pingcap/tidb-operator/assets/13897016/c2a3b5c2-03be-4f2e-9623-3f72673f0b42)

![image](https://github.com/pingcap/tidb-operator/assets/13897016/b67957ff-ae6c-41e8-b917-771628838a51)


### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
