### PR TITLE
opt(ticdc): support to overwrite the default cluster TLS cert secret name

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -16586,6 +16586,19 @@ client certificates for the downstream.</p>
 </tr>
 <tr>
 <td>
+<code>clusterTLSSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ClusterTLSSecretName is used for overwriting the default mTLS cert secret name (see also: pkg/util/util.go:ClusterTLSSecretName)
+This field is useful for sharing the same mTLS cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code></br>
 <em>
 string

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -16599,6 +16599,21 @@ This field is useful for sharing the same mTLS cert secret for multiple ticdc cl
 </tr>
 <tr>
 <td>
+<code>clusterClientTLSSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ClusterTLSSecretName is used for overwriting the default <strong>cluster client</strong> cert secret name (see also: pkg/util/util.go:ClusterClientTLSSecretName)
+This field is useful for sharing the same cluster client cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.
+The ClusterClientTLSSecret is actually not directly used by ticdc, but it is useful for executing some commands via <code>ticdc-ctl</code>
+by <code>kubectl exec -it ticdc-0 -- /cdc cli --ca /var/lib/cluster-client-tls/ca.crt --cert /var/lib/cluster-client-tls/tls.crt --key /var/lib/cluster-client-tls/tls.key ...</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code></br>
 <em>
 string

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -13152,6 +13152,8 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                  clusterClientTLSSecretName:
+                    type: string
                   clusterTLSSecretName:
                     type: string
                   config:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -13152,6 +13152,8 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                  clusterTLSSecretName:
+                    type: string
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                   configUpdateStrategy:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -9416,6 +9416,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiCDCSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"clusterClientTLSSecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClusterTLSSecretName is used for overwriting the default **cluster client** cert secret name (see also: pkg/util/util.go:ClusterClientTLSSecretName) This field is useful for sharing the same cluster client cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster. The ClusterClientTLSSecret is actually not directly used by ticdc, but it is useful for executing some commands via `ticdc-ctl`\n by `kubectl exec -it ticdc-0 -- /cdc cli --ca /var/lib/cluster-client-tls/ca.crt --cert /var/lib/cluster-client-tls/tls.crt --key /var/lib/cluster-client-tls/tls.key ...`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"baseImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Base image of the component, image tag is now allowed during validation",

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -9409,6 +9409,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiCDCSpec(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"clusterTLSSecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClusterTLSSecretName is used for overwriting the default mTLS cert secret name (see also: pkg/util/util.go:ClusterTLSSecretName) This field is useful for sharing the same mTLS cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"baseImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Base image of the component, image tag is now allowed during validation",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -864,6 +864,13 @@ type TiCDCSpec struct {
 	// +optional
 	ClusterTLSSecretName string `json:"clusterTLSSecretName,omitempty"`
 
+	// ClusterTLSSecretName is used for overwriting the default **cluster client** cert secret name (see also: pkg/util/util.go:ClusterClientTLSSecretName)
+	// This field is useful for sharing the same cluster client cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.
+	// The ClusterClientTLSSecret is actually not directly used by ticdc, but it is useful for executing some commands via `ticdc-ctl`
+	//  by `kubectl exec -it ticdc-0 -- /cdc cli --ca /var/lib/cluster-client-tls/ca.crt --cert /var/lib/cluster-client-tls/tls.crt --key /var/lib/cluster-client-tls/tls.key ...`.
+	// +optional
+	ClusterClientTLSSecretName string `json:"clusterClientTLSSecretName,omitempty"`
+
 	// Base image of the component, image tag is now allowed during validation
 	// +kubebuilder:default=pingcap/ticdc
 	// +optional

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -859,6 +859,11 @@ type TiCDCSpec struct {
 	// +optional
 	TLSClientSecretNames []string `json:"tlsClientSecretNames,omitempty"`
 
+	// ClusterTLSSecretName is used for overwriting the default mTLS cert secret name (see also: pkg/util/util.go:ClusterTLSSecretName)
+	// This field is useful for sharing the same mTLS cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.
+	// +optional
+	ClusterTLSSecretName string `json:"clusterTLSSecretName,omitempty"`
+
 	// Base image of the component, image tag is now allowed during validation
 	// +kubebuilder:default=pingcap/ticdc
 	// +optional

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -391,6 +391,10 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		vols = append(vols, annVolume)
 	}
 
+	clusterTLSSecretName := util.ClusterTLSSecretName(tc.Name, label.TiCDCLabelVal)
+	if tc.Spec.TiCDC.ClusterTLSSecretName != "" {
+		clusterTLSSecretName = tc.Spec.TiCDC.ClusterTLSSecretName
+	}
 	if tc.IsTLSClusterEnabled() {
 		volMounts = append(volMounts, corev1.VolumeMount{
 			Name:      ticdcCertVolumeMount,
@@ -405,7 +409,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		vols = append(vols, corev1.Volume{
 			Name: ticdcCertVolumeMount, VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.ClusterTLSSecretName(tc.Name, label.TiCDCLabelVal),
+					SecretName: clusterTLSSecretName,
 				},
 			},
 		}, corev1.Volume{

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -411,7 +411,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		}, corev1.Volume{
 			Name: util.ClusterClientVolName, VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.ClusterClientTLSSecretName(tc.Name),
+					SecretName: getTiCDCClusterClientTLSCertSecretName(tc),
 				},
 			},
 		})
@@ -573,6 +573,15 @@ func getTiCDCClusterTLSCertSecretName(tc *v1alpha1.TidbCluster) string {
 	}
 
 	return clusterTLSSecretName
+}
+
+func getTiCDCClusterClientTLSCertSecretName(tc *v1alpha1.TidbCluster) string {
+	clusterClientTLSSecretName := util.ClusterClientTLSSecretName(tc.Name)
+	if tc.Spec.TiCDC.ClusterClientTLSSecretName != "" {
+		clusterClientTLSSecretName = tc.Spec.TiCDC.ClusterClientTLSSecretName
+	}
+
+	return clusterClientTLSSecretName
 }
 
 func labelTiCDC(tc *v1alpha1.TidbCluster) label.Label {

--- a/pkg/manager/member/ticdc_member_manager.go
+++ b/pkg/manager/member/ticdc_member_manager.go
@@ -391,10 +391,6 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		vols = append(vols, annVolume)
 	}
 
-	clusterTLSSecretName := util.ClusterTLSSecretName(tc.Name, label.TiCDCLabelVal)
-	if tc.Spec.TiCDC.ClusterTLSSecretName != "" {
-		clusterTLSSecretName = tc.Spec.TiCDC.ClusterTLSSecretName
-	}
 	if tc.IsTLSClusterEnabled() {
 		volMounts = append(volMounts, corev1.VolumeMount{
 			Name:      ticdcCertVolumeMount,
@@ -409,7 +405,7 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 		vols = append(vols, corev1.Volume{
 			Name: ticdcCertVolumeMount, VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: clusterTLSSecretName,
+					SecretName: getTiCDCClusterTLSCertSecretName(tc),
 				},
 			},
 		}, corev1.Volume{
@@ -568,6 +564,15 @@ func getNewTiCDCStatefulSet(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap) (*ap
 	}
 	ticdcSts.Spec.VolumeClaimTemplates = append(ticdcSts.Spec.VolumeClaimTemplates, additionalPVCs...)
 	return ticdcSts, nil
+}
+
+func getTiCDCClusterTLSCertSecretName(tc *v1alpha1.TidbCluster) string {
+	clusterTLSSecretName := util.ClusterTLSSecretName(tc.Name, label.TiCDCLabelVal)
+	if tc.Spec.TiCDC.ClusterTLSSecretName != "" {
+		clusterTLSSecretName = tc.Spec.TiCDC.ClusterTLSSecretName
+	}
+
+	return clusterTLSSecretName
 }
 
 func labelTiCDC(tc *v1alpha1.TidbCluster) label.Label {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

This PR introduces a new field `clusterTLSSecretName` in `tc.spec.ticdc` that support overwriting the default cluster TLS secret name. This is useful sharing the same mTLS cert secret for multiple ticdc clusters connecting to the same upstream tidb cluster.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

* Create a TC with ticdc enabled
* The ticdc pod should mount '{TC_NAME}-ticdc-cluster-secret' as the `ticdc-tls`
```yaml
  - name: ticdc-tls
    secret:
      defaultMode: 420
      secretName: db-ticdc-cluster-secret
```
* Set 'tc.spec.ticdc.clusterTLSSecretName' to 'db-cluster-client-secret', the ticdc pod should be recreated and mount the secret 'db-cluster-client-secret' as the `ticdc-tls`
```yaml
  - name: ticdc-tls
    secret:
      defaultMode: 420
      secretName: db-cluster-client-secret
```

```
db-ticdc-0                               1/1     Terminating   0          38m
db-ticdc-0                               0/1     Completed     0          38m
db-ticdc-0                               0/1     Completed     0          38m
db-ticdc-0                               0/1     Completed     0          38m
db-ticdc-0                               0/1     Pending       0          0s
db-ticdc-0                               0/1     Pending       0          0s
db-ticdc-0                               0/1     ContainerCreating   0          0s
db-ticdc-0                               1/1     Running             0          6s
db-ticdc-0                               1/1     Running             0          7s
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
