### PR TITLE
Add pvc volume replace for TiFlash component

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,7 +95,7 @@ This will show errors if your code change does not pass checks (e.g. fmt, lint).
 If you change code related to CRD, such as type definitions in `pkg/apis/pingcap/v1alpha1/types.go`, please also run following commands to generate necessary code and artifacts.
 
 ```sh
-$ hack/update-all.sh
+$ make generate
 ```
 
 #### Start TiDB Operator locally and do manual tests

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -45017,6 +45017,8 @@ spec:
                       - state
                       type: object
                     type: object
+                  volReplaceInProgress:
+                    type: boolean
                   volumes:
                     additionalProperties:
                       properties:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -25963,6 +25963,8 @@ spec:
                       - state
                       type: object
                     type: object
+                  volReplaceInProgress:
+                    type: boolean
                   volumes:
                     additionalProperties:
                       properties:

--- a/pkg/apis/pingcap/v1alpha1/component_status.go
+++ b/pkg/apis/pingcap/v1alpha1/component_status.go
@@ -403,7 +403,7 @@ func (s *TiFlashStatus) GetStatefulSet() *appsv1.StatefulSetStatus {
 	return s.StatefulSet
 }
 func (s *TiFlashStatus) GetVolReplaceInProgress() bool {
-	return false
+	return s.VolReplaceInProgress
 }
 func (s *TiFlashStatus) SetSynced(synced bool) {
 	s.Synced = synced
@@ -433,7 +433,9 @@ func (s *TiFlashStatus) SetStatefulSet(sts *appsv1.StatefulSetStatus) {
 func (s *TiFlashStatus) SetVolumes(vols map[StorageVolumeName]*StorageVolumeStatus) {
 	s.Volumes = vols
 }
-func (s *TiFlashStatus) SetVolReplaceInProgress(status bool) {}
+func (s *TiFlashStatus) SetVolReplaceInProgress(status bool) {
+	s.VolReplaceInProgress = status
+}
 
 func (s *TiCDCStatus) MemberType() MemberType {
 	return TiCDCMemberType

--- a/pkg/apis/pingcap/v1alpha1/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbcluster.go
@@ -743,7 +743,7 @@ func (tc *TidbCluster) TiFlashAllPodsStarted() bool {
 	return tc.TiFlashStsDesiredReplicas() == tc.TiFlashStsActualReplicas()
 }
 
-// TiFlashAllPodsStarted return whether all stores of TiFlash are ready.
+// TiFlashAllStoresReady return whether all stores of TiFlash are ready.
 //
 // If TiFlash isn't specified, return false.
 func (tc *TidbCluster) TiFlashAllStoresReady() bool {

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1692,6 +1692,8 @@ type TiFlashStatus struct {
 	// +optional
 	// +nullable
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// Indicates that a Volume replace using VolumeReplacing feature is in progress.
+	VolReplaceInProgress bool `json:"volReplaceInProgress,omitempty"`
 }
 
 // TiProxyMember is TiProxy member

--- a/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
+++ b/pkg/controller/tidbcluster/tidb_cluster_controller_test.go
@@ -302,6 +302,17 @@ func newTidbCluster() *v1alpha1.TidbCluster {
 					Image: "tidb-test-image",
 				},
 			},
+			TiFlash: &v1alpha1.TiFlashSpec{
+				Replicas: 1,
+				ComponentSpec: v1alpha1.ComponentSpec{
+					Image: "tiflash-test-image",
+				},
+				ResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("10G"),
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -503,8 +503,31 @@ func TiKVStoreFromStatus(tc *v1alpha1.TidbCluster, podName string) (v1alpha1.TiK
 	return v1alpha1.TiKVStore{}, fmt.Errorf("store is not found in tikv status")
 }
 
+func TiFlashStoreFromStatus(tc *v1alpha1.TidbCluster, podName string) (v1alpha1.TiKVStore, error) {
+	for _, store := range tc.Status.TiFlash.Stores {
+		if store.PodName == podName {
+			return store, nil
+		}
+	}
+	return v1alpha1.TiKVStore{}, fmt.Errorf("store is not found in tiflash status")
+}
+
 func TiKVStoreIDFromStatus(tc *v1alpha1.TidbCluster, podName string) (uint64, error) {
 	store, err := TiKVStoreFromStatus(tc, podName)
+	if err != nil {
+		return 0, err
+	}
+
+	storeID, err := strconv.ParseUint(store.ID, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return storeID, nil
+}
+
+func TiFlashStoreIDFromStatus(tc *v1alpha1.TidbCluster, podName string) (uint64, error) {
+	store, err := TiFlashStoreFromStatus(tc, podName)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Adds volume replace support for TiFlash component

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
There is an existing reconciliation for replacing PVC of TiDB components. However, TiFlash component reconciliation was not written. This PR adds support for TiFlash volume replace as well. It works almost similar to TiKV except for leader eviction which is not required for TiFlash as all the regions are learner regions only.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Volume Replace is not supported for TiFlash component
```
