### PR TITLE
Fix advanced TidbCluster example

### DIFF
--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -824,7 +824,7 @@ spec:
   #     app.kubernetes.io/component: pump
   #   annotations:
   #     node.kubernetes.io/instance-type: some-vm-type
-  #   tolerations: {}
+  #   tolerations: []
   #   configUpdateStrategy: RollingUpdate
   #   statefulSetUpdateStrategy: RollingUpdate
   #   podSecurityContext: {}
@@ -868,7 +868,7 @@ spec:
   #     app.kubernetes.io/component: ticdc
   #   annotations:
   #     node.kubernetes.io/instance-type: some-vm-type
-  #   tolerations: {}
+  #   tolerations: []
   #   configUpdateStrategy: RollingUpdate
   #   statefulSetUpdateStrategy: RollingUpdate
   #   podSecurityContext: {}
@@ -918,7 +918,7 @@ spec:
   #     app.kubernetes.io/component: tiflash
   #   annotations:
   #     node.kubernetes.io/instance-type: some-vm-type
-  #   tolerations: {}
+  #   tolerations: []
   #   configUpdateStrategy: RollingUpdate
   #   statefulSetUpdateStrategy: RollingUpdate
   #   podSecurityContext: {}
@@ -970,7 +970,7 @@ spec:
   #     # configure the configuration file for TiFlash Proxy process
   #     proxy: |
   #       [security]
-  #         cert-allowed-cn = "CNNAME"
+  #         cert-allowed-cn = ["CNNAME"]
   #   # TopologySpreadConstraints for pod scheduling, will overwrite the cluster level spread constraints setting
   #   # Ref: pkg/apis/pingcap/v1alpha1/types.go#TopologySpreadConstraint
   #   topologySpreadConstraints:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Fixes https://github.com/pingcap/tidb-operator/issues/5742


### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Fix example types in the examples/advanced/tidb-cluster.yaml

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

No code change. Only changing the example YAML file

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
