### PR TITLE
fix(manager): declare status port in tikv pods

### DIFF
--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -641,6 +641,11 @@ func getNewTiKVSetForTidbCluster(tc *v1alpha1.TidbCluster, cm *corev1.ConfigMap)
 				ContainerPort: v1alpha1.DefaultTiKVServerPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
+			{
+				Name:          "status",
+				ContainerPort: v1alpha1.DefaultTiKVStatusPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
 		},
 		VolumeMounts: volMounts,
 		Resources:    controller.ContainerResource(tc.Spec.TiKV.ResourceRequirements),


### PR DESCRIPTION
### What problem does this PR solve?
When scraping pods with victoriametrics, it automatically drops targets (pods in this case) that don't have the port to scrape declared in its `spec.ports`.

### What is changed and how does it work?
Declared the status port in the pod spec.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
- [ ] Unit test
- [ ] E2E test
- [ ] Manual test
- [ ] No code

### Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects

### Related changes

- [x] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

### Release Notes
```release-note
NONE
```
