### PR TITLE
feat(pd): rename underlying resource names

### DIFF
--- a/apis/core/v1alpha1/cluster_types.go
+++ b/apis/core/v1alpha1/cluster_types.go
@@ -185,17 +185,14 @@ func (c *Cluster) IsTLSClusterEnabled() bool {
 	return c.Spec.TLSCluster != nil && c.Spec.TLSCluster.Enabled
 }
 
-// TLSClusterSecretName returns the mTLS secret name for a component group.
-func (c *Cluster) TLSClusterSecretName(groupName string) string {
-	return fmt.Sprintf("%s-%s-cluster-secret", c.Name, groupName)
-}
-
 // ClusterClientTLSSecretName returns the mTLS secret name for the cluster client.
+// TODO: move it to namer pkg
 func (c *Cluster) ClusterClientTLSSecretName() string {
 	return TLSClusterClientSecretName(c.Name)
 }
 
 // TLSClusterClientSecretName returns the mTLS secret name for the cluster client.
+// TODO: move it to namer pkg
 func TLSClusterClientSecretName(clusterName string) string {
 	return fmt.Sprintf("%s-cluster-client-secret", clusterName)
 }

--- a/apis/core/v1alpha1/pd_types.go
+++ b/apis/core/v1alpha1/pd_types.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -247,6 +249,30 @@ func (in *PD) GetPeerPort() int32 {
 		return in.Spec.Server.Ports.Peer.Port
 	}
 	return DefaultPDPortPeer
+}
+
+// NOTE: name prefix is used to generate all names of underlying resources of this instance
+func (in *PD) NamePrefixAndSuffix() (prefix, suffix string) {
+	index := strings.LastIndexByte(in.Name, '-')
+	// TODO(liubo02): validate name to avoid '-' is not found
+	if index == -1 {
+		panic("cannot get name prefix")
+	}
+	return in.Name[:index], in.Name[index+1:]
+}
+
+// This name is not only for pod, but also configMap, hostname and almost all underlying resources
+// TODO(liubo02): rename to more reasonable one
+func (in *PD) PodName() string {
+	prefix, suffix := in.NamePrefixAndSuffix()
+	return prefix + "-pd-" + suffix
+}
+
+// TLSClusterSecretName returns the mTLS secret name for a component.
+// TODO(liubo02): move to namer
+func (in *PD) TLSClusterSecretName() string {
+	prefix, _ := in.NamePrefixAndSuffix()
+	return prefix + "-pd-cluster-secret"
 }
 
 // PDGroupSpec describes the common attributes of a PDGroup

--- a/apis/core/v1alpha1/tiflash_types.go
+++ b/apis/core/v1alpha1/tiflash_types.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -267,6 +269,30 @@ func (in *TiFlash) GetProxyStatusPort() int32 {
 		return in.Spec.Server.Ports.ProxyStatus.Port
 	}
 	return DefaultTiFlashPortProxyStatus
+}
+
+// NOTE: name prefix is used to generate all names of underlying resources of this instance
+func (in *TiFlash) NamePrefixAndSuffix() (prefix, suffix string) {
+	index := strings.LastIndexByte(in.Name, '-')
+	// TODO(liubo02): validate name to avoid '-' is not found
+	if index == -1 {
+		panic("cannot get name prefix")
+	}
+	return in.Name[:index], in.Name[index+1:]
+}
+
+// This name is not only for pod, but also configMap, hostname and almost all underlying resources
+// TODO(liubo02): rename to more reasonable one
+func (in *TiFlash) PodName() string {
+	prefix, suffix := in.NamePrefixAndSuffix()
+	return prefix + "-tiflash-" + suffix
+}
+
+// TLSClusterSecretName returns the mTLS secret name for a component.
+// TODO(liubo02): move to namer
+func (in *TiFlash) TLSClusterSecretName() string {
+	prefix, _ := in.NamePrefixAndSuffix()
+	return prefix + "-tiflash-cluster-secret"
 }
 
 type TiFlashGroupSpec struct {

--- a/apis/core/v1alpha1/tikv_types.go
+++ b/apis/core/v1alpha1/tikv_types.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -257,6 +259,30 @@ func (in *TiKV) GetStatusPort() int32 {
 		return in.Spec.Server.Ports.Status.Port
 	}
 	return DefaultTiKVPortStatus
+}
+
+// NOTE: name prefix is used to generate all names of underlying resources of this instance
+func (in *TiKV) NamePrefixAndSuffix() (prefix, suffix string) {
+	index := strings.LastIndexByte(in.Name, '-')
+	// TODO(liubo02): validate name to avoid '-' is not found
+	if index == -1 {
+		panic("cannot get name prefix")
+	}
+	return in.Name[:index], in.Name[index+1:]
+}
+
+// This name is not only for pod, but also configMap, hostname and almost all underlying resources
+// TODO(liubo02): rename to more reasonable one
+func (in *TiKV) PodName() string {
+	prefix, suffix := in.NamePrefixAndSuffix()
+	return prefix + "-tikv-" + suffix
+}
+
+// TLSClusterSecretName returns the mTLS secret name for a component.
+// TODO(liubo02): move to namer
+func (in *TiKV) TLSClusterSecretName() string {
+	prefix, _ := in.NamePrefixAndSuffix()
+	return prefix + "-tikv-cluster-secret"
 }
 
 // TiKVGroupSpec describes the common attributes of a TiKVGroup

--- a/pkg/configs/pd/config.go
+++ b/pkg/configs/pd/config.go
@@ -162,7 +162,7 @@ func getAdvertiseClientURLs(pd *v1alpha1.PD, scheme string) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	host := pd.Name + "." + pd.Spec.Subdomain + "." + ns
+	host := pd.PodName() + "." + pd.Spec.Subdomain + "." + ns
 	return fmt.Sprintf("%s://%s:%d", scheme, host, pd.GetClientPort())
 }
 
@@ -175,7 +175,7 @@ func getAdvertisePeerURLs(pd *v1alpha1.PD, scheme string) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	host := pd.Name + "." + pd.Spec.Subdomain + "." + ns
+	host := pd.PodName() + "." + pd.Spec.Subdomain + "." + ns
 	return fmt.Sprintf("%s://%s:%d", scheme, host, pd.GetPeerPort())
 }
 

--- a/pkg/configs/tidb/config.go
+++ b/pkg/configs/tidb/config.go
@@ -136,7 +136,7 @@ func getAdvertiseAddress(tidb *v1alpha1.TiDB) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return tidb.Name + "." + tidb.Spec.Subdomain + "." + ns + ".svc"
+	return tidb.PodName() + "." + tidb.Spec.Subdomain + "." + ns + ".svc"
 }
 
 func removeHTTPPrefix(url string) string {

--- a/pkg/configs/tiflash/config.go
+++ b/pkg/configs/tiflash/config.go
@@ -188,7 +188,7 @@ func GetServiceAddr(tiflash *v1alpha1.TiFlash) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return fmt.Sprintf("%s.%s.%s:%d", tiflash.Name, tiflash.Spec.Subdomain, ns, tiflash.GetFlashPort())
+	return fmt.Sprintf("%s.%s.%s:%d", tiflash.PodName(), tiflash.Spec.Subdomain, ns, tiflash.GetFlashPort())
 }
 
 func getProxyAddr(tiflash *v1alpha1.TiFlash) string {
@@ -200,7 +200,7 @@ func getProxyAdvertiseAddr(tiflash *v1alpha1.TiFlash) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return fmt.Sprintf("%s.%s.%s:%d", tiflash.Name, tiflash.Spec.Subdomain, ns, tiflash.GetProxyPort())
+	return fmt.Sprintf("%s.%s.%s:%d", tiflash.PodName(), tiflash.Spec.Subdomain, ns, tiflash.GetProxyPort())
 }
 
 func getProxyAdvertiseStatusAddr(tiflash *v1alpha1.TiFlash) string {
@@ -208,7 +208,7 @@ func getProxyAdvertiseStatusAddr(tiflash *v1alpha1.TiFlash) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return fmt.Sprintf("%s.%s.%s:%d", tiflash.Name, tiflash.Spec.Subdomain, ns, tiflash.GetProxyStatusPort())
+	return fmt.Sprintf("%s.%s.%s:%d", tiflash.PodName(), tiflash.Spec.Subdomain, ns, tiflash.GetProxyStatusPort())
 }
 
 func GetServerLogPath(tiflash *v1alpha1.TiFlash) string {

--- a/pkg/configs/tikv/config.go
+++ b/pkg/configs/tikv/config.go
@@ -157,7 +157,7 @@ func GetAdvertiseClientURLs(tikv *v1alpha1.TiKV) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return fmt.Sprintf("%s.%s.%s:%d", tikv.Name, tikv.Spec.Subdomain, ns, tikv.GetClientPort())
+	return fmt.Sprintf("%s.%s.%s:%d", tikv.PodName(), tikv.Spec.Subdomain, ns, tikv.GetClientPort())
 }
 
 func getStatusURLs(tikv *v1alpha1.TiKV) string {
@@ -169,5 +169,5 @@ func getAdvertiseStatusURLs(tikv *v1alpha1.TiKV) string {
 	if ns == "" {
 		ns = corev1.NamespaceDefault
 	}
-	return fmt.Sprintf("%s.%s.%s:%d", tikv.Name, tikv.Spec.Subdomain, ns, tikv.GetStatusPort())
+	return fmt.Sprintf("%s.%s.%s:%d", tikv.PodName(), tikv.Spec.Subdomain, ns, tikv.GetStatusPort())
 }

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -58,8 +58,8 @@ func (t *TaskStatus) Sync(ctx task.Context[ReconcileContext]) task.Result {
 		if rtx.Cluster.IsTLSClusterEnabled() {
 			scheme = "https"
 		}
-		pdAddr := fmt.Sprintf("%s://%s-%s.%s:%d", scheme, rtx.Cluster.Name,
-			rtx.PDGroup.Name, rtx.PDGroup.Namespace, rtx.PDGroup.GetClientPort())
+		// TODO(liubo02): extract a common util to get pd addr
+		pdAddr := fmt.Sprintf("%s://%s-pd.%s:%d", scheme, rtx.PDGroup.Name, rtx.PDGroup.Namespace, rtx.PDGroup.GetClientPort())
 		if rtx.Cluster.Status.PD != pdAddr { // TODO(csuzhangxc): verify switch between TLS and non-TLS
 			rtx.Cluster.Status.PD = pdAddr
 			needUpdate = true

--- a/pkg/controllers/pd/tasks/cm.go
+++ b/pkg/controllers/pd/tasks/cm.go
@@ -62,7 +62,7 @@ func TaskConfigMap(ctx *ReconcileContext, _ logr.Logger, c client.Client) task.T
 func newConfigMap(pd *v1alpha1.PD, data []byte, hash string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ConfigMapName(pd.Name),
+			Name:      pd.PodName(),
 			Namespace: pd.Namespace,
 			Labels: maputil.Merge(pd.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   pd.Name,

--- a/pkg/controllers/pd/tasks/ctx.go
+++ b/pkg/controllers/pd/tasks/ctx.go
@@ -85,9 +85,11 @@ func (ctx *ReconcileContext) SetCluster(c *v1alpha1.Cluster) {
 	ctx.Cluster = c
 }
 
-// Pod always uses same namespace and name of PD
 func (ctx *ReconcileContext) PodKey() types.NamespacedName {
-	return ctx.Key
+	return types.NamespacedName{
+		Namespace: ctx.PD.Namespace,
+		Name:      ctx.PD.PodName(),
+	}
 }
 
 func (ctx *ReconcileContext) GetPod() *corev1.Pod {

--- a/pkg/controllers/pd/tasks/pvc.go
+++ b/pkg/controllers/pd/tasks/pvc.go
@@ -47,7 +47,7 @@ func newPVCs(pd *v1alpha1.PD) []*corev1.PersistentVolumeClaim {
 		vol := &pd.Spec.Volumes[i]
 		pvcs = append(pvcs, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PersistentVolumeClaimName(pd.Name, vol.Name),
+				Name:      PersistentVolumeClaimName(pd.PodName(), vol.Name),
 				Namespace: pd.Namespace,
 				Labels: maputil.Merge(pd.Labels, map[string]string{
 					v1alpha1.LabelKeyInstance: pd.Name,

--- a/pkg/controllers/pd/tasks/util.go
+++ b/pkg/controllers/pd/tasks/util.go
@@ -23,16 +23,12 @@ import (
 	"github.com/pingcap/tidb-operator/apis/core/v1alpha1"
 )
 
-func ConfigMapName(pdName string) string {
-	return pdName
-}
-
-func PersistentVolumeClaimName(pdName, volName string) string {
+func PersistentVolumeClaimName(podName, volName string) string {
 	// ref: https://github.com/pingcap/tidb-operator/blob/v1.6.0/pkg/apis/pingcap/v1alpha1/helpers.go#L92
 	if volName == "" {
-		return "pd-" + pdName
+		return "pd-" + podName
 	}
-	return "pd-" + pdName + "-" + volName
+	return "pd-" + podName + "-" + volName
 }
 
 func LongestHealthPeer(pd *v1alpha1.PD, peers []*v1alpha1.PD) string {

--- a/pkg/controllers/pdgroup/tasks/svc.go
+++ b/pkg/controllers/pdgroup/tasks/svc.go
@@ -69,7 +69,7 @@ func newHeadlessService(pdg *v1alpha1.PDGroup) *corev1.Service {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      HeadlessServiceName(pdg.Spec.Cluster.Name, pdg.Name),
+			Name:      HeadlessServiceName(pdg.Name),
 			Namespace: pdg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,
@@ -114,7 +114,7 @@ func newInternalService(pdg *v1alpha1.PDGroup) *corev1.Service {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", pdg.Spec.Cluster.Name, pdg.Name),
+			Name:      fmt.Sprintf("%s-pd", pdg.Name),
 			Namespace: pdg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,

--- a/pkg/controllers/pdgroup/tasks/updater.go
+++ b/pkg/controllers/pdgroup/tasks/updater.go
@@ -165,10 +165,13 @@ func needVersionUpgrade(pdg *v1alpha1.PDGroup) bool {
 	return pdg.Spec.Version != pdg.Status.Version && pdg.Status.Version != ""
 }
 
+const (
+	suffixLen = 6
+)
+
 func PDNewer(pdg *v1alpha1.PDGroup, rev string) updater.NewFactory[*runtime.PD] {
 	return updater.NewFunc[*runtime.PD](func() *runtime.PD {
-		//nolint:mnd // refactor to use a constant
-		name := fmt.Sprintf("%s-%s-%s", pdg.Spec.Cluster.Name, pdg.Name, random.Random(6))
+		name := fmt.Sprintf("%s-%s", pdg.Name, random.Random(suffixLen))
 		spec := pdg.Spec.Template.Spec.DeepCopy()
 
 		var bootAnno map[string]string
@@ -202,7 +205,7 @@ func PDNewer(pdg *v1alpha1.PDGroup, rev string) updater.NewFactory[*runtime.PD] 
 			Spec: v1alpha1.PDSpec{
 				Cluster:        pdg.Spec.Cluster,
 				Version:        pdg.Spec.Version,
-				Subdomain:      HeadlessServiceName(pdg.Spec.Cluster.Name, pdg.Name),
+				Subdomain:      HeadlessServiceName(pdg.Name),
 				PDTemplateSpec: *spec,
 			},
 		}

--- a/pkg/controllers/pdgroup/tasks/util.go
+++ b/pkg/controllers/pdgroup/tasks/util.go
@@ -21,9 +21,10 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/updater"
 )
 
-// TODO: fix length issue
-func HeadlessServiceName(clusterName, groupName string) string {
-	return fmt.Sprintf("%s-%s-peer", clusterName, groupName)
+// TODO(liubo02): fix length issue
+// TODO(liubo02): extract into common utils
+func HeadlessServiceName(groupName string) string {
+	return fmt.Sprintf("%s-pd-peer", groupName)
 }
 
 func NotLeaderPolicy() updater.PreferPolicy[*runtime.PD] {

--- a/pkg/controllers/tidb/tasks/cm.go
+++ b/pkg/controllers/tidb/tasks/cm.go
@@ -75,7 +75,7 @@ func (t *TaskConfigMap) Sync(ctx task.Context[ReconcileContext]) task.Result {
 func newConfigMap(tidb *v1alpha1.TiDB, data []byte, hash string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ConfigMapName(tidb.Name),
+			Name:      tidb.PodName(),
 			Namespace: tidb.Namespace,
 			Labels: maputil.Merge(tidb.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tidb.Name,

--- a/pkg/controllers/tidb/tasks/cm_test.go
+++ b/pkg/controllers/tidb/tasks/cm_test.go
@@ -107,7 +107,7 @@ func TestConfigMap(t *testing.T) {
 			expected: task.Complete().With(""),
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-tidb",
+					Name: "test-tidb-tidb",
 					Labels: map[string]string{
 						"aaa":                                 "bbb",
 						v1alpha1.LabelKeyInstance:             "test-tidb",
@@ -126,7 +126,7 @@ func TestConfigMap(t *testing.T) {
 					},
 				},
 				Data: map[string]string{
-					v1alpha1.ConfigFileName: `advertise-address = 'test-tidb.subdomain.default.svc'
+					v1alpha1.ConfigFileName: `advertise-address = 'test-tidb-tidb.subdomain.default.svc'
 graceful-wait-before-shutdown = 30
 host = '::'
 path = 'test-pd.default:2379'
@@ -165,7 +165,7 @@ graceful-wait-before-shutdown = 60`),
 			expected: task.Complete().With(""),
 			expectedCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-tidb",
+					Name: "test-tidb-tidb",
 					Labels: map[string]string{
 						"aaa":                                 "bbb",
 						v1alpha1.LabelKeyInstance:             "test-tidb",
@@ -184,7 +184,7 @@ graceful-wait-before-shutdown = 60`),
 					},
 				},
 				Data: map[string]string{
-					v1alpha1.ConfigFileName: `advertise-address = 'test-tidb.subdomain.default.svc'
+					v1alpha1.ConfigFileName: `advertise-address = 'test-tidb-tidb.subdomain.default.svc'
 graceful-wait-before-shutdown = 60
 host = '::'
 path = 'test-pd.default:2379'
@@ -230,7 +230,7 @@ slow-query-file = '/var/log/tidb/slowlog'
 
 			cm := corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ConfigMapName(ctx.TiDB.Name),
+					Name: ConfigMapName(ctx.TiDB.PodName()),
 				},
 			}
 			err := fc.Get(ctx, client.ObjectKeyFromObject(&cm), &cm)

--- a/pkg/controllers/tidb/tasks/ctx.go
+++ b/pkg/controllers/tidb/tasks/ctx.go
@@ -104,7 +104,7 @@ func TaskContextPod(c client.Client) task.Task[ReconcileContext] {
 		rtx := ctx.Self()
 		var pod corev1.Pod
 		if err := c.Get(ctx, client.ObjectKey{
-			Name:      rtx.TiDB.Name,
+			Name:      rtx.TiDB.PodName(),
 			Namespace: rtx.TiDB.Namespace,
 		}, &pod); err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/controllers/tidb/tasks/pvc.go
+++ b/pkg/controllers/tidb/tasks/pvc.go
@@ -63,7 +63,7 @@ func newPVCs(tidb *v1alpha1.TiDB) []*corev1.PersistentVolumeClaim {
 		vol := &tidb.Spec.Volumes[i]
 		pvcs = append(pvcs, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PersistentVolumeClaimName(tidb.Name, vol.Name),
+				Name:      PersistentVolumeClaimName(tidb.PodName(), vol.Name),
 				Namespace: tidb.Namespace,
 				Labels: maputil.Merge(tidb.Labels, map[string]string{
 					v1alpha1.LabelKeyInstance: tidb.Name,

--- a/pkg/controllers/tidb/tasks/server_labels.go
+++ b/pkg/controllers/tidb/tasks/server_labels.go
@@ -56,7 +56,7 @@ func (t *TaskServerLabels) Sync(ctx task.Context[ReconcileContext]) task.Result 
 
 	nodeName := rtx.Pod.Spec.NodeName
 	if nodeName == "" {
-		return task.Fail().With("pod %s/%s has not been scheduled", rtx.TiDB.Namespace, rtx.TiDB.Name)
+		return task.Fail().With("pod %s/%s has not been scheduled", rtx.Pod.Namespace, rtx.Pod.Name)
 	}
 	var node corev1.Node
 	if err := t.Client.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {

--- a/pkg/controllers/tidb/tasks/util.go
+++ b/pkg/controllers/tidb/tasks/util.go
@@ -24,15 +24,15 @@ func ConfigMapName(tidbName string) string {
 	return tidbName
 }
 
-func PersistentVolumeClaimName(tidbName, volName string) string {
+func PersistentVolumeClaimName(podName, volName string) string {
 	// ref: https://github.com/pingcap/tidb-operator/blob/v1.6.0/pkg/apis/pingcap/v1alpha1/helpers.go#L92
 	if volName == "" {
-		return "tidb-" + tidbName
+		return "tidb-" + podName
 	}
-	return "tidb-" + tidbName + "-" + volName
+	return "tidb-" + podName + "-" + volName
 }
 
 // TiDBServiceURL returns the service URL of a tidb member.
 func TiDBServiceURL(tidb *v1alpha1.TiDB, scheme string) string {
-	return fmt.Sprintf("%s://%s.%s.%s.svc:%d", scheme, tidb.Name, tidb.Spec.Subdomain, tidb.Namespace, tidb.GetStatusPort())
+	return fmt.Sprintf("%s://%s.%s.%s.svc:%d", scheme, tidb.PodName(), tidb.Spec.Subdomain, tidb.Namespace, tidb.GetStatusPort())
 }

--- a/pkg/controllers/tidbgroup/tasks/svc.go
+++ b/pkg/controllers/tidbgroup/tasks/svc.go
@@ -69,7 +69,7 @@ func newHeadlessService(tidbg *v1alpha1.TiDBGroup) *corev1.Service {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      HeadlessServiceName(tidbg.Spec.Cluster.Name, tidbg.Name),
+			Name:      HeadlessServiceName(tidbg.Name),
 			Namespace: tidbg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,
@@ -112,7 +112,7 @@ func newService(tidbg *v1alpha1.TiDBGroup) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", tidbg.Spec.Cluster.Name, tidbg.Name),
+			Name:      tidbg.Name + "-tidb",
 			Namespace: tidbg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,

--- a/pkg/controllers/tidbgroup/tasks/updater.go
+++ b/pkg/controllers/tidbgroup/tasks/updater.go
@@ -153,10 +153,13 @@ func needVersionUpgrade(dbg *v1alpha1.TiDBGroup) bool {
 	return dbg.Spec.Version != dbg.Status.Version && dbg.Status.Version != ""
 }
 
+const (
+	suffixLen = 6
+)
+
 func TiDBNewer(dbg *v1alpha1.TiDBGroup, rev string) updater.NewFactory[*runtime.TiDB] {
 	return updater.NewFunc[*runtime.TiDB](func() *runtime.TiDB {
-		//nolint:mnd // refactor to use a constant
-		name := fmt.Sprintf("%s-%s-%s", dbg.Spec.Cluster.Name, dbg.Name, random.Random(6))
+		name := fmt.Sprintf("%s-%s", dbg.Name, random.Random(suffixLen))
 		spec := dbg.Spec.Template.Spec.DeepCopy()
 
 		tidb := &v1alpha1.TiDB{
@@ -178,7 +181,7 @@ func TiDBNewer(dbg *v1alpha1.TiDBGroup, rev string) updater.NewFactory[*runtime.
 			Spec: v1alpha1.TiDBSpec{
 				Cluster:          dbg.Spec.Cluster,
 				Version:          dbg.Spec.Version,
-				Subdomain:        HeadlessServiceName(dbg.Spec.Cluster.Name, dbg.Name), // same as headless service
+				Subdomain:        HeadlessServiceName(dbg.Name), // same as headless service
 				TiDBTemplateSpec: *spec,
 			},
 		}

--- a/pkg/controllers/tidbgroup/tasks/util.go
+++ b/pkg/controllers/tidbgroup/tasks/util.go
@@ -18,6 +18,6 @@ import (
 	"fmt"
 )
 
-func HeadlessServiceName(clusterName, groupName string) string {
-	return fmt.Sprintf("%s-%s-peer", clusterName, groupName)
+func HeadlessServiceName(groupName string) string {
+	return fmt.Sprintf("%s-tidb-peer", groupName)
 }

--- a/pkg/controllers/tiflash/tasks/cm.go
+++ b/pkg/controllers/tiflash/tasks/cm.go
@@ -86,7 +86,7 @@ func (t *TaskConfigMap) Sync(ctx task.Context[ReconcileContext]) task.Result {
 func newConfigMap(tiflash *v1alpha1.TiFlash, flashData, proxyData []byte, hash string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ConfigMapName(tiflash.Name),
+			Name:      tiflash.PodName(),
 			Namespace: tiflash.Namespace,
 			Labels: maputil.Merge(tiflash.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tiflash.Name,

--- a/pkg/controllers/tiflash/tasks/ctx.go
+++ b/pkg/controllers/tiflash/tasks/ctx.go
@@ -140,7 +140,7 @@ func TaskContextPod(c client.Client) task.Task[ReconcileContext] {
 		rtx := ctx.Self()
 		var pod corev1.Pod
 		if err := c.Get(ctx, client.ObjectKey{
-			Name:      rtx.TiFlash.Name,
+			Name:      rtx.TiFlash.PodName(),
 			Namespace: rtx.TiFlash.Namespace,
 		}, &pod); err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/controllers/tiflash/tasks/pod.go
+++ b/pkg/controllers/tiflash/tasks/pod.go
@@ -107,7 +107,7 @@ func (*TaskPod) newPod(cluster *v1alpha1.Cluster, _ *v1alpha1.TiFlashGroup, tifl
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: ConfigMapName(tiflash.Name),
+						Name: tiflash.PodName(),
 					},
 				},
 			},
@@ -133,7 +133,7 @@ func (*TaskPod) newPod(cluster *v1alpha1.Cluster, _ *v1alpha1.TiFlashGroup, tifl
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					// the format is "data{i}-tiflash-xxx" to compatible with TiDB Operator v1
-					ClaimName: PersistentVolumeClaimName(tiflash.Name, i),
+					ClaimName: PersistentVolumeClaimName(tiflash.PodName(), i),
 				},
 			},
 		})
@@ -148,12 +148,11 @@ func (*TaskPod) newPod(cluster *v1alpha1.Cluster, _ *v1alpha1.TiFlashGroup, tifl
 	}
 
 	if cluster.IsTLSClusterEnabled() {
-		groupName := tiflash.Labels[v1alpha1.LabelKeyGroup]
 		vols = append(vols, corev1.Volume{
 			Name: v1alpha1.TiFlashClusterTLSVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: cluster.TLSClusterSecretName(groupName),
+					SecretName: tiflash.TLSClusterSecretName(),
 				},
 			},
 		})
@@ -167,7 +166,7 @@ func (*TaskPod) newPod(cluster *v1alpha1.Cluster, _ *v1alpha1.TiFlashGroup, tifl
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: tiflash.Namespace,
-			Name:      tiflash.Name,
+			Name:      tiflash.PodName(),
 			Labels: maputil.Merge(tiflash.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tiflash.Name,
 				v1alpha1.LabelKeyConfigHash: configHash,
@@ -178,7 +177,7 @@ func (*TaskPod) newPod(cluster *v1alpha1.Cluster, _ *v1alpha1.TiFlashGroup, tifl
 			},
 		},
 		Spec: corev1.PodSpec{
-			Hostname:     tiflash.Name,
+			Hostname:     tiflash.PodName(),
 			Subdomain:    tiflash.Spec.Subdomain,
 			NodeSelector: tiflash.Spec.Topology,
 			InitContainers: []corev1.Container{

--- a/pkg/controllers/tiflash/tasks/pvc.go
+++ b/pkg/controllers/tiflash/tasks/pvc.go
@@ -64,7 +64,7 @@ func newPVCs(tiflash *v1alpha1.TiFlash) []*corev1.PersistentVolumeClaim {
 		pvcs = append(pvcs, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				// the format is "data{i}-tiflash-xxx" to compatible with TiDB Operator v1
-				Name:      PersistentVolumeClaimName(tiflash.Name, i),
+				Name:      PersistentVolumeClaimName(tiflash.PodName(), i),
 				Namespace: tiflash.Namespace,
 				Labels: maputil.Merge(tiflash.Labels, map[string]string{
 					v1alpha1.LabelKeyInstance: tiflash.Name,

--- a/pkg/controllers/tiflash/tasks/store_labels.go
+++ b/pkg/controllers/tiflash/tasks/store_labels.go
@@ -53,7 +53,7 @@ func (t *TaskStoreLabels) Sync(ctx task.Context[ReconcileContext]) task.Result {
 
 	nodeName := rtx.Pod.Spec.NodeName
 	if nodeName == "" {
-		return task.Fail().With("pod %s/%s has not been scheduled", rtx.TiFlash.Namespace, rtx.TiFlash.Name)
+		return task.Fail().With("pod %s/%s has not been scheduled", rtx.Pod.Namespace, rtx.Pod.Name)
 	}
 
 	var node corev1.Node

--- a/pkg/controllers/tiflashgroup/tasks/svc.go
+++ b/pkg/controllers/tiflashgroup/tasks/svc.go
@@ -60,20 +60,20 @@ func (t *TaskService) Sync(ctx task.Context[ReconcileContext]) task.Result {
 	return task.Complete().With("headless service of tiflash has been applied")
 }
 
-func newHeadlessService(flashg *v1alpha1.TiFlashGroup) *corev1.Service {
+func newHeadlessService(fg *v1alpha1.TiFlashGroup) *corev1.Service {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      HeadlessServiceName(flashg.Spec.Cluster.Name, flashg.Name),
-			Namespace: flashg.Namespace,
+			Name:      HeadlessServiceName(fg.Name),
+			Namespace: fg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,
 				v1alpha1.LabelKeyComponent: v1alpha1.LabelValComponentTiFlash,
-				v1alpha1.LabelKeyCluster:   flashg.Spec.Cluster.Name,
-				v1alpha1.LabelKeyGroup:     flashg.Name,
+				v1alpha1.LabelKeyCluster:   fg.Spec.Cluster.Name,
+				v1alpha1.LabelKeyGroup:     fg.Name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(flashg, v1alpha1.SchemeGroupVersion.WithKind("TiFlashGroup")),
+				*metav1.NewControllerRef(fg, v1alpha1.SchemeGroupVersion.WithKind("TiFlashGroup")),
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -83,31 +83,31 @@ func newHeadlessService(flashg *v1alpha1.TiFlashGroup) *corev1.Service {
 			Selector: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,
 				v1alpha1.LabelKeyComponent: v1alpha1.LabelValComponentTiFlash,
-				v1alpha1.LabelKeyCluster:   flashg.Spec.Cluster.Name,
-				v1alpha1.LabelKeyGroup:     flashg.Name,
+				v1alpha1.LabelKeyCluster:   fg.Spec.Cluster.Name,
+				v1alpha1.LabelKeyGroup:     fg.Name,
 			},
 			Ports: []corev1.ServicePort{
 				{
 					Name:       v1alpha1.TiFlashPortNameFlash,
-					Port:       flashg.GetFlashPort(),
+					Port:       fg.GetFlashPort(),
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromString(v1alpha1.TiFlashPortNameFlash),
 				},
 				{
 					Name:       v1alpha1.TiFlashPortNameProxy,
-					Port:       flashg.GetProxyPort(),
+					Port:       fg.GetProxyPort(),
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromString(v1alpha1.TiFlashPortNameProxy),
 				},
 				{
 					Name:       v1alpha1.TiFlashPortNameMetrics,
-					Port:       flashg.GetMetricsPort(),
+					Port:       fg.GetMetricsPort(),
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromString(v1alpha1.TiFlashPortNameMetrics),
 				},
 				{
 					Name:       v1alpha1.TiFlashPortNameProxyStatus,
-					Port:       flashg.GetProxyStatusPort(),
+					Port:       fg.GetProxyStatusPort(),
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromString(v1alpha1.TiFlashPortNameProxyStatus),
 				},

--- a/pkg/controllers/tiflashgroup/tasks/updater.go
+++ b/pkg/controllers/tiflashgroup/tasks/updater.go
@@ -150,10 +150,13 @@ func needVersionUpgrade(flashg *v1alpha1.TiFlashGroup) bool {
 	return flashg.Spec.Version != flashg.Status.Version && flashg.Status.Version != ""
 }
 
+const (
+	suffixLen = 6
+)
+
 func TiFlashNewer(fg *v1alpha1.TiFlashGroup, rev string) updater.NewFactory[*runtime.TiFlash] {
 	return updater.NewFunc[*runtime.TiFlash](func() *runtime.TiFlash {
-		//nolint:mnd // refactor to use a constant
-		name := fmt.Sprintf("%s-%s-%s", fg.Spec.Cluster.Name, fg.Name, random.Random(6))
+		name := fmt.Sprintf("%s-%s", fg.Name, random.Random(suffixLen))
 		spec := fg.Spec.Template.Spec.DeepCopy()
 
 		tiflash := &v1alpha1.TiFlash{
@@ -175,7 +178,7 @@ func TiFlashNewer(fg *v1alpha1.TiFlashGroup, rev string) updater.NewFactory[*run
 			Spec: v1alpha1.TiFlashSpec{
 				Cluster:             fg.Spec.Cluster,
 				Version:             fg.Spec.Version,
-				Subdomain:           HeadlessServiceName(fg.Spec.Cluster.Name, fg.Name),
+				Subdomain:           HeadlessServiceName(fg.Name),
 				TiFlashTemplateSpec: *spec,
 			},
 		}

--- a/pkg/controllers/tiflashgroup/tasks/util.go
+++ b/pkg/controllers/tiflashgroup/tasks/util.go
@@ -19,6 +19,6 @@ import (
 )
 
 // TODO: fix length issue
-func HeadlessServiceName(clusterName, groupName string) string {
-	return fmt.Sprintf("%s-%s-peer", clusterName, groupName)
+func HeadlessServiceName(groupName string) string {
+	return fmt.Sprintf("%s-tiflash-peer", groupName)
 }

--- a/pkg/controllers/tikv/tasks/cm.go
+++ b/pkg/controllers/tikv/tasks/cm.go
@@ -74,7 +74,7 @@ func (t *TaskConfigMap) Sync(ctx task.Context[ReconcileContext]) task.Result {
 func newConfigMap(tikv *v1alpha1.TiKV, data []byte, hash string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ConfigMapName(tikv.Name),
+			Name:      tikv.PodName(),
 			Namespace: tikv.Namespace,
 			Labels: maputil.Merge(tikv.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tikv.Name,

--- a/pkg/controllers/tikv/tasks/ctx.go
+++ b/pkg/controllers/tikv/tasks/ctx.go
@@ -141,7 +141,7 @@ func TaskContextPod(c client.Client) task.Task[ReconcileContext] {
 		rtx := ctx.Self()
 		var pod corev1.Pod
 		if err := c.Get(ctx, client.ObjectKey{
-			Name:      rtx.TiKV.Name,
+			Name:      rtx.TiKV.PodName(),
 			Namespace: rtx.TiKV.Namespace,
 		}, &pod); err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/controllers/tikv/tasks/pvc.go
+++ b/pkg/controllers/tikv/tasks/pvc.go
@@ -63,7 +63,7 @@ func newPVCs(tikv *v1alpha1.TiKV) []*corev1.PersistentVolumeClaim {
 		vol := tikv.Spec.Volumes[i]
 		pvcs = append(pvcs, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PersistentVolumeClaimName(tikv.Name, vol.Name),
+				Name:      PersistentVolumeClaimName(tikv.PodName(), vol.Name),
 				Namespace: tikv.Namespace,
 				Labels: maputil.Merge(tikv.Labels, map[string]string{
 					v1alpha1.LabelKeyInstance: tikv.Name,

--- a/pkg/controllers/tikvgroup/tasks/svc.go
+++ b/pkg/controllers/tikvgroup/tasks/svc.go
@@ -64,7 +64,7 @@ func newHeadlessService(kvg *v1alpha1.TiKVGroup) *corev1.Service {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      HeadlessServiceName(kvg.Spec.Cluster.Name, kvg.Name),
+			Name:      HeadlessServiceName(kvg.Name),
 			Namespace: kvg.Namespace,
 			Labels: map[string]string{
 				v1alpha1.LabelKeyManagedBy: v1alpha1.LabelValManagedByOperator,

--- a/pkg/controllers/tikvgroup/tasks/updater.go
+++ b/pkg/controllers/tikvgroup/tasks/updater.go
@@ -148,10 +148,13 @@ func needVersionUpgrade(kvg *v1alpha1.TiKVGroup) bool {
 	return kvg.Spec.Version != kvg.Status.Version && kvg.Status.Version != ""
 }
 
+const (
+	suffixLen = 6
+)
+
 func TiKVNewer(kvg *v1alpha1.TiKVGroup, rev string) updater.NewFactory[*runtime.TiKV] {
 	return updater.NewFunc[*runtime.TiKV](func() *runtime.TiKV {
-		//nolint:mnd // refactor to use a constant
-		name := fmt.Sprintf("%s-%s-%s", kvg.Spec.Cluster.Name, kvg.Name, random.Random(6))
+		name := fmt.Sprintf("%s-%s", kvg.Name, random.Random(suffixLen))
 
 		spec := kvg.Spec.Template.Spec.DeepCopy()
 
@@ -174,7 +177,7 @@ func TiKVNewer(kvg *v1alpha1.TiKVGroup, rev string) updater.NewFactory[*runtime.
 			Spec: v1alpha1.TiKVSpec{
 				Cluster:          kvg.Spec.Cluster,
 				Version:          kvg.Spec.Version,
-				Subdomain:        HeadlessServiceName(kvg.Spec.Cluster.Name, kvg.Name),
+				Subdomain:        HeadlessServiceName(kvg.Name),
 				TiKVTemplateSpec: *spec,
 			},
 		}

--- a/pkg/controllers/tikvgroup/tasks/util.go
+++ b/pkg/controllers/tikvgroup/tasks/util.go
@@ -19,6 +19,6 @@ import (
 )
 
 // TODO: fix length issue
-func HeadlessServiceName(clusterName, groupName string) string {
-	return fmt.Sprintf("%s-%s-peer", clusterName, groupName)
+func HeadlessServiceName(groupName string) string {
+	return fmt.Sprintf("%s-tikv-peer", groupName)
 }

--- a/pkg/runtime/group.go
+++ b/pkg/runtime/group.go
@@ -19,8 +19,6 @@ type group interface {
 
 	SetReplicas(replicas *int32)
 	Replicas() *int32
-	Cluster() string
-	Component() string
 }
 
 type Group interface {

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -22,6 +22,8 @@ import (
 type object interface {
 	metav1.Object
 
+	Cluster() string
+	Component() string
 	To() client.Object
 	Conditions() []metav1.Condition
 }

--- a/pkg/runtime/pd.go
+++ b/pkg/runtime/pd.go
@@ -99,6 +99,14 @@ func (pd *PD) Conditions() []metav1.Condition {
 	return pd.Status.Conditions
 }
 
+func (pd *PD) Cluster() string {
+	return pd.Spec.Cluster.Name
+}
+
+func (*PD) Component() string {
+	return v1alpha1.LabelValComponentPD
+}
+
 var _ group = &PDGroup{}
 
 func (pdg *PDGroup) DeepCopyObject() runtime.Object {

--- a/pkg/runtime/tidb.go
+++ b/pkg/runtime/tidb.go
@@ -74,3 +74,11 @@ func (db *TiDB) IsUpToDate() bool {
 func (db *TiDB) Conditions() []metav1.Condition {
 	return db.Status.Conditions
 }
+
+func (db *TiDB) Cluster() string {
+	return db.Spec.Cluster.Name
+}
+
+func (*TiDB) Component() string {
+	return v1alpha1.LabelValComponentTiDB
+}

--- a/pkg/runtime/tiflash.go
+++ b/pkg/runtime/tiflash.go
@@ -74,3 +74,11 @@ func (f *TiFlash) IsUpToDate() bool {
 func (f *TiFlash) Conditions() []metav1.Condition {
 	return f.Status.Conditions
 }
+
+func (f *TiFlash) Cluster() string {
+	return f.Spec.Cluster.Name
+}
+
+func (*TiFlash) Component() string {
+	return v1alpha1.LabelValComponentTiFlash
+}

--- a/pkg/runtime/tikv.go
+++ b/pkg/runtime/tikv.go
@@ -74,3 +74,11 @@ func (kv *TiKV) IsUpToDate() bool {
 func (kv *TiKV) Conditions() []metav1.Condition {
 	return kv.Status.Conditions
 }
+
+func (kv *TiKV) Cluster() string {
+	return kv.Spec.Cluster.Name
+}
+
+func (*TiKV) Component() string {
+	return v1alpha1.LabelValComponentTiKV
+}

--- a/pkg/timanager/pd/pd.go
+++ b/pkg/timanager/pd/pd.go
@@ -129,7 +129,7 @@ func NewUnderlayClientFunc(c client.Client) timanager.NewUnderlayClientFunc[*v1a
 			return nil, fmt.Errorf("cannot find cluster %s: %w", pdg.Spec.Cluster.Name, err)
 		}
 
-		host := fmt.Sprintf("%s-%s.%s:%d", pdg.Spec.Cluster.Name, pdg.Name, pdg.Namespace, pdg.GetClientPort())
+		host := fmt.Sprintf("%s-pd.%s:%d", pdg.Name, pdg.Namespace, pdg.GetClientPort())
 
 		if cluster.IsTLSClusterEnabled() {
 			tlsConfig, err := tlsutil.GetTLSConfigFromSecret(ctx, c,

--- a/pkg/updater/builder.go
+++ b/pkg/updater/builder.go
@@ -142,7 +142,12 @@ func (b *builder[PT]) WithUpdatePreferPolicy(ps ...PreferPolicy[PT]) Builder[PT]
 
 func split[PT runtime.Instance](all []PT, rev string) (update, outdated []PT) {
 	for _, instance := range all {
-		if instance.GetUpdateRevision() == rev && instance.GetDeletionTimestamp().IsZero() {
+		// if instance is deleting, just ignore it
+		// TODO(liubo02): make sure it's ok for PD
+		if !instance.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		if instance.GetUpdateRevision() == rev {
 			update = append(update, instance)
 		} else {
 			outdated = append(outdated, instance)

--- a/tests/e2e/cluster/tls.go
+++ b/tests/e2e/cluster/tls.go
@@ -59,10 +59,10 @@ var tidbCertificatesTmpl = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .TiDBGroupName}}-server-secret
+  name: {{ .TiDBGroupName}}-tidb-server-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .TiDBGroupName}}-server-secret
+  secretName: {{ .TiDBGroupName}}-tidb-server-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -72,12 +72,12 @@ spec:
   usages:
     - server auth
   dnsNames:
-    - "{{ .ClusterName }}-{{ .TiDBGroupName}}"
-    - "{{ .ClusterName }}-{{ .TiDBGroupName}}.{{ .Namespace }}"
-    - "{{ .ClusterName }}-{{ .TiDBGroupName}}.{{ .Namespace }}.svc"
-    - "*.{{ .ClusterName }}-{{ .TiDBGroupName}}"
-    - "*.{{ .ClusterName }}-{{ .TiDBGroupName}}.{{ .Namespace }}"
-    - "*.{{ .ClusterName }}-{{ .TiDBGroupName}}.{{ .Namespace }}.svc"
+    - "{{ .TiDBGroupName}}-tidb"
+    - "{{ .TiDBGroupName}}-tidb.{{ .Namespace }}"
+    - "{{ .TiDBGroupName}}-tidb.{{ .Namespace }}.svc"
+    - "*.{{ .TiDBGroupName}}-tidb"
+    - "*.{{ .TiDBGroupName}}-tidb.{{ .Namespace }}"
+    - "*.{{ .TiDBGroupName}}-tidb.{{ .Namespace }}.svc"
   ipAddresses:
     - 127.0.0.1
     - ::1
@@ -89,10 +89,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .TiDBGroupName}}-client-secret
+  name: {{ .TiDBGroupName}}-tidb-client-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .TiDBGroupName}}-client-secret
+  secretName: {{ .TiDBGroupName}}-tidb-client-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -111,10 +111,10 @@ var tidbComponentsCertificatesTmpl = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .PDGroupName }}-cluster-secret
+  name: {{ .PDGroupName }}-pd-cluster-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .PDGroupName }}-cluster-secret
+  secretName: {{ .PDGroupName }}-pd-cluster-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -125,15 +125,15 @@ spec:
     - server auth
     - client auth
   dnsNames:
-  - "{{ .ClusterName }}-{{ .PDGroupName }}"
-  - "{{ .ClusterName }}-{{ .PDGroupName }}.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .PDGroupName }}.{{ .Namespace }}.svc"
-  - "{{ .ClusterName }}-{{ .PDGroupName }}-peer"
-  - "{{ .ClusterName }}-{{ .PDGroupName }}-peer.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .PDGroupName }}-peer.{{ .Namespace }}.svc"
-  - "*.{{ .ClusterName }}-{{ .PDGroupName }}-peer"
-  - "*.{{ .ClusterName }}-{{ .PDGroupName }}-peer.{{ .Namespace }}"
-  - "*.{{ .ClusterName }}-{{ .PDGroupName }}-peer.{{ .Namespace }}.svc"
+  - "{{ .PDGroupName }}-pd"
+  - "{{ .PDGroupName }}-pd.{{ .Namespace }}"
+  - "{{ .PDGroupName }}-pd.{{ .Namespace }}.svc"
+  - "{{ .PDGroupName }}-pd-peer"
+  - "{{ .PDGroupName }}-pd-peer.{{ .Namespace }}"
+  - "{{ .PDGroupName }}-pd-peer.{{ .Namespace }}.svc"
+  - "*.{{ .PDGroupName }}-pd-peer"
+  - "*.{{ .PDGroupName }}-pd-peer.{{ .Namespace }}"
+  - "*.{{ .PDGroupName }}-pd-peer.{{ .Namespace }}.svc"
   ipAddresses:
   - 127.0.0.1
   - ::1
@@ -145,10 +145,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .TiKVGroupName }}-cluster-secret
+  name: {{ .TiKVGroupName }}-tikv-cluster-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .TiKVGroupName }}-cluster-secret
+  secretName: {{ .TiKVGroupName }}-tikv-cluster-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -159,15 +159,15 @@ spec:
     - server auth
     - client auth
   dnsNames:
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}"
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}.{{ .Namespace }}.svc"
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}-peer"
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}-peer.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiKVGroupName }}-peer.{{ .Namespace }}.svc"
-  - "*.{{ .ClusterName }}-{{ .TiKVGroupName }}-peer"
-  - "*.{{ .ClusterName }}-{{ .TiKVGroupName }}-peer.{{ .Namespace }}"
-  - "*.{{ .ClusterName }}-{{ .TiKVGroupName }}-peer.{{ .Namespace }}.svc"
+  - "{{ .TiKVGroupName }}-tikv"
+  - "{{ .TiKVGroupName }}-tikv.{{ .Namespace }}"
+  - "{{ .TiKVGroupName }}-tikv.{{ .Namespace }}.svc"
+  - "{{ .TiKVGroupName }}-tikv-peer"
+  - "{{ .TiKVGroupName }}-tikv-peer.{{ .Namespace }}"
+  - "{{ .TiKVGroupName }}-tikv-peer.{{ .Namespace }}.svc"
+  - "*.{{ .TiKVGroupName }}-tikv-peer"
+  - "*.{{ .TiKVGroupName }}-tikv-peer.{{ .Namespace }}"
+  - "*.{{ .TiKVGroupName }}-tikv-peer.{{ .Namespace }}.svc"
   ipAddresses:
   - 127.0.0.1
   - ::1
@@ -179,10 +179,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .TiDBGroupName }}-cluster-secret
+  name: {{ .TiDBGroupName }}-tidb-cluster-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .TiDBGroupName }}-cluster-secret
+  secretName: {{ .TiDBGroupName }}-tidb-cluster-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -193,15 +193,15 @@ spec:
     - server auth
     - client auth
   dnsNames:
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}"
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}.{{ .Namespace }}.svc"
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}-peer"
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}-peer.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiDBGroupName }}-peer.{{ .Namespace }}.svc"
-  - "*.{{ .ClusterName }}-{{ .TiDBGroupName }}-peer"
-  - "*.{{ .ClusterName }}-{{ .TiDBGroupName }}-peer.{{ .Namespace }}"
-  - "*.{{ .ClusterName }}-{{ .TiDBGroupName }}-peer.{{ .Namespace }}.svc"
+  - "{{ .TiDBGroupName }}-tidb"
+  - "{{ .TiDBGroupName }}-tidb.{{ .Namespace }}"
+  - "{{ .TiDBGroupName }}-tidb.{{ .Namespace }}.svc"
+  - "{{ .TiDBGroupName }}-tidb-peer"
+  - "{{ .TiDBGroupName }}-tidb-peer.{{ .Namespace }}"
+  - "{{ .TiDBGroupName }}-tidb-peer.{{ .Namespace }}.svc"
+  - "*.{{ .TiDBGroupName }}-tidb-peer"
+  - "*.{{ .TiDBGroupName }}-tidb-peer.{{ .Namespace }}"
+  - "*.{{ .TiDBGroupName }}-tidb-peer.{{ .Namespace }}.svc"
   ipAddresses:
   - 127.0.0.1
   - ::1
@@ -213,10 +213,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .ClusterName }}-{{ .TiFlashGroupName }}-cluster-secret
+  name: {{ .TiFlashGroupName }}-tiflash-cluster-secret
   namespace: {{ .Namespace }}
 spec:
-  secretName: {{ .ClusterName }}-{{ .TiFlashGroupName }}-cluster-secret
+  secretName: {{ .TiFlashGroupName }}-tiflash-cluster-secret
   duration: 8760h # 365d
   renewBefore: 360h # 15d
   subject:
@@ -227,15 +227,15 @@ spec:
     - server auth
     - client auth
   dnsNames:
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}"
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}.{{ .Namespace }}.svc"
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer"
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer.{{ .Namespace }}"
-  - "{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer.{{ .Namespace }}.svc"
-  - "*.{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer"
-  - "*.{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer.{{ .Namespace }}"
-  - "*.{{ .ClusterName }}-{{ .TiFlashGroupName }}-peer.{{ .Namespace }}.svc"
+  - "{{ .TiFlashGroupName }}-tiflash"
+  - "{{ .TiFlashGroupName }}-tiflash.{{ .Namespace }}"
+  - "{{ .TiFlashGroupName }}-tiflash.{{ .Namespace }}.svc"
+  - "{{ .TiFlashGroupName }}-tiflash-peer"
+  - "{{ .TiFlashGroupName }}-tiflash-peer.{{ .Namespace }}"
+  - "{{ .TiFlashGroupName }}-tiflash-peer.{{ .Namespace }}.svc"
+  - "*.{{ .TiFlashGroupName }}-tiflash-peer"
+  - "*.{{ .TiFlashGroupName }}-tiflash-peer.{{ .Namespace }}"
+  - "*.{{ .TiFlashGroupName }}-tiflash-peer.{{ .Namespace }}.svc"
   ipAddresses:
   - 127.0.0.1
   - ::1
@@ -280,14 +280,17 @@ func installTiDBIssuer(ctx context.Context, yamlApplier *k8s.YAMLApplier, ns, cl
 
 func installTiDBCertificates(ctx context.Context, yamlApplier *k8s.YAMLApplier, ns, clusterName, tidbGroupName string) error {
 	return installCert(ctx, yamlApplier, tidbCertificatesTmpl, tcTmplMeta{
-		Namespace: ns, ClusterName: clusterName, TiDBGroupName: tidbGroupName})
+		Namespace: ns, ClusterName: clusterName, TiDBGroupName: tidbGroupName,
+	})
 }
 
 func installTiDBComponentsCertificates(ctx context.Context, yamlApplier *k8s.YAMLApplier, ns, clusterName string,
-	pdGroupName, tikvGroupName, tidbGroupName, tiFlashGroupName string) error {
+	pdGroupName, tikvGroupName, tidbGroupName, tiFlashGroupName string,
+) error {
 	return installCert(ctx, yamlApplier, tidbComponentsCertificatesTmpl, tcTmplMeta{
 		Namespace: ns, ClusterName: clusterName,
-		PDGroupName: pdGroupName, TiKVGroupName: tikvGroupName, TiDBGroupName: tidbGroupName, TiFlashGroupName: tiFlashGroupName})
+		PDGroupName: pdGroupName, TiKVGroupName: tikvGroupName, TiDBGroupName: tidbGroupName, TiFlashGroupName: tiFlashGroupName,
+	})
 }
 
 func installCert(ctx context.Context, yamlApplier *k8s.YAMLApplier, tmplStr string, tp any) error {


### PR DESCRIPTION
Change `{cluster}-{group}` to `{group}-{component}` as the "name space" of underlying native resources.

This change fixes two conflicts.

```
cluster1="aaa-xxx"
group1="bbb"

cluster2="aaa"
group2="xxx-bbb"
```

and

```
tidbgroup="bbb"
tikvgroup="bbb"
```

