### PR TITLE
fix(TidbMonitor): do not set OwnerReferences for ClusterRole and ClusterRoleBinding

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -192,6 +192,9 @@ const (
 	// TiDBMonitorVal is Monitor label value
 	TiDBMonitorVal string = "monitor"
 
+	// TiDBMonitorProtectionFinalizer is the name of finalizer on TidbMonitors
+	TiDBMonitorProtectionFinalizer string = "tidb.pingcap.com/monitor-protection"
+
 	// CleanJobLabelVal is clean job label value
 	CleanJobLabelVal string = "clean"
 	// RestoreJobLabelVal is restore job label value

--- a/pkg/controller/generic_control.go
+++ b/pkg/controller/generic_control.go
@@ -103,7 +103,7 @@ func (w *typedWrapper) CreateOrUpdateClusterRoleBinding(controller client.Object
 		existingCRB.RoleRef = desiredCRB.RoleRef
 		existingCRB.Subjects = desiredCRB.Subjects
 		return nil
-	}, true)
+	}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (w *typedWrapper) CreateOrUpdateClusterRole(controller client.Object, clust
 		existingCRole.Labels = desiredCRole.Labels
 		existingCRole.Rules = desiredCRole.Rules
 		return nil
-	}, true)
+	}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/monitor/monitor/monitor_manager_test.go
+++ b/pkg/monitor/monitor/monitor_manager_test.go
@@ -14,6 +14,7 @@
 package monitor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -72,6 +73,8 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 		if tm.Spec.Shards == nil {
 			tm.Spec.Shards = pointer.Int32Ptr(0)
 		}
+		_, err = tmm.deps.Clientset.PingcapV1alpha1().TidbMonitors(tm.Namespace).Create(context.Background(), tm, metav1.CreateOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
 
 		err = tmm.SyncMonitor(tm)
 		if test.errExpectFn != nil {

--- a/pkg/monitor/monitor/monitor_manager_test.go
+++ b/pkg/monitor/monitor/monitor_manager_test.go
@@ -551,6 +551,8 @@ func TestTidbMonitorSyncUpdate(t *testing.T) {
 		if test.prepare != nil {
 			test.prepare(tmm, tm)
 		}
+		_, err = tmm.deps.Clientset.PingcapV1alpha1().TidbMonitors(tm.Namespace).Create(context.Background(), tm, metav1.CreateOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
 
 		err = tmm.SyncMonitor(tm)
 

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -253,10 +253,9 @@ func getMonitorRole(monitor *v1alpha1.TidbMonitor, policyRules []rbac.PolicyRule
 func getMonitorClusterRole(monitor *v1alpha1.TidbMonitor, policyRules []rbac.PolicyRule) *rbac.ClusterRole {
 	return &rbac.ClusterRole{
 		ObjectMeta: meta.ObjectMeta{
-			Name:            GetMonitorObjectNameCrossNamespace(monitor),
-			Namespace:       monitor.Namespace,
-			Labels:          buildTidbMonitorLabel(monitor.Name),
-			OwnerReferences: []meta.OwnerReference{controller.GetTiDBMonitorOwnerRef(monitor)},
+			Name:      GetMonitorObjectNameCrossNamespace(monitor),
+			Namespace: monitor.Namespace,
+			Labels:    buildTidbMonitorLabel(monitor.Name),
 		},
 		Rules: policyRules,
 	}
@@ -265,10 +264,9 @@ func getMonitorClusterRole(monitor *v1alpha1.TidbMonitor, policyRules []rbac.Pol
 func getMonitorClusterRoleBinding(sa *core.ServiceAccount, role *rbac.ClusterRole, monitor *v1alpha1.TidbMonitor) *rbac.ClusterRoleBinding {
 	return &rbac.ClusterRoleBinding{
 		ObjectMeta: meta.ObjectMeta{
-			Name:            GetMonitorObjectNameCrossNamespace(monitor),
-			Namespace:       monitor.Namespace,
-			Labels:          buildTidbMonitorLabel(monitor.Name),
-			OwnerReferences: []meta.OwnerReference{controller.GetTiDBMonitorOwnerRef(monitor)},
+			Name:      GetMonitorObjectNameCrossNamespace(monitor),
+			Namespace: monitor.Namespace,
+			Labels:    buildTidbMonitorLabel(monitor.Name),
 		},
 		Subjects: []rbac.Subject{
 			{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

fixes #5299

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - check no error log
  - check ClusterRole/ClusterRoleBinding is deleted after TidbMonitor is deleted
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
fix TidbMonitor can't update ClusterRole/ClusterRoleBinding when clusterScoped is set
```
