### PR TITLE
BR: support Azure blob storage sas token

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -3400,7 +3400,9 @@ string
 </em>
 </td>
 <td>
-<p>StorageAccount is the storage account of the azure blob storage</p>
+<p>StorageAccount is the storage account of the azure blob storage
+If this field is set, then use this to set backup-manager env
+Otherwise retrieve the storage account from secret</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -3394,6 +3394,28 @@ azblob service account credentials.</p>
 </tr>
 <tr>
 <td>
+<code>storageAccount</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>StorageAccount is the storage account of the azure blob storage</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sasToken</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SasToken is the sas token of the storage account</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>prefix</code></br>
 <em>
 string

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1187,7 +1187,11 @@ spec:
                     type: string
                   prefix:
                     type: string
+                  sasToken:
+                    type: string
                   secretName:
+                    type: string
+                  storageAccount:
                     type: string
                 type: object
               backoffRetryPolicy:
@@ -3603,7 +3607,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   backoffRetryPolicy:
@@ -5832,7 +5840,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   backoffRetryPolicy:
@@ -17214,7 +17226,11 @@ spec:
                     type: string
                   prefix:
                     type: string
+                  sasToken:
+                    type: string
                   secretName:
+                    type: string
+                  storageAccount:
                     type: string
                 type: object
               backupType:
@@ -18101,7 +18117,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   gcs:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackups.yaml
@@ -805,7 +805,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   br:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumebackupschedules.yaml
@@ -810,7 +810,11 @@ spec:
                             type: string
                           prefix:
                             type: string
+                          sasToken:
+                            type: string
                           secretName:
+                            type: string
+                          storageAccount:
                             type: string
                         type: object
                       br:

--- a/manifests/crd/federation/v1/federation.pingcap.com_volumerestores.yaml
+++ b/manifests/crd/federation/v1/federation.pingcap.com_volumerestores.yaml
@@ -61,7 +61,11 @@ spec:
                               type: string
                             prefix:
                               type: string
+                            sasToken:
+                              type: string
                             secretName:
+                              type: string
+                            storageAccount:
                               type: string
                           type: object
                         gcs:

--- a/manifests/crd/v1/pingcap.com_backups.yaml
+++ b/manifests/crd/v1/pingcap.com_backups.yaml
@@ -1187,7 +1187,11 @@ spec:
                     type: string
                   prefix:
                     type: string
+                  sasToken:
+                    type: string
                   secretName:
+                    type: string
+                  storageAccount:
                     type: string
                 type: object
               backoffRetryPolicy:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -1162,7 +1162,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   backoffRetryPolicy:
@@ -3391,7 +3395,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   backoffRetryPolicy:

--- a/manifests/crd/v1/pingcap.com_restores.yaml
+++ b/manifests/crd/v1/pingcap.com_restores.yaml
@@ -1160,7 +1160,11 @@ spec:
                     type: string
                   prefix:
                     type: string
+                  sasToken:
+                    type: string
                   secretName:
+                    type: string
+                  storageAccount:
                     type: string
                 type: object
               backupType:
@@ -2047,7 +2051,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   gcs:

--- a/manifests/federation-crd.yaml
+++ b/manifests/federation-crd.yaml
@@ -805,7 +805,11 @@ spec:
                         type: string
                       prefix:
                         type: string
+                      sasToken:
+                        type: string
                       secretName:
+                        type: string
+                      storageAccount:
                         type: string
                     type: object
                   br:
@@ -2638,7 +2642,11 @@ spec:
                             type: string
                           prefix:
                             type: string
+                          sasToken:
+                            type: string
                           secretName:
+                            type: string
+                          storageAccount:
                             type: string
                         type: object
                       br:
@@ -3674,7 +3682,11 @@ spec:
                               type: string
                             prefix:
                               type: string
+                            sasToken:
+                              type: string
                             secretName:
+                              type: string
+                            storageAccount:
                               type: string
                           type: object
                         gcs:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -582,7 +582,7 @@ func schema_pkg_apis_pingcap_v1alpha1_AzblobStorageProvider(ref common.Reference
 					},
 					"storageAccount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StorageAccount is the storage account of the azure blob storage",
+							Description: "StorageAccount is the storage account of the azure blob storage If this field is set, then use this to set backup-manager env Otherwise retrieve the storage account from secret",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -580,6 +580,20 @@ func schema_pkg_apis_pingcap_v1alpha1_AzblobStorageProvider(ref common.Reference
 							Format:      "",
 						},
 					},
+					"storageAccount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StorageAccount is the storage account of the azure blob storage",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"sasToken": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SasToken is the sas token of the storage account",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"prefix": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Prefix of the data path.",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2013,6 +2013,8 @@ type AzblobStorageProvider struct {
 	// azblob service account credentials.
 	SecretName string `json:"secretName,omitempty"`
 	// StorageAccount is the storage account of the azure blob storage
+	// If this field is set, then use this to set backup-manager env
+	// Otherwise retrieve the storage account from secret
 	StorageAccount string `json:"storageAccount,omitempty"`
 	// SasToken is the sas token of the storage account
 	SasToken string `json:"sasToken,omitempty"`

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2012,6 +2012,10 @@ type AzblobStorageProvider struct {
 	// SecretName is the name of secret which stores the
 	// azblob service account credentials.
 	SecretName string `json:"secretName,omitempty"`
+	// StorageAccount is the storage account of the azure blob storage
+	StorageAccount string `json:"storageAccount,omitempty"`
+	// SasToken is the sas token of the storage account
+	SasToken string `json:"sasToken,omitempty"`
 	// Prefix of the data path.
 	Prefix string `json:"prefix,omitempty"`
 }

--- a/pkg/backup/util/util.go
+++ b/pkg/backup/util/util.go
@@ -184,7 +184,7 @@ func generateGcsCertEnvVar(gcs *v1alpha1.GcsStorageProvider) ([]corev1.EnvVar, s
 }
 
 // generateAzblobCertEnvVar generate the env info in order to access azure blob storage
-func generateAzblobCertEnvVar(azblob *v1alpha1.AzblobStorageProvider, useAAD bool) ([]corev1.EnvVar, string, error) {
+func generateAzblobCertEnvVar(azblob *v1alpha1.AzblobStorageProvider, secret *corev1.Secret, useSasToken bool) ([]corev1.EnvVar, string, error) {
 	if len(azblob.AccessTier) == 0 {
 		azblob.AccessTier = "Cool"
 	}
@@ -193,64 +193,63 @@ func generateAzblobCertEnvVar(azblob *v1alpha1.AzblobStorageProvider, useAAD boo
 			Name:  "AZURE_ACCESS_TIER",
 			Value: azblob.AccessTier,
 		},
+		{
+			Name:  "AZURE_STORAGE_ACCOUNT",
+			Value: azblob.StorageAccount,
+		},
 	}
-	if azblob.SecretName != "" {
+	if useSasToken {
+		return envVars, "", nil
+	}
+	_, exist := CheckAllKeysExistInSecret(secret, constants.AzblobClientID, constants.AzblobClientScrt, constants.AzblobTenantID)
+	if exist { // using AAD auth
 		envVars = append(envVars, []corev1.EnvVar{
 			{
-				Name: "AZURE_STORAGE_ACCOUNT",
+				Name: "AZURE_CLIENT_ID",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
-						Key:                  constants.AzblobAccountName,
+						Key:                  constants.AzblobClientID,
+					},
+				},
+			},
+			{
+				Name: "AZURE_CLIENT_SECRET",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
+						Key:                  constants.AzblobClientScrt,
+					},
+				},
+			},
+			{
+				Name: "AZURE_TENANT_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
+						Key:                  constants.AzblobTenantID,
 					},
 				},
 			},
 		}...)
-		if useAAD {
-			envVars = append(envVars, []corev1.EnvVar{
-				{
-					Name: "AZURE_CLIENT_ID",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
-							Key:                  constants.AzblobClientID,
-						},
-					},
-				},
-				{
-					Name: "AZURE_CLIENT_SECRET",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
-							Key:                  constants.AzblobClientScrt,
-						},
-					},
-				},
-				{
-					Name: "AZURE_TENANT_ID",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
-							Key:                  constants.AzblobTenantID,
-						},
-					},
-				},
-			}...)
-		} else {
-			envVars = append(envVars, []corev1.EnvVar{
-				{
-					Name: "AZURE_STORAGE_KEY",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
-							Key:                  constants.AzblobAccountKey,
-						},
-					},
-				},
-			}...)
-		}
+		return envVars, "", nil
 	}
-	return envVars, "", nil
+	_, exist = CheckAllKeysExistInSecret(secret, constants.AzblobAccountKey)
+	if exist { // use access key auth
+		envVars = append(envVars, []corev1.EnvVar{
+			{
+				Name: "AZURE_STORAGE_KEY",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: azblob.SecretName},
+						Key:                  constants.AzblobAccountKey,
+					},
+				},
+			},
+		}...)
+		return envVars, "", nil
+	}
+	return nil, "azblobKeyOrAADMissing", fmt.Errorf("secret %s/%s missing some keys", secret.Namespace, secret.Name)
 }
 
 // GenerateStorageCertEnv generate the env info in order to access backend backup storage
@@ -303,27 +302,25 @@ func GenerateStorageCertEnv(ns string, useKMS bool, provider v1alpha1.StoragePro
 			return certEnv, reason, err
 		}
 	case v1alpha1.BackupStorageTypeAzblob:
-		useAAD := true
 		azblobSecretName := provider.Azblob.SecretName
+		var secret *corev1.Secret
 		if azblobSecretName != "" {
-			secret, err := secretLister.Secrets(ns).Get(azblobSecretName)
+			secret, err = secretLister.Secrets(ns).Get(azblobSecretName)
 			if err != nil {
 				err := fmt.Errorf("get azblob secret %s/%s failed, err: %v", ns, azblobSecretName, err)
 				return certEnv, "GetAzblobSecretFailed", err
 			}
-
-			keyStrAAD, exist := CheckAllKeysExistInSecret(secret, constants.AzblobAccountName, constants.AzblobClientID, constants.AzblobClientScrt, constants.AzblobTenantID)
-			if !exist {
-				keyStrShared, exist := CheckAllKeysExistInSecret(secret, constants.AzblobAccountName, constants.AzblobAccountKey)
-				if !exist {
-					err := fmt.Errorf("the azblob secret %s/%s missing some keys for AAD %s or shared %s", ns, azblobSecretName, keyStrAAD, keyStrShared)
-					return certEnv, "azblobKeyNotExist", err
-				}
-				useAAD = false
-			}
 		}
-
-		certEnv, reason, err = generateAzblobCertEnvVar(provider.Azblob, useAAD)
+		if provider.Azblob.StorageAccount == "" { // try to get storageAccount from secret
+			account := string(secret.Data[constants.AzblobAccountName])
+			if account == "" {
+				err := fmt.Errorf("secret %s/%s missing some keys, storage account unspecified: %v", ns, azblobSecretName, secret.Data)
+				return certEnv, "azblobAccountNotExist", err
+			}
+			provider.Azblob.StorageAccount = account
+		}
+		useSasToken := provider.Azblob.SasToken != ""
+		certEnv, reason, err = generateAzblobCertEnvVar(provider.Azblob, secret, useSasToken)
 
 		if err != nil {
 			return certEnv, reason, err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Previously, tidb-operator only supports access key and AAD authentication for Azure blob storage. The [SAS (Shared Access Signature)](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview) token is also commonly used, especially for cross Azure tenant scenario. The BR kernel already supports SAS token authentication. This PR adds SAS token support in tidb-operator.

On Azure, the storage account is a namespace for Azure storage. In this respect, it's similar to S3 and GCS bucket. Though Azure blob storage has another hierarchy `container`. So the storage account should also be in the `Backup` CR spec. The BR kernel should also re-organize the storage account as normal argument.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
I add two new fields (`StorageAccount`, `SasToken`) in `AzblobStorageProvider` and concatenate the br command arguments with these two new fields. Now the authentication for Azure is as follows:
* If `Backup.Spec.StorageProvider.Azblob.SasToken` is specified, then use SAS token authentication
* If `Backup.Spec.StorageProvider.Azblob.StorageAccount` is specified, then use this to set backup-manager pod env. Otherwise get storage account from secret as before.
* If sas token is unspecified, then try to use access key or AAD authentication.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

I've tested this PR manually in local kind environment with Azure blob storage SAS token. The backup job finished successfully. The storage account and sas token are all set in `Backup` CR spec without specifying `spec.azblob.secretName`
![image](https://github.com/user-attachments/assets/9ec9ad4e-6179-4900-b097-66c5b25bcaa5)

I've also tested backup via access key with following two cases:
* Specifying a secret with only `AZURE_STORAGE_KEY` and specifying the storage account in the `spec.azblob.storageAccount`
* Specifying both `AZURE_STORAGE_KEY` and `AZURE_STORAGE_ACCOUNT` in secret, but not specifying `spec.azblob.storageAccount`

Both cases succeeded as expected.

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Support Backup & Restore using Azure blob storage SAS token authentication
```
