### PR TITLE
Opt(tidb): do not use sleep action for better compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ lint: bin/golangci-lint
 unit:
 	go test $$(go list -e ./... | grep -v cmd | grep -v tools | grep -v tests | grep -v third_party) \
 		-cover -coverprofile=coverage.txt -covermode=atomic
-	sed -i.bak '/generated/d;/fake.go/d' coverage.txt && rm coverage.txt.bak
+	sed -i.bak '/generated/d;/fake.go/d' coverage.txt && rm coverage.txt coverage.txt.bak
 
 .PHONY: check
 check: lint unit verify

--- a/pkg/controllers/tidb/tasks/pod.go
+++ b/pkg/controllers/tidb/tasks/pod.go
@@ -252,8 +252,12 @@ func newPod(cluster *v1alpha1.Cluster,
 					Resources:    k8s.GetResourceRequirements(tidb.Spec.Resources),
 					Lifecycle: &corev1.Lifecycle{
 						PreStop: &corev1.LifecycleHandler{
-							Sleep: &corev1.SleepAction{
-								Seconds: preStopSleepSeconds,
+							Exec: &corev1.ExecAction{
+								Command: []string{
+									"/bin/sh",
+									"-c",
+									fmt.Sprintf("sleep %d", preStopSleepSeconds),
+								},
 							},
 						},
 					},

--- a/pkg/controllers/tidb/tasks/pod_test.go
+++ b/pkg/controllers/tidb/tasks/pod_test.go
@@ -30,7 +30,10 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
 )
 
-const fakeVersion = "v1.2.3"
+const (
+	fakeVersion = "v1.2.3"
+	podSpecHash = "9bbf8897b"
+)
 
 func TestTaskPod(t *testing.T) {
 	cases := []struct {
@@ -123,7 +126,7 @@ func TestTaskPod(t *testing.T) {
 					pod: fake.FakeObj("aaa-tidb-xxx", func(obj *corev1.Pod) *corev1.Pod {
 						obj.Labels = map[string]string{
 							v1alpha1.LabelKeyConfigHash:  "newest",
-							v1alpha1.LabelKeyPodSpecHash: "5656465c8c",
+							v1alpha1.LabelKeyPodSpecHash: podSpecHash,
 						}
 						return obj
 					}),
@@ -147,7 +150,7 @@ func TestTaskPod(t *testing.T) {
 					pod: fake.FakeObj("aaa-tidb-xxx", func(obj *corev1.Pod) *corev1.Pod {
 						obj.Labels = map[string]string{
 							v1alpha1.LabelKeyConfigHash:  "old",
-							v1alpha1.LabelKeyPodSpecHash: "5656465c8c",
+							v1alpha1.LabelKeyPodSpecHash: podSpecHash,
 						}
 						return obj
 					}),
@@ -171,7 +174,7 @@ func TestTaskPod(t *testing.T) {
 					pod: fake.FakeObj("aaa-tidb-xxx", func(obj *corev1.Pod) *corev1.Pod {
 						obj.Labels = map[string]string{
 							v1alpha1.LabelKeyConfigHash:  "newest",
-							v1alpha1.LabelKeyPodSpecHash: "5656465c8c",
+							v1alpha1.LabelKeyPodSpecHash: podSpecHash,
 							"xxx":                        "yyy",
 						}
 						return obj
@@ -196,7 +199,7 @@ func TestTaskPod(t *testing.T) {
 					pod: fake.FakeObj("aaa-tidb-xxx", func(obj *corev1.Pod) *corev1.Pod {
 						obj.Labels = map[string]string{
 							v1alpha1.LabelKeyConfigHash:  "newest",
-							v1alpha1.LabelKeyPodSpecHash: "5656465c8c",
+							v1alpha1.LabelKeyPodSpecHash: podSpecHash,
 							"xxx":                        "yyy",
 						}
 						return obj
@@ -222,7 +225,7 @@ func TestTaskPod(t *testing.T) {
 						obj.Labels = map[string]string{
 							v1alpha1.LabelKeyInstance:    "aaa-xxx",
 							v1alpha1.LabelKeyConfigHash:  "newest",
-							v1alpha1.LabelKeyPodSpecHash: "5656465c8c",
+							v1alpha1.LabelKeyPodSpecHash: podSpecHash,
 						}
 						return obj
 					}),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
