### PR TITLE
br: a more straight forward operator interface

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -174,9 +174,6 @@ func (bo *Options) doResumeLogBackup(ctx context.Context, backup *v1alpha1.Backu
 		"resume",
 		fmt.Sprintf("--task-name=%s", backup.Name),
 	}
-	// if bo.CommitTS != "" && bo.CommitTS != "0" {
-	// 	specificArgs = append(specificArgs, fmt.Sprintf("--start-ts=%s", bo.CommitTS))
-	// }
 	fullArgs, err := bo.backupCommandTemplate(backup, specificArgs, false)
 	if err != nil {
 		return err

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -167,6 +167,23 @@ func (bo *Options) doStartLogBackup(ctx context.Context, backup *v1alpha1.Backup
 	return bo.brCommandRun(ctx, fullArgs)
 }
 
+// doResumeLogBackup generates br args about log backup resume and runs br binary to do the real backup work.
+func (bo *Options) doResumeLogBackup(ctx context.Context, backup *v1alpha1.Backup) error {
+	specificArgs := []string{
+		"log",
+		"resume",
+		fmt.Sprintf("--task-name=%s", backup.Name),
+	}
+	// if bo.CommitTS != "" && bo.CommitTS != "0" {
+	// 	specificArgs = append(specificArgs, fmt.Sprintf("--start-ts=%s", bo.CommitTS))
+	// }
+	fullArgs, err := bo.backupCommandTemplate(backup, specificArgs, false)
+	if err != nil {
+		return err
+	}
+	return bo.brCommandRun(ctx, fullArgs)
+}
+
 // doStoplogBackup generates br args about log backup stop and runs br binary to do the real backup work.
 func (bo *Options) doStopLogBackup(ctx context.Context, backup *v1alpha1.Backup) error {
 	specificArgs := []string{

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -198,6 +198,20 @@ func (bo *Options) doStopLogBackup(ctx context.Context, backup *v1alpha1.Backup)
 	return bo.brCommandRun(ctx, fullArgs)
 }
 
+// doPauselogBackup generates br args about log backup pause and runs br binary to do the real backup work.
+func (bo *Options) doPauseLogBackup(ctx context.Context, backup *v1alpha1.Backup) error {
+	specificArgs := []string{
+		"log",
+		"pause",
+		fmt.Sprintf("--task-name=%s", backup.Name),
+	}
+	fullArgs, err := bo.backupCommandTemplate(backup, specificArgs, false)
+	if err != nil {
+		return err
+	}
+	return bo.brCommandRun(ctx, fullArgs)
+}
+
 // doTruncateLogBackup generates br args about log backup truncate and runs br binary to do the real backup work.
 func (bo *Options) doTruncateLogBackup(ctx context.Context, backup *v1alpha1.Backup) error {
 	specificArgs := []string{

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -472,6 +472,10 @@ func (bm *Manager) performLogBackup(ctx context.Context, backup *v1alpha1.Backup
 		resultStatus, reason, err = bm.stopLogBackup(ctx, backup)
 	case string(v1alpha1.LogTruncateCommand):
 		resultStatus, reason, err = bm.truncateLogBackup(ctx, backup)
+	case string(v1alpha1.LogResumeCommand):
+		klog.Errorf("Log resume command is not supported yet")
+	case string(v1alpha1.LogPauseCommand):
+		klog.Errorf("Log pause command is not supported yet")
 	default:
 		return fmt.Errorf("log backup %s unknown log subcommand %s", bm, bm.SubCommand)
 	}

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -472,11 +472,10 @@ func (bm *Manager) performLogBackup(ctx context.Context, backup *v1alpha1.Backup
 		resultStatus, reason, err = bm.stopLogBackup(ctx, backup)
 	case string(v1alpha1.LogTruncateCommand):
 		resultStatus, reason, err = bm.truncateLogBackup(ctx, backup)
-	//TODO: (Ris) support more funcs
 	case string(v1alpha1.LogResumeCommand):
 		resultStatus, reason, err = bm.resumeLogBackup(ctx, backup)
 	case string(v1alpha1.LogPauseCommand):
-		klog.Errorf("Log pause command is not supported yet")
+		resultStatus, reason, err = bm.pauseLogBackup(ctx, backup)
 	default:
 		return fmt.Errorf("log backup %s unknown log subcommand %s", bm, bm.SubCommand)
 	}
@@ -559,23 +558,13 @@ func (bm *Manager) startLogBackup(ctx context.Context, backup *v1alpha1.Backup) 
 // resumeLogBackup resume log backup.
 func (bm *Manager) resumeLogBackup(ctx context.Context, backup *v1alpha1.Backup) (*controller.BackupUpdateStatus, string, error) {
 	started := time.Now()
-	backupFullPath, err := util.GetStoragePath(backup)
-	if err != nil {
-		klog.Errorf("Get backup full path of cluster %s failed, err: %s", bm, err)
-		return nil, "GetBackupRemotePathFailed", err
-	}
-	klog.Infof("Get backup full path %s of cluster %s success", backupFullPath, bm)
-
-	updatePathStatus := &controller.BackupUpdateStatus{
-		BackupPath: &backupFullPath,
-	}
 
 	// change Prepare to Running before real backup process start
 	if err := bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{
 		Command: v1alpha1.LogResumeCommand,
 		Type:    v1alpha1.BackupRunning,
 		Status:  corev1.ConditionTrue,
-	}, updatePathStatus); err != nil {
+	}, nil); err != nil {
 		return nil, "UpdateStatusFailed", err
 	}
 
@@ -586,7 +575,7 @@ func (bm *Manager) resumeLogBackup(ctx context.Context, backup *v1alpha1.Backup)
 		klog.Errorf("Resume log backup of cluster %s failed, err: %s", bm, backupErr)
 		return nil, "ResumeLogBackuFailed", backupErr
 	}
-	klog.Infof("Resume log backup of cluster %s to %s success", bm, backupFullPath)
+	klog.Infof("Resume log backup of cluster %s success", bm)
 
 	finish := time.Now()
 	updateStatus := &controller.BackupUpdateStatus{
@@ -617,6 +606,37 @@ func (bm *Manager) stopLogBackup(ctx context.Context, backup *v1alpha1.Backup) (
 		return nil, "StopLogBackupFailed", backupErr
 	}
 	klog.Infof("Stop log backup of cluster %s success", bm)
+
+	finish := time.Now()
+
+	updateStatus := &controller.BackupUpdateStatus{
+		TimeStarted:   &metav1.Time{Time: started},
+		TimeCompleted: &metav1.Time{Time: finish},
+	}
+	return updateStatus, "", nil
+}
+
+// pauseLogBackup stops log backup.
+func (bm *Manager) pauseLogBackup(ctx context.Context, backup *v1alpha1.Backup) (*controller.BackupUpdateStatus, string, error) {
+	started := time.Now()
+
+	// change Prepare to Running before real backup process start
+	if err := bm.StatusUpdater.Update(backup, &v1alpha1.BackupCondition{
+		Command: v1alpha1.LogPauseCommand,
+		Type:    v1alpha1.BackupRunning,
+		Status:  corev1.ConditionTrue,
+	}, nil); err != nil {
+		return nil, "UpdateStatusFailed", err
+	}
+
+	// run br binary to do the real job
+	backupErr := bm.doPauseLogBackup(ctx, backup)
+
+	if backupErr != nil {
+		klog.Errorf("Pause log backup of cluster %s failed, err: %s", bm, backupErr)
+		return nil, "PauseLogBackupFailed", backupErr
+	}
+	klog.Infof("Pause log backup of cluster %s success", bm)
 
 	finish := time.Now()
 

--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -616,7 +616,7 @@ func (bm *Manager) stopLogBackup(ctx context.Context, backup *v1alpha1.Backup) (
 	return updateStatus, "", nil
 }
 
-// pauseLogBackup stops log backup.
+// pauseLogBackup pauses log backup.
 func (bm *Manager) pauseLogBackup(ctx context.Context, backup *v1alpha1.Backup) (*controller.BackupUpdateStatus, string, error) {
 	started := time.Now()
 

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -245,6 +245,18 @@ Default is current timestamp.</p>
 </tr>
 <tr>
 <td>
+<code>logSubcommand</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subcommand is the subcommand for BR, such as start, stop, pause etc.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>logTruncateUntil</code></br>
 <em>
 string
@@ -4230,6 +4242,18 @@ string
 <p>CommitTs is the commit ts of the backup, snapshot ts for full backup or start ts for log backup.
 Format supports TSO or datetime, e.g. &lsquo;400036290571534337&rsquo;, &lsquo;2018-05-11 01:42:23&rsquo;.
 Default is current timestamp.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logSubcommand</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subcommand is the subcommand for BR, such as start, stop, pause etc.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -247,7 +247,9 @@ Default is current timestamp.</p>
 <td>
 <code>logSubcommand</code></br>
 <em>
-string
+<a href="#logsubcommandtype">
+LogSubCommandType
+</a>
 </em>
 </td>
 <td>
@@ -4248,7 +4250,9 @@ Default is current timestamp.</p>
 <td>
 <code>logSubcommand</code></br>
 <em>
-string
+<a href="#logsubcommandtype">
+LogSubCommandType
+</a>
 </em>
 </td>
 <td>
@@ -8914,6 +8918,7 @@ BackupConditionType
 <p>
 (<em>Appears on:</em>
 <a href="#backupcondition">BackupCondition</a>, 
+<a href="#backupspec">BackupSpec</a>, 
 <a href="#logsubcommandstatus">LogSubCommandStatus</a>)
 </p>
 <p>

--- a/hack/local-up-operator.sh
+++ b/hack/local-up-operator.sh
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# This command runs tidb-operator in Kubernetes.
-#
-
 # Default provider is kind
 PROVIDER=${PROVIDER:-kind}
 

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2114,7 +2114,6 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -2282,6 +2281,13 @@ spec:
                     default: 600
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
               imagePullSecrets:
                 items:
                   properties:
@@ -4350,7 +4356,6 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4518,6 +4523,13 @@ spec:
                     default: 600
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
               maxBackups:
                 format: int32
                 type: integer
@@ -6696,7 +6708,6 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
-                default: log-start
                 type: string
               logTruncateUntil:
                 type: string
@@ -6864,6 +6875,13 @@ spec:
                 default: 600
                 type: integer
             type: object
+            x-kubernetes-validations:
+            - message: Field `logStop` is the old version field, please use `logSubcommand`
+                instead
+              rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+            - message: Field `logStop` is the old version field, please use `logSubcommand`
+                instead
+              rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
           status:
             properties:
               backoffRetryStatus:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2115,7 +2115,6 @@ spec:
                     type: boolean
                   logSubcommand:
                     enum:
-                    - ""
                     - log-start
                     - log-stop
                     - log-pause
@@ -4362,7 +4361,6 @@ spec:
                     type: boolean
                   logSubcommand:
                     enum:
-                    - ""
                     - log-start
                     - log-stop
                     - log-pause
@@ -6719,7 +6717,6 @@ spec:
                 type: boolean
               logSubcommand:
                 enum:
-                - ""
                 - log-start
                 - log-stop
                 - log-pause

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2114,6 +2114,11 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
+                    enum:
+                    - ""
+                    - log-start
+                    - log-stop
+                    - log-pause
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4356,6 +4361,11 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
+                    enum:
+                    - ""
+                    - log-start
+                    - log-stop
+                    - log-pause
                     type: string
                   logTruncateUntil:
                     type: string
@@ -6708,6 +6718,11 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
+                enum:
+                - ""
+                - log-start
+                - log-stop
+                - log-pause
                 type: string
               logTruncateUntil:
                 type: string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2114,7 +2114,7 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: start
+                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4350,7 +4350,7 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: start
+                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -6696,7 +6696,7 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
-                default: start
+                default: log-start
                 type: string
               logTruncateUntil:
                 type: string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4,2451 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: backups.pingcap.com
-spec:
-  group: pingcap.com
-  names:
-    kind: Backup
-    listKind: BackupList
-    plural: backups
-    shortNames:
-    - bk
-    singular: backup
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: the type of backup, such as full, db, table. Only used when Mode
-        = snapshot.
-      jsonPath: .spec.backupType
-      name: Type
-      type: string
-    - description: the mode of backup, such as snapshot, log.
-      jsonPath: .spec.backupMode
-      name: Mode
-      type: string
-    - description: The current status of the backup
-      jsonPath: .status.phase
-      name: Status
-      type: string
-    - description: The full path of backup data
-      jsonPath: .status.backupPath
-      name: BackupPath
-      type: string
-    - description: The data size of the backup
-      jsonPath: .status.backupSizeReadable
-      name: BackupSize
-      type: string
-    - description: The real size of volume snapshot backup, only valid to volume snapshot
-        backup
-      jsonPath: .status.incrementalBackupSizeReadable
-      name: IncrementalBackupSize
-      priority: 10
-      type: string
-    - description: The commit ts of the backup
-      jsonPath: .status.commitTs
-      name: CommitTS
-      type: string
-    - description: The log backup truncate until ts
-      jsonPath: .status.logSuccessTruncateUntil
-      name: LogTruncateUntil
-      type: string
-    - description: The time at which the backup was started
-      jsonPath: .status.timeStarted
-      name: Started
-      priority: 1
-      type: date
-    - description: The time at which the backup was completed
-      jsonPath: .status.timeCompleted
-      name: Completed
-      priority: 1
-      type: date
-    - description: The time that the backup takes
-      jsonPath: .status.timeTaken
-      name: TimeTaken
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              additionalVolumeMounts:
-                items:
-                  properties:
-                    mountPath:
-                      type: string
-                    mountPropagation:
-                      type: string
-                    name:
-                      type: string
-                    readOnly:
-                      type: boolean
-                    subPath:
-                      type: string
-                    subPathExpr:
-                      type: string
-                  required:
-                  - mountPath
-                  - name
-                  type: object
-                type: array
-              additionalVolumes:
-                items:
-                  properties:
-                    awsElasticBlockStore:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      properties:
-                        cachingMode:
-                          type: string
-                        diskName:
-                          type: string
-                        diskURI:
-                          type: string
-                        fsType:
-                          type: string
-                        kind:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      properties:
-                        readOnly:
-                          type: boolean
-                        secretName:
-                          type: string
-                        shareName:
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      properties:
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretFile:
-                          type: string
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        user:
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    csi:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        nodePublishSecretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        readOnly:
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      properties:
-                        medium:
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    ephemeral:
-                      properties:
-                        volumeClaimTemplate:
-                          properties:
-                            metadata:
-                              type: object
-                            spec:
-                              properties:
-                                accessModes:
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  properties:
-                                    apiGroup:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                dataSourceRef:
-                                  properties:
-                                    apiGroup:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                    namespace:
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                resources:
-                                  properties:
-                                    claims:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                  type: object
-                                selector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                storageClassName:
-                                  type: string
-                                volumeMode:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              type: object
-                          required:
-                          - spec
-                          type: object
-                      type: object
-                    fc:
-                      properties:
-                        fsType:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        targetWWNs:
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      properties:
-                        datasetName:
-                          type: string
-                        datasetUUID:
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        pdName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      properties:
-                        directory:
-                          type: string
-                        repository:
-                          type: string
-                        revision:
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      properties:
-                        endpoints:
-                          type: string
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      properties:
-                        path:
-                          type: string
-                        type:
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      properties:
-                        chapAuthDiscovery:
-                          type: boolean
-                        chapAuthSession:
-                          type: boolean
-                        fsType:
-                          type: string
-                        initiatorName:
-                          type: string
-                        iqn:
-                          type: string
-                        iscsiInterface:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        portals:
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        targetPortal:
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      type: string
-                    nfs:
-                      properties:
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        server:
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      properties:
-                        claimName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        pdID:
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        sources:
-                          items:
-                            properties:
-                              configMap:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              downwardAPI:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                properties:
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              serviceAccountToken:
-                                properties:
-                                  audience:
-                                    type: string
-                                  expirationSeconds:
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      type: object
-                    quobyte:
-                      properties:
-                        group:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        registry:
-                          type: string
-                        tenant:
-                          type: string
-                        user:
-                          type: string
-                        volume:
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      properties:
-                        fsType:
-                          type: string
-                        image:
-                          type: string
-                        keyring:
-                          type: string
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        user:
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      properties:
-                        fsType:
-                          type: string
-                        gateway:
-                          type: string
-                        protectionDomain:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        sslEnabled:
-                          type: boolean
-                        storageMode:
-                          type: string
-                        storagePool:
-                          type: string
-                        system:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          type: boolean
-                        secretName:
-                          type: string
-                      type: object
-                    storageos:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        volumeName:
-                          type: string
-                        volumeNamespace:
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        storagePolicyID:
-                          type: string
-                        storagePolicyName:
-                          type: string
-                        volumePath:
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              affinity:
-                properties:
-                  nodeAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            preference:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        properties:
-                          nodeSelectorTerms:
-                            items:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
-                  podAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaceSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaceSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaceSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaceSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              azblob:
-                properties:
-                  accessTier:
-                    type: string
-                  container:
-                    type: string
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  sasToken:
-                    type: string
-                  secretName:
-                    type: string
-                  storageAccount:
-                    type: string
-                type: object
-              backoffRetryPolicy:
-                properties:
-                  maxRetryTimes:
-                    default: 2
-                    type: integer
-                  minRetryDuration:
-                    default: 300s
-                    type: string
-                  retryTimeout:
-                    default: 30m
-                    type: string
-                type: object
-              backupMode:
-                default: snapshot
-                type: string
-              backupType:
-                type: string
-              br:
-                properties:
-                  checkRequirements:
-                    type: boolean
-                  checksum:
-                    type: boolean
-                  cluster:
-                    type: string
-                  clusterNamespace:
-                    type: string
-                  concurrency:
-                    format: int32
-                    type: integer
-                  db:
-                    type: string
-                  logLevel:
-                    type: string
-                  onLine:
-                    type: boolean
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  rateLimit:
-                    type: integer
-                  sendCredToTikv:
-                    type: boolean
-                  statusAddr:
-                    type: string
-                  table:
-                    type: string
-                  timeAgo:
-                    type: string
-                required:
-                - cluster
-                type: object
-              calcSizeLevel:
-                default: all
-                type: string
-              cleanOption:
-                properties:
-                  backoffEnabled:
-                    type: boolean
-                  batchConcurrency:
-                    format: int32
-                    type: integer
-                  disableBatchConcurrency:
-                    type: boolean
-                  pageSize:
-                    format: int64
-                    type: integer
-                  retryCount:
-                    default: 5
-                    type: integer
-                  routineConcurrency:
-                    format: int32
-                    type: integer
-                  snapshotsDeleteRatio:
-                    default: 1
-                    type: number
-                type: object
-              cleanPolicy:
-                type: string
-              commitTs:
-                type: string
-              dumpling:
-                properties:
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  tableFilter:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              env:
-                items:
-                  properties:
-                    name:
-                      type: string
-                    value:
-                      type: string
-                    valueFrom:
-                      properties:
-                        configMapKeyRef:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fieldRef:
-                          properties:
-                            apiVersion:
-                              type: string
-                            fieldPath:
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        resourceFieldRef:
-                          properties:
-                            containerName:
-                              type: string
-                            divisor:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            resource:
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        secretKeyRef:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              federalVolumeBackupPhase:
-                type: string
-              from:
-                properties:
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                  secretName:
-                    type: string
-                  tlsClientSecretName:
-                    type: string
-                  user:
-                    type: string
-                required:
-                - host
-                - secretName
-                type: object
-              gcs:
-                properties:
-                  bucket:
-                    type: string
-                  bucketAcl:
-                    type: string
-                  location:
-                    type: string
-                  objectAcl:
-                    type: string
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  projectId:
-                    type: string
-                  secretName:
-                    type: string
-                  storageClass:
-                    type: string
-                required:
-                - projectId
-                type: object
-              imagePullSecrets:
-                items:
-                  properties:
-                    name:
-                      type: string
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
-              local:
-                properties:
-                  prefix:
-                    type: string
-                  volume:
-                    properties:
-                      awsElasticBlockStore:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        properties:
-                          cachingMode:
-                            type: string
-                          diskName:
-                            type: string
-                          diskURI:
-                            type: string
-                          fsType:
-                            type: string
-                          kind:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          secretName:
-                            type: string
-                          shareName:
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        properties:
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretFile:
-                            type: string
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          user:
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csi:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          nodePublishSecretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          readOnly:
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      downwardAPI:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              required:
-                              - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        properties:
-                          medium:
-                            type: string
-                          sizeLimit:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        type: object
-                      ephemeral:
-                        properties:
-                          volumeClaimTemplate:
-                            properties:
-                              metadata:
-                                type: object
-                              spec:
-                                properties:
-                                  accessModes:
-                                    items:
-                                      type: string
-                                    type: array
-                                  dataSource:
-                                    properties:
-                                      apiGroup:
-                                        type: string
-                                      kind:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                    - kind
-                                    - name
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  dataSourceRef:
-                                    properties:
-                                      apiGroup:
-                                        type: string
-                                      kind:
-                                        type: string
-                                      name:
-                                        type: string
-                                      namespace:
-                                        type: string
-                                    required:
-                                    - kind
-                                    - name
-                                    type: object
-                                  resources:
-                                    properties:
-                                      claims:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-map-keys:
-                                        - name
-                                        x-kubernetes-list-type: map
-                                      limits:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                      requests:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                    type: object
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  storageClassName:
-                                    type: string
-                                  volumeMode:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                type: object
-                            required:
-                            - spec
-                            type: object
-                        type: object
-                      fc:
-                        properties:
-                          fsType:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          targetWWNs:
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        required:
-                        - driver
-                        type: object
-                      flocker:
-                        properties:
-                          datasetName:
-                            type: string
-                          datasetUUID:
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          pdName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        properties:
-                          directory:
-                            type: string
-                          repository:
-                            type: string
-                          revision:
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        properties:
-                          endpoints:
-                            type: string
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        properties:
-                          path:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      iscsi:
-                        properties:
-                          chapAuthDiscovery:
-                            type: boolean
-                          chapAuthSession:
-                            type: boolean
-                          fsType:
-                            type: string
-                          initiatorName:
-                            type: string
-                          iqn:
-                            type: string
-                          iscsiInterface:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          portals:
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          targetPortal:
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        type: string
-                      nfs:
-                        properties:
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          server:
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        properties:
-                          claimName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          pdID:
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          sources:
-                            items:
-                              properties:
-                                configMap:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                downwardAPI:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                serviceAccountToken:
-                                  properties:
-                                    audience:
-                                      type: string
-                                    expirationSeconds:
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      quobyte:
-                        properties:
-                          group:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          registry:
-                            type: string
-                          tenant:
-                            type: string
-                          user:
-                            type: string
-                          volume:
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        properties:
-                          fsType:
-                            type: string
-                          image:
-                            type: string
-                          keyring:
-                            type: string
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          user:
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        properties:
-                          fsType:
-                            type: string
-                          gateway:
-                            type: string
-                          protectionDomain:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          sslEnabled:
-                            type: boolean
-                          storageMode:
-                            type: string
-                          storagePool:
-                            type: string
-                          system:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          optional:
-                            type: boolean
-                          secretName:
-                            type: string
-                        type: object
-                      storageos:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          volumeName:
-                            type: string
-                          volumeNamespace:
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          storagePolicyID:
-                            type: string
-                          storagePolicyName:
-                            type: string
-                          volumePath:
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  volumeMount:
-                    properties:
-                      mountPath:
-                        type: string
-                      mountPropagation:
-                        type: string
-                      name:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                      subPathExpr:
-                        type: string
-                    required:
-                    - mountPath
-                    - name
-                    type: object
-                required:
-                - volume
-                - volumeMount
-                type: object
-              logStop:
-                type: boolean
-              logTruncateUntil:
-                type: string
-              podSecurityContext:
-                properties:
-                  fsGroup:
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    type: string
-                  runAsGroup:
-                    format: int64
-                    type: integer
-                  runAsNonRoot:
-                    type: boolean
-                  runAsUser:
-                    format: int64
-                    type: integer
-                  seLinuxOptions:
-                    properties:
-                      level:
-                        type: string
-                      role:
-                        type: string
-                      type:
-                        type: string
-                      user:
-                        type: string
-                    type: object
-                  seccompProfile:
-                    properties:
-                      localhostProfile:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  supplementalGroups:
-                    items:
-                      format: int64
-                      type: integer
-                    type: array
-                  sysctls:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        value:
-                          type: string
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
-                  windowsOptions:
-                    properties:
-                      gmsaCredentialSpec:
-                        type: string
-                      gmsaCredentialSpecName:
-                        type: string
-                      hostProcess:
-                        type: boolean
-                      runAsUserName:
-                        type: string
-                    type: object
-                type: object
-              priorityClassName:
-                type: string
-              resources:
-                properties:
-                  claims:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                type: object
-              resumeGcSchedule:
-                type: boolean
-              s3:
-                properties:
-                  acl:
-                    type: string
-                  bucket:
-                    type: string
-                  endpoint:
-                    type: string
-                  options:
-                    items:
-                      type: string
-                    type: array
-                  path:
-                    type: string
-                  prefix:
-                    type: string
-                  provider:
-                    type: string
-                  region:
-                    type: string
-                  secretName:
-                    type: string
-                  sse:
-                    type: string
-                  storageClass:
-                    type: string
-                required:
-                - provider
-                type: object
-              serviceAccount:
-                type: string
-              storageClassName:
-                type: string
-              storageSize:
-                type: string
-              tableFilter:
-                items:
-                  type: string
-                type: array
-              tikvGCLifeTime:
-                type: string
-              tolerations:
-                items:
-                  properties:
-                    effect:
-                      type: string
-                    key:
-                      type: string
-                    operator:
-                      type: string
-                    tolerationSeconds:
-                      format: int64
-                      type: integer
-                    value:
-                      type: string
-                  type: object
-                type: array
-              toolImage:
-                type: string
-              useKMS:
-                type: boolean
-              volumeBackupInitJobMaxActiveSeconds:
-                default: 600
-                type: integer
-            type: object
-          status:
-            properties:
-              backoffRetryStatus:
-                items:
-                  properties:
-                    detectFailedAt:
-                      format: date-time
-                      type: string
-                    expectedRetryAt:
-                      format: date-time
-                      type: string
-                    originalReason:
-                      type: string
-                    realRetryAt:
-                      format: date-time
-                      type: string
-                    retryNum:
-                      type: integer
-                    retryReason:
-                      type: string
-                  type: object
-                type: array
-              backupPath:
-                type: string
-              backupSize:
-                format: int64
-                type: integer
-              backupSizeReadable:
-                type: string
-              commitTs:
-                type: string
-              conditions:
-                items:
-                  properties:
-                    command:
-                      type: string
-                    lastTransitionTime:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                nullable: true
-                type: array
-              incrementalBackupSize:
-                format: int64
-                type: integer
-              incrementalBackupSizeReadable:
-                type: string
-              logCheckpointTs:
-                type: string
-              logSubCommandStatuses:
-                additionalProperties:
-                  properties:
-                    command:
-                      type: string
-                    conditions:
-                      items:
-                        properties:
-                          command:
-                            type: string
-                          lastTransitionTime:
-                            format: date-time
-                            nullable: true
-                            type: string
-                          message:
-                            type: string
-                          reason:
-                            type: string
-                          status:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      nullable: true
-                      type: array
-                    logTruncatingUntil:
-                      type: string
-                    phase:
-                      type: string
-                    timeCompleted:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    timeStarted:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-                type: object
-              logSuccessTruncateUntil:
-                type: string
-              phase:
-                type: string
-              progresses:
-                items:
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    progress:
-                      type: number
-                    step:
-                      type: string
-                  type: object
-                nullable: true
-                type: array
-              timeCompleted:
-                format: date-time
-                nullable: true
-                type: string
-              timeStarted:
-                format: date-time
-                nullable: true
-                type: string
-              timeTaken:
-                type: string
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
   name: backupschedules.pingcap.com
 spec:
   group: pingcap.com
@@ -4558,6 +2113,9 @@ spec:
                     type: object
                   logStop:
                     type: boolean
+                  logSubcommand:
+                    default: start
+                    type: string
                   logTruncateUntil:
                     type: string
                   podSecurityContext:
@@ -6791,6 +4349,9 @@ spec:
                     type: object
                   logStop:
                     type: boolean
+                  logSubcommand:
+                    default: start
+                    type: string
                   logTruncateUntil:
                     type: string
                   podSecurityContext:
@@ -6985,6 +4546,2454 @@ spec:
                 format: date-time
                 type: string
               logBackup:
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: backups.pingcap.com
+spec:
+  group: pingcap.com
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - bk
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: the type of backup, such as full, db, table. Only used when Mode
+        = snapshot.
+      jsonPath: .spec.backupType
+      name: Type
+      type: string
+    - description: the mode of backup, such as snapshot, log.
+      jsonPath: .spec.backupMode
+      name: Mode
+      type: string
+    - description: The current status of the backup
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: The full path of backup data
+      jsonPath: .status.backupPath
+      name: BackupPath
+      type: string
+    - description: The data size of the backup
+      jsonPath: .status.backupSizeReadable
+      name: BackupSize
+      type: string
+    - description: The real size of volume snapshot backup, only valid to volume snapshot
+        backup
+      jsonPath: .status.incrementalBackupSizeReadable
+      name: IncrementalBackupSize
+      priority: 10
+      type: string
+    - description: The commit ts of the backup
+      jsonPath: .status.commitTs
+      name: CommitTS
+      type: string
+    - description: The log backup truncate until ts
+      jsonPath: .status.logSuccessTruncateUntil
+      name: LogTruncateUntil
+      type: string
+    - description: The time at which the backup was started
+      jsonPath: .status.timeStarted
+      name: Started
+      priority: 1
+      type: date
+    - description: The time at which the backup was completed
+      jsonPath: .status.timeCompleted
+      name: Completed
+      priority: 1
+      type: date
+    - description: The time that the backup takes
+      jsonPath: .status.timeTaken
+      name: TimeTaken
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              additionalVolumeMounts:
+                items:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+              additionalVolumes:
+                items:
+                  properties:
+                    awsElasticBlockStore:
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          format: int32
+                          type: integer
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      properties:
+                        cachingMode:
+                          type: string
+                        diskName:
+                          type: string
+                        diskURI:
+                          type: string
+                        fsType:
+                          type: string
+                        kind:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      properties:
+                        readOnly:
+                          type: boolean
+                        secretName:
+                          type: string
+                        shareName:
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      properties:
+                        monitors:
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretFile:
+                          type: string
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        nodePublishSecretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      properties:
+                        volumeClaimTemplate:
+                          properties:
+                            metadata:
+                              type: object
+                            spec:
+                              properties:
+                                accessModes:
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  properties:
+                                    apiGroup:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  properties:
+                                    apiGroup:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  type: string
+                                volumeMode:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      properties:
+                        fsType:
+                          type: string
+                        lun:
+                          format: int32
+                          type: integer
+                        readOnly:
+                          type: boolean
+                        targetWWNs:
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      properties:
+                        datasetName:
+                          type: string
+                        datasetUUID:
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          format: int32
+                          type: integer
+                        pdName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      properties:
+                        directory:
+                          type: string
+                        repository:
+                          type: string
+                        revision:
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      properties:
+                        endpoints:
+                          type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      properties:
+                        chapAuthDiscovery:
+                          type: boolean
+                        chapAuthSession:
+                          type: boolean
+                        fsType:
+                          type: string
+                        initiatorName:
+                          type: string
+                        iqn:
+                          type: string
+                        iscsiInterface:
+                          type: string
+                        lun:
+                          format: int32
+                          type: integer
+                        portals:
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      type: string
+                    nfs:
+                      properties:
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        server:
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      properties:
+                        claimName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      properties:
+                        fsType:
+                          type: string
+                        pdID:
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        sources:
+                          items:
+                            properties:
+                              configMap:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                properties:
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                properties:
+                                  audience:
+                                    type: string
+                                  expirationSeconds:
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    quobyte:
+                      properties:
+                        group:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        registry:
+                          type: string
+                        tenant:
+                          type: string
+                        user:
+                          type: string
+                        volume:
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      properties:
+                        fsType:
+                          type: string
+                        image:
+                          type: string
+                        keyring:
+                          type: string
+                        monitors:
+                          items:
+                            type: string
+                          type: array
+                        pool:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      properties:
+                        fsType:
+                          type: string
+                        gateway:
+                          type: string
+                        protectionDomain:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          type: boolean
+                        storageMode:
+                          type: string
+                        storagePool:
+                          type: string
+                        system:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      properties:
+                        defaultMode:
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                format: int32
+                                type: integer
+                              path:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        optional:
+                          type: boolean
+                        secretName:
+                          type: string
+                      type: object
+                    storageos:
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          type: string
+                        volumeNamespace:
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      properties:
+                        fsType:
+                          type: string
+                        storagePolicyID:
+                          type: string
+                        storagePolicyName:
+                          type: string
+                        volumePath:
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              affinity:
+                properties:
+                  nodeAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            preference:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              azblob:
+                properties:
+                  accessTier:
+                    type: string
+                  container:
+                    type: string
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  sasToken:
+                    type: string
+                  secretName:
+                    type: string
+                  storageAccount:
+                    type: string
+                type: object
+              backoffRetryPolicy:
+                properties:
+                  maxRetryTimes:
+                    default: 2
+                    type: integer
+                  minRetryDuration:
+                    default: 300s
+                    type: string
+                  retryTimeout:
+                    default: 30m
+                    type: string
+                type: object
+              backupMode:
+                default: snapshot
+                type: string
+              backupType:
+                type: string
+              br:
+                properties:
+                  checkRequirements:
+                    type: boolean
+                  checksum:
+                    type: boolean
+                  cluster:
+                    type: string
+                  clusterNamespace:
+                    type: string
+                  concurrency:
+                    format: int32
+                    type: integer
+                  db:
+                    type: string
+                  logLevel:
+                    type: string
+                  onLine:
+                    type: boolean
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  rateLimit:
+                    type: integer
+                  sendCredToTikv:
+                    type: boolean
+                  statusAddr:
+                    type: string
+                  table:
+                    type: string
+                  timeAgo:
+                    type: string
+                required:
+                - cluster
+                type: object
+              calcSizeLevel:
+                default: all
+                type: string
+              cleanOption:
+                properties:
+                  backoffEnabled:
+                    type: boolean
+                  batchConcurrency:
+                    format: int32
+                    type: integer
+                  disableBatchConcurrency:
+                    type: boolean
+                  pageSize:
+                    format: int64
+                    type: integer
+                  retryCount:
+                    default: 5
+                    type: integer
+                  routineConcurrency:
+                    format: int32
+                    type: integer
+                  snapshotsDeleteRatio:
+                    default: 1
+                    type: number
+                type: object
+              cleanPolicy:
+                type: string
+              commitTs:
+                type: string
+              dumpling:
+                properties:
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  tableFilter:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              env:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          properties:
+                            apiVersion:
+                              type: string
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          properties:
+                            containerName:
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              federalVolumeBackupPhase:
+                type: string
+              from:
+                properties:
+                  host:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                  secretName:
+                    type: string
+                  tlsClientSecretName:
+                    type: string
+                  user:
+                    type: string
+                required:
+                - host
+                - secretName
+                type: object
+              gcs:
+                properties:
+                  bucket:
+                    type: string
+                  bucketAcl:
+                    type: string
+                  location:
+                    type: string
+                  objectAcl:
+                    type: string
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  projectId:
+                    type: string
+                  secretName:
+                    type: string
+                  storageClass:
+                    type: string
+                required:
+                - projectId
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              local:
+                properties:
+                  prefix:
+                    type: string
+                  volume:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  dataSourceRef:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  volumeMount:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                required:
+                - volume
+                - volumeMount
+                type: object
+              logStop:
+                type: boolean
+              logSubcommand:
+                default: start
+                type: string
+              logTruncateUntil:
+                type: string
+              podSecurityContext:
+                properties:
+                  fsGroup:
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    type: string
+                  runAsGroup:
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    type: boolean
+                  runAsUser:
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    properties:
+                      level:
+                        type: string
+                      role:
+                        type: string
+                      type:
+                        type: string
+                      user:
+                        type: string
+                    type: object
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    properties:
+                      gmsaCredentialSpec:
+                        type: string
+                      gmsaCredentialSpecName:
+                        type: string
+                      hostProcess:
+                        type: boolean
+                      runAsUserName:
+                        type: string
+                    type: object
+                type: object
+              priorityClassName:
+                type: string
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              resumeGcSchedule:
+                type: boolean
+              s3:
+                properties:
+                  acl:
+                    type: string
+                  bucket:
+                    type: string
+                  endpoint:
+                    type: string
+                  options:
+                    items:
+                      type: string
+                    type: array
+                  path:
+                    type: string
+                  prefix:
+                    type: string
+                  provider:
+                    type: string
+                  region:
+                    type: string
+                  secretName:
+                    type: string
+                  sse:
+                    type: string
+                  storageClass:
+                    type: string
+                required:
+                - provider
+                type: object
+              serviceAccount:
+                type: string
+              storageClassName:
+                type: string
+              storageSize:
+                type: string
+              tableFilter:
+                items:
+                  type: string
+                type: array
+              tikvGCLifeTime:
+                type: string
+              tolerations:
+                items:
+                  properties:
+                    effect:
+                      type: string
+                    key:
+                      type: string
+                    operator:
+                      type: string
+                    tolerationSeconds:
+                      format: int64
+                      type: integer
+                    value:
+                      type: string
+                  type: object
+                type: array
+              toolImage:
+                type: string
+              useKMS:
+                type: boolean
+              volumeBackupInitJobMaxActiveSeconds:
+                default: 600
+                type: integer
+            type: object
+          status:
+            properties:
+              backoffRetryStatus:
+                items:
+                  properties:
+                    detectFailedAt:
+                      format: date-time
+                      type: string
+                    expectedRetryAt:
+                      format: date-time
+                      type: string
+                    originalReason:
+                      type: string
+                    realRetryAt:
+                      format: date-time
+                      type: string
+                    retryNum:
+                      type: integer
+                    retryReason:
+                      type: string
+                  type: object
+                type: array
+              backupPath:
+                type: string
+              backupSize:
+                format: int64
+                type: integer
+              backupSizeReadable:
+                type: string
+              commitTs:
+                type: string
+              conditions:
+                items:
+                  properties:
+                    command:
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              incrementalBackupSize:
+                format: int64
+                type: integer
+              incrementalBackupSizeReadable:
+                type: string
+              logCheckpointTs:
+                type: string
+              logSubCommandStatuses:
+                additionalProperties:
+                  properties:
+                    command:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          command:
+                            type: string
+                          lastTransitionTime:
+                            format: date-time
+                            nullable: true
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      nullable: true
+                      type: array
+                    logTruncatingUntil:
+                      type: string
+                    phase:
+                      type: string
+                    timeCompleted:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    timeStarted:
+                      format: date-time
+                      nullable: true
+                      type: string
+                  type: object
+                type: object
+              logSuccessTruncateUntil:
+                type: string
+              phase:
+                type: string
+              progresses:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    progress:
+                      type: number
+                    step:
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              timeCompleted:
+                format: date-time
+                nullable: true
+                type: string
+              timeStarted:
+                format: date-time
+                nullable: true
+                type: string
+              timeTaken:
                 type: string
             type: object
         required:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -2139,7 +2139,7 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
-                default: start
+                default: log-start
                 type: string
               logTruncateUntil:
                 type: string

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -2140,7 +2140,6 @@ spec:
                 type: boolean
               logSubcommand:
                 enum:
-                - ""
                 - log-start
                 - log-stop
                 - log-pause

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -2139,7 +2139,6 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
-                default: log-start
                 type: string
               logTruncateUntil:
                 type: string
@@ -2307,6 +2306,13 @@ spec:
                 default: 600
                 type: integer
             type: object
+            x-kubernetes-validations:
+            - message: Field `logStop` is the old version field, please use `logSubcommand`
+                instead
+              rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+            - message: Field `logStop` is the old version field, please use `logSubcommand`
+                instead
+              rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
           status:
             properties:
               backoffRetryStatus:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -2138,6 +2138,9 @@ spec:
                 type: object
               logStop:
                 type: boolean
+              logSubcommand:
+                default: start
+                type: string
               logTruncateUntil:
                 type: string
               podSecurityContext:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -2139,6 +2139,11 @@ spec:
               logStop:
                 type: boolean
               logSubcommand:
+                enum:
+                - ""
+                - log-start
+                - log-stop
+                - log-pause
                 type: string
               logTruncateUntil:
                 type: string

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -2114,6 +2114,11 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
+                    enum:
+                    - ""
+                    - log-start
+                    - log-stop
+                    - log-pause
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4356,6 +4361,11 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
+                    enum:
+                    - ""
+                    - log-start
+                    - log-stop
+                    - log-pause
                     type: string
                   logTruncateUntil:
                     type: string

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -2113,6 +2113,9 @@ spec:
                     type: object
                   logStop:
                     type: boolean
+                  logSubcommand:
+                    default: start
+                    type: string
                   logTruncateUntil:
                     type: string
                   podSecurityContext:
@@ -4346,6 +4349,9 @@ spec:
                     type: object
                   logStop:
                     type: boolean
+                  logSubcommand:
+                    default: start
+                    type: string
                   logTruncateUntil:
                     type: string
                   podSecurityContext:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -2114,7 +2114,6 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -2282,6 +2281,13 @@ spec:
                     default: 600
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
               imagePullSecrets:
                 items:
                   properties:
@@ -4350,7 +4356,6 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4518,6 +4523,13 @@ spec:
                     default: 600
                     type: integer
                 type: object
+                x-kubernetes-validations:
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logSubcommand) ? !has(self.logStop) : true'
+                - message: Field `logStop` is the old version field, please use `logSubcommand`
+                    instead
+                  rule: 'has(self.logStop) ? !has(self.logSubcommand) : true'
               maxBackups:
                 format: int32
                 type: integer

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -2114,7 +2114,7 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: start
+                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string
@@ -4350,7 +4350,7 @@ spec:
                   logStop:
                     type: boolean
                   logSubcommand:
-                    default: start
+                    default: log-start
                     type: string
                   logTruncateUntil:
                     type: string

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -2115,7 +2115,6 @@ spec:
                     type: boolean
                   logSubcommand:
                     enum:
-                    - ""
                     - log-start
                     - log-stop
                     - log-pause
@@ -4362,7 +4361,6 @@ spec:
                     type: boolean
                   logSubcommand:
                     enum:
-                    - ""
                     - log-start
                     - log-stop
                     - log-pause

--- a/manifests/federation-crd.yaml
+++ b/manifests/federation-crd.yaml
@@ -4,6 +4,1795 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  name: volumebackupschedules.federation.pingcap.com
+spec:
+  group: federation.pingcap.com
+  names:
+    kind: VolumeBackupSchedule
+    listKind: VolumeBackupScheduleList
+    plural: volumebackupschedules
+    shortNames:
+    - vbks
+    singular: volumebackupschedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The cron format string used for backup scheduling
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: The max number of backups we want to keep
+      jsonPath: .spec.maxBackups
+      name: MaxBackups
+      type: integer
+    - description: How long backups we want to keep
+      jsonPath: .spec.maxReservedTime
+      name: MaxReservedTime
+      type: string
+    - description: The last backup CR name
+      jsonPath: .status.lastBackup
+      name: LastBackup
+      priority: 1
+      type: string
+    - description: The last time the backup was successfully created
+      jsonPath: .status.lastBackupTime
+      name: LastBackupTime
+      priority: 1
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              backupTemplate:
+                properties:
+                  clusters:
+                    items:
+                      properties:
+                        k8sClusterName:
+                          type: string
+                        tcName:
+                          type: string
+                        tcNamespace:
+                          type: string
+                      type: object
+                    type: array
+                  template:
+                    properties:
+                      additionalVolumeMounts:
+                        items:
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      additionalVolumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      azblob:
+                        properties:
+                          accessTier:
+                            type: string
+                          container:
+                            type: string
+                          path:
+                            type: string
+                          prefix:
+                            type: string
+                          sasToken:
+                            type: string
+                          secretName:
+                            type: string
+                          storageAccount:
+                            type: string
+                        type: object
+                      br:
+                        properties:
+                          checkRequirements:
+                            type: boolean
+                          concurrency:
+                            format: int32
+                            type: integer
+                          options:
+                            items:
+                              type: string
+                            type: array
+                          sendCredToTikv:
+                            type: boolean
+                        type: object
+                      calcSizeLevel:
+                        default: all
+                        type: string
+                      cleanPolicy:
+                        type: string
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      gcs:
+                        properties:
+                          bucket:
+                            type: string
+                          bucketAcl:
+                            type: string
+                          location:
+                            type: string
+                          objectAcl:
+                            type: string
+                          path:
+                            type: string
+                          prefix:
+                            type: string
+                          projectId:
+                            type: string
+                          secretName:
+                            type: string
+                          storageClass:
+                            type: string
+                        required:
+                        - projectId
+                        type: object
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      local:
+                        properties:
+                          prefix:
+                            type: string
+                          volume:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                properties:
+                                  volumeClaimTemplate:
+                                    properties:
+                                      metadata:
+                                        type: object
+                                      spec:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          volumeMount:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                        required:
+                        - volume
+                        - volumeMount
+                        type: object
+                      priorityClassName:
+                        type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      s3:
+                        properties:
+                          acl:
+                            type: string
+                          bucket:
+                            type: string
+                          endpoint:
+                            type: string
+                          options:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          prefix:
+                            type: string
+                          provider:
+                            type: string
+                          region:
+                            type: string
+                          secretName:
+                            type: string
+                          sse:
+                            type: string
+                          storageClass:
+                            type: string
+                        required:
+                        - provider
+                        type: object
+                      serviceAccount:
+                        type: string
+                      snapshotsDeleteRatio:
+                        default: 1
+                        type: number
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      toolImage:
+                        type: string
+                      volumeBackupInitJobMaxActiveSeconds:
+                        default: 600
+                        type: integer
+                    type: object
+                type: object
+              maxBackups:
+                format: int32
+                type: integer
+              maxReservedTime:
+                type: string
+              pause:
+                type: boolean
+              schedule:
+                type: string
+            required:
+            - backupTemplate
+            - schedule
+            type: object
+          status:
+            properties:
+              allBackupCleanTime:
+                format: date-time
+                type: string
+              lastBackup:
+                type: string
+              lastBackupTime:
+                format: date-time
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumebackups.federation.pingcap.com
 spec:
   group: federation.pingcap.com
@@ -1821,1795 +3610,6 @@ spec:
                 nullable: true
                 type: string
               timeTaken:
-                type: string
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: volumebackupschedules.federation.pingcap.com
-spec:
-  group: federation.pingcap.com
-  names:
-    kind: VolumeBackupSchedule
-    listKind: VolumeBackupScheduleList
-    plural: volumebackupschedules
-    shortNames:
-    - vbks
-    singular: volumebackupschedule
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: The cron format string used for backup scheduling
-      jsonPath: .spec.schedule
-      name: Schedule
-      type: string
-    - description: The max number of backups we want to keep
-      jsonPath: .spec.maxBackups
-      name: MaxBackups
-      type: integer
-    - description: How long backups we want to keep
-      jsonPath: .spec.maxReservedTime
-      name: MaxReservedTime
-      type: string
-    - description: The last backup CR name
-      jsonPath: .status.lastBackup
-      name: LastBackup
-      priority: 1
-      type: string
-    - description: The last time the backup was successfully created
-      jsonPath: .status.lastBackupTime
-      name: LastBackupTime
-      priority: 1
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              backupTemplate:
-                properties:
-                  clusters:
-                    items:
-                      properties:
-                        k8sClusterName:
-                          type: string
-                        tcName:
-                          type: string
-                        tcNamespace:
-                          type: string
-                      type: object
-                    type: array
-                  template:
-                    properties:
-                      additionalVolumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      additionalVolumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            ephemeral:
-                              properties:
-                                volumeClaimTemplate:
-                                  properties:
-                                    metadata:
-                                      type: object
-                                    spec:
-                                      properties:
-                                        accessModes:
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
-                                          properties:
-                                            apiGroup:
-                                              type: string
-                                            kind:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        dataSourceRef:
-                                          properties:
-                                            apiGroup:
-                                              type: string
-                                            kind:
-                                              type: string
-                                            name:
-                                              type: string
-                                            namespace:
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                        resources:
-                                          properties:
-                                            claims:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                              - name
-                                              x-kubernetes-list-type: map
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        storageClassName:
-                                          type: string
-                                        volumeMode:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      type: object
-                                  required:
-                                  - spec
-                                  type: object
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      azblob:
-                        properties:
-                          accessTier:
-                            type: string
-                          container:
-                            type: string
-                          path:
-                            type: string
-                          prefix:
-                            type: string
-                          sasToken:
-                            type: string
-                          secretName:
-                            type: string
-                          storageAccount:
-                            type: string
-                        type: object
-                      br:
-                        properties:
-                          checkRequirements:
-                            type: boolean
-                          concurrency:
-                            format: int32
-                            type: integer
-                          options:
-                            items:
-                              type: string
-                            type: array
-                          sendCredToTikv:
-                            type: boolean
-                        type: object
-                      calcSizeLevel:
-                        default: all
-                        type: string
-                      cleanPolicy:
-                        type: string
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      gcs:
-                        properties:
-                          bucket:
-                            type: string
-                          bucketAcl:
-                            type: string
-                          location:
-                            type: string
-                          objectAcl:
-                            type: string
-                          path:
-                            type: string
-                          prefix:
-                            type: string
-                          projectId:
-                            type: string
-                          secretName:
-                            type: string
-                          storageClass:
-                            type: string
-                        required:
-                        - projectId
-                        type: object
-                      imagePullSecrets:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        type: array
-                      local:
-                        properties:
-                          prefix:
-                            type: string
-                          volume:
-                            properties:
-                              awsElasticBlockStore:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  partition:
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    type: boolean
-                                  volumeID:
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              azureDisk:
-                                properties:
-                                  cachingMode:
-                                    type: string
-                                  diskName:
-                                    type: string
-                                  diskURI:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                - diskName
-                                - diskURI
-                                type: object
-                              azureFile:
-                                properties:
-                                  readOnly:
-                                    type: boolean
-                                  secretName:
-                                    type: string
-                                  shareName:
-                                    type: string
-                                required:
-                                - secretName
-                                - shareName
-                                type: object
-                              cephfs:
-                                properties:
-                                  monitors:
-                                    items:
-                                      type: string
-                                    type: array
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretFile:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  user:
-                                    type: string
-                                required:
-                                - monitors
-                                type: object
-                              cinder:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  volumeID:
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              configMap:
-                                properties:
-                                  defaultMode:
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              csi:
-                                properties:
-                                  driver:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  nodePublishSecretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  readOnly:
-                                    type: boolean
-                                  volumeAttributes:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                required:
-                                - driver
-                                type: object
-                              downwardAPI:
-                                properties:
-                                  defaultMode:
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    items:
-                                      properties:
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                        resourceFieldRef:
-                                          properties:
-                                            containerName:
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              emptyDir:
-                                properties:
-                                  medium:
-                                    type: string
-                                  sizeLimit:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                type: object
-                              ephemeral:
-                                properties:
-                                  volumeClaimTemplate:
-                                    properties:
-                                      metadata:
-                                        type: object
-                                      spec:
-                                        properties:
-                                          accessModes:
-                                            items:
-                                              type: string
-                                            type: array
-                                          dataSource:
-                                            properties:
-                                              apiGroup:
-                                                type: string
-                                              kind:
-                                                type: string
-                                              name:
-                                                type: string
-                                            required:
-                                            - kind
-                                            - name
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          dataSourceRef:
-                                            properties:
-                                              apiGroup:
-                                                type: string
-                                              kind:
-                                                type: string
-                                              name:
-                                                type: string
-                                              namespace:
-                                                type: string
-                                            required:
-                                            - kind
-                                            - name
-                                            type: object
-                                          resources:
-                                            properties:
-                                              claims:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-map-keys:
-                                                - name
-                                                x-kubernetes-list-type: map
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          selector:
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    operator:
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          storageClassName:
-                                            type: string
-                                          volumeMode:
-                                            type: string
-                                          volumeName:
-                                            type: string
-                                        type: object
-                                    required:
-                                    - spec
-                                    type: object
-                                type: object
-                              fc:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  lun:
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    type: boolean
-                                  targetWWNs:
-                                    items:
-                                      type: string
-                                    type: array
-                                  wwids:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              flexVolume:
-                                properties:
-                                  driver:
-                                    type: string
-                                  fsType:
-                                    type: string
-                                  options:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                required:
-                                - driver
-                                type: object
-                              flocker:
-                                properties:
-                                  datasetName:
-                                    type: string
-                                  datasetUUID:
-                                    type: string
-                                type: object
-                              gcePersistentDisk:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  partition:
-                                    format: int32
-                                    type: integer
-                                  pdName:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                - pdName
-                                type: object
-                              gitRepo:
-                                properties:
-                                  directory:
-                                    type: string
-                                  repository:
-                                    type: string
-                                  revision:
-                                    type: string
-                                required:
-                                - repository
-                                type: object
-                              glusterfs:
-                                properties:
-                                  endpoints:
-                                    type: string
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                - endpoints
-                                - path
-                                type: object
-                              hostPath:
-                                properties:
-                                  path:
-                                    type: string
-                                  type:
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                              iscsi:
-                                properties:
-                                  chapAuthDiscovery:
-                                    type: boolean
-                                  chapAuthSession:
-                                    type: boolean
-                                  fsType:
-                                    type: string
-                                  initiatorName:
-                                    type: string
-                                  iqn:
-                                    type: string
-                                  iscsiInterface:
-                                    type: string
-                                  lun:
-                                    format: int32
-                                    type: integer
-                                  portals:
-                                    items:
-                                      type: string
-                                    type: array
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  targetPortal:
-                                    type: string
-                                required:
-                                - iqn
-                                - lun
-                                - targetPortal
-                                type: object
-                              name:
-                                type: string
-                              nfs:
-                                properties:
-                                  path:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  server:
-                                    type: string
-                                required:
-                                - path
-                                - server
-                                type: object
-                              persistentVolumeClaim:
-                                properties:
-                                  claimName:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                required:
-                                - claimName
-                                type: object
-                              photonPersistentDisk:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  pdID:
-                                    type: string
-                                required:
-                                - pdID
-                                type: object
-                              portworxVolume:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  volumeID:
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              projected:
-                                properties:
-                                  defaultMode:
-                                    format: int32
-                                    type: integer
-                                  sources:
-                                    items:
-                                      properties:
-                                        configMap:
-                                          properties:
-                                            items:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        downwardAPI:
-                                          properties:
-                                            items:
-                                              items:
-                                                properties:
-                                                  fieldRef:
-                                                    properties:
-                                                      apiVersion:
-                                                        type: string
-                                                      fieldPath:
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                  resourceFieldRef:
-                                                    properties:
-                                                      containerName:
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                required:
-                                                - path
-                                                type: object
-                                              type: array
-                                          type: object
-                                        secret:
-                                          properties:
-                                            items:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  mode:
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              type: string
-                                            optional:
-                                              type: boolean
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        serviceAccountToken:
-                                          properties:
-                                            audience:
-                                              type: string
-                                            expirationSeconds:
-                                              format: int64
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - path
-                                          type: object
-                                      type: object
-                                    type: array
-                                type: object
-                              quobyte:
-                                properties:
-                                  group:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  registry:
-                                    type: string
-                                  tenant:
-                                    type: string
-                                  user:
-                                    type: string
-                                  volume:
-                                    type: string
-                                required:
-                                - registry
-                                - volume
-                                type: object
-                              rbd:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  image:
-                                    type: string
-                                  keyring:
-                                    type: string
-                                  monitors:
-                                    items:
-                                      type: string
-                                    type: array
-                                  pool:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  user:
-                                    type: string
-                                required:
-                                - image
-                                - monitors
-                                type: object
-                              scaleIO:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  gateway:
-                                    type: string
-                                  protectionDomain:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  sslEnabled:
-                                    type: boolean
-                                  storageMode:
-                                    type: string
-                                  storagePool:
-                                    type: string
-                                  system:
-                                    type: string
-                                  volumeName:
-                                    type: string
-                                required:
-                                - gateway
-                                - secretRef
-                                - system
-                                type: object
-                              secret:
-                                properties:
-                                  defaultMode:
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  optional:
-                                    type: boolean
-                                  secretName:
-                                    type: string
-                                type: object
-                              storageos:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  volumeName:
-                                    type: string
-                                  volumeNamespace:
-                                    type: string
-                                type: object
-                              vsphereVolume:
-                                properties:
-                                  fsType:
-                                    type: string
-                                  storagePolicyID:
-                                    type: string
-                                  storagePolicyName:
-                                    type: string
-                                  volumePath:
-                                    type: string
-                                required:
-                                - volumePath
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          volumeMount:
-                            properties:
-                              mountPath:
-                                type: string
-                              mountPropagation:
-                                type: string
-                              name:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              subPath:
-                                type: string
-                              subPathExpr:
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                        required:
-                        - volume
-                        - volumeMount
-                        type: object
-                      priorityClassName:
-                        type: string
-                      resources:
-                        properties:
-                          claims:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      s3:
-                        properties:
-                          acl:
-                            type: string
-                          bucket:
-                            type: string
-                          endpoint:
-                            type: string
-                          options:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          prefix:
-                            type: string
-                          provider:
-                            type: string
-                          region:
-                            type: string
-                          secretName:
-                            type: string
-                          sse:
-                            type: string
-                          storageClass:
-                            type: string
-                        required:
-                        - provider
-                        type: object
-                      serviceAccount:
-                        type: string
-                      snapshotsDeleteRatio:
-                        default: 1
-                        type: number
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      toolImage:
-                        type: string
-                      volumeBackupInitJobMaxActiveSeconds:
-                        default: 600
-                        type: integer
-                    type: object
-                type: object
-              maxBackups:
-                format: int32
-                type: integer
-              maxReservedTime:
-                type: string
-              pause:
-                type: boolean
-              schedule:
-                type: string
-            required:
-            - backupTemplate
-            - schedule
-            type: object
-          status:
-            properties:
-              allBackupCleanTime:
-                format: date-time
-                type: string
-              lastBackup:
-                type: string
-              lastBackupTime:
-                format: date-time
                 type: string
             type: object
         required:

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -339,6 +339,9 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	}
 	switch backup.Spec.LogSubcommand {
 	case "log-start":
+		if IsLogBackupAlreadyStart(backup) {
+			return LogResumeCommand
+		}
 		return LogStartCommand
 	case "log-stop":
 		return LogStopCommand

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -320,7 +320,6 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 
 	var subCommand LogSubCommandType
 
-	// Maintain backward compatibility: 
 	// Users can omit the LogSubcommand field and use the `LogStop` field to stop log backups as in older version.
     if backup.Spec.LogSubcommand == "" {
         if backup.Spec.LogStop || IsLogBackupAlreadyStop(backup) {

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -339,7 +339,7 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	}
 	switch backup.Spec.LogSubcommand {
 	case "log-start":
-		if IsLogBackupAlreadyStart(backup) {
+		if IsLogBackupAlreadyPaused(backup) {
 			return LogResumeCommand
 		}
 		return LogStartCommand
@@ -350,11 +350,10 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	case "log-truncate":
 		return LogTruncateCommand
 	default:
-		return ""
+		return LogStartCommand
 	}
 }
 
-// TODO: (Ris) move logic about truncate to elsewhere
 // IsLogBackupSubCommandOntheCondition return whether the log subcommand on the condition.
 func IsLogBackupSubCommandOntheCondition(backup *Backup, conditionType BackupConditionType) bool {
 	command := ParseLogBackupSubcommand(backup)
@@ -419,7 +418,6 @@ func IsLogBackupAlreadyStop(backup *Backup) bool {
 }
 
 // IsLogBackupAlreadyStop return whether log backup has already paused.
-//TODO: (Ris) deal with task stopped
 func IsLogBackupAlreadyPaused(backup *Backup) bool {
 	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupPaused
 }

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -201,6 +201,13 @@ func IsBackupScheduled(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+func HaveTruncateUntil(backup *Backup) bool {
+	if backup.Spec.Mode != BackupModeLog {
+		return false
+	}
+	return backup.Spec.LogTruncateUntil != ""
+}
+
 // IsBackupRunning returns true if a Backup is Running.
 func IsBackupRunning(backup *Backup) bool {
 	if backup.Spec.Mode == BackupModeLog {
@@ -332,10 +339,10 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 		return LogTruncateCommand
 	default:
 		return ""
-	}	
+	}
 }
 
-//TODO: (Ris) move logic about truncate to elsewhere
+// TODO: (Ris) move logic about truncate to elsewhere
 // IsLogBackupSubCommandOntheCondition return whether the log subcommand on the condition.
 func IsLogBackupSubCommandOntheCondition(backup *Backup, conditionType BackupConditionType) bool {
 	command := ParseLogBackupSubcommand(backup)

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -321,30 +321,30 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	var subCommand LogSubCommandType
 
 	// Users can omit the LogSubcommand field and use the `LogStop` field to stop log backups as in older version.
-    if backup.Spec.LogSubcommand == "" {
-        if backup.Spec.LogStop || IsLogBackupAlreadyStop(backup) {
-            subCommand = LogStopCommand
-        } else if IsLogBackupAlreadyPaused(backup){
-            subCommand = LogResumeCommand
-        } else {
+	if backup.Spec.LogSubcommand == "" {
+		if backup.Spec.LogStop || IsLogBackupAlreadyStop(backup) {
+			subCommand = LogStopCommand
+		} else if IsLogBackupAlreadyPaused(backup) {
+			subCommand = LogResumeCommand
+		} else {
 			subCommand = LogStartCommand
 		}
-    } else {
-        switch backup.Spec.LogSubcommand {
-        case LogStartCommand:
-            if IsLogBackupAlreadyPaused(backup) {
-                subCommand = LogResumeCommand
-            } else {
-                subCommand = LogStartCommand
-            }
-        case LogStopCommand:
-            subCommand = LogStopCommand
-        case LogPauseCommand:
-            subCommand = LogPauseCommand
-        default:
-            return LogUnknownCommand
-        }
-    }
+	} else {
+		switch backup.Spec.LogSubcommand {
+		case LogStartCommand:
+			if IsLogBackupAlreadyPaused(backup) {
+				subCommand = LogResumeCommand
+			} else {
+				subCommand = LogStartCommand
+			}
+		case LogStopCommand:
+			subCommand = LogStopCommand
+		case LogPauseCommand:
+			subCommand = LogPauseCommand
+		default:
+			return LogUnknownCommand
+		}
+	}
 
 	// If the selected subcommand is already sync and logTruncateUntil is set, switch to LogTruncateCommand
 	if IsLogSubcommandAlreadySync(backup, subCommand) && backup.Spec.LogTruncateUntil != "" && backup.Spec.LogTruncateUntil != backup.Status.LogSuccessTruncateUntil {

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -371,7 +371,7 @@ func IsLogSubcommandAlreadySync(backup *Backup, subCommand LogSubCommandType) bo
 func IsLogBackupSubCommandOntheCondition(backup *Backup, conditionType BackupConditionType) bool {
 	command := ParseLogBackupSubcommand(backup)
 	switch command {
-	case LogStartCommand, LogStopCommand:
+	case LogStartCommand, LogStopCommand, LogPauseCommand, LogResumeCommand:
 		if subStatus, ok := backup.Status.LogSubCommandStatuses[command]; ok {
 			return subStatus.Phase == conditionType
 		}

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -320,7 +320,7 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 
 	// Compatible with the old version
 	if backup.Spec.LogStop {
-		if IsLogSubcommandAlreadySync(backup, LogStopCommand) && backup.Spec.LogTruncateUntil != "" {
+		if IsLogBackupAlreadyStop(backup) && backup.Spec.LogTruncateUntil != "" && backup.Spec.LogTruncateUntil != backup.Status.LogSuccessTruncateUntil {
 			return LogTruncateCommand
 		}
 		return LogStopCommand
@@ -345,7 +345,7 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	}
 
 	// If the selected subcommand is already sync and logTruncateUntil is set, switch to LogTruncateCommand
-	if IsLogSubcommandAlreadySync(backup, subCommand) && backup.Spec.LogTruncateUntil != "" {
+	if IsLogSubcommandAlreadySync(backup, subCommand) && backup.Spec.LogTruncateUntil != "" && backup.Spec.LogTruncateUntil != backup.Status.LogSuccessTruncateUntil {
 		return LogTruncateCommand
 	}
 

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -320,28 +320,26 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 
 	var subCommand LogSubCommandType
 
+	switch backup.Spec.LogSubcommand {
 	// Users can omit the LogSubcommand field and use the `LogStop` field to stop log backups as in older version.
-	if backup.Spec.LogSubcommand == "" {
+	case "":
 		if backup.Spec.LogStop || IsLogBackupAlreadyStop(backup) {
 			subCommand = LogStopCommand
 		} else {
 			subCommand = LogStartCommand
 		}
-	} else {
-		switch backup.Spec.LogSubcommand {
-		case LogStartCommand:
-			if IsLogBackupAlreadyPaused(backup) {
-				subCommand = LogResumeCommand
-			} else {
-				subCommand = LogStartCommand
-			}
-		case LogStopCommand:
-			subCommand = LogStopCommand
-		case LogPauseCommand:
-			subCommand = LogPauseCommand
-		default:
-			return LogUnknownCommand
+	case LogStartCommand:
+		if IsLogBackupAlreadyPaused(backup) {
+			subCommand = LogResumeCommand
+		} else {
+			subCommand = LogStartCommand
 		}
+	case LogStopCommand:
+		subCommand = LogStopCommand
+	case LogPauseCommand:
+		subCommand = LogPauseCommand
+	default:
+		return LogUnknownCommand
 	}
 
 	// If the selected subcommand is already sync and logTruncateUntil is set, switch to LogTruncateCommand

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -391,10 +391,7 @@ func GetLogSubcommandConditionInfo(backup *Backup) (reason, message string) {
 
 // IsLogBackupAlreadyStart return whether log backup has already started.
 func IsLogBackupAlreadyStart(backup *Backup) bool {
-	if backup.Spec.Mode != BackupModeLog || backup.Status.CommitTs == "" {
-		return false
-	}
-	return backup.Status.Phase == BackupRunning
+	return backup.Spec.Mode == BackupModeLog && backup.Status.CommitTs != ""
 }
 
 // IsLogBackupAlreadyTruncate return whether log backup has already truncated.
@@ -428,6 +425,6 @@ func IsLogBackupAlreadyPaused(backup *Backup) bool {
 }
 
 // IsLogBackupAlreadyRestart return whether log backup has already resumed.
-func IsLogBackupAlreadyResumed(backup *Backup) bool {
+func IsLogBackupAlreadyRunning(backup *Backup) bool {
 	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupRunning
 }

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -321,15 +321,21 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	if backup.Spec.Mode != BackupModeLog {
 		return ""
 	}
-	if backup.Spec.LogStop {
+	switch backup.Spec.LogSubcommand {
+	case "log-start":
+		return LogStartCommand
+	case "log-stop":
 		return LogStopCommand
-	}
-	if backup.Spec.LogTruncateUntil != "" {
+	case "log-pause":
+		return LogPauseCommand
+	case "log-truncate":
 		return LogTruncateCommand
-	}
-	return LogStartCommand
+	default:
+		return ""
+	}	
 }
 
+//TODO: (Ris) move logic about truncate to elsewhere
 // IsLogBackupSubCommandOntheCondition return whether the log subcommand on the condition.
 func IsLogBackupSubCommandOntheCondition(backup *Backup, conditionType BackupConditionType) bool {
 	command := ParseLogBackupSubcommand(backup)

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -414,3 +414,14 @@ func IsLogBackupAlreadyTruncate(backup *Backup) bool {
 func IsLogBackupAlreadyStop(backup *Backup) bool {
 	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupStopped
 }
+
+// IsLogBackupAlreadyStop return whether log backup has already paused.
+//TODO: (Ris) deal with task stopped
+func IsLogBackupAlreadyPaused(backup *Backup) bool {
+	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupPaused
+}
+
+// IsLogBackupAlreadyRestart return whether log backup has already resumed.
+func IsLogBackupAlreadyResumed(backup *Backup) bool {
+	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupRestart
+}

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -349,8 +349,6 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 		subCommand = LogStopCommand
 	case "log-pause":
 		subCommand = LogPauseCommand
-	case "log-truncate":
-		subCommand = LogTruncateCommand
 	default:
 		subCommand = LogStartCommand
 	}

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -353,7 +353,7 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 }
 
 // IsLogSubcommandAlreadySync return whether the log subcommand already sync.
-// It only check start/stop/pause subcommand. Truncate subcommand need to check the `logTruncateUntil` seperately.
+// It only check start/stop/pause subcommand. Truncate subcommand need to check the `logTruncateUntil` separately.
 func IsLogSubcommandAlreadySync(backup *Backup, subCommand LogSubCommandType) bool {
 	switch subCommand {
 	case LogStartCommand:

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -330,15 +330,15 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	switch backup.Spec.LogSubcommand {
 	case "":
 		fallthrough
-	case "log-start":
+	case LogStartCommand:
 		if IsLogBackupAlreadyPaused(backup) {
 			subCommand = LogResumeCommand
 		} else {
 			subCommand = LogStartCommand
 		}
-	case "log-stop":
+	case LogStopCommand:
 		subCommand = LogStopCommand
-	case "log-pause":
+	case LogPauseCommand:
 		subCommand = LogPauseCommand
 	default:
 		return LogUnknownCommand

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -324,8 +324,6 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 	if backup.Spec.LogSubcommand == "" {
 		if backup.Spec.LogStop || IsLogBackupAlreadyStop(backup) {
 			subCommand = LogStopCommand
-		} else if IsLogBackupAlreadyPaused(backup) {
-			subCommand = LogResumeCommand
 		} else {
 			subCommand = LogStartCommand
 		}

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -201,11 +201,20 @@ func IsBackupScheduled(backup *Backup) bool {
 	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
+// HaveTruncateUntil returns true if a Backup has truncate until set
 func HaveTruncateUntil(backup *Backup) bool {
 	if backup.Spec.Mode != BackupModeLog {
 		return false
 	}
 	return backup.Spec.LogTruncateUntil != ""
+}
+
+func IsBackupPaused(backup *Backup) bool {
+	if backup.Spec.Mode == BackupModeLog {
+		return IsLogBackupSubCommandOntheCondition(backup, BackupPaused)
+	}
+	_, condition := GetBackupCondition(&backup.Status, BackupPaused)
+	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
 // IsBackupRunning returns true if a Backup is Running.

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -391,7 +391,10 @@ func GetLogSubcommandConditionInfo(backup *Backup) (reason, message string) {
 
 // IsLogBackupAlreadyStart return whether log backup has already started.
 func IsLogBackupAlreadyStart(backup *Backup) bool {
-	return backup.Spec.Mode == BackupModeLog && backup.Status.CommitTs != ""
+	if backup.Spec.Mode != BackupModeLog || backup.Status.CommitTs == "" {
+		return false
+	}
+	return backup.Status.Phase == BackupRunning
 }
 
 // IsLogBackupAlreadyTruncate return whether log backup has already truncated.
@@ -426,5 +429,5 @@ func IsLogBackupAlreadyPaused(backup *Backup) bool {
 
 // IsLogBackupAlreadyRestart return whether log backup has already resumed.
 func IsLogBackupAlreadyResumed(backup *Backup) bool {
-	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupRestart
+	return backup.Spec.Mode == BackupModeLog && backup.Status.Phase == BackupRunning
 }

--- a/pkg/apis/pingcap/v1alpha1/backup.go
+++ b/pkg/apis/pingcap/v1alpha1/backup.go
@@ -328,6 +328,8 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 
 	var subCommand LogSubCommandType
 	switch backup.Spec.LogSubcommand {
+	case "":
+		fallthrough
 	case "log-start":
 		if IsLogBackupAlreadyPaused(backup) {
 			subCommand = LogResumeCommand
@@ -338,8 +340,6 @@ func ParseLogBackupSubcommand(backup *Backup) LogSubCommandType {
 		subCommand = LogStopCommand
 	case "log-pause":
 		subCommand = LogPauseCommand
-	case "":
-		subCommand = LogStartCommand
 	default:
 		return LogUnknownCommand
 	}

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1079,6 +1079,13 @@ func schema_pkg_apis_pingcap_v1alpha1_BackupSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"logSubcommand": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subcommand is the subcommand for BR, such as start, stop, pause etc.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"logTruncateUntil": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LogTruncateUntil is log backup truncate until timestamp. Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1879,7 +1879,6 @@ type TLSCluster struct {
 // +kubebuilder:printcolumn:name="Completed",type=date,JSONPath=`.status.timeCompleted`,description="The time at which the backup was completed",priority=1
 // +kubebuilder:printcolumn:name="TimeTaken",type=string,JSONPath=`.status.timeTaken`,description="The time that the backup takes"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-// +kubebuilder:validation:OneOf={"logSubCommand", "logStop"}
 type Backup struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
@@ -2409,6 +2408,8 @@ const (
 	LogPauseCommand LogSubCommandType = "log-pause"
 	// LogResumeCommand is the resume command of log backup.
 	LogResumeCommand LogSubCommandType = "log-resume"
+	// LogUnknownCommand is the unknown command of log backup.
+	LogUnknownCommand LogSubCommandType = "log-unknown"
 )
 
 // LogSubCommandStatus is the log backup subcommand's status.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2181,7 +2181,7 @@ type BackupSpec struct {
 	CommitTs string `json:"commitTs,omitempty"`
 	// Subcommand is the subcommand for BR, such as start, stop, pause etc.
 	// +optional
-	// +kubebuilder:validation:Enum:="";"log-start";"log-stop";"log-pause"
+	// +kubebuilder:validation:Enum:="log-start";"log-stop";"log-pause"
 	LogSubcommand LogSubCommandType `json:"logSubcommand,omitempty"`
 	// LogTruncateUntil is log backup truncate until timestamp.
 	// Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2354,6 +2354,9 @@ const (
 	BackupComplete BackupConditionType = "Complete"
 	// BackupClean means the clean job has been created to clean backup data
 	BackupClean BackupConditionType = "Clean"
+	// BackupRepeatable should ONLY be used in log backup
+	// It means some log backup sub-command completed and the log backup can be re-run
+	BackupRepeatable BackupConditionType = "Repeatable"
 	// BackupFailed means the backup has failed.
 	BackupFailed BackupConditionType = "Failed"
 	// BackupRetryTheFailed means this failure can be retried

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -1879,6 +1879,7 @@ type TLSCluster struct {
 // +kubebuilder:printcolumn:name="Completed",type=date,JSONPath=`.status.timeCompleted`,description="The time at which the backup was completed",priority=1
 // +kubebuilder:printcolumn:name="TimeTaken",type=string,JSONPath=`.status.timeTaken`,description="The time that the backup takes"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:validation:OneOf={"logSubCommand", "logStop"}
 type Backup struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
@@ -2179,7 +2180,6 @@ type BackupSpec struct {
 	CommitTs string `json:"commitTs,omitempty"`
 	// Subcommand is the subcommand for BR, such as start, stop, pause etc.
 	// +optional
-	// +kubebuilder:default="log-start"
 	LogSubcommand string `json:"logSubcommand,omitempty"`
 	// LogTruncateUntil is log backup truncate until timestamp.
 	// Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2131,6 +2131,8 @@ type Progress struct {
 
 // BackupSpec contains the backup specification for a tidb cluster.
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="has(self.logSubcommand) ? !has(self.logStop) : true",message="Field `logStop` is the old version field, please use `logSubcommand` instead"
+// +kubebuilder:validation:XValidation:rule="has(self.logStop) ? !has(self.logSubcommand) : true",message="Field `logStop` is the old version field, please use `logSubcommand` instead"
 type BackupSpec struct {
 	corev1.ResourceRequirements `json:"resources,omitempty"`
 	// List of environment variables to set in the container, like v1.Container.Env.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2177,6 +2177,10 @@ type BackupSpec struct {
 	// Default is current timestamp.
 	// +optional
 	CommitTs string `json:"commitTs,omitempty"`
+	// Subcommand is the subcommand for BR, such as start, stop, pause etc.
+	// +optional
+	// +kubebuilder:default="start"
+	LogSubcommand string `json:"logSubcommand,omitempty"`
 	// LogTruncateUntil is log backup truncate until timestamp.
 	// Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.
 	// +optional
@@ -2397,6 +2401,8 @@ const (
 	LogTruncateCommand LogSubCommandType = "log-truncate"
 	// LogStopCommand is the stop command of log backup.
 	LogStopCommand LogSubCommandType = "log-stop"
+	// LogPauseCommand is the pause command of log backup.
+	LogPauseCommand LogSubCommandType = "log-pause"
 )
 
 // LogSubCommandStatus is the log backup subcommand's status.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2363,7 +2363,7 @@ const (
 	// BackupPrepare means the backup prepare backup process
 	BackupPrepare BackupConditionType = "Prepare"
 	// BackupPaused means the backup was paused
-	BackupPaused  BackupConditionType = "Paused"
+	BackupPaused BackupConditionType = "Paused"
 	// BackupStopped means the backup was stopped, just log backup has this condition
 	BackupStopped BackupConditionType = "Stopped"
 	// BackupRestart means the backup was restarted, now just support snapshot backup

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2181,7 +2181,8 @@ type BackupSpec struct {
 	CommitTs string `json:"commitTs,omitempty"`
 	// Subcommand is the subcommand for BR, such as start, stop, pause etc.
 	// +optional
-	LogSubcommand string `json:"logSubcommand,omitempty"`
+	// +kubebuilder:validation:Enum:="";"log-start";"log-stop";"log-pause"
+	LogSubcommand LogSubCommandType `json:"logSubcommand,omitempty"`
 	// LogTruncateUntil is log backup truncate until timestamp.
 	// Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.
 	// +optional

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2179,7 +2179,7 @@ type BackupSpec struct {
 	CommitTs string `json:"commitTs,omitempty"`
 	// Subcommand is the subcommand for BR, such as start, stop, pause etc.
 	// +optional
-	// +kubebuilder:default="start"
+	// +kubebuilder:default="log-start"
 	LogSubcommand string `json:"logSubcommand,omitempty"`
 	// LogTruncateUntil is log backup truncate until timestamp.
 	// Format supports TSO or datetime, e.g. '400036290571534337', '2018-05-11 01:42:23'.
@@ -2362,6 +2362,8 @@ const (
 	BackupInvalid BackupConditionType = "Invalid"
 	// BackupPrepare means the backup prepare backup process
 	BackupPrepare BackupConditionType = "Prepare"
+	// BackupPaused means the backup was paused
+	BackupPaused  BackupConditionType = "Paused"
 	// BackupStopped means the backup was stopped, just log backup has this condition
 	BackupStopped BackupConditionType = "Stopped"
 	// BackupRestart means the backup was restarted, now just support snapshot backup
@@ -2403,6 +2405,8 @@ const (
 	LogStopCommand LogSubCommandType = "log-stop"
 	// LogPauseCommand is the pause command of log backup.
 	LogPauseCommand LogSubCommandType = "log-pause"
+	// LogResumeCommand is the resume command of log backup.
+	LogResumeCommand LogSubCommandType = "log-resume"
 )
 
 // LogSubCommandStatus is the log backup subcommand's status.

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -1090,6 +1090,12 @@ func (bm *backupManager) skipLogBackupSync(backup *v1alpha1.Backup) (bool, error
 	switch command {
 	case v1alpha1.LogStartCommand:
 		skip = v1alpha1.IsLogBackupAlreadyStart(backup)
+	case v1alpha1.LogStopCommand:
+		skip = v1alpha1.IsLogBackupAlreadyStop(backup)
+	case v1alpha1.LogPauseCommand:
+		skip = v1alpha1.IsLogBackupAlreadyPaused(backup)
+	case v1alpha1.LogResumeCommand:
+		skip = !v1alpha1.IsLogBackupAlreadyResumed(backup)
 	case v1alpha1.LogTruncateCommand:
 		if v1alpha1.IsLogBackupAlreadyTruncate(backup) {
 			skip = true
@@ -1105,8 +1111,6 @@ func (bm *backupManager) skipLogBackupSync(backup *v1alpha1.Backup) (bool, error
 				Status:  corev1.ConditionTrue,
 			}, updateStatus)
 		}
-	case v1alpha1.LogStopCommand:
-		skip = v1alpha1.IsLogBackupAlreadyStop(backup)
 	default:
 		return false, nil
 	}

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -1095,7 +1095,7 @@ func (bm *backupManager) skipLogBackupSync(backup *v1alpha1.Backup) (bool, error
 	case v1alpha1.LogPauseCommand:
 		skip = v1alpha1.IsLogBackupAlreadyPaused(backup)
 	case v1alpha1.LogResumeCommand:
-		skip = !v1alpha1.IsLogBackupAlreadyResumed(backup)
+		skip = !v1alpha1.IsLogBackupAlreadyRunning(backup)
 	case v1alpha1.LogTruncateCommand:
 		if v1alpha1.IsLogBackupAlreadyTruncate(backup) {
 			skip = true

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -161,7 +161,6 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 	var job *batchv1.Job
 	var reason string
 	var updateStatus *controller.BackupUpdateStatus
-	//TODO: (Ris)modify the backupJobs
 	if job, updateStatus, reason, err = bm.makeBackupJob(backup); err != nil {
 		klog.Errorf("backup %s/%s create job %s failed, reason is %s, error %v.", ns, name, backupJobName, reason, err)
 		return err
@@ -1095,7 +1094,7 @@ func (bm *backupManager) skipLogBackupSync(backup *v1alpha1.Backup) (bool, error
 	case v1alpha1.LogPauseCommand:
 		skip = v1alpha1.IsLogBackupAlreadyPaused(backup)
 	case v1alpha1.LogResumeCommand:
-		skip = !v1alpha1.IsLogBackupAlreadyRunning(backup)
+		skip = v1alpha1.IsLogBackupAlreadyRunning(backup)
 	case v1alpha1.LogTruncateCommand:
 		if v1alpha1.IsLogBackupAlreadyTruncate(backup) {
 			skip = true
@@ -1240,7 +1239,7 @@ func shouldLogBackupCommandRequeue(backup *v1alpha1.Backup) bool {
 	}
 	command := v1alpha1.ParseLogBackupSubcommand(backup)
 
-	if command == v1alpha1.LogTruncateCommand || command == v1alpha1.LogStopCommand {
+	if command == v1alpha1.LogTruncateCommand || command == v1alpha1.LogStopCommand || command == v1alpha1.LogPauseCommand {
 		return backup.Status.CommitTs == ""
 	}
 	return false

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -191,11 +191,23 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 func (bm *backupManager) validateBackup(backup *v1alpha1.Backup) error {
 	ns := backup.GetNamespace()
 	name := backup.GetName()
-	logBackupSubcommand := v1alpha1.ParseLogBackupSubcommand(backup)
 	var err error
+	logBackupSubcommand := v1alpha1.ParseLogBackupSubcommand(backup)
 	if backup.Spec.BR == nil {
 		err = backuputil.ValidateBackup(backup, "", nil)
 	} else {
+		if backup.Spec.Mode == v1alpha1.BackupModeLog && logBackupSubcommand == v1alpha1.LogUnknownCommand {
+			err = fmt.Errorf("log backup %s/%s subcommand `%s` is not supported", ns, name, backup.Spec.LogSubcommand)	
+			bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
+				Command: logBackupSubcommand,
+				Type:    v1alpha1.BackupRetryTheFailed,
+				Status:  corev1.ConditionTrue,
+				Reason:  err.Error(),
+				Message: err.Error(),
+			}, nil)		
+			return err
+		}
+
 		backupNamespace := backup.GetNamespace()
 		if backup.Spec.BR.ClusterNamespace != "" {
 			backupNamespace = backup.Spec.BR.ClusterNamespace

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -197,14 +197,14 @@ func (bm *backupManager) validateBackup(backup *v1alpha1.Backup) error {
 		err = backuputil.ValidateBackup(backup, "", nil)
 	} else {
 		if backup.Spec.Mode == v1alpha1.BackupModeLog && logBackupSubcommand == v1alpha1.LogUnknownCommand {
-			err = fmt.Errorf("log backup %s/%s subcommand `%s` is not supported", ns, name, backup.Spec.LogSubcommand)	
+			err = fmt.Errorf("log backup %s/%s subcommand `%s` is not supported", ns, name, backup.Spec.LogSubcommand)
 			bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
 				Command: logBackupSubcommand,
 				Type:    v1alpha1.BackupRetryTheFailed,
 				Status:  corev1.ConditionTrue,
 				Reason:  err.Error(),
 				Message: err.Error(),
-			}, nil)		
+			}, nil)
 			return err
 		}
 

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -161,6 +161,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 	var job *batchv1.Job
 	var reason string
 	var updateStatus *controller.BackupUpdateStatus
+	//TODO: (Ris)modify the backupJobs
 	if job, updateStatus, reason, err = bm.makeBackupJob(backup); err != nil {
 		klog.Errorf("backup %s/%s create job %s failed, reason is %s, error %v.", ns, name, backupJobName, reason, err)
 		return err

--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -168,6 +168,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 	}
 
 	// create k8s job
+	klog.Infof("backup %s/%s creating job %s.", ns, name, backupJobName)
 	if err := bm.deps.JobControl.CreateJob(backup, job); err != nil {
 		errMsg := fmt.Errorf("create backup %s/%s job %s failed, err: %v", ns, name, backupJobName, err)
 		bm.statusUpdater.Update(backup, &v1alpha1.BackupCondition{

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -240,8 +240,16 @@ func (c *Controller) updateBackup(cur interface{}) {
 		return
 	}
 
+
 	klog.V(4).Infof("backup object %s/%s enqueue", ns, name)
 	c.enqueueBackup(newBackup)
+
+	//For log backup with truncate, we need to create a truncate job
+	if v1alpha1.HaveTruncateUntil(newBackup) {
+		truncateTask := newBackup.DeepCopy()
+		truncateTask.Spec.LogSubcommand = string(v1alpha1.LogTruncateCommand)
+		c.enqueueBackup(truncateTask)
+	}
 }
 
 func (c *Controller) deleteJob(obj interface{}) {

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -208,7 +208,7 @@ func (c *Controller) updateBackup(cur interface{}) {
 		return
 	}
 
-	// TODO: log backup check all subcommand job's pod status
+	// TODO: (Ris)log backup check all subcommand job's pod status
 	if newBackup.Spec.Mode != v1alpha1.BackupModeLog {
 		// we will create backup job when we mark backup as scheduled status,
 		// but the backup job or its pod may failed due to insufficient resources or other reasons in k8s,

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -234,7 +234,7 @@ func (c *Controller) updateBackup(cur interface{}) {
 		return
 	}
 
-	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsLogBackupStopped(newBackup) {
+	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsLogBackupAlreadyStop(newBackup) {
 		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing or Failed, skipping.", ns, name)
 		return
 	}

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -234,7 +234,7 @@ func (c *Controller) updateBackup(cur interface{}) {
 		return
 	}
 
-	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsLogBackupAlreadyStop(newBackup) {
+	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsBackupFailed(newBackup) {
 		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing or Failed, skipping.", ns, name)
 		return
 	}

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -155,6 +155,7 @@ func (c *Controller) sync(key string) (err error) {
 		return err
 	}
 
+	klog.Infof("Syncing Backup %s/%s", ns, name)
 	return c.syncBackup(backup.DeepCopy())
 }
 
@@ -167,16 +168,9 @@ func (c *Controller) updateBackup(cur interface{}) {
 	ns := newBackup.GetNamespace()
 	name := newBackup.GetName()
 
-	//For log backup with truncate, we need to create a truncate job
-	if newBackup.Spec.LogSubcommand != string(v1alpha1.LogTruncateCommand) && v1alpha1.HaveTruncateUntil(newBackup) {
-		truncateTask := newBackup.DeepCopy()
-		truncateTask.Spec.LogSubcommand = string(v1alpha1.LogTruncateCommand)
-		defer c.updateBackup(truncateTask)
-	}
-
 	if newBackup.DeletionTimestamp != nil {
 		// the backup is being deleted, we need to do some cleanup work, enqueue backup.
-		klog.Infof("backup %s/%s - %s is being deleted", ns, name, string(newBackup.Spec.LogSubcommand))
+		klog.Infof("backup %s/%s is being deleted", ns, name)
 		c.enqueueBackup(newBackup)
 		return
 	}

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -155,7 +155,6 @@ func (c *Controller) sync(key string) (err error) {
 		return err
 	}
 
-	klog.Infof("Syncing Backup %s/%s", ns, name)
 	return c.syncBackup(backup.DeepCopy())
 }
 
@@ -238,10 +237,6 @@ func (c *Controller) updateBackup(cur interface{}) {
 	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsLogBackupStopped(newBackup) {
 		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing or Failed, skipping.", ns, name)
 		return
-	}
-
-	if newBackup.Spec.Mode == v1alpha1.BackupModeLog && newBackup.Spec.LogSubcommand == string(v1alpha1.LogStartCommand) && v1alpha1.IsBackupPaused(newBackup) {
-		newBackup.Spec.LogSubcommand = string(v1alpha1.LogResumeCommand)
 	}
 
 	klog.V(4).Infof("backup object %s/%s enqueue", ns, name)

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -254,6 +254,7 @@ func updateLogSubcommandStatus(backup *v1alpha1.Backup, condition *v1alpha1.Back
 }
 
 // updateWholeLogBackupStatus updates the whole log backup status.
+//TODO: (Ris) add more states
 func updateWholeLogBackupStatus(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *BackupUpdateStatus) bool {
 	// call real update interface to update whole status
 	doUpdateStatusAndCondition := func(newCondition *v1alpha1.BackupCondition, newStatus *BackupUpdateStatus) bool {

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -209,7 +209,6 @@ func updateSnapshotBackupStatus(backup *v1alpha1.Backup, condition *v1alpha1.Bac
 
 // updateLogBackupStatus update log backup status.
 // it will update both the log backup sub command status and the whole log backup status.
-//TODO: (Ris) add more states here
 func updateLogBackupStatus(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, newStatus *BackupUpdateStatus) bool {
 	// update whole backup status
 	isWholeStatusUpdate := updateWholeLogBackupStatus(backup, condition, newStatus)

--- a/pkg/controller/backup_status_updater.go
+++ b/pkg/controller/backup_status_updater.go
@@ -248,6 +248,12 @@ func updateLogSubcommandStatus(backup *v1alpha1.Backup, condition *v1alpha1.Back
 	subcomandConditionUpdate := updateLogSubCommandConditionOnly(&subStatus, condition)
 	if subcommandStatusUpdate || subcomandConditionUpdate {
 		backup.Status.LogSubCommandStatuses[condition.Command] = subStatus
+		if condition.Command == v1alpha1.LogPauseCommand {
+			delete(backup.Status.LogSubCommandStatuses, v1alpha1.LogResumeCommand)
+		}
+		if condition.Command == v1alpha1.LogResumeCommand {
+			delete(backup.Status.LogSubCommandStatuses, v1alpha1.LogPauseCommand)
+		}
 		return true
 	}
 	return false

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -413,7 +413,6 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Truncate log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
-				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
@@ -423,7 +422,6 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Truncate log backup again")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
-				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
@@ -442,7 +440,6 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Truncate log backup after stop")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
-				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -404,6 +404,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Start log backup")
 			backup, err := createBackupAndWaitForComplete(f, backupName, backupClusterName, typ, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = "log-start"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 			})
@@ -412,6 +413,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Truncate log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
@@ -421,6 +423,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Truncate log backup again")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
@@ -430,19 +433,19 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Stop log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = "log-stop"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
-				backup.Spec.LogStop = true
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupStopped)
 
 			ginkgo.By("Truncate log backup after stop")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = "log-truncate"
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
-				backup.Spec.LogStop = false
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -378,7 +378,85 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 	})
 
 	ginkgo.Context("Log Backup Test", func() {
-		ginkgo.It("start,truncate,stop log backup", func() {
+		ginkgo.It("start,truncate,stop log backup using old interface", func() {
+			backupClusterName := "log-backup"
+			backupVersion := utilimage.TiDBLatest
+			enableTLS := false
+			skipCA := false
+			backupName := backupClusterName
+			typ := strings.ToLower(typeBR)
+
+			ns := f.Namespace.Name
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ginkgo.By("Create log-backup.enable TiDB cluster for log backup")
+			err := createLogBackupEnableTidbCluster(f, backupClusterName, backupVersion, enableTLS, skipCA)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Wait for backup TiDB cluster ready")
+			err = utiltidbcluster.WaitForTCConditionReady(f.ExtClient, ns, backupClusterName, tidbReadyTimeout, 0)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Create RBAC for log backup")
+			err = createRBAC(f)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Start log backup")
+			backup, err := createBackupAndWaitForComplete(f, backupName, backupClusterName, typ, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectNotEqual(backup.Status.CommitTs, "")
+
+			ginkgo.By("Truncate log backup")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)
+
+			ginkgo.By("Truncate log backup again")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)
+
+			ginkgo.By("Stop log backup")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogStop = true
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupStopped)
+
+			ginkgo.By("Truncate log backup after stop")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogTruncateUntil = time.Now().Format(time.RFC3339)
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)
+
+			ginkgo.By("Delete backup")
+			err = deleteBackup(f, backupName)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Check if all backup files in storage is deleted")
+			cleaned, err := f.Storage.IsDataCleaned(ctx, ns, backup.Spec.S3.Prefix) // now we only use s3
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(cleaned, true, "storage should be cleaned")
+		})
+
+		ginkgo.It("start -> pause -> resume -> pause -> resume -> stop log backup", func() {
 			backupClusterName := "log-backup"
 			backupVersion := utilimage.TiDBLatest
 			enableTLS := false
@@ -420,6 +498,15 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)
 
+			ginkgo.By("Pause log backup")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogSubcommand = "log-pause"
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupPaused)
+
 			ginkgo.By("Truncate log backup again")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
@@ -428,6 +515,33 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.LogSuccessTruncateUntil, backup.Spec.LogTruncateUntil)
+
+			ginkgo.By("resume log backup")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogSubcommand = "log-start"
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupRunning)
+
+			ginkgo.By("Pause log backup again")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogSubcommand = "log-pause"
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupPaused)
+
+			ginkgo.By("resume log backup again")
+			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
+				backup.Spec.Mode = v1alpha1.BackupModeLog
+				backup.Spec.LogSubcommand = "log-start"
+			})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupRunning)
 
 			ginkgo.By("Stop log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {

--- a/tests/e2e/br/br.go
+++ b/tests/e2e/br/br.go
@@ -482,7 +482,7 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Start log backup")
 			backup, err := createBackupAndWaitForComplete(f, backupName, backupClusterName, typ, func(backup *v1alpha1.Backup) {
-				backup.Spec.LogSubcommand = "log-start"
+				backup.Spec.LogSubcommand = v1alpha1.LogStartCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 			})
@@ -500,9 +500,9 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("Pause log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = v1alpha1.LogPauseCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
-				backup.Spec.LogSubcommand = "log-pause"
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupPaused)
@@ -518,34 +518,34 @@ var _ = ginkgo.Describe("Backup and Restore", func() {
 
 			ginkgo.By("resume log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = v1alpha1.LogStartCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
-				backup.Spec.LogSubcommand = "log-start"
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupRunning)
 
 			ginkgo.By("Pause log backup again")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = v1alpha1.LogPauseCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
-				backup.Spec.LogSubcommand = "log-pause"
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupPaused)
 
 			ginkgo.By("resume log backup again")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
+				backup.Spec.LogSubcommand = v1alpha1.LogStartCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
-				backup.Spec.LogSubcommand = "log-start"
 			})
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(backup.Status.Phase, v1alpha1.BackupRunning)
 
 			ginkgo.By("Stop log backup")
 			backup, err = continueLogBackupAndWaitForComplete(f, backup, func(backup *v1alpha1.Backup) {
-				backup.Spec.LogSubcommand = "log-stop"
+				backup.Spec.LogSubcommand = v1alpha1.LogStopCommand
 				backup.Spec.CleanPolicy = v1alpha1.CleanPolicyTypeDelete
 				backup.Spec.Mode = v1alpha1.BackupModeLog
 			})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Closes #5699 

1. Use a more straight forward operator interface to replace the old one.
2. support pause and resume pitr task

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Now, the crd to control log backup would loops like
```spec:
  backupMode: log
  logSubcommand: log-start/log-stop/log-pause
  logTruncateUntil: "xxxxxxxxx"
```
(If no subcommand is provided, the default value is `log-start`)

If the task is not created before:
It could transfer to `running` state using `log-start`

If the task is running:
It could transfer to `paused` state using `log-pause`
It could transfer to `stop` state using `log-stop`

If the task is paused:
It could transfer to `running` state using `log-start`
It could transfer to `stop` state using `log-stop`

If the task is stopped:
This is the end state and can't transfer state again

As long as the task is created, user could set `logTruncateUntil` and truncate would be sync after subcommand is done

<img width="1031" alt="截屏2024-09-02 17 50 46" src="https://github.com/user-attachments/assets/37d2c49c-04a6-44f3-aa5e-bda5f26b9598">


### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
1. Use a more straight forward operator interface to replace the old one.
Now, the crd to control log backup would loops like
`spec:
  backupMode: log
  logSubcommand: `log-start`/`log-stop`/`log-pause`
  logTruncateUntil: "xxxxxxxxx"
`
(If no subcommand is provided, the default value is `log-start`)

2. Support pause and resume pitr task
Now, users could pause and resume pitr task by using `log-pause` and `log-start`
```
