### PR TITLE
Adding support for logRestoreStartTs option in PITR restore spec

### DIFF
--- a/cmd/backup-manager/app/restore/restore.go
+++ b/cmd/backup-manager/app/restore/restore.go
@@ -95,7 +95,6 @@ func (ro *Options) restoreData(
 
 		fullBackupArgs, err := pkgutil.GenStorageArgsForFlag(restore.Spec.PitrFullBackupStorageProvider, "full-backup-storage")
 		if err != nil {
-			klog.Errorf("error: %+v", err)
 			if restore.Spec.LogRestoreStartTs == "" {
 				return fmt.Errorf("error: Either pitrFullBackupStorageProvider or logRestoreStartTs option needs to be passed in pitr mode")
 			}

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1337,7 +1337,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.</p>
+<p>LogRestoreStartTs is the start timestamp which log restore from.</p>
 </td>
 </tr>
 <tr>
@@ -14494,7 +14494,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.</p>
+<p>LogRestoreStartTs is the start timestamp which log restore from.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1336,6 +1336,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.</p>
 </td>
 </tr>
@@ -1405,6 +1406,7 @@ StorageProvider
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>PitrFullBackupStorageProvider configures where and how pitr dependent full backup should be stored.</p>
 </td>
 </tr>
@@ -14491,6 +14493,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.</p>
 </td>
 </tr>
@@ -14560,6 +14563,7 @@ StorageProvider
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>PitrFullBackupStorageProvider configures where and how pitr dependent full backup should be stored.</p>
 </td>
 </tr>

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -8164,7 +8164,7 @@ func schema_pkg_apis_pingcap_v1alpha1_RestoreSpec(ref common.ReferenceCallback) 
 					},
 					"logRestoreStartTs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.",
+							Description: "LogRestoreStartTs is the start timestamp which log restore from.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2630,6 +2630,7 @@ type RestoreSpec struct {
 	// PitrRestoredTs is the pitr restored ts.
 	PitrRestoredTs string `json:"pitrRestoredTs,omitempty"`
 	// LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.
+	// +optional
 	LogRestoreStartTs string `json:"logRestoreStartTs,omitempty"`
 	// FederalVolumeRestorePhase indicates which phase to execute in federal volume restore
 	// +optional
@@ -2645,6 +2646,7 @@ type RestoreSpec struct {
 	// StorageProvider configures where and how backups should be stored.
 	StorageProvider `json:",inline"`
 	// PitrFullBackupStorageProvider configures where and how pitr dependent full backup should be stored.
+	// +optional
 	PitrFullBackupStorageProvider StorageProvider `json:"pitrFullBackupStorageProvider,omitempty"`
 	// The storageClassName of the persistent volume for Restore data storage.
 	// Defaults to Kubernetes default storage class.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2629,7 +2629,7 @@ type RestoreSpec struct {
 	Mode RestoreMode `json:"restoreMode,omitempty"`
 	// PitrRestoredTs is the pitr restored ts.
 	PitrRestoredTs string `json:"pitrRestoredTs,omitempty"`
-	// LogRestoreStartTs is the start timestamp which log restore from and it will be used in the future.
+	// LogRestoreStartTs is the start timestamp which log restore from.
 	// +optional
 	LogRestoreStartTs string `json:"logRestoreStartTs,omitempty"`
 	// FederalVolumeRestorePhase indicates which phase to execute in federal volume restore

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -600,6 +600,18 @@ func ValidateRestore(restore *v1alpha1.Restore, tikvImage string, acrossK8s bool
 			return fmt.Errorf("DB should be configured for BR with restore type %s in spec of %s/%s", restore.Spec.Type, ns, name)
 		}
 
+		if restore.Spec.Mode == v1alpha1.RestoreModePiTR {
+			_, err := GetStoragePath(restore.Spec.PitrFullBackupStorageProvider)
+			// err is nil when there is a valid storage provider
+			if err == nil && restore.Spec.LogRestoreStartTs != "" {
+				return fmt.Errorf("pitrFullBackupStorageProvider and logRestoreStartTs option can not co-exists in pitr mode")
+			}
+
+			if err != nil && restore.Spec.LogRestoreStartTs == "" {
+				return fmt.Errorf("either pitrFullBackupStorageProvider or logRestoreStartTs option needs to be passed in pitr mode")
+			}
+		}
+
 		if restore.Spec.Type == v1alpha1.BackupTypeTable && restore.Spec.BR.Table == "" {
 			return fmt.Errorf("table should be configured for BR with restore type table in spec of %s/%s", ns, name)
 		}


### PR DESCRIPTION
### What problem does this PR solve?
This PR is addressing the issue [issue-5657](https://github.com/pingcap/tidb-operator/issues/5657)

Adding support for the **logRestoreStartTs** option in the PITR restore spec.

### What is changed and how does it work?
With this update, the Point-in-Time Recovery (PITR) restore mode allows users to apply PITR logs within a specified time range. Specifically, users can define the **start** and **end** timestamps using the **logRestoreStartTs**(start timestamp) and **pitrRestoredTs**(end timestamp) options in the restore spec, respectively. This enhancement enables more precise control over the restoration process, allowing users to restore data to an exact point in time by specifying the interval of PITR logs to be applied.

After this change the user can use a combination of **pitrFullBackupStorageProvider** and **pitrRestoredTs**, to restore the full backup snapshot and apply PITR logs. or else a combination of the **logRestoreStartTs** and **pitrRestoredTs** options in the restore spec to apply PITR logs within a specified time.

If the user fails to specify either the **pitrFullBackupStorageProvider** or **logRestoreStartTs** option in the restore specification, the restore job will result in an error.


### Code changes
- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
- [ ] Unit test
- [ ] E2E test
- [x] Manual test
### PITR up to mentioned **restoreTs** along with full backup restore. 
1. Create a `TiDBCluster`
2. Generate some data in the database (I used Sysbench prepare subcommand)
3. Start the PITR log Backup, refer [Log Backup](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br#log-backup)
4. Create a full backup, [Full backup](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-gcs-using-br#perform-an-ad-hoc-backup)
5. Now create another `TiDBCluster` to test the backup restoration.
6. Follow the steps to restore full backup and apply PITR logs to the specified point(timestamp). refer [Restore full backup + apply logs](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-gcs-using-br#point-in-time-recovery)  

### Apply PITR logs within a specified time range.
1. Create a `restore-pitr.yaml` file as follows, then use `kubectl apply` to apply the yaml. 

       `
         # restore-pitr.yaml
         ---
         apiVersion: pingcap.com/v1alpha1
         kind: Restore
         metadata:
            name: demo3-restore-gcs
            namespace: restore-test
        spec:
          restoreMode: pitr
         br:
             cluster: demo3
             clusterNamespace: test3
         gcs:
             projectId: ${project_id}
             secretName: gcs-secret
             bucket: my-bucket
             prefix: my-log-backup-folder-pitr
          logRestoreStartTs: "2022-10-10T16:21:00+08:00"
          pitrRestoredTs: "2022-10-10T17:21:00+08:00"
       `

### Side effects
- [ ] Breaking backward compatibility: NONE 
- [ ] Other side effects: NONE

### Related changes
- [ ] Need to cherry-pick to the release branch
- [x] Need to update the documentation

### Release Notes
NONE
