### PR TITLE
br: add some log to record the CR we are processing

### DIFF
--- a/cmd/backup-manager/app/backup/manager.go
+++ b/cmd/backup-manager/app/backup/manager.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -95,6 +96,13 @@ func (bm *Manager) ProcessBackup() error {
 		return errorutils.NewAggregate(errs)
 	}
 
+	crData, err := json.Marshal(backup)
+	if err != nil {
+		klog.Errorf("failed to marshal backup %v to json, err: %v", backup, err)
+	} else {
+		klog.Infof("start to process backup: %s", string(crData))
+	}
+
 	// we treat snapshot backup as restarted if its status is not scheduled when backup pod just start to run
 	// we will clean backup data before run br command
 	if backup.Spec.Mode == v1alpha1.BackupModeSnapshot && (backup.Status.Phase != v1alpha1.BackupScheduled || v1alpha1.IsBackupRestart(backup)) {
@@ -121,6 +129,9 @@ func (bm *Manager) ProcessBackup() error {
 		// skip the DB initialization if spec.from is not specified
 		return bm.performBackup(ctx, backup.DeepCopy(), nil)
 	}
+
+	klog.Infof("start to connect to tidb server (%s:%d) as the .spec.from field is specified",
+		backup.Spec.From.Host, backup.Spec.From.Port)
 
 	// validate and create from db
 	var db *sql.DB

--- a/cmd/backup-manager/app/export/manager.go
+++ b/cmd/backup-manager/app/export/manager.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -97,6 +98,13 @@ func (bm *BackupManager) ProcessBackup() error {
 		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
+	}
+
+	crData, err := json.Marshal(backup)
+	if err != nil {
+		klog.Errorf("failed to marshal backup %v to json, err: %v", backup, err)
+	} else {
+		klog.Infof("start to process backup: %s", string(crData))
 	}
 
 	reason, err := bm.setOptions(backup)

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -92,7 +92,7 @@ func (rm *RestoreManager) ProcessRestore() error {
 	if err != nil {
 		klog.Errorf("failed to marshal restore %v to json, err: %s", restore, err)
 	} else {
-		klog.Infof("start to process restore %s, %s", rm, string(crData))
+		klog.Infof("start to process restore: %s", string(crData))
 	}
 
 	rm.setOptions(restore)

--- a/cmd/backup-manager/app/import/manager.go
+++ b/cmd/backup-manager/app/import/manager.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog/v2"
 )
 
@@ -85,6 +86,13 @@ func (rm *RestoreManager) ProcessRestore() error {
 		}, nil)
 		errs = append(errs, uerr)
 		return errorutils.NewAggregate(errs)
+	}
+
+	crData, err := json.Marshal(restore)
+	if err != nil {
+		klog.Errorf("failed to marshal restore %v to json, err: %s", restore, err)
+	} else {
+		klog.Infof("start to process restore %s, %s", rm, string(crData))
 	}
 
 	rm.setOptions(restore)

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -96,11 +97,21 @@ func (rm *Manager) ProcessRestore() error {
 		return fmt.Errorf("no br config in %s", rm)
 	}
 
+	crData, err := json.Marshal(restore)
+	if err != nil {
+		klog.Errorf("failed to marshal restore %v to json, err: %s", restore, err)
+	} else {
+		klog.Infof("start to process restore %s, %s", rm, string(crData))
+	}
+
 	if restore.Spec.To == nil {
 		return rm.performRestore(ctx, restore.DeepCopy(), nil)
 	}
 
 	rm.setOptions(restore)
+
+	klog.Infof("start to connect to tidb server (%s:%d) as the .spec.to field is specified",
+		restore.Spec.To.Host, restore.Spec.To.Port)
 
 	var db *sql.DB
 	var dsn string

--- a/cmd/backup-manager/app/restore/manager.go
+++ b/cmd/backup-manager/app/restore/manager.go
@@ -101,7 +101,7 @@ func (rm *Manager) ProcessRestore() error {
 	if err != nil {
 		klog.Errorf("failed to marshal restore %v to json, err: %s", restore, err)
 	} else {
-		klog.Infof("start to process restore %s, %s", rm, string(crData))
+		klog.Infof("start to process restore: %s", string(crData))
 	}
 
 	if restore.Spec.To == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Add some log to record the CR we are processing, so that even the CR is deleted in K8s, we can still get this information from our log.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Backup **with** `.spec.from`

```
I0823 04:07:07.095130      15 backup.go:77] start to process backup default/bk-after-restart
I0823 04:07:07.096848      15 manager.go:103] start to process backup: {"kind":"Backup","apiVersion":"pingcap.com/v1alpha1","metadata":{"name":"bk-after-restart","namespace":"default","uid":"b0c40f67-71c9-48dd-9f6d-00cd16185fbb","resourceVersion":"6697723","generation":2,"creationTimestamp":"2024-08-23T04:07:05Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"pingcap.com/v1alpha1\",\"kind\":\"Backup\",\"metadata\":{\"annotations\":{},\"name\":\"bk-after-restart\",\"namespace\":\"default\"},\"spec\":{\"backupType\":\"full\",\"br\":{\"cluster\":\"basic\"},\"from\":{\"host\":\"basic-tidb.default.svc\",\"port\":4000,\"secretName\":\"tidb-secret\",\"user\":\"root\"},\"s3\":{\"bucket\":\"transfer\",\"endpoint\":\"https://s3.zhangxc.com\",\"prefix\":\"bk-after-restart\",\"provider\":\"aws\",\"region\":\"us-west-1\",\"secretName\":\"s3-secret\",\"storageClass\":\"STANDARD\"}}}\n"},"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T04:07:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:backupMode":{},"f:backupType":{},"f:br":{".":{},"f:cluster":{}},"f:from":{".":{},"f:host":{},"f:port":{},"f:secretName":{},"f:user":{}},"f:s3":{".":{},"f:bucket":{},"f:endpoint":{},"f:prefix":{},"f:provider":{},"f:region":{},"f:secretName":{},"f:storageClass":{}}}}},{"manager":"tidb-controller-manager","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T04:07:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:backoffRetryPolicy":{".":{},"f:maxRetryTimes":{},"f:minRetryDuration":{},"f:retryTimeout":{}},"f:resources":{}},"f:status":{".":{},"f:conditions":{},"f:phase":{},"f:timeCompleted":{},"f:timeStarted":{}}}}]},"spec":{"resources":{},"from":{"host":"basic-tidb.default.svc","port":4000,"user":"root","secretName":"tidb-secret"},"backupType":"full","backupMode":"snapshot","s3":{"provider":"aws","region":"us-west-1","bucket":"transfer","endpoint":"https://s3.zhangxc.com","storageClass":"STANDARD","secretName":"s3-secret","prefix":"bk-after-restart"},"br":{"cluster":"basic"},"backoffRetryPolicy":{"minRetryDuration":"300s","maxRetryTimes":2,"retryTimeout":"30m"}},"status":{"timeStarted":null,"timeCompleted":null,"phase":"Scheduled","conditions":[{"type":"Scheduled","status":"True","lastTransitionTime":"2024-08-23T04:07:05Z"}]}}
I0823 04:07:07.096876      15 manager.go:133] start to connect to tidb server (basic-tidb.default.svc:4000) as the .spec.from field is specified
```

Backup **without**  `.spec.from`

```
I0823 06:19:30.613517      15 backup.go:77] start to process backup default/bk-after-restart
I0823 06:19:30.616603      15 manager.go:103] start to process backup: {"kind":"Backup","apiVersion":"pingcap.com/v1alpha1","metadata":{"name":"bk-after-restart","namespace":"default","uid":"73c051f9-22fd-416f-bfa6-df255d44207f","resourceVersion":"6718147","generation":2,"creationTimestamp":"2024-08-23T06:19:28Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"pingcap.com/v1alpha1\",\"kind\":\"Backup\",\"metadata\":{\"annotations\":{},\"name\":\"bk-after-restart\",\"namespace\":\"default\"},\"spec\":{\"backupType\":\"full\",\"br\":{\"cluster\":\"basic\"},\"s3\":{\"bucket\":\"transfer\",\"endpoint\":\"https://s3.zhangxc.com\",\"prefix\":\"bk-after-restart\",\"provider\":\"aws\",\"region\":\"us-west-1\",\"secretName\":\"s3-secret\",\"storageClass\":\"STANDARD\"}}}\n"},"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:19:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:backupMode":{},"f:backupType":{},"f:br":{".":{},"f:cluster":{}},"f:s3":{".":{},"f:bucket":{},"f:endpoint":{},"f:prefix":{},"f:provider":{},"f:region":{},"f:secretName":{},"f:storageClass":{}}}}},{"manager":"tidb-controller-manager","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:19:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:backoffRetryPolicy":{".":{},"f:maxRetryTimes":{},"f:minRetryDuration":{},"f:retryTimeout":{}},"f:resources":{}},"f:status":{".":{},"f:conditions":{},"f:phase":{},"f:timeCompleted":{},"f:timeStarted":{}}}}]},"spec":{"resources":{},"backupType":"full","backupMode":"snapshot","s3":{"provider":"aws","region":"us-west-1","bucket":"transfer","endpoint":"https://s3.zhangxc.com","storageClass":"STANDARD","secretName":"s3-secret","prefix":"bk-after-restart"},"br":{"cluster":"basic"},"backoffRetryPolicy":{"minRetryDuration":"300s","maxRetryTimes":2,"retryTimeout":"30m"}},"status":{"timeStarted":null,"timeCompleted":null,"phase":"Scheduled","conditions":[{"type":"Scheduled","status":"True","lastTransitionTime":"2024-08-23T06:19:28Z"}]}}
```

---

Restore **with** `.spec.to`

```
I0823 06:40:21.039956      15 restore.go:79] start to process restore default/restore
I0823 06:40:21.042993      15 manager.go:105] start to process restore: {"kind":"Restore","apiVersion":"pingcap.com/v1alpha1","metadata":{"name":"restore","namespace":"default","uid":"f1e6d309-995c-40c4-8253-d1159669c2c7","resourceVersion":"6721380","generation":2,"creationTimestamp":"2024-08-23T06:40:17Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"pingcap.com/v1alpha1\",\"kind\":\"Restore\",\"metadata\":{\"annotations\":{},\"name\":\"restore\",\"namespace\":\"default\"},\"spec\":{\"br\":{\"cluster\":\"basic\"},\"s3\":{\"bucket\":\"transfer\",\"endpoint\":\"https://s3.zhangxc.com\",\"prefix\":\"bk-after-restart\",\"provider\":\"aws\",\"region\":\"us-west-1\",\"secretName\":\"s3-secret\",\"storageClass\":\"STANDARD\"},\"storageSize\":\"1Gi\",\"to\":{\"host\":\"basic-tidb.default.svc\",\"port\":4000,\"secretName\":\"tidb-secret\",\"user\":\"root\"}}}\n"},"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:40:17Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:br":{".":{},"f:cluster":{}},"f:restoreMode":{},"f:s3":{".":{},"f:bucket":{},"f:endpoint":{},"f:prefix":{},"f:provider":{},"f:region":{},"f:secretName":{},"f:storageClass":{}},"f:storageSize":{},"f:to":{".":{},"f:host":{},"f:port":{},"f:secretName":{},"f:user":{}}}}},{"manager":"tidb-controller-manager","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:40:17Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:pitrFullBackupStorageProvider":{},"f:resources":{}},"f:status":{".":{},"f:conditions":{},"f:phase":{},"f:timeCompleted":{},"f:timeStarted":{}}}}]},"spec":{"resources":{},"to":{"host":"basic-tidb.default.svc","port":4000,"user":"root","secretName":"tidb-secret"},"restoreMode":"snapshot","s3":{"provider":"aws","region":"us-west-1","bucket":"transfer","endpoint":"https://s3.zhangxc.com","storageClass":"STANDARD","secretName":"s3-secret","prefix":"bk-after-restart"},"pitrFullBackupStorageProvider":{},"storageSize":"1Gi","br":{"cluster":"basic"}},"status":{"timeStarted":null,"timeCompleted":null,"phase":"Scheduled","conditions":[{"type":"Scheduled","status":"True","lastTransitionTime":"2024-08-23T06:40:17Z"}]}}
I0823 06:40:21.043205      15 manager.go:115] start to connect to tidb server (basic-tidb.default.svc:4000) as the .spec.to field is specified
```

Restore **without** `.spec.to`

```
I0823 06:47:20.101781      15 restore.go:79] start to process restore default/restore
I0823 06:47:20.104161      15 manager.go:105] start to process restore: {"kind":"Restore","apiVersion":"pingcap.com/v1alpha1","metadata":{"name":"restore","namespace":"default","uid":"1b9c07c0-5349-4baa-9da2-70321b49f5a9","resourceVersion":"6722487","generation":2,"creationTimestamp":"2024-08-23T06:47:18Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"pingcap.com/v1alpha1\",\"kind\":\"Restore\",\"metadata\":{\"annotations\":{},\"name\":\"restore\",\"namespace\":\"default\"},\"spec\":{\"br\":{\"cluster\":\"basic\"},\"s3\":{\"bucket\":\"transfer\",\"endpoint\":\"https://s3.zhangxc.com\",\"prefix\":\"bk-after-restart\",\"provider\":\"aws\",\"region\":\"us-west-1\",\"secretName\":\"s3-secret\",\"storageClass\":\"STANDARD\"},\"storageSize\":\"1Gi\"}}\n"},"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:47:18Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:br":{".":{},"f:cluster":{}},"f:restoreMode":{},"f:s3":{".":{},"f:bucket":{},"f:endpoint":{},"f:prefix":{},"f:provider":{},"f:region":{},"f:secretName":{},"f:storageClass":{}},"f:storageSize":{}}}},{"manager":"tidb-controller-manager","operation":"Update","apiVersion":"pingcap.com/v1alpha1","time":"2024-08-23T06:47:18Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:pitrFullBackupStorageProvider":{},"f:resources":{}},"f:status":{".":{},"f:conditions":{},"f:phase":{},"f:timeCompleted":{},"f:timeStarted":{}}}}]},"spec":{"resources":{},"restoreMode":"snapshot","s3":{"provider":"aws","region":"us-west-1","bucket":"transfer","endpoint":"https://s3.zhangxc.com","storageClass":"STANDARD","secretName":"s3-secret","prefix":"bk-after-restart"},"pitrFullBackupStorageProvider":{},"storageSize":"1Gi","br":{"cluster":"basic"}},"status":{"timeStarted":null,"timeCompleted":null,"phase":"Scheduled","conditions":[{"type":"Scheduled","status":"True","lastTransitionTime":"2024-08-23T06:47:18Z"}]}}
```

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
