### PR TITLE
Add support to customize spare replicas during VolumeReplace

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -12316,6 +12316,21 @@ string
 <p>Mode is the mode of PD cluster</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>spareVolReplaceReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The default number of spare replicas to scale up when using VolumeReplace feature.
+In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid
+zone skew after volume replace (total replicas always whole multiples of zones).
+Optional: Defaults to 1</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="pdstatus">PDStatus</h3>
@@ -22634,6 +22649,21 @@ ScalePolicy
 <td>
 <em>(Optional)</em>
 <p>ScalePolicy is the scale configuration for TiKV</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spareVolReplaceReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The default number of spare replicas to scale up when using VolumeReplace feature.
+In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid
+zone skew after volume replace (total replicas always whole multiples of zones).
+Optional: Defaults to 1</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -24777,6 +24777,10 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  spareVolReplaceReplicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   startTimeout:
                     default: 30
                     type: integer
@@ -41160,6 +41164,10 @@ spec:
                     type: boolean
                   serviceAccount:
                     type: string
+                  spareVolReplaceReplicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -5723,6 +5723,10 @@ spec:
                     type: object
                   serviceAccount:
                     type: string
+                  spareVolReplaceReplicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   startTimeout:
                     default: 30
                     type: integer
@@ -22106,6 +22110,10 @@ spec:
                     type: boolean
                   serviceAccount:
                     type: string
+                  spareVolReplaceReplicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   statefulSetUpdateStrategy:
                     type: string
                   storageClassName:

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
@@ -115,6 +115,9 @@ func setTikvSpecDefault(tc *v1alpha1.TidbCluster) {
 	if tc.Spec.TiKV.MaxFailoverCount == nil {
 		tc.Spec.TiKV.MaxFailoverCount = pointer.Int32Ptr(3)
 	}
+	if tc.Spec.TiKV.SpareVolReplaceReplicas == nil {
+		tc.Spec.TiKV.SpareVolReplaceReplicas = pointer.Int32Ptr(1)
+	}
 }
 
 func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
@@ -125,6 +128,9 @@ func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
 	}
 	if tc.Spec.PD.MaxFailoverCount == nil {
 		tc.Spec.PD.MaxFailoverCount = pointer.Int32Ptr(3)
+	}
+	if tc.Spec.PD.SpareVolReplaceReplicas == nil {
+		tc.Spec.PD.SpareVolReplaceReplicas = pointer.Int32Ptr(1)
 	}
 }
 

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -6914,6 +6914,13 @@ func schema_pkg_apis_pingcap_v1alpha1_PDSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"spareVolReplaceReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The default number of spare replicas to scale up when using VolumeReplace feature. In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid zone skew after volume replace (total replicas always whole multiples of zones). Optional: Defaults to 1",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"replicas"},
 			},
@@ -13399,6 +13406,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiKVSpec(ref common.ReferenceCallback) com
 							Description: "ScalePolicy is the scale configuration for TiKV",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1.ScalePolicy"),
+						},
+					},
+					"spareVolReplaceReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The default number of spare replicas to scale up when using VolumeReplace feature. In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid zone skew after volume replace (total replicas always whole multiples of zones). Optional: Defaults to 1",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -630,7 +630,7 @@ func (tc *TidbCluster) PDStsDesiredReplicas() int32 {
 	}
 	var spareReplaceReplicas int32 = 0
 	if tc.Status.PD.VolReplaceInProgress {
-		spareReplaceReplicas = 1
+		spareReplaceReplicas = *tc.Spec.PD.SpareVolReplaceReplicas
 	}
 	return tc.Spec.PD.Replicas + tc.GetPDDeletedFailureReplicas() + spareReplaceReplicas
 }
@@ -708,7 +708,7 @@ func (tc *TidbCluster) TiKVStsDesiredReplicas() int32 {
 	}
 	var spareReplaceReplicas int32 = 0
 	if tc.Status.TiKV.VolReplaceInProgress {
-		spareReplaceReplicas = 1
+		spareReplaceReplicas = *tc.Spec.TiKV.SpareVolReplaceReplicas
 	}
 	return tc.Spec.TiKV.Replicas + int32(len(tc.Status.TiKV.FailureStores)) + spareReplaceReplicas
 }

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -571,6 +571,14 @@ type PDSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum:="";"ms"
 	Mode string `json:"mode,omitempty"`
+
+	// The default number of spare replicas to scale up when using VolumeReplace feature.
+	// In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid
+	// zone skew after volume replace (total replicas always whole multiples of zones).
+	// Optional: Defaults to 1
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	SpareVolReplaceReplicas *int32 `json:"spareVolReplaceReplicas,omitempty"`
 }
 
 // +k8s:openapi-gen=true
@@ -753,6 +761,14 @@ type TiKVSpec struct {
 	// ScalePolicy is the scale configuration for TiKV
 	// +optional
 	ScalePolicy ScalePolicy `json:"scalePolicy,omitempty"`
+
+	// The default number of spare replicas to scale up when using VolumeReplace feature.
+	// In multi-az deployments with topology spread constraints you may need to set this to number of zones to avoid
+	// zone skew after volume replace (total replicas always whole multiples of zones).
+	// Optional: Defaults to 1
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	SpareVolReplaceReplicas *int32 `json:"spareVolReplaceReplicas,omitempty"`
 }
 
 // TiFlashSpec contains details of TiFlash members

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -3976,6 +3976,11 @@ func (in *PDSpec) DeepCopyInto(out *PDSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SpareVolReplaceReplicas != nil {
+		in, out := &in.SpareVolReplaceReplicas, &out.SpareVolReplaceReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 
@@ -8346,6 +8351,11 @@ func (in *TiKVSpec) DeepCopyInto(out *TiKVSpec) {
 		copy(*out, *in)
 	}
 	in.ScalePolicy.DeepCopyInto(&out.ScalePolicy)
+	if in.SpareVolReplaceReplicas != nil {
+		in, out := &in.SpareVolReplaceReplicas, &out.SpareVolReplaceReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/manager/member/tikv_member_manager_test.go
+++ b/pkg/manager/member/tikv_member_manager_test.go
@@ -413,6 +413,7 @@ func TestTiKVMemberManagerSyncUpdate(t *testing.T) {
 			modify: func(tc *v1alpha1.TidbCluster) {
 				// Random test change to affect pod spec template.
 				tc.Spec.TiKV.ServiceAccount = "test_new_account"
+				tc.Spec.TiKV.SpareVolReplaceReplicas = pointer.Int32(1)
 				tc.Status.TiKV.VolReplaceInProgress = true
 			},
 			pdStores:                     &pdapi.StoresInfo{Count: 0, Stores: []*pdapi.StoreInfo{}},
@@ -2149,7 +2150,8 @@ func TestGetNewTiKVSetForTidbCluster(t *testing.T) {
 				},
 				Spec: v1alpha1.TidbClusterSpec{
 					TiKV: &v1alpha1.TiKVSpec{
-						Replicas: 3,
+						Replicas:                3,
+						SpareVolReplaceReplicas: pointer.Int32(1),
 					},
 					PD:   &v1alpha1.PDSpec{},
 					TiDB: &v1alpha1.TiDBSpec{},


### PR DESCRIPTION
### What problem does this PR solve?
Currently the VolumeReplace feature assumes a default spare replica of 1 for PD & TiKV.
Sometimes it is useful to change this number. Setting a larger spare replica number helps for faster tikv region transfer
In multi-az setups, it is possible to get zone skewness with only a single replica, which will cause issues during scale down of spare replica.

Example multi-az senario:
3 zones , 6 replicas, initial zones per replica: 1,2,3,1,2,3
After adding 1 spare replica: 1,2,3,1,2,3,1
Now replace will start replacing from start, but now the new disks can get different zones, example:
after replacing first disk it could now become 2,2,3,1,2,3,1
After this if we scale down the spare replica (last one), it will become 2,2,3,1,2,3 which is zone-skewed and can be blocked depending on configured topology constraints.

In this case setting spareReplicas to 3 will avoid this issue

### What is changed and how does it work?
Add a config option in TidbCluster spec, inside TiKVSpec and PDSpec to configure spare replicas

### Code changes

- [X] Has Go code change
- [ ] Has CI related scripts change

### Tests
Re ran the manual test described in : https://github.com/pingcap/tidb-operator/pull/5150
Ran once as it is, and observed default spare replica of 1 was used.
Ran once by setting tikv spare replicas to 3, and observed 3 spare replicas was used

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [X] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
VolumeReplace feature now supports customizing the number of spare replicas used during TiKV or PD disk replacements inside the TidbCluster spec.
```
