### PR TITLE
Record owner's generation into STS's annotation

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -111,7 +111,10 @@ const (
 	// AnnoPrefixConfigMapNameBeforeDelete is the last used ConfigMap name before STS deleted. xxx_member_manager should use its
 	// annotation value as ConfigMap name if the value is not empty when it tries to CREATE or RESTORE sts.
 	AnnoPrefixConfigMapNameBeforeDelete = "tidb.pingcap.com/configmap-name-before-delete-"
-	AnnoOwnerGeneration                 = "tidb.pingcap.com/owner-generation"
+	// AnnoOwnerGeneration store the generation of owner, for example, save generation of TC into tikv STS's annotation.
+	// It's useful for scenario where you need to know whether the STS is already updated with the latest TC.spec.{component}.
+	// Though the number of owner of object may more than one, but in our scenario, it's only one.
+	AnnoOwnerGeneration = "tidb.pingcap.com/owner-generation"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only
 	AnnPVCScaleInTime = "tidb.pingcap.com/scale-in-time"

--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -111,6 +111,7 @@ const (
 	// AnnoPrefixConfigMapNameBeforeDelete is the last used ConfigMap name before STS deleted. xxx_member_manager should use its
 	// annotation value as ConfigMap name if the value is not empty when it tries to CREATE or RESTORE sts.
 	AnnoPrefixConfigMapNameBeforeDelete = "tidb.pingcap.com/configmap-name-before-delete-"
+	AnnoOwnerGeneration                 = "tidb.pingcap.com/owner-generation"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only
 	AnnPVCScaleInTime = "tidb.pingcap.com/scale-in-time"

--- a/pkg/manager/utils/statefulset.go
+++ b/pkg/manager/utils/statefulset.go
@@ -16,6 +16,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
@@ -151,6 +152,11 @@ func UpdateStatefulSet(setCtl controller.StatefulSetControlInterface, object run
 	if ok {
 		set.Annotations[label.AnnStsLastSyncTimestamp] = v
 	}
+	controllerMo, ok := object.(metav1.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a metav1.Object, cannot call UpdateStatefulSet", object)
+	}
+	set.Annotations[label.AnnoOwnerGeneration] = strconv.FormatInt(controllerMo.GetGeneration(), 10)
 
 	err := SetStatefulSetLastAppliedConfigAnnotation(&set)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Currently, we have no ability to check whether the STS is already updated with the latest TC.spec.{component}. But for some scenarios, we want to know whether is a STS successfully updated. Therefore, this PR introduces a new annotation `tidb.pingcap.com/owner-generation` to store the generation of its owner into STS's annotation.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

* create a cluster with old tidb-operator
* deploy new tidb-operator, components of this cluster shouldn't restart and all STSs shouldn't be annotated with that annotation
* scale tidb out, that annotation should be annotated into STS db-tidb and the old tidb pod shouldn't be restarted.
* scale tidb in, that annotation should be annotated into STS db-tidb and the another one tidb pod shouldn't be restarted.

```bash
k get tc -oyaml | grep generation
    generation: 31

get asts db-tidb -oyaml | grep owner-generation
    tidb.pingcap.com/owner-generation: "31"
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
