### PR TITLE
tc level flag to enablePVCReplace feature

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1984,6 +1984,19 @@ Optional: Defaults to false</p>
 </tr>
 <tr>
 <td>
+<code>enablePVCReplace</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether enable PVC replace to recreate the PVC with different specs
+Optional: Defaults to false</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tlsCluster</code></br>
 <em>
 <a href="#tlscluster">
@@ -24398,6 +24411,19 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Whether enable PVC reclaim for orphan PVC left by statefulset scale-in
+Optional: Defaults to false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enablePVCReplace</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether enable PVC replace to recreate the PVC with different specs
 Optional: Defaults to false</p>
 </td>
 </tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -22150,6 +22150,8 @@ spec:
                 type: string
               enableDynamicConfiguration:
                 type: boolean
+              enablePVCReplace:
+                type: boolean
               enablePVReclaim:
                 type: boolean
               helper:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -3096,6 +3096,8 @@ spec:
                 type: string
               enableDynamicConfiguration:
                 type: boolean
+              enablePVCReplace:
+                type: boolean
               enablePVReclaim:
                 type: boolean
               helper:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -14669,6 +14669,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbClusterSpec(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"enablePVCReplace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether enable PVC replace to recreate the PVC with different specs Optional: Defaults to false",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"tlsCluster": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether enable the TLS connection between TiDB server components Optional: Defaults to nil",

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -37,6 +37,7 @@ const (
 	defaultSeparateRocksDBLog = false
 	defaultSeparateRaftLog    = false
 	defaultEnablePVReclaim    = false
+	defaultEnablePVCReplace   = false
 	// defaultEvictLeaderTimeout is the timeout limit of evict leader
 	defaultEvictLeaderTimeout            = 1500 * time.Minute
 	defaultWaitLeaderTransferBackTimeout = 400 * time.Second
@@ -1059,6 +1060,14 @@ func (tc *TidbCluster) IsPVReclaimEnabled() bool {
 	enabled := tc.Spec.EnablePVReclaim
 	if enabled == nil {
 		return defaultEnablePVReclaim
+	}
+	return *enabled
+}
+
+func (tc *TidbCluster) IsPVCReplaceEnabled() bool {
+	enabled := tc.Spec.EnablePVCReplace
+	if enabled == nil {
+		return defaultEnablePVCReplace
 	}
 	return *enabled
 }

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -295,6 +295,11 @@ type TidbClusterSpec struct {
 	// +optional
 	EnablePVReclaim *bool `json:"enablePVReclaim,omitempty"`
 
+	// Whether enable PVC replace to recreate the PVC with different specs
+	// Optional: Defaults to false
+	// +optional
+	EnablePVCReplace *bool `json:"enablePVCReplace,omitempty"`
+
 	// Whether enable the TLS connection between TiDB server components
 	// Optional: Defaults to nil
 	// +optional

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -9182,6 +9182,11 @@ func (in *TidbClusterSpec) DeepCopyInto(out *TidbClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnablePVCReplace != nil {
+		in, out := &in.EnablePVCReplace, &out.EnablePVCReplace
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TLSCluster != nil {
 		in, out := &in.TLSCluster, &out.TLSCluster
 		*out = new(TLSCluster)

--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -180,7 +180,7 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) {
+	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) && tc.IsPVCReplaceEnabled() {
 		if err := c.pvcReplacer.UpdateStatus(tc); err != nil {
 			metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "pvc_replacer_updatestatus").Inc()
 			return err
@@ -306,7 +306,7 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 	}
 
 	// Replace volumes if necessary. Note: if enabled, takes precedence over pvcModifier.
-	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) {
+	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) && tc.IsPVCReplaceEnabled() {
 		if err := c.pvcReplacer.Sync(tc); err != nil {
 			metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "pvc_replacer_sync").Inc()
 			return err

--- a/pkg/controller/tidbcluster/tidb_cluster_control.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_control.go
@@ -180,7 +180,7 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) && tc.IsPVCReplaceEnabled() {
+	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) || tc.IsPVCReplaceEnabled() {
 		if err := c.pvcReplacer.UpdateStatus(tc); err != nil {
 			metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "pvc_replacer_updatestatus").Inc()
 			return err
@@ -306,7 +306,7 @@ func (c *defaultTidbClusterControl) updateTidbCluster(tc *v1alpha1.TidbCluster) 
 	}
 
 	// Replace volumes if necessary. Note: if enabled, takes precedence over pvcModifier.
-	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) && tc.IsPVCReplaceEnabled() {
+	if features.DefaultFeatureGate.Enabled(features.VolumeReplacing) || tc.IsPVCReplaceEnabled() {
 		if err := c.pvcReplacer.Sync(tc); err != nil {
 			metrics.ClusterUpdateErrors.WithLabelValues(ns, tcName, "pvc_replacer_sync").Inc()
 			return err

--- a/pkg/manager/volumes/pvc_replacer.go
+++ b/pkg/manager/volumes/pvc_replacer.go
@@ -73,6 +73,11 @@ func (p *pvcReplacer) getVolReplaceStatusForComponent(tc *v1alpha1.TidbCluster, 
 }
 
 func (p *pvcReplacer) UpdateStatus(tc *v1alpha1.TidbCluster) error {
+	if !tc.IsPVCReplaceEnabled() {
+		// skip if PVC replace is not enabled for tc
+		return nil
+	}
+
 	components := tc.AllComponentStatus()
 	errs := []error{}
 
@@ -100,6 +105,11 @@ func (p *pvcReplacer) UpdateStatus(tc *v1alpha1.TidbCluster) error {
 }
 
 func (p *pvcReplacer) Sync(tc *v1alpha1.TidbCluster) error {
+	if !tc.IsPVCReplaceEnabled() {
+		// skip if PVC replace is not enabled for tc
+		return nil
+	}
+
 	components := tc.AllComponentStatus()
 	errs := []error{}
 

--- a/pkg/manager/volumes/pvc_replacer.go
+++ b/pkg/manager/volumes/pvc_replacer.go
@@ -73,11 +73,6 @@ func (p *pvcReplacer) getVolReplaceStatusForComponent(tc *v1alpha1.TidbCluster, 
 }
 
 func (p *pvcReplacer) UpdateStatus(tc *v1alpha1.TidbCluster) error {
-	if !tc.IsPVCReplaceEnabled() {
-		// skip if PVC replace is not enabled for tc
-		return nil
-	}
-
 	components := tc.AllComponentStatus()
 	errs := []error{}
 
@@ -105,11 +100,6 @@ func (p *pvcReplacer) UpdateStatus(tc *v1alpha1.TidbCluster) error {
 }
 
 func (p *pvcReplacer) Sync(tc *v1alpha1.TidbCluster) error {
-	if !tc.IsPVCReplaceEnabled() {
-		// skip if PVC replace is not enabled for tc
-		return nil
-	}
-
 	components := tc.AllComponentStatus()
 	errs := []error{}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
https://github.com/pingcap/tidb-operator/blob/9ef26f88bf75338cef427b44aa6303237ddcdbd6/pkg/features/features.go#L55C9-L57C44
PVC replace feature is currently enabled / disabled at tidb-operator level, which might not be comforting situation as a single tidb-operator can be handling multiple tidbclusters, so this PR enables tidbcluster level flag to enable / disable this feature. This is similar to another similar feature `enablePVReclaim` flag

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Added a new flag in CRD `enablePVCReplace` with a false as default value. If this flag is enabled then only tidb-operator would perform the PVC replacement process.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
ACTION REQUIRED: Introduces a new feature flag at a tidb-cluster level for enablePVCReplace, this works the same as VolumeReplacing but only enables specified tidb-cluster for VolumeReplacing. Enabling either the tidb-cluster level feature flag or the operator level feature flag will turn on this feature for a given tidb-cluster.
```
