### PR TITLE
[tidb-dashboard] use portName for service

### DIFF
--- a/pkg/manager/tidbdashboard/manager.go
+++ b/pkg/manager/tidbdashboard/manager.go
@@ -388,6 +388,14 @@ func generateTiDBDashboardMeta(td *v1alpha1.TidbDashboard, name string) (metav1.
 	return objMeta, ls
 }
 
+func getOrDefault(value *string, defaultValue string) string {
+	if value == nil || *value == "" {
+		return defaultValue
+	} else {
+		return *value
+	}
+}
+
 func generateTiDBDashboardService(td *v1alpha1.TidbDashboard) *corev1.Service {
 	meta, labels := generateTiDBDashboardMeta(td, ServiceName(td.Name))
 
@@ -400,7 +408,7 @@ func generateTiDBDashboardService(td *v1alpha1.TidbDashboard) *corev1.Service {
 			Type: td.Spec.Service.Type,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "tidb-dashboard",
+					Name:       getOrDefault(td.Spec.Service.PortName, "tidb-dashboard"),
 					Port:       port,
 					TargetPort: intstr.FromInt(port),
 					Protocol:   corev1.ProtocolTCP,

--- a/pkg/manager/tidbdashboard/manager_test.go
+++ b/pkg/manager/tidbdashboard/manager_test.go
@@ -409,7 +409,7 @@ func TestGenerateTiDBDashboardService(t *testing.T) {
 			},
 		},
 		{
-			name:      "override port",
+			name: "override port",
 			setInputs: func(td *v1alpha1.TidbDashboard) {
 				port := "foobar"
 				td.Spec.Service.PortName = &port

--- a/pkg/manager/tidbdashboard/manager_test.go
+++ b/pkg/manager/tidbdashboard/manager_test.go
@@ -408,6 +408,18 @@ func TestGenerateTiDBDashboardService(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:      "override port",
+			setInputs: func(td *v1alpha1.TidbDashboard) {
+				port := "foobar"
+				td.Spec.Service.PortName = &port
+			},
+			expectFn: func(td *v1alpha1.TidbDashboard, svc *corev1.Service) {
+				if diff := cmp.Diff(&svc.Spec.Ports[0].Name, td.Spec.Service.PortName); diff != "" {
+					t.Errorf("unexpected port name (-want, +got): %s", diff)
+				}
+			},
+		},
 	}
 
 	for _, testcase := range cases {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Currently, tidb-dashboard ignores the PortName specified in the service configuration and always uses the default `tidb-dashboard`. 
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
If a PortName is specified in the service configuration, tidb-dashboard uses that port name instead. If no PortName is specified, it uses the default `tidb-dashboard`. 
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
NONE
```
