### PR TITLE
Fix(e2e): run a mysql client in kind to test graceful shutdown case

### DIFF
--- a/cmd/testing-workload/main.go
+++ b/cmd/testing-workload/main.go
@@ -1,0 +1,134 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	host              string
+	durationInMinutes int
+	maxConnections    int
+	sleepIntervalSec  int
+	longTxnSleepSec   int
+)
+
+//nolint:mnd // default values
+func main() {
+	flag.StringVar(&host, "host", "", "host")
+	flag.IntVar(&durationInMinutes, "duration", 10, "duration in minutes")
+	flag.IntVar(&maxConnections, "max-connections", 30, "max connections")
+	flag.IntVar(&sleepIntervalSec, "sleep-interval", 1, "sleep interval in seconds")
+	flag.IntVar(&longTxnSleepSec, "long-txn-sleep", 10, "how many seconds to sleep to simulate a long transaction")
+	flag.Parse()
+
+	db, err := sql.Open("mysql", fmt.Sprintf("root:@(%s:4000)/test?charset=utf8mb4", host))
+	if err != nil {
+		panic(err)
+	}
+	if err = db.Ping(); err != nil {
+		panic(err)
+	}
+	defer db.Close()
+	db.SetConnMaxLifetime(time.Minute)
+	db.SetMaxIdleConns(maxConnections)
+	db.SetMaxOpenConns(maxConnections)
+
+	table := "test.e2e_test"
+	str := fmt.Sprintf("create table if not exists %s(id int primary key auto_increment, v int);", table)
+	_, err = db.Exec(str)
+	if err != nil {
+		panic(err)
+	}
+
+	var totalCount, failCount atomic.Uint64
+	var wg sync.WaitGroup
+	clientCtx, cancel := context.WithTimeout(context.Background(), time.Duration(durationInMinutes)*time.Minute)
+	defer cancel()
+
+	for i := 1; i <= maxConnections; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-clientCtx.Done():
+					return
+				default:
+					err := executeSimpleTransaction(db, id, table)
+					totalCount.Add(1)
+					if err != nil {
+						fmt.Printf("[%d-%s] failed to execute simple transaction(long: %v): %v\n", id, time.Now().String(), id%3 == 0, err)
+						failCount.Add(1)
+					}
+					time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	fmt.Printf("total count: %d, fail count: %d\n", totalCount.Load(), failCount.Load())
+	if failCount.Load() > 0 {
+		panic("there are failed transactions")
+	}
+}
+
+// ExecuteSimpleTransaction performs a transaction to insert or update the given id in the specified table.
+func executeSimpleTransaction(db *sql.DB, id int, table string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin txn: %w", err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Prepare SQL statement to replace or insert a record
+	//nolint:gosec // only for testing
+	str := fmt.Sprintf("replace into %s(id, v) values(?, ?);", table)
+	if _, err = tx.Exec(str, id, id); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to exec statement: %w", err)
+	}
+
+	// Simulate a different operation by updating the value
+	if _, err = tx.Exec(fmt.Sprintf("update %s set v = ? where id = ?;", table), id*2, id); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to exec update statement: %w", err)
+	}
+
+	// Simulate a long transaction by sleeping for 10 seconds
+	if id%3 == 0 {
+		time.Sleep(time.Duration(longTxnSleepSec) * time.Second)
+	}
+
+	// Commit the transaction
+	if err = tx.Commit(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		return fmt.Errorf("failed to commit txn: %w", err)
+	}
+	return nil
+}

--- a/hack/lib/build.sh
+++ b/hack/lib/build.sh
@@ -46,7 +46,7 @@ function build::all() {
         shift
     done
     if [[ ${#targets[@]} -eq 0 ]]; then
-        targets=("operator" "prestop-checker")
+        targets=("operator" "prestop-checker" "testing-workload")
     fi
 
     local platforms

--- a/hack/lib/e2e.sh
+++ b/hack/lib/e2e.sh
@@ -129,7 +129,7 @@ function e2e::prepare() {
     e2e::install_rbac
     
     # build the operator image and load it into the kind cluster
-    image::build prestop-checker operator --push
+    image::build prestop-checker operator testing-workload --push
     e2e::uninstall_operator
     e2e::install_operator
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -37,7 +37,6 @@ USER 65532:65532
 
 ENTRYPOINT ["/operator"]
 
-
 FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.9.2 AS prestop-checker
 
 ARG TARGETPLATFORM
@@ -50,3 +49,16 @@ COPY --from=builder ./_output/$TARGETPLATFORM/bin/prestop-checker prestop-checke
 USER 65532:65532
 
 ENTRYPOINT ["/prestop-checker"]
+
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.9.2 AS testing-workload
+
+ARG TARGETPLATFORM
+
+WORKDIR /
+
+COPY --from=builder ./_output/$TARGETPLATFORM/bin/testing-workload testing-workload
+
+# nonroot user of distroless
+USER 65532:65532
+
+ENTRYPOINT ["/testing-workload"]

--- a/pkg/configs/tidb/config.go
+++ b/pkg/configs/tidb/config.go
@@ -28,7 +28,7 @@ const (
 	// defaultGracefulWaitBeforeShutdownInSeconds is the default value of the tidb config `graceful-wait-before-shutdown`,
 	// which is set by the operator if not set by the user, for graceful shutdown.
 	// Note that the default value is zero in tidb-server.
-	defaultGracefulWaitBeforeShutdownInSeconds = 30
+	defaultGracefulWaitBeforeShutdownInSeconds = 60
 )
 
 // Config is a subset config of tidb

--- a/pkg/controllers/tidb/tasks/cm_test.go
+++ b/pkg/controllers/tidb/tasks/cm_test.go
@@ -125,7 +125,7 @@ func TestConfigMap(t *testing.T) {
 				},
 				Data: map[string]string{
 					v1alpha1.ConfigFileName: `advertise-address = 'test-tidb-tidb.subdomain.default.svc'
-graceful-wait-before-shutdown = 30
+graceful-wait-before-shutdown = 60
 host = '::'
 path = 'test-pd.default:2379'
 store = 'tikv'


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

The e2e case `should be able to gracefully shutdown tidb` is not stable, because we use port-forward to connect to tidb.

According to `kubectl port-forward` doc:

> If there are multiple pods matching the criteria, a pod will be selected automatically. The forwarding session ends when the selected pod terminates, and a rerun of the command is needed to resume forwarding.

https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/#synopsis

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

This PR adds a binary and deploy it to KinD to test the graceful shutdown case. The binary acts as a mysql client, it connects to the tidb cluster via k8s service's cluster IP.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
