### PR TITLE
TidbCluster: disable evict leader for TiKV EBS modification

### DIFF
--- a/pkg/manager/volumes/vol_compare_utils.go
+++ b/pkg/manager/volumes/vol_compare_utils.go
@@ -70,7 +70,7 @@ type componentVolumeContext struct {
 	tc     *v1alpha1.TidbCluster
 	status v1alpha1.ComponentStatus
 
-	// always be true now
+	// always be false now
 	// as we think there is no need to evict leader for AWS EBS modification
 	shouldEvict bool
 

--- a/pkg/manager/volumes/vol_compare_utils.go
+++ b/pkg/manager/volumes/vol_compare_utils.go
@@ -70,6 +70,8 @@ type componentVolumeContext struct {
 	tc     *v1alpha1.TidbCluster
 	status v1alpha1.ComponentStatus
 
+	// always be true now
+	// as we think there is no need to evict leader for AWS EBS modification
 	shouldEvict bool
 
 	pods []*corev1.Pod
@@ -109,7 +111,6 @@ func (u *volCompareUtils) BuildContextForTC(tc *v1alpha1.TidbCluster, status v1a
 
 	ctx.pods = pods
 	ctx.sts = sts
-	ctx.shouldEvict = comp == v1alpha1.TiKVMemberType
 
 	return ctx, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

evict leader for TiKV may take a long time, and the performance drop without leader-eviction is very low.

So we decide to disable this leader-eviction behavior for TiKV EBS modification.

**NOTE**: do not upgrade TiDB Operator when some leader-eviction (with EBS modification, but do not include EBS size modification, ref #5101) is happening as after this PR no "remove evict-leader-scheduler" will be performed then some evict-leader-scheduler may be kept.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
disable leader-eviction for TiKV EBS modification
```
