### PR TITLE
New certificate layout for tiproxy

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -23522,6 +23522,13 @@ int32
 </tr>
 </tbody>
 </table>
+<h3 id="tiproxycertlayout">TiProxyCertLayout</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#tiproxyspec">TiProxySpec</a>)
+</p>
+<p>
+</p>
 <h3 id="tiproxyconfigwraper">TiProxyConfigWraper</h3>
 <p>
 (<em>Appears on:</em>
@@ -23706,6 +23713,21 @@ string
 <em>(Optional)</em>
 <p>TLSClientSecretName is the name of secret which stores tidb server client certificate
 used by TiProxy to check health status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certLayout</code></br>
+<em>
+<a href="#tiproxycertlayout">
+TiProxyCertLayout
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TiProxyCertLayout is the certificate layout of TiProxy that determines how tidb-operator mount cert secrets
+and how configure TLS configurations for tiproxy.</p>
 </td>
 </tr>
 <tr>

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -24312,6 +24312,8 @@ spec:
                   baseImage:
                     default: pingcap/tiproxy
                     type: string
+                  certLayout:
+                    type: string
                   claims:
                     items:
                       properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -14115,6 +14115,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TiProxySpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"certLayout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TiProxyCertLayout is the certificate layout of TiProxy that determines how tidb-operator mount cert secrets and how configure TLS configurations for tiproxy.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"baseImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Base image of the component, image tag is now allowed during validation",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -161,6 +161,14 @@ const (
 	StartScriptV2FeatureFlagPreferPDAddressesOverDiscovery = "PreferPDAddressesOverDiscovery"
 )
 
+type TiProxyCertLayout string
+
+const (
+	TiProxyCertLayoutLegacy TiProxyCertLayout = ""
+	// TiProxyCertLayoutV1 is a refined version of legacy layout. It's more intuitive and more flexible.
+	TiProxyCertLayoutV1 TiProxyCertLayout = "v1"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -931,6 +939,11 @@ type TiProxySpec struct {
 	// used by TiProxy to check health status.
 	// +optional
 	TLSClientSecretName *string `json:"tlsClientSecretName,omitempty"`
+
+	// TiProxyCertLayout is the certificate layout of TiProxy that determines how tidb-operator mount cert secrets
+	// and how configure TLS configurations for tiproxy.
+	// +optional
+	CertLayout TiProxyCertLayout `json:"certLayout,omitempty"`
 
 	// Base image of the component, image tag is now allowed during validation
 	// +kubebuilder:default=pingcap/tiproxy

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -41,10 +41,19 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const tiproxyVolumeMountPath = "/var/lib/tiproxy"
-const tiproxySQLPath = "/var/lib/tiproxy-sql-tls"
-const tiproxyServerPath = "/var/lib/tiproxy-server-tls"
-const tiproxyHTTPServerPath = "/var/lib/tiproxy-http-server-tls"
+const (
+	tiproxyVolumeMountPath = "/var/lib/tiproxy"
+
+	// [security.sql-tls]
+	tiproxySQLPath = "/var/lib/tiproxy-sql-tls"
+	// [security.server-tls]
+	tiproxyServerPath = "/var/lib/tiproxy-server-tls"
+	// [security.server-http-tls]
+	tiproxyHTTPServerPath = "/var/lib/tiproxy-http-server-tls"
+	// [security.cluster-tls]
+	tiproxyClusterCertPath        = "/var/lib/tiproxy-tls"
+	tiProxyClusterCertVolumeMount = "tiproxy-tls"
+)
 
 func labelTiProxy(tc *v1alpha1.TidbCluster) label.Label {
 	instanceName := tc.GetInstanceName()
@@ -128,44 +137,10 @@ func (m *tiproxyMemberManager) syncConfigMap(tc *v1alpha1.TidbCluster, set *apps
 		cfgWrapper.Set("proxy.require-backend-tls", false)
 	}
 
-	tlsCluster := tc.IsTLSClusterEnabled()
-	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
-	if tlsCluster {
-		cfgWrapper.Set("security.cluster-tls.ca", path.Join(util.ClusterClientTLSPath, "ca.crt"))
-		cfgWrapper.Set("security.cluster-tls.key", path.Join(util.ClusterClientTLSPath, "tls.key"))
-		cfgWrapper.Set("security.cluster-tls.cert", path.Join(util.ClusterClientTLSPath, "tls.crt"))
-	}
-	if tlsTiDB {
-		cfgWrapper.Set("security.server-tls.ca", path.Join(tiproxyServerPath, "ca.crt"))
-		cfgWrapper.Set("security.server-tls.key", path.Join(tiproxyServerPath, "tls.key"))
-		cfgWrapper.Set("security.server-tls.cert", path.Join(tiproxyServerPath, "tls.crt"))
-		if cfgWrapper.Get("security.server-tls.skip-ca") == nil {
-			cfgWrapper.Set("security.server-tls.skip-ca", true)
-		}
-
-		if tc.Spec.TiProxy.SSLEnableTiDB || !tc.SkipTLSWhenConnectTiDB() {
-			if cfgWrapper.Get("security.sql-tls.skip-ca") == nil && tc.Spec.TiDB.TLSClient.SkipInternalClientCA {
-				cfgWrapper.Set("security.sql-tls.skip-ca", true)
-			} else {
-				cfgWrapper.Set("security.sql-tls.ca", path.Join(tiproxySQLPath, "ca.crt"))
-			}
-			if !tc.Spec.TiDB.TLSClient.DisableClientAuthn {
-				cfgWrapper.Set("security.sql-tls.key", path.Join(tiproxySQLPath, "tls.key"))
-				cfgWrapper.Set("security.sql-tls.cert", path.Join(tiproxySQLPath, "tls.crt"))
-			}
-		}
-	}
-	// TODO: this should only be set on `tlsCluster`. `tlsTiDB` check is for backward compatibility.
-	// and it should be removed in the future.
-	if tlsCluster || tlsTiDB {
-		p := tiproxyServerPath
-		if !tlsTiDB {
-			p = tiproxyHTTPServerPath
-		}
-		cfgWrapper.Set("security.server-http-tls.ca", path.Join(p, "ca.crt"))
-		cfgWrapper.Set("security.server-http-tls.key", path.Join(p, "tls.key"))
-		cfgWrapper.Set("security.server-http-tls.cert", path.Join(p, "tls.crt"))
-		cfgWrapper.Set("security.server-http-tls.skip-ca", true)
+	if tc.Spec.TiProxy.CertLayout == v1alpha1.TiProxyCertLayoutV1 {
+		m.modifyConfigMapForTLSV1(tc, cfgWrapper)
+	} else {
+		m.modifyConfigMapForTLSLegacy(tc, cfgWrapper)
 	}
 
 	cfgBytes, err := cfgWrapper.MarshalTOML()
@@ -443,62 +418,17 @@ func (m *tiproxyMemberManager) getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *c
 		annMount,
 	}
 
-	tlsCluster := tc.IsTLSClusterEnabled()
-	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
-	if tlsCluster {
-		volMounts = append(volMounts, corev1.VolumeMount{
-			Name:      util.ClusterClientVolName,
-			ReadOnly:  true,
-			MountPath: util.ClusterClientTLSPath,
-		})
-
-		vols = append(vols, corev1.Volume{
-			Name: util.ClusterClientVolName, VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.ClusterClientTLSSecretName(tc.Name),
-				},
-			},
-		})
+	var (
+		tlsVols      []corev1.Volume
+		tlsVolMounts []corev1.VolumeMount
+	)
+	if tc.Spec.TiProxy.CertLayout == v1alpha1.TiProxyCertLayoutV1 {
+		tlsVols, tlsVolMounts = m.buildVolumesAndVolumeMountsForTLSV1(tc)
+	} else {
+		tlsVols, tlsVolMounts = m.buildVolumesAndVolumeMountsForTLSLegacy(tc)
 	}
-	if tlsTiDB {
-		volMounts = append(volMounts, corev1.VolumeMount{
-			Name: "tidb-server-tls", ReadOnly: true, MountPath: tiproxyServerPath,
-		})
-
-		vols = append(vols, corev1.Volume{
-			Name: "tidb-server-tls", VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.TiDBServerTLSSecretName(tc.Name),
-				},
-			},
-		})
-
-		if tc.Spec.TiProxy.SSLEnableTiDB || !tc.SkipTLSWhenConnectTiDB() {
-			volMounts = append(volMounts, corev1.VolumeMount{
-				Name: "tidb-client-tls", ReadOnly: true, MountPath: tiproxySQLPath,
-			})
-			vols = append(vols, corev1.Volume{
-				Name: "tidb-client-tls", VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.TiDBClientTLSSecretName(tc.Name, tc.Spec.TiProxy.TLSClientSecretName),
-					},
-				},
-			})
-		}
-	}
-	if tlsCluster && !tlsTiDB {
-		volMounts = append(volMounts, corev1.VolumeMount{
-			Name: "tiproxy-tls", ReadOnly: true, MountPath: tiproxyHTTPServerPath,
-		})
-
-		vols = append(vols, corev1.Volume{
-			Name: "tiproxy-tls", VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: util.ClusterTLSSecretName(tc.Name, label.TiProxyLabelVal),
-				},
-			},
-		})
-	}
+	vols = append(vols, tlsVols...)
+	volMounts = append(volMounts, tlsVolMounts...)
 
 	// handle StorageVolumes and AdditionalVolumeMounts in ComponentSpec
 	storageVolMounts, additionalPVCs := util.BuildStorageVolumeAndVolumeMount(tc.Spec.TiProxy.StorageVolumes, tc.Spec.TiProxy.StorageClassName, v1alpha1.TiProxyMemberType)
@@ -605,6 +535,209 @@ func (m *tiproxyMemberManager) getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *c
 	}
 	tiproxySts.Spec.VolumeClaimTemplates = append(tiproxySts.Spec.VolumeClaimTemplates, additionalPVCs...)
 	return tiproxySts, nil
+}
+
+func (m *tiproxyMemberManager) modifyConfigMapForTLSLegacy(tc *v1alpha1.TidbCluster, cfgWrapper *v1alpha1.TiProxyConfigWraper) {
+	tlsCluster := tc.IsTLSClusterEnabled()
+	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
+	if tlsCluster {
+		cfgWrapper.Set("security.cluster-tls.ca", path.Join(util.ClusterClientTLSPath, "ca.crt"))
+		cfgWrapper.Set("security.cluster-tls.key", path.Join(util.ClusterClientTLSPath, "tls.key"))
+		cfgWrapper.Set("security.cluster-tls.cert", path.Join(util.ClusterClientTLSPath, "tls.crt"))
+	}
+	if tlsTiDB {
+		cfgWrapper.Set("security.server-tls.ca", path.Join(tiproxyServerPath, "ca.crt"))
+		cfgWrapper.Set("security.server-tls.key", path.Join(tiproxyServerPath, "tls.key"))
+		cfgWrapper.Set("security.server-tls.cert", path.Join(tiproxyServerPath, "tls.crt"))
+		if cfgWrapper.Get("security.server-tls.skip-ca") == nil {
+			cfgWrapper.Set("security.server-tls.skip-ca", true)
+		}
+
+		if tc.Spec.TiProxy.SSLEnableTiDB || !tc.SkipTLSWhenConnectTiDB() {
+			if cfgWrapper.Get("security.sql-tls.skip-ca") == nil && tc.Spec.TiDB.TLSClient.SkipInternalClientCA {
+				cfgWrapper.Set("security.sql-tls.skip-ca", true)
+			} else {
+				cfgWrapper.Set("security.sql-tls.ca", path.Join(tiproxySQLPath, "ca.crt"))
+			}
+			if !tc.Spec.TiDB.TLSClient.DisableClientAuthn {
+				cfgWrapper.Set("security.sql-tls.key", path.Join(tiproxySQLPath, "tls.key"))
+				cfgWrapper.Set("security.sql-tls.cert", path.Join(tiproxySQLPath, "tls.crt"))
+			}
+		}
+	}
+	// TODO: this should only be set on `tlsCluster`. `tlsTiDB` check is for backward compatibility.
+	// and it should be removed in the future.
+	if tlsCluster || tlsTiDB {
+		p := tiproxyServerPath
+		if !tlsTiDB {
+			p = tiproxyHTTPServerPath
+		}
+		cfgWrapper.Set("security.server-http-tls.ca", path.Join(p, "ca.crt"))
+		cfgWrapper.Set("security.server-http-tls.key", path.Join(p, "tls.key"))
+		cfgWrapper.Set("security.server-http-tls.cert", path.Join(p, "tls.crt"))
+		cfgWrapper.Set("security.server-http-tls.skip-ca", true)
+	}
+}
+
+func (m *tiproxyMemberManager) buildVolumesAndVolumeMountsForTLSLegacy(tc *v1alpha1.TidbCluster) ([]corev1.Volume, []corev1.VolumeMount) {
+	var (
+		vols      []corev1.Volume
+		volMounts []corev1.VolumeMount
+	)
+
+	tlsCluster := tc.IsTLSClusterEnabled()
+	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
+	if tlsCluster {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name:      util.ClusterClientVolName,
+			ReadOnly:  true,
+			MountPath: util.ClusterClientTLSPath,
+		})
+
+		vols = append(vols, corev1.Volume{
+			Name: util.ClusterClientVolName, VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.ClusterClientTLSSecretName(tc.Name),
+				},
+			},
+		})
+	}
+	if tlsTiDB {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name: "tidb-server-tls", ReadOnly: true, MountPath: tiproxyServerPath,
+		})
+
+		vols = append(vols, corev1.Volume{
+			Name: "tidb-server-tls", VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.TiDBServerTLSSecretName(tc.Name),
+				},
+			},
+		})
+
+		if tc.Spec.TiProxy.SSLEnableTiDB || !tc.SkipTLSWhenConnectTiDB() {
+			volMounts = append(volMounts, corev1.VolumeMount{
+				Name: "tidb-client-tls", ReadOnly: true, MountPath: tiproxySQLPath,
+			})
+			vols = append(vols, corev1.Volume{
+				Name: "tidb-client-tls", VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: util.TiDBClientTLSSecretName(tc.Name, tc.Spec.TiProxy.TLSClientSecretName),
+					},
+				},
+			})
+		}
+	}
+	if tlsCluster && !tlsTiDB {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name: "tiproxy-tls", ReadOnly: true, MountPath: tiproxyHTTPServerPath,
+		})
+
+		vols = append(vols, corev1.Volume{
+			Name: "tiproxy-tls", VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.ClusterTLSSecretName(tc.Name, label.TiProxyLabelVal),
+				},
+			},
+		})
+	}
+	return vols, volMounts
+}
+
+func (m *tiproxyMemberManager) buildVolumesAndVolumeMountsForTLSV1(tc *v1alpha1.TidbCluster) ([]corev1.Volume, []corev1.VolumeMount) {
+	var (
+		vols      []corev1.Volume
+		volMounts []corev1.VolumeMount
+	)
+
+	tlsCluster := tc.IsTLSClusterEnabled()
+	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
+	if tlsCluster {
+		// This cert is not directly used by tiproxy itself, but mount it is useful for debug purpose.
+		// the common client mTLS cert
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name:      util.ClusterClientVolName,
+			ReadOnly:  true,
+			MountPath: util.ClusterClientTLSPath,
+		})
+		vols = append(vols, corev1.Volume{
+			Name: util.ClusterClientVolName, VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.ClusterClientTLSSecretName(tc.Name),
+				},
+			},
+		})
+
+		// inter-components (cluster) mTLS cert for tiproxy
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name:      tiProxyClusterCertVolumeMount,
+			ReadOnly:  true,
+			MountPath: tiproxyClusterCertPath,
+		})
+		vols = append(vols, corev1.Volume{
+			Name: tiProxyClusterCertVolumeMount, VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.ClusterTLSSecretName(tc.Name, label.TiProxyLabelVal),
+				},
+			},
+		})
+	}
+
+	// use the same server-side cert at SQL port (default 4000) for tiproxy and tidb
+	if tlsTiDB {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name: "tidb-server-tls", ReadOnly: true, MountPath: tiproxyServerPath,
+		})
+
+		vols = append(vols, corev1.Volume{
+			Name: "tidb-server-tls", VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: util.TiDBServerTLSSecretName(tc.Name),
+				},
+			},
+		})
+	}
+
+	return vols, volMounts
+}
+
+func (m *tiproxyMemberManager) modifyConfigMapForTLSV1(tc *v1alpha1.TidbCluster, cfgWrapper *v1alpha1.TiProxyConfigWraper) {
+	tlsCluster := tc.IsTLSClusterEnabled()
+	tlsTiDB := tc.Spec.TiDB != nil && tc.Spec.TiDB.IsTLSClientEnabled()
+	if tlsCluster {
+		cfgWrapper.Set("security.cluster-tls.ca", path.Join(tiproxyClusterCertPath, "ca.crt"))
+		cfgWrapper.Set("security.cluster-tls.key", path.Join(tiproxyClusterCertPath, "tls.key"))
+		cfgWrapper.Set("security.cluster-tls.cert", path.Join(tiproxyClusterCertPath, "tls.crt"))
+	}
+
+	if tlsTiDB {
+		cfgWrapper.Set("security.server-tls.key", path.Join(tiproxyServerPath, "tls.key"))
+		cfgWrapper.Set("security.server-tls.cert", path.Join(tiproxyServerPath, "tls.crt"))
+		// fixme(chenfei): why?
+		if cfgWrapper.Get("security.server-tls.skip-ca") == nil {
+			cfgWrapper.Set("security.server-tls.skip-ca", true)
+		}
+
+		// Note: We don't present any client cert/key when tiproxy connect to tidb server. Instead, just mount the ca cert
+		// of tidb server-side cert to verify tidb server-side cert.
+		// Client cert/key is not required for enabling TLS between SQL client and server.
+		if tc.Spec.TiProxy.SSLEnableTiDB || !tc.SkipTLSWhenConnectTiDB() {
+			if cfgWrapper.Get("security.sql-tls.skip-ca") == nil && tc.Spec.TiDB.TLSClient.SkipInternalClientCA {
+				cfgWrapper.Set("security.sql-tls.skip-ca", true)
+			} else {
+				// the ca.crt in `tiproxyServerPath` is the CA cert of tidb server-side cert. So we use
+				// it to verify the tidb server-side cert presented by tidb-server when tiproxy connect to tidb-server.
+				cfgWrapper.Set("security.sql-tls.ca", path.Join(tiproxyServerPath, "ca.crt"))
+			}
+		}
+	}
+
+	// use the same cert as cluster mTLS cert for tiproxy HTTP server to simplify the cert management.
+	cfgWrapper.Set("security.server-http-tls.ca", path.Join(tiproxyClusterCertPath, "ca.crt"))
+	cfgWrapper.Set("security.server-http-tls.key", path.Join(tiproxyClusterCertPath, "tls.key"))
+	cfgWrapper.Set("security.server-http-tls.cert", path.Join(tiproxyClusterCertPath, "tls.crt"))
+	// fixme(chenfei): why?
+	cfgWrapper.Set("security.server-http-tls.skip-ca", true)
 }
 
 func (m *tiproxyMemberManager) statefulSetIsUpgradingFn(podLister corelisters.PodLister, set *apps.StatefulSet, tc *v1alpha1.TidbCluster) (bool, error) {

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -713,7 +713,6 @@ func (m *tiproxyMemberManager) modifyConfigMapForTLSV1(tc *v1alpha1.TidbCluster,
 	if tlsTiDB {
 		cfgWrapper.Set("security.server-tls.key", path.Join(tiproxyServerPath, "tls.key"))
 		cfgWrapper.Set("security.server-tls.cert", path.Join(tiproxyServerPath, "tls.crt"))
-		// fixme(chenfei): why?
 		if cfgWrapper.Get("security.server-tls.skip-ca") == nil {
 			cfgWrapper.Set("security.server-tls.skip-ca", true)
 		}
@@ -736,7 +735,7 @@ func (m *tiproxyMemberManager) modifyConfigMapForTLSV1(tc *v1alpha1.TidbCluster,
 	cfgWrapper.Set("security.server-http-tls.ca", path.Join(tiproxyClusterCertPath, "ca.crt"))
 	cfgWrapper.Set("security.server-http-tls.key", path.Join(tiproxyClusterCertPath, "tls.key"))
 	cfgWrapper.Set("security.server-http-tls.cert", path.Join(tiproxyClusterCertPath, "tls.crt"))
-	// fixme(chenfei): why?
+	// todo: Mount `db-cluster-client-secret` to TiproxyControl (pkg/controller/tiproxy_control.go) so that we can remove this.
 	cfgWrapper.Set("security.server-http-tls.skip-ca", true)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

This PR introduces a new spec field for tiproxy: `certLayout`. It determines how tidb-operator mounts certificate related k8s secrets and how to configure TLS related configuration for tiproxy.
For compatibility, the old certLayout is kept as legacy (the default value), the newly added one is the `v1`. So that upgrading tidb-operator to new version is safe and change nothing.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

* After deploy the new tidb-operator, the existing TCs having tiproxy enabled shouldn't have any pod restarts.
* Set `certLayout` to `v1 for this tc, the tiproxy pods should be restarted
```yaml
  tiproxy:
    certLayout: v1
```
** the tiproxy pods have been restarted
```
db-tiproxy-0                                          0/1     Terminating   0          6m6s
db-tiproxy-0                                          0/1     Pending       0          0s
db-tiproxy-0                                          0/1     Pending       0          0s
db-tiproxy-0                                          0/1     ContainerCreating   0          0s
db-tiproxy-0                                          1/1     Running             0          1s
```
* the tiproxy pods should have new cert mount layout
```yaml
volumeMounts:
    - mountPath: /var/lib/cluster-client-tls
      name: cluster-client-tls
      readOnly: true
    - mountPath: /var/lib/tiproxy-tls
      name: tiproxy-tls
      readOnly: true
    - mountPath: /var/lib/tiproxy-server-tls
      name: tidb-server-tls
      readOnly: true
    - mountPath: /var/lib/tidb-client-tls
      name: tidb-client-tls
      readOnly: true

  volumes:
  - name: cluster-client-tls
    secret:
      defaultMode: 420
      secretName: db-cluster-client-secret
  - name: tiproxy-tls
    secret:
      defaultMode: 420
      secretName: db-tiproxy-cluster-secret
  - name: tidb-server-tls
    secret:
      defaultMode: 420
      secretName: db-tidb-server-secret
  - name: tidb-client-tls
    secret:
      defaultMode: 420
      secretName: db-tidb-client-secret
```
* The configuration of tiproxy should have been changed to adapt the new cert layout
 ```toml
    [security]
      [security.cluster-tls]
        ca = "/var/lib/tiproxy-tls/ca.crt"
        cert = "/var/lib/tiproxy-tls/tls.crt"
        key = "/var/lib/tiproxy-tls/tls.key"
      [security.server-http-tls]
        ca = "/var/lib/tiproxy-tls/ca.crt"
        cert = "/var/lib/tiproxy-tls/tls.crt"
        key = "/var/lib/tiproxy-tls/tls.key"
        skip-ca = true
      [security.server-tls]
        ca = "/var/lib/tidb-client-tls/ca.crt"  # mount the client CA cert from the `tidb-client-tls` cert
        cert = "/var/lib/tiproxy-server-tls/tls.crt"  # use the same server-side cert/key as the tidb-server
        key = "/var/lib/tiproxy-server-tls/tls.key"
        skip-ca = true
      [security.sql-tls]
        ca = "/var/lib/tiproxy-server-tls/ca.crt"  # mount the tidb server CA cert to verify tidb-server's server-side cert
```

* Connect to tidb without client certificates should be success
```
mycli --ssl -htidb-server -uroot -P4000 --password='xxxx' -e 'show variables like "%Ssl%"'
Variable_name	Value
have_openssl	YES
have_ssl	YES
ssl_ca	/var/lib/tidb-server-tls/ca.crt
ssl_cert	/var/lib/tidb-server-tls/tls.crt
ssl_cipher
ssl_key	/var/lib/tidb-server-tls/tls.key
```

* Connect to tidb with incorrect client cert/key should be failed
```
 mycli --ssl --ssl-key /tmp/tls.key --ssl-cert /tmp/tls.crt -htidb-server -uroot -P4000 --password='xxxx' -e 'show variables like "%Ssl%"'
(2013, 'Lost connection to MySQL server during query ([SSL: SSLV3_ALERT_BAD_CERTIFICATE] ssl/tls alert bad certificate (_ssl.c:2580))')
```

* Connect to tidb with correct client cert/key should be successfull
```
mycli --ssl --ssl-key /tmp/tls1.key --ssl-cert /tmp/tls1.crt -htidb-server -uroot -P4000 --password='xxxx' -e 'show variables like "%Ssl%"'

Variable_name	Value
have_openssl	YES
have_ssl	YES
ssl_ca	/var/lib/tidb-server-tls/ca.crt
ssl_cert	/var/lib/tidb-server-tls/tls.crt
ssl_cipher
ssl_key	/var/lib/tidb-server-tls/tls.key
```

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
