### PR TITLE
Add generation to all component statuses

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -9592,6 +9592,16 @@ MemberPhase
 </tr>
 <tr>
 <td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>statefulSet</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#statefulsetstatus-v1-apps">
@@ -11174,6 +11184,16 @@ MemberPhase
 </tr>
 <tr>
 <td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>statefulSet</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#statefulsetstatus-v1-apps">
@@ -12382,6 +12402,16 @@ bool
 <a href="#memberphase">
 MemberPhase
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
 </em>
 </td>
 <td>
@@ -13805,6 +13835,16 @@ bool
 <a href="#memberphase">
 MemberPhase
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
 </em>
 </td>
 <td>
@@ -16630,6 +16670,16 @@ MemberPhase
 </tr>
 <tr>
 <td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>statefulSet</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#statefulsetstatus-v1-apps">
@@ -18005,6 +18055,16 @@ The probe binary in the image should be placed under the root directory, i.e., <
 <a href="#memberphase">
 MemberPhase
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
 </em>
 </td>
 <td>
@@ -22725,6 +22785,16 @@ MemberPhase
 </tr>
 <tr>
 <td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>bootStrapped</code></br>
 <em>
 bool
@@ -23731,6 +23801,16 @@ bool
 <a href="#memberphase">
 MemberPhase
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
 </em>
 </td>
 <td>
@@ -27276,6 +27356,16 @@ bool
 <a href="#memberphase">
 MemberPhase
 </a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
 </em>
 </td>
 <td>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -15484,6 +15484,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -15665,6 +15668,9 @@ spec:
                       - stage
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -44077,6 +44083,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerMembers:
                     additionalProperties:
                       properties:
@@ -44259,6 +44268,9 @@ spec:
                       type: array
                     name:
                       type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
                     phase:
                       type: string
                     statefulSet:
@@ -44407,6 +44419,9 @@ spec:
                       - state
                       type: object
                     type: array
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -44552,6 +44567,9 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -44715,6 +44733,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   passwordInitialized:
                     type: boolean
                   phase:
@@ -44877,6 +44898,9 @@ spec:
                     type: object
                   image:
                     type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerStores:
                     additionalProperties:
                       properties:
@@ -45136,6 +45160,9 @@ spec:
                     type: object
                   image:
                     type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerStores:
                     additionalProperties:
                       properties:
@@ -45375,6 +45402,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -45475,7 +45505,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/manifests/crd/v1/pingcap.com_dmclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_dmclusters.yaml
@@ -8635,6 +8635,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -8816,6 +8819,9 @@ spec:
                       - stage
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -25023,6 +25023,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerMembers:
                     additionalProperties:
                       properties:
@@ -25205,6 +25208,9 @@ spec:
                       type: array
                     name:
                       type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
                     phase:
                       type: string
                     statefulSet:
@@ -25353,6 +25359,9 @@ spec:
                       - state
                       type: object
                     type: array
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -25498,6 +25507,9 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -25661,6 +25673,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   passwordInitialized:
                     type: boolean
                   phase:
@@ -25823,6 +25838,9 @@ spec:
                     type: object
                   image:
                     type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerStores:
                     additionalProperties:
                       properties:
@@ -26082,6 +26100,9 @@ spec:
                     type: object
                   image:
                     type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   peerStores:
                     additionalProperties:
                       properties:
@@ -26321,6 +26342,9 @@ spec:
                       - name
                       type: object
                     type: object
+                  observedGeneration:
+                    format: int64
+                    type: integer
                   phase:
                     type: string
                   statefulSet:
@@ -26421,7 +26445,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/pingcap/v1alpha1/component_status.go
+++ b/pkg/apis/pingcap/v1alpha1/component_status.go
@@ -58,6 +58,8 @@ type ComponentStatus interface {
 	//
 	// Not supported for tidb and pump
 	SetSynced(bool)
+	// SetObservedGeneration sets the generation of the component.
+	SetObservedGeneration(generation int64)
 	// SetPhase sets the phase of the component.
 	SetPhase(phase MemberPhase)
 	// SetVolumes sets the `status.volumes`
@@ -173,6 +175,9 @@ func (s *PDStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *PDStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *PDStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -223,6 +228,9 @@ func (s *PDMSStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *PDMSStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *PDMSStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -270,6 +278,9 @@ func (s *TiKVStatus) RemoveCondition(conditionType string) {
 	conditions := s.Conditions
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
+}
+func (s *TiKVStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
 }
 func (s *TiKVStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
@@ -322,6 +333,9 @@ func (s *TiDBStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *TiDBStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *TiDBStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -372,6 +386,9 @@ func (s *PumpStatus) RemoveCondition(conditionType string) {
 	conditions := s.Conditions
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
+}
+func (s *PumpStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
 }
 func (s *PumpStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
@@ -424,6 +441,9 @@ func (s *TiFlashStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *TiFlashStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *TiFlashStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -474,6 +494,9 @@ func (s *TiCDCStatus) RemoveCondition(conditionType string) {
 	conditions := s.Conditions
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
+}
+func (s *TiCDCStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
 }
 func (s *TiCDCStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
@@ -526,6 +549,9 @@ func (s *MasterStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *MasterStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *MasterStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -577,6 +603,9 @@ func (s *WorkerStatus) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
 }
+func (s *WorkerStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
+}
 func (s *WorkerStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase
 }
@@ -627,6 +656,9 @@ func (s *TiProxyStatus) RemoveCondition(conditionType string) {
 	conditions := s.Conditions
 	meta.RemoveStatusCondition(&conditions, conditionType)
 	s.Conditions = conditions
+}
+func (s *TiProxyStatus) SetObservedGeneration(generation int64) {
+	s.ObservedGeneration = generation
 }
 func (s *TiProxyStatus) SetPhase(phase MemberPhase) {
 	s.Phase = phase

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -168,6 +168,7 @@ const (
 //
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:shortName="tc"
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="PD",type=string,JSONPath=`.status.pd.image`,description="The image for PD cluster"
 // +kubebuilder:printcolumn:name="Storage",type=string,JSONPath=`.spec.pd.requests.storage`,description="The storage size specified for PD node"
@@ -1470,9 +1471,10 @@ type SuspendAction struct {
 // PDStatus is PD status
 type PDStatus struct {
 	// +optional
-	Synced      bool                    `json:"synced"`
-	Phase       MemberPhase             `json:"phase,omitempty"`
-	StatefulSet *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
+	Synced             bool                    `json:"synced"`
+	Phase              MemberPhase             `json:"phase,omitempty"`
+	ObservedGeneration int64                   `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
 	// Members contains PDs in current TidbCluster
 	Members map[string]PDMember `json:"members,omitempty"`
 	// PeerMembers contains PDs NOT in current TidbCluster
@@ -1495,9 +1497,10 @@ type PDStatus struct {
 type PDMSStatus struct {
 	Name string `json:"name,omitempty"`
 	// +optional
-	Synced      bool                    `json:"synced"`
-	Phase       MemberPhase             `json:"phase,omitempty"`
-	StatefulSet *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
+	Synced             bool                    `json:"synced"`
+	Phase              MemberPhase             `json:"phase,omitempty"`
+	ObservedGeneration int64                   `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Members contains other service in current TidbCluster
@@ -1551,6 +1554,7 @@ type UnjoinedMember struct {
 // TiDBStatus is TiDB status
 type TiDBStatus struct {
 	Phase                    MemberPhase                  `json:"phase,omitempty"`
+	ObservedGeneration       int64                        `json:"observedGeneration,omitempty"`
 	StatefulSet              *apps.StatefulSetStatus      `json:"statefulSet,omitempty"`
 	Members                  map[string]TiDBMember        `json:"members,omitempty"`
 	FailureMembers           map[string]TiDBFailureMember `json:"failureMembers,omitempty"`
@@ -1654,17 +1658,18 @@ const (
 
 // TiKVStatus is TiKV status
 type TiKVStatus struct {
-	Synced          bool                          `json:"synced,omitempty"`
-	Phase           MemberPhase                   `json:"phase,omitempty"`
-	BootStrapped    bool                          `json:"bootStrapped,omitempty"`
-	StatefulSet     *apps.StatefulSetStatus       `json:"statefulSet,omitempty"`
-	Stores          map[string]TiKVStore          `json:"stores,omitempty"` // key: store id
-	PeerStores      map[string]TiKVStore          `json:"peerStores,omitempty"`
-	TombstoneStores map[string]TiKVStore          `json:"tombstoneStores,omitempty"`
-	FailureStores   map[string]TiKVFailureStore   `json:"failureStores,omitempty"`
-	FailoverUID     types.UID                     `json:"failoverUID,omitempty"`
-	Image           string                        `json:"image,omitempty"`
-	EvictLeader     map[string]*EvictLeaderStatus `json:"evictLeader,omitempty"`
+	Synced             bool                          `json:"synced,omitempty"`
+	Phase              MemberPhase                   `json:"phase,omitempty"`
+	ObservedGeneration int64                         `json:"observedGeneration,omitempty"`
+	BootStrapped       bool                          `json:"bootStrapped,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus       `json:"statefulSet,omitempty"`
+	Stores             map[string]TiKVStore          `json:"stores,omitempty"` // key: store id
+	PeerStores         map[string]TiKVStore          `json:"peerStores,omitempty"`
+	TombstoneStores    map[string]TiKVStore          `json:"tombstoneStores,omitempty"`
+	FailureStores      map[string]TiKVFailureStore   `json:"failureStores,omitempty"`
+	FailoverUID        types.UID                     `json:"failoverUID,omitempty"`
+	Image              string                        `json:"image,omitempty"`
+	EvictLeader        map[string]*EvictLeaderStatus `json:"evictLeader,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
@@ -1677,15 +1682,16 @@ type TiKVStatus struct {
 
 // TiFlashStatus is TiFlash status
 type TiFlashStatus struct {
-	Synced          bool                        `json:"synced,omitempty"`
-	Phase           MemberPhase                 `json:"phase,omitempty"`
-	StatefulSet     *apps.StatefulSetStatus     `json:"statefulSet,omitempty"`
-	Stores          map[string]TiKVStore        `json:"stores,omitempty"`
-	PeerStores      map[string]TiKVStore        `json:"peerStores,omitempty"`
-	TombstoneStores map[string]TiKVStore        `json:"tombstoneStores,omitempty"`
-	FailureStores   map[string]TiKVFailureStore `json:"failureStores,omitempty"`
-	FailoverUID     types.UID                   `json:"failoverUID,omitempty"`
-	Image           string                      `json:"image,omitempty"`
+	Synced             bool                        `json:"synced,omitempty"`
+	Phase              MemberPhase                 `json:"phase,omitempty"`
+	ObservedGeneration int64                       `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus     `json:"statefulSet,omitempty"`
+	Stores             map[string]TiKVStore        `json:"stores,omitempty"`
+	PeerStores         map[string]TiKVStore        `json:"peerStores,omitempty"`
+	TombstoneStores    map[string]TiKVStore        `json:"tombstoneStores,omitempty"`
+	FailureStores      map[string]TiKVFailureStore `json:"failureStores,omitempty"`
+	FailoverUID        types.UID                   `json:"failoverUID,omitempty"`
+	Image              string                      `json:"image,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
@@ -1709,11 +1715,12 @@ type TiProxyMember struct {
 
 // TiProxyStatus is TiProxy status
 type TiProxyStatus struct {
-	Synced      bool                                       `json:"synced,omitempty"`
-	Phase       MemberPhase                                `json:"phase,omitempty"`
-	Members     map[string]TiProxyMember                   `json:"members,omitempty"`
-	StatefulSet *apps.StatefulSetStatus                    `json:"statefulSet,omitempty"`
-	Volumes     map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
+	Synced             bool                                       `json:"synced,omitempty"`
+	Phase              MemberPhase                                `json:"phase,omitempty"`
+	ObservedGeneration int64                                      `json:"observedGeneration,omitempty"`
+	Members            map[string]TiProxyMember                   `json:"members,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus                    `json:"statefulSet,omitempty"`
+	Volumes            map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
 	// +optional
 	// +nullable
@@ -1722,10 +1729,11 @@ type TiProxyStatus struct {
 
 // TiCDCStatus is TiCDC status
 type TiCDCStatus struct {
-	Synced      bool                    `json:"synced,omitempty"`
-	Phase       MemberPhase             `json:"phase,omitempty"`
-	StatefulSet *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
-	Captures    map[string]TiCDCCapture `json:"captures,omitempty"`
+	Synced             bool                    `json:"synced,omitempty"`
+	Phase              MemberPhase             `json:"phase,omitempty"`
+	ObservedGeneration int64                   `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
+	Captures           map[string]TiCDCCapture `json:"captures,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
@@ -1788,9 +1796,10 @@ type PumpNodeStatus struct {
 
 // PumpStatus is Pump status
 type PumpStatus struct {
-	Phase       MemberPhase             `json:"phase,omitempty"`
-	StatefulSet *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
-	Members     []*PumpNodeStatus       `json:"members,omitempty"`
+	Phase              MemberPhase             `json:"phase,omitempty"`
+	ObservedGeneration int64                   `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus `json:"statefulSet,omitempty"`
+	Members            []*PumpNodeStatus       `json:"members,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
@@ -3171,14 +3180,15 @@ const (
 
 // MasterStatus is dm-master status
 type MasterStatus struct {
-	Synced          bool                           `json:"synced,omitempty"`
-	Phase           MemberPhase                    `json:"phase,omitempty"`
-	StatefulSet     *apps.StatefulSetStatus        `json:"statefulSet,omitempty"`
-	Members         map[string]MasterMember        `json:"members,omitempty"`
-	Leader          MasterMember                   `json:"leader,omitempty"`
-	FailureMembers  map[string]MasterFailureMember `json:"failureMembers,omitempty"`
-	UnjoinedMembers map[string]UnjoinedMember      `json:"unjoinedMembers,omitempty"`
-	Image           string                         `json:"image,omitempty"`
+	Synced             bool                           `json:"synced,omitempty"`
+	Phase              MemberPhase                    `json:"phase,omitempty"`
+	ObservedGeneration int64                          `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus        `json:"statefulSet,omitempty"`
+	Members            map[string]MasterMember        `json:"members,omitempty"`
+	Leader             MasterMember                   `json:"leader,omitempty"`
+	FailureMembers     map[string]MasterFailureMember `json:"failureMembers,omitempty"`
+	UnjoinedMembers    map[string]UnjoinedMember      `json:"unjoinedMembers,omitempty"`
+	Image              string                         `json:"image,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.
@@ -3212,13 +3222,14 @@ type MasterFailureMember struct {
 
 // WorkerStatus is dm-worker status
 type WorkerStatus struct {
-	Synced         bool                           `json:"synced,omitempty"`
-	Phase          MemberPhase                    `json:"phase,omitempty"`
-	StatefulSet    *apps.StatefulSetStatus        `json:"statefulSet,omitempty"`
-	Members        map[string]WorkerMember        `json:"members,omitempty"`
-	FailureMembers map[string]WorkerFailureMember `json:"failureMembers,omitempty"`
-	FailoverUID    types.UID                      `json:"failoverUID,omitempty"`
-	Image          string                         `json:"image,omitempty"`
+	Synced             bool                           `json:"synced,omitempty"`
+	Phase              MemberPhase                    `json:"phase,omitempty"`
+	ObservedGeneration int64                          `json:"observedGeneration,omitempty"`
+	StatefulSet        *apps.StatefulSetStatus        `json:"statefulSet,omitempty"`
+	Members            map[string]WorkerMember        `json:"members,omitempty"`
+	FailureMembers     map[string]WorkerFailureMember `json:"failureMembers,omitempty"`
+	FailoverUID        types.UID                      `json:"failoverUID,omitempty"`
+	Image              string                         `json:"image,omitempty"`
 	// Volumes contains the status of all volumes.
 	Volumes map[StorageVolumeName]*StorageVolumeStatus `json:"volumes,omitempty"`
 	// Represents the latest available observations of a component's state.

--- a/pkg/manager/member/dm_master_member_manager.go
+++ b/pkg/manager/member/dm_master_member_manager.go
@@ -212,6 +212,7 @@ func (m *masterMemberManager) syncMasterStatefulSetForDMCluster(dc *v1alpha1.DMC
 
 	// Force update takes precedence over scaling because force upgrade won't take effect when cluster gets stuck at scaling
 	if !dc.Status.Master.Synced && NeedForceUpgrade(dc.Annotations) {
+		dc.Status.Master.ObservedGeneration = dc.Generation
 		dc.Status.Master.Phase = v1alpha1.UpgradePhase
 		mngerutils.SetUpgradePartition(newMasterSet, 0)
 		errSTS := mngerutils.UpdateStatefulSet(m.deps.StatefulSetControl, dc, newMasterSet, oldMasterSet)
@@ -292,6 +293,7 @@ func (m *masterMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set *a
 		return err
 	}
 
+	dc.Status.Master.ObservedGeneration = dc.Generation
 	// Scaling takes precedence over upgrading.
 	if dc.MasterStsDesiredReplicas() != *set.Spec.Replicas {
 		dc.Status.Master.Phase = v1alpha1.ScalePhase

--- a/pkg/manager/member/dm_master_upgrader.go
+++ b/pkg/manager/member/dm_master_upgrader.go
@@ -57,6 +57,7 @@ func (u *masterUpgrader) gracefulUpgrade(dc *v1alpha1.DMCluster, oldSet *apps.St
 		return nil
 	}
 
+	dc.Status.Master.ObservedGeneration = dc.Generation
 	dc.Status.Master.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil
@@ -136,6 +137,7 @@ func (u *fakeMasterUpgrader) Upgrade(dc *v1alpha1.DMCluster, _ *apps.StatefulSet
 	if !dc.Status.Master.Synced {
 		return fmt.Errorf("dmcluster: dm-master status sync failed,can not to be upgraded")
 	}
+	dc.Status.Master.ObservedGeneration = dc.Generation
 	dc.Status.Master.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/dm_worker_member_manager.go
+++ b/pkg/manager/member/dm_worker_member_manager.go
@@ -250,6 +250,7 @@ func (m *workerMemberManager) syncDMClusterStatus(dc *v1alpha1.DMCluster, set *a
 	if err != nil {
 		return err
 	}
+	dc.Status.Worker.ObservedGeneration = dc.Generation
 	if upgrading {
 		dc.Status.Worker.Phase = v1alpha1.UpgradePhase
 	} else if dc.WorkerStsDesiredReplicas() != *set.Spec.Replicas {

--- a/pkg/manager/member/pd_member_manager.go
+++ b/pkg/manager/member/pd_member_manager.go
@@ -233,6 +233,7 @@ func (m *pdMemberManager) syncPDStatefulSetForTidbCluster(tc *v1alpha1.TidbClust
 		onlyOnePD := *oldPDSet.Spec.Replicas < 2 && len(tc.Status.PD.PeerMembers) == 0 // it's acceptable to use old record about peer members
 
 		if forceUpgradeAnnoSet || onlyOnePD {
+			tc.Status.PD.ObservedGeneration = tc.Generation
 			tc.Status.PD.Phase = v1alpha1.UpgradePhase
 			mngerutils.SetUpgradePartition(newPDSet, 0)
 			errSTS := mngerutils.UpdateStatefulSet(m.deps.StatefulSetControl, tc, newPDSet, oldPDSet)
@@ -329,6 +330,8 @@ func (m *pdMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set *a
 	if err != nil {
 		return err
 	}
+
+	tc.Status.PD.ObservedGeneration = tc.Generation
 
 	// Scaling takes precedence over upgrading.
 	if tc.PDStsDesiredReplicas() != *set.Spec.Replicas {

--- a/pkg/manager/member/pd_member_manager_test.go
+++ b/pkg/manager/member/pd_member_manager_test.go
@@ -949,9 +949,10 @@ func newTidbClusterForPD() *v1alpha1.TidbCluster {
 			APIVersion: "pingcap.com/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: corev1.NamespaceDefault,
-			UID:       types.UID("test"),
+			Name:       "test",
+			Namespace:  corev1.NamespaceDefault,
+			UID:        types.UID("test"),
+			Generation: 10,
 		},
 		Spec: v1alpha1.TidbClusterSpec{
 			PD: &v1alpha1.PDSpec{

--- a/pkg/manager/member/pd_ms_member_manager.go
+++ b/pkg/manager/member/pd_ms_member_manager.go
@@ -345,6 +345,8 @@ func (m *pdMSMemberManager) syncStatus(tc *v1alpha1.TidbCluster, sts *apps.State
 		return err
 	}
 
+	tc.Status.PDMS[curService].ObservedGeneration = tc.Generation
+
 	// Scaling takes precedence over upgrading.
 	if tc.PDMSStsDesiredReplicas(curService) != *sts.Spec.Replicas {
 		tc.Status.PDMS[curService].Phase = v1alpha1.ScalePhase

--- a/pkg/manager/member/pd_upgrader.go
+++ b/pkg/manager/member/pd_upgrader.go
@@ -64,6 +64,7 @@ func (u *pdUpgrader) gracefulUpgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Stat
 		return nil
 	}
 
+	tc.Status.PD.ObservedGeneration = tc.Generation
 	tc.Status.PD.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil
@@ -234,6 +235,7 @@ func (u *fakePDUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, 
 	if !tc.Status.PD.Synced {
 		return fmt.Errorf("tidbcluster: pd status sync failed, can not to be upgraded")
 	}
+	tc.Status.PD.ObservedGeneration = tc.Generation
 	tc.Status.PD.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/pump_member_manager.go
+++ b/pkg/manager/member/pump_member_manager.go
@@ -200,6 +200,7 @@ func (m *pumpMemberManager) syncTiDBClusterStatus(tc *v1alpha1.TidbCluster, set 
 		return err
 	}
 
+	tc.Status.Pump.ObservedGeneration = tc.Generation
 	if upgrading {
 		tc.Status.Pump.Phase = v1alpha1.UpgradePhase
 	} else {

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -242,6 +242,7 @@ func (m *ticdcMemberManager) syncTiCDCStatus(tc *v1alpha1.TidbCluster, sts *apps
 		tc.Status.TiCDC.Synced = false
 		return err
 	}
+	tc.Status.TiCDC.ObservedGeneration = tc.Generation
 	if upgrading {
 		tc.Status.TiCDC.Phase = v1alpha1.UpgradePhase
 	} else {

--- a/pkg/manager/member/ticdc_upgrader.go
+++ b/pkg/manager/member/ticdc_upgrader.go
@@ -66,6 +66,7 @@ func (u *ticdcUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulS
 		return nil
 	}
 
+	tc.Status.TiCDC.ObservedGeneration = tc.Generation
 	tc.Status.TiCDC.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -1147,6 +1147,8 @@ func (m *tidbMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, set 
 		return err
 	}
 
+	tc.Status.TiDB.ObservedGeneration = tc.Generation
+
 	if tc.TiDBStsDesiredReplicas() != *set.Spec.Replicas {
 		tc.Status.TiDB.Phase = v1alpha1.ScalePhase
 	} else if upgrading && tc.Status.TiKV.Phase != v1alpha1.UpgradePhase &&

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -404,6 +404,7 @@ func TestTiDBMemberManagerSyncTidbClusterStatus(t *testing.T) {
 		}
 		if test.updateSts != nil {
 			test.updateSts(set)
+			tc.Generation = tc.Generation + 1
 		}
 		pmm, _, tidbControl, _ := newFakeTiDBMemberManager()
 
@@ -449,6 +450,7 @@ func TestTiDBMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiDB.StatefulSet.Replicas).To(Equal(int32(3)))
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.UpgradePhase))
+				g.Expect(tc.Status.TiDB.ObservedGeneration).To(Equal(tc.Generation))
 			},
 		},
 		{
@@ -464,6 +466,7 @@ func TestTiDBMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiDB.StatefulSet.Replicas).To(Equal(int32(3)))
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.TiDB.ObservedGeneration).To(Equal(tc.Generation))
 			},
 		},
 		{
@@ -479,6 +482,7 @@ func TestTiDBMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiDB.StatefulSet.Replicas).To(Equal(int32(3)))
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.TiDB.ObservedGeneration).To(Equal(tc.Generation))
 			},
 		},
 		{
@@ -492,6 +496,7 @@ func TestTiDBMemberManagerSyncTidbClusterStatus(t *testing.T) {
 			tcExpectFn: func(g *GomegaWithT, tc *v1alpha1.TidbCluster) {
 				g.Expect(tc.Status.TiDB.StatefulSet.Replicas).To(Equal(int32(3)))
 				g.Expect(tc.Status.TiDB.Phase).To(Equal(v1alpha1.NormalPhase))
+				g.Expect(tc.Status.TiDB.ObservedGeneration).To(Equal(tc.Generation))
 			},
 		},
 		{

--- a/pkg/manager/member/tidb_upgrader.go
+++ b/pkg/manager/member/tidb_upgrader.go
@@ -75,6 +75,7 @@ func (u *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSe
 		return nil
 	}
 
+	tc.Status.TiDB.ObservedGeneration = tc.Generation
 	tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil
@@ -148,6 +149,7 @@ func NewFakeTiDBUpgrader() Upgrader {
 }
 
 func (u *fakeTiDBUpgrader) Upgrade(tc *v1alpha1.TidbCluster, _ *apps.StatefulSet, _ *apps.StatefulSet) error {
+	tc.Status.TiDB.ObservedGeneration = tc.Generation
 	tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
 	return nil
 }

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -743,6 +743,7 @@ func (m *tiflashMemberManager) syncTidbClusterStatus(tc *v1alpha1.TidbCluster, s
 	if err != nil {
 		return err
 	}
+	tc.Status.TiFlash.ObservedGeneration = tc.Generation
 	if tc.TiFlashStsDesiredReplicas() != *set.Spec.Replicas {
 		tc.Status.TiFlash.Phase = v1alpha1.ScalePhase
 	} else if upgrading {

--- a/pkg/manager/member/tiflash_upgrader.go
+++ b/pkg/manager/member/tiflash_upgrader.go
@@ -75,6 +75,7 @@ func (u *tiflashUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 		return fmt.Errorf("cluster: [%s/%s]'s TiFlash status is not synced, can not upgrade", ns, tcName)
 	}
 
+	tc.Status.TiFlash.ObservedGeneration = tc.Generation
 	tc.Status.TiFlash.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -834,6 +834,8 @@ func (m *tikvMemberManager) syncTiKVClusterStatus(tc *v1alpha1.TidbCluster, set 
 		}
 	}
 
+	tc.Status.TiKV.ObservedGeneration = tc.Generation
+
 	// Scaling takes precedence over upgrading.
 	if tc.TiKVStsDesiredReplicas() != *set.Spec.Replicas {
 		tc.Status.TiKV.Phase = v1alpha1.ScalePhase

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -288,6 +288,7 @@ func (m *tiproxyMemberManager) syncStatus(tc *v1alpha1.TidbCluster, sts *apps.St
 		tc.Status.TiProxy.Synced = false
 		return err
 	}
+	tc.Status.TiProxy.ObservedGeneration = tc.Generation
 	if tc.Spec.TiProxy.Replicas != *sts.Spec.Replicas {
 		tc.Status.TiProxy.Phase = v1alpha1.ScalePhase
 	} else if upgrading {

--- a/pkg/manager/member/tiproxy_upgrader.go
+++ b/pkg/manager/member/tiproxy_upgrader.go
@@ -60,6 +60,7 @@ func (u *tiproxyUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.Statefu
 		return nil
 	}
 
+	tc.Status.TiProxy.ObservedGeneration = tc.Generation
 	tc.Status.TiProxy.Phase = v1alpha1.UpgradePhase
 	if !templateEqual(newSet, oldSet) {
 		return nil

--- a/pkg/manager/suspender/suspender.go
+++ b/pkg/manager/suspender/suspender.go
@@ -194,6 +194,7 @@ func (s *suspender) begin(ctx *suspendComponentCtx) error {
 	phase := v1alpha1.SuspendPhase
 	klog.Infof("begin to suspend component %s and transfer phase from %s to %s",
 		ctx.ComponentID(), status.GetPhase(), phase)
+	ctx.status.SetObservedGeneration(ctx.cluster.GetGeneration())
 	ctx.status.SetPhase(phase)
 	return nil
 }
@@ -203,6 +204,7 @@ func (s *suspender) end(ctx *suspendComponentCtx) error {
 	phase := v1alpha1.NormalPhase
 	klog.Infof("end to suspend component %s and transfer phase from %s to %s",
 		ctx.ComponentID(), status.GetPhase(), phase)
+	ctx.status.SetObservedGeneration(ctx.cluster.GetGeneration())
 	ctx.status.SetPhase(phase)
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
tidb-operator currently does not propagate the CR object meta's generation to the status. This is problematic because it means external systems cannot always tell whether the status corresponds to the current version of the CRD spec, or if it is an old status. For example consider the series of events
```
process A updates CR spec
process B reads CR status
tidb-operator reconciliation triggers on the object and updates status
```
Here, process B will think that the status corresponds to the updated spec as written by process A, when in reality it is a stale status belonging to a previous version of the CR. This is exacerbated if the operator has high latency or is briefly unavailable due to deploys or other reasons.

<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
Each component status within the overarching TidbClusterStatus now has a `generation` field in addition to its other fields like `phase`. Whenever the `phase` is updated by the respective controllers, the generation is also set to be equal to the current CR's generation. Kubernetes increments this generation anytime the spec for the CR is updated, so this provides a consistent way to indicate the status reflects the current version of the CR spec.

Note this practice of passing the generation through to the status is standard practice and is how Kubernetes deployments work, and Kubernetes source code even indicates that [all custom operators should do this](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go#L92-L99).

<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [x] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
TidbCluster now registers status as a subresource, meaning changes to status do not increment the CR's generation number.
- [x] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->
CRD changes need to be deployed to clusters

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
TidbCluster CRD now registers `status` as a subresource of the CR, so updates to status no longer update the `generation` meta field of the CR.

TiDB Operator now sets `observedGeneration` field on each component status anytime a component's `phase` is updated.
```
