### PR TITLE
feat: add cluster/member/store ID for Pod and PVC

### DIFF
--- a/apis/core/v1alpha1/cluster_types.go
+++ b/apis/core/v1alpha1/cluster_types.go
@@ -155,6 +155,9 @@ type ClusterStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
+	// ID is the cluster id.
+	ID string `json:"id"`
+
 	// PD means url of the pd service, it's prepared for internal use
 	// e.g. https://pd:2379
 	PD string `json:"pd,omitempty"`

--- a/apis/core/v1alpha1/common_types.go
+++ b/apis/core/v1alpha1/common_types.go
@@ -71,6 +71,16 @@ const (
 	// Instead, we choose to hash the user-specified config,
 	// and the worst case is that users expect a reboot but it doesn't happen.
 	LabelKeyConfigHash = LabelKeyPrefix + "config-hash"
+
+	// LabelKeyClusterID is the unique identifier of the cluster.
+	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	LabelKeyClusterID = "tidb.pingcap.com/cluster-id"
+	// LabelKeyMemberID is the unique identifier of a PD member.
+	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	LabelKeyMemberID = "tidb.pingcap.com/member-id"
+	// LabelKeyStoreID is the unique identifier of a TiKV or TiFlash store.
+	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	LabelKeyStoreID = "tidb.pingcap.com/store-id"
 )
 
 const (

--- a/apis/core/v1alpha1/common_types.go
+++ b/apis/core/v1alpha1/common_types.go
@@ -73,13 +73,13 @@ const (
 	LabelKeyConfigHash = LabelKeyPrefix + "config-hash"
 
 	// LabelKeyClusterID is the unique identifier of the cluster.
-	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	// This label is used for backward compatibility with TiDB Operator v1, so it has a different prefix.
 	LabelKeyClusterID = "tidb.pingcap.com/cluster-id"
 	// LabelKeyMemberID is the unique identifier of a PD member.
-	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	// This label is used for backward compatibility with TiDB Operator v1, so it has a different prefix.
 	LabelKeyMemberID = "tidb.pingcap.com/member-id"
 	// LabelKeyStoreID is the unique identifier of a TiKV or TiFlash store.
-	// It has a different prefix for backward compatibility with TiDB Operator v1.
+	// This label is used for backward compatibility with TiDB Operator v1, so it has a different prefix.
 	LabelKeyStoreID = "tidb.pingcap.com/store-id"
 )
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -209,7 +209,7 @@ func addIndexer(ctx context.Context, mgr ctrl.Manager) error {
 }
 
 func setupControllers(mgr ctrl.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.Modifier) error {
-	if err := cluster.Setup(mgr, c); err != nil {
+	if err := cluster.Setup(mgr, c, pdcm); err != nil {
 		return fmt.Errorf("unable to create controller Cluster: %w", err)
 	}
 	if err := pdgroup.Setup(mgr, c, pdcm); err != nil {

--- a/manifests/crd/core.pingcap.com_clusters.yaml
+++ b/manifests/crd/core.pingcap.com_clusters.yaml
@@ -215,6 +215,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                description: ID is the cluster id.
+                type: string
               observedGeneration:
                 description: |-
                   observedGeneration is the most recent generation observed for this Cluster. It corresponds to the
@@ -226,6 +229,8 @@ spec:
                   PD means url of the pd service, it's prepared for internal use
                   e.g. https://pd:2379
                 type: string
+            required:
+            - id
             type: object
         type: object
     served: true

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -83,6 +83,7 @@ func (t *TaskStatus) Sync(ctx task.Context[ReconcileContext]) task.Result {
 
 	if rtx.Cluster.Status.ID == "" {
 		// no watch for this, so we need to retry
+		//nolint:mnd // only one usage
 		return task.Retry(5 * time.Second).With("cluster id is not set")
 	}
 	return task.Complete().With("updated status")

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -15,9 +15,12 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -25,18 +28,21 @@ import (
 
 	"github.com/pingcap/tidb-operator/apis/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
+	pdm "github.com/pingcap/tidb-operator/pkg/timanager/pd"
 	"github.com/pingcap/tidb-operator/pkg/utils/task"
 )
 
 type TaskStatus struct {
-	Logger logr.Logger
-	Client client.Client
+	Logger          logr.Logger
+	Client          client.Client
+	PDClientManager pdm.PDClientManager
 }
 
-func NewTaskStatus(logger logr.Logger, c client.Client) task.Task[ReconcileContext] {
+func NewTaskStatus(logger logr.Logger, c client.Client, pdcm pdm.PDClientManager) task.Task[ReconcileContext] {
 	return &TaskStatus{
-		Logger: logger,
-		Client: c,
+		Logger:          logger,
+		Client:          c,
+		PDClientManager: pdcm,
 	}
 }
 
@@ -67,6 +73,7 @@ func (t *TaskStatus) Sync(ctx task.Context[ReconcileContext]) task.Result {
 	}
 	needUpdate = t.syncComponentStatus(rtx) || needUpdate
 	needUpdate = t.syncConditions(rtx) || needUpdate
+	needUpdate = t.syncClusterID(ctx, rtx) || needUpdate
 
 	if needUpdate {
 		if err := t.Client.Status().Update(ctx, rtx.Cluster); err != nil {
@@ -74,6 +81,10 @@ func (t *TaskStatus) Sync(ctx task.Context[ReconcileContext]) task.Result {
 		}
 	}
 
+	if rtx.Cluster.Status.ID == "" {
+		// no watch for this, so we need to retry
+		return task.Retry(5 * time.Second).With("cluster id is not set")
+	}
 	return task.Complete().With("updated status")
 }
 
@@ -192,4 +203,30 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 		Reason:             v1alpha1.ClusterSuspendReason,
 		Message:            suspendMessage,
 	}) || changed
+}
+
+func (t *TaskStatus) syncClusterID(ctx context.Context, rtx *ReconcileContext) bool {
+	if rtx.Cluster.Status.ID != "" {
+		// already synced, this will nerver change
+		return false
+	}
+
+	pdClient, ok := t.PDClientManager.Get(pdm.PrimaryKey(rtx.Cluster.Namespace, rtx.Cluster.Name))
+	if !ok {
+		t.Logger.Info("pd client is not registered")
+		return false // wait for next sync
+	}
+
+	cluster, err := pdClient.Underlay().GetCluster(ctx)
+	if err != nil {
+		t.Logger.Error(err, "failed to get cluster info")
+		return false
+	}
+
+	if cluster.Id == 0 {
+		return false
+	}
+
+	rtx.Cluster.Status.ID = strconv.FormatUint(cluster.Id, 10)
+	return true
 }

--- a/pkg/controllers/pd/tasks/ctx.go
+++ b/pkg/controllers/pd/tasks/ctx.go
@@ -34,8 +34,9 @@ type ReconcileContext struct {
 	Initialized bool
 	Healthy     bool
 
-	MemberID string
-	IsLeader bool
+	ClusterID string
+	MemberID  string
+	IsLeader  bool
 
 	// ConfigHash stores the hash of **user-specified** config (i.e.`.Spec.Config`),
 	// which will be used to determine whether the config has changed.
@@ -71,6 +72,7 @@ func TaskContextInfoFromPD(state *ReconcileContext, cm pdm.PDClientManager) task
 			return task.Fail().With("cannot get member: %w", err)
 		}
 
+		state.ClusterID = m.ClusterID
 		state.MemberID = m.ID
 		state.IsLeader = m.IsLeader
 

--- a/pkg/controllers/pd/tasks/pod.go
+++ b/pkg/controllers/pd/tasks/pod.go
@@ -197,6 +197,7 @@ func newPod(state *ReconcileContext) *corev1.Pod {
 				v1alpha1.LabelKeyInstance:   pd.Name,
 				v1alpha1.LabelKeyConfigHash: state.ConfigHash,
 				v1alpha1.LabelKeyClusterID:  state.ClusterID,
+				v1alpha1.LabelKeyMemberID:   state.MemberID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentPD)),
 			Annotations: anno,
 			OwnerReferences: []metav1.OwnerReference{

--- a/pkg/controllers/pd/tasks/pod_test.go
+++ b/pkg/controllers/pd/tasks/pod_test.go
@@ -442,7 +442,7 @@ func TestTaskPod(t *testing.T) {
 			assert.Equal(tt, c.expectedPodIsTerminating, c.state.PodIsTerminating, c.desc)
 
 			if c.expectUpdatedPod {
-				expectedPod := newPod(c.state.Cluster(), c.state.PD(), c.state.ConfigHash)
+				expectedPod := newPod(c.state)
 				actual := c.state.Pod().DeepCopy()
 				actual.Kind = ""
 				actual.APIVersion = ""

--- a/pkg/controllers/pd/tasks/pvc_test.go
+++ b/pkg/controllers/pd/tasks/pvc_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/pingcap/tidb-operator/apis/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
-	"github.com/pingcap/tidb-operator/pkg/controllers/common"
 	"github.com/pingcap/tidb-operator/pkg/utils/fake"
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
 	"github.com/pingcap/tidb-operator/pkg/volumes"
@@ -38,7 +37,7 @@ import (
 func TestTaskPVC(t *testing.T) {
 	cases := []struct {
 		desc          string
-		state         common.PDState
+		state         *ReconcileContext
 		pvcs          []*corev1.PersistentVolumeClaim
 		unexpectedErr bool
 
@@ -47,40 +46,49 @@ func TestTaskPVC(t *testing.T) {
 	}{
 		{
 			desc: "no pvc",
-			state: &state{
-				pd: fake.FakeObj[v1alpha1.PD]("aaa-xxx"),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					pd:      fake.FakeObj[v1alpha1.PD]("aaa-xxx"),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 0,
 		},
 		{
 			desc: "create a data vol",
-			state: &state{
-				pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 1,
 		},
 		{
 			desc: "has a data vol",
-			state: &state{
-				pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-pd-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -93,16 +101,19 @@ func TestTaskPVC(t *testing.T) {
 		},
 		{
 			desc: "has a data vol, but failed to apply",
-			state: &state{
-				pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					pd: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.PD) *v1alpha1.PD {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-pd-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -132,7 +143,7 @@ func TestTaskPVC(t *testing.T) {
 
 			ctrl := gomock.NewController(tt)
 			vm := volumes.NewMockModifier(ctrl)
-			expectedPVCs := newPVCs(c.state.PD())
+			expectedPVCs := newPVCs(c.state)
 			for _, expected := range expectedPVCs {
 				for _, current := range c.pvcs {
 					if current.Name == expected.Name {

--- a/pkg/controllers/pd/tasks/status.go
+++ b/pkg/controllers/pd/tasks/status.go
@@ -76,6 +76,7 @@ func TaskStatus(state *ReconcileContext, c client.Client) task.Task {
 		if !healthy || !state.Initialized {
 			return task.Wait().With("pd may not be initialized or healthy, wait for next event")
 		}
+		// TODO(csuzhangxc): if we reach here, is "ClusterID" always set?
 
 		return task.Complete().With("status is synced")
 	})

--- a/pkg/controllers/tidb/handler.go
+++ b/pkg/controllers/tidb/handler.go
@@ -37,6 +37,8 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 
 			if newObj.Status.PD != oldObj.Status.PD {
 				r.Logger.Info("pd url is updating", "from", oldObj.Status.PD, "to", newObj.Status.PD)
+			} else if newObj.Status.ID != oldObj.Status.ID {
+				r.Logger.Info("cluster id is updating", "from", oldObj.Status.ID, "to", newObj.Status.ID)
 			} else if !reflect.DeepEqual(oldObj.Spec.SuspendAction, newObj.Spec.SuspendAction) {
 				r.Logger.Info("suspend action is updating", "from", oldObj.Spec.SuspendAction, "to", newObj.Spec.SuspendAction)
 			} else if oldObj.Spec.Paused != newObj.Spec.Paused {

--- a/pkg/controllers/tidb/tasks/pod.go
+++ b/pkg/controllers/tidb/tasks/pod.go
@@ -52,7 +52,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
-		expected := newPod(state.Cluster(), state.TiDB(), state.GracefulWaitTimeInSeconds, state.ConfigHash)
+		expected := newPod(state)
 		if state.Pod() == nil {
 			if err := c.Apply(ctx, expected); err != nil {
 				return task.Fail().With("can't create pod of tidb: %w", err)
@@ -89,9 +89,9 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	})
 }
 
-func newPod(cluster *v1alpha1.Cluster,
-	tidb *v1alpha1.TiDB, gracePeriod int64, configHash string,
-) *corev1.Pod {
+func newPod(state *ReconcileContext) *corev1.Pod {
+	cluster := state.Cluster()
+	tidb := state.TiDB()
 	vols := []corev1.Volume{
 		{
 			Name: v1alpha1.VolumeNameConfig,
@@ -225,7 +225,7 @@ func newPod(cluster *v1alpha1.Cluster,
 			Name:      tidb.PodName(),
 			Labels: maputil.Merge(tidb.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tidb.Name,
-				v1alpha1.LabelKeyConfigHash: configHash,
+				v1alpha1.LabelKeyConfigHash: state.ConfigHash,
 				v1alpha1.LabelKeyClusterID:  cluster.Status.ID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentTiDB)),
 			Annotations: maputil.Merge(tidb.GetAnnotations(), k8s.AnnoProm(tidb.GetStatusPort(), metricsPath)),
@@ -277,7 +277,7 @@ func newPod(cluster *v1alpha1.Cluster,
 				},
 			},
 			Volumes:                       vols,
-			TerminationGracePeriodSeconds: ptr.To(gracePeriod + preStopSleepSeconds + bufferSeconds),
+			TerminationGracePeriodSeconds: ptr.To(state.GracefulWaitTimeInSeconds + preStopSleepSeconds + bufferSeconds),
 		},
 	}
 

--- a/pkg/controllers/tidb/tasks/pod.go
+++ b/pkg/controllers/tidb/tasks/pod.go
@@ -226,6 +226,7 @@ func newPod(cluster *v1alpha1.Cluster,
 			Labels: maputil.Merge(tidb.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tidb.Name,
 				v1alpha1.LabelKeyConfigHash: configHash,
+				v1alpha1.LabelKeyClusterID:  cluster.Status.ID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentTiDB)),
 			Annotations: maputil.Merge(tidb.GetAnnotations(), k8s.AnnoProm(tidb.GetStatusPort(), metricsPath)),
 			OwnerReferences: []metav1.OwnerReference{

--- a/pkg/controllers/tidb/tasks/pod_test.go
+++ b/pkg/controllers/tidb/tasks/pod_test.go
@@ -266,7 +266,7 @@ func TestTaskPod(t *testing.T) {
 			assert.Equal(tt, c.expectedPodIsTerminating, c.state.PodIsTerminating, c.desc)
 
 			if c.expectUpdatedPod {
-				expectedPod := newPod(c.state.Cluster(), c.state.TiDB(), c.state.GracefulWaitTimeInSeconds, c.state.ConfigHash)
+				expectedPod := newPod(c.state)
 				actual := c.state.Pod().DeepCopy()
 				actual.Kind = ""
 				actual.APIVersion = ""

--- a/pkg/controllers/tidb/tasks/pvc_test.go
+++ b/pkg/controllers/tidb/tasks/pvc_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/pingcap/tidb-operator/apis/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
-	"github.com/pingcap/tidb-operator/pkg/controllers/common"
 	"github.com/pingcap/tidb-operator/pkg/utils/fake"
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
 	"github.com/pingcap/tidb-operator/pkg/volumes"
@@ -38,7 +37,7 @@ import (
 func TestTaskPVC(t *testing.T) {
 	cases := []struct {
 		desc          string
-		state         common.TiDBState
+		state         *ReconcileContext
 		pvcs          []*corev1.PersistentVolumeClaim
 		unexpectedErr bool
 
@@ -47,40 +46,49 @@ func TestTaskPVC(t *testing.T) {
 	}{
 		{
 			desc: "no pvc",
-			state: &state{
-				tidb: fake.FakeObj[v1alpha1.TiDB]("aaa-xxx"),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tidb:    fake.FakeObj[v1alpha1.TiDB]("aaa-xxx"),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 0,
 		},
 		{
 			desc: "create a data vol",
-			state: &state{
-				tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 1,
 		},
 		{
 			desc: "has a data vol",
-			state: &state{
-				tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-tidb-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -93,16 +101,19 @@ func TestTaskPVC(t *testing.T) {
 		},
 		{
 			desc: "has a data vol, but failed to apply",
-			state: &state{
-				tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tidb: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-tidb-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -132,7 +143,7 @@ func TestTaskPVC(t *testing.T) {
 
 			ctrl := gomock.NewController(tt)
 			vm := volumes.NewMockModifier(ctrl)
-			expectedPVCs := newPVCs(c.state.TiDB())
+			expectedPVCs := newPVCs(c.state)
 			for _, expected := range expectedPVCs {
 				for _, current := range c.pvcs {
 					if current.Name == expected.Name {

--- a/pkg/controllers/tiflash/handler.go
+++ b/pkg/controllers/tiflash/handler.go
@@ -41,6 +41,8 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 
 			if newObj.Status.PD != oldObj.Status.PD {
 				r.Logger.Info("pd url is updating", "from", oldObj.Status.PD, "to", newObj.Status.PD)
+			} else if newObj.Status.ID != oldObj.Status.ID {
+				r.Logger.Info("cluster id is updating", "from", oldObj.Status.ID, "to", newObj.Status.ID)
 			} else if !reflect.DeepEqual(oldObj.Spec.SuspendAction, newObj.Spec.SuspendAction) {
 				r.Logger.Info("suspend action is updating", "from", oldObj.Spec.SuspendAction, "to", newObj.Spec.SuspendAction)
 			} else if oldObj.Spec.Paused != newObj.Spec.Paused {

--- a/pkg/controllers/tiflash/tasks/pod.go
+++ b/pkg/controllers/tiflash/tasks/pod.go
@@ -41,7 +41,7 @@ const (
 func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
-		expected := newPod(state.Cluster(), state.TiFlash(), state.ConfigHash)
+		expected := newPod(state)
 		if state.Pod() == nil {
 			if err := c.Apply(ctx, expected); err != nil {
 				return task.Fail().With("can't apply pod of tiflash: %w", err)
@@ -77,7 +77,9 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	})
 }
 
-func newPod(cluster *v1alpha1.Cluster, tiflash *v1alpha1.TiFlash, configHash string) *corev1.Pod {
+func newPod(state *ReconcileContext) *corev1.Pod {
+	cluster := state.Cluster()
+	tiflash := state.TiFlash()
 	vols := []corev1.Volume{
 		{
 			Name: v1alpha1.VolumeNameConfig,
@@ -144,8 +146,9 @@ func newPod(cluster *v1alpha1.Cluster, tiflash *v1alpha1.TiFlash, configHash str
 			Name:      tiflash.PodName(),
 			Labels: maputil.Merge(tiflash.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tiflash.Name,
-				v1alpha1.LabelKeyConfigHash: configHash,
+				v1alpha1.LabelKeyConfigHash: state.ConfigHash,
 				v1alpha1.LabelKeyClusterID:  cluster.Status.ID,
+				v1alpha1.LabelKeyStoreID:    state.StoreID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentTiFlash)),
 			Annotations: maputil.Merge(tiflash.GetAnnotations(),
 				k8s.AnnoProm(tiflash.GetMetricsPort(), metricsPath),

--- a/pkg/controllers/tiflash/tasks/pod.go
+++ b/pkg/controllers/tiflash/tasks/pod.go
@@ -145,6 +145,7 @@ func newPod(cluster *v1alpha1.Cluster, tiflash *v1alpha1.TiFlash, configHash str
 			Labels: maputil.Merge(tiflash.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tiflash.Name,
 				v1alpha1.LabelKeyConfigHash: configHash,
+				v1alpha1.LabelKeyClusterID:  cluster.Status.ID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentTiFlash)),
 			Annotations: maputil.Merge(tiflash.GetAnnotations(),
 				k8s.AnnoProm(tiflash.GetMetricsPort(), metricsPath),

--- a/pkg/controllers/tiflash/tasks/pod_test.go
+++ b/pkg/controllers/tiflash/tasks/pod_test.go
@@ -266,7 +266,7 @@ func TestTaskPod(t *testing.T) {
 			assert.Equal(tt, c.expectedPodIsTerminating, c.state.PodIsTerminating, c.desc)
 
 			if c.expectUpdatedPod {
-				expectedPod := newPod(c.state.Cluster(), c.state.TiFlash(), c.state.ConfigHash)
+				expectedPod := newPod(c.state)
 				actual := c.state.Pod().DeepCopy()
 				actual.Kind = ""
 				actual.APIVersion = ""

--- a/pkg/controllers/tiflash/tasks/pvc_test.go
+++ b/pkg/controllers/tiflash/tasks/pvc_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/pingcap/tidb-operator/apis/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
-	"github.com/pingcap/tidb-operator/pkg/controllers/common"
 	"github.com/pingcap/tidb-operator/pkg/utils/fake"
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
 	"github.com/pingcap/tidb-operator/pkg/volumes"
@@ -38,7 +37,7 @@ import (
 func TestTaskPVC(t *testing.T) {
 	cases := []struct {
 		desc          string
-		state         common.TiFlashState
+		state         *ReconcileContext
 		pvcs          []*corev1.PersistentVolumeClaim
 		unexpectedErr bool
 
@@ -47,40 +46,49 @@ func TestTaskPVC(t *testing.T) {
 	}{
 		{
 			desc: "no pvc",
-			state: &state{
-				tiflash: fake.FakeObj[v1alpha1.TiFlash]("aaa-xxx"),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tiflash: fake.FakeObj[v1alpha1.TiFlash]("aaa-xxx"),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 0,
 		},
 		{
 			desc: "create a data vol",
-			state: &state{
-				tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			expectedStatus: task.SComplete,
 			expectedPVCNum: 1,
 		},
 		{
 			desc: "has a data vol",
-			state: &state{
-				tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-tiflash-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -93,16 +101,19 @@ func TestTaskPVC(t *testing.T) {
 		},
 		{
 			desc: "has a data vol, but failed to apply",
-			state: &state{
-				tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
-					obj.Spec.Volumes = []v1alpha1.Volume{
-						{
-							Name:    "data",
-							Storage: resource.MustParse("10Gi"),
-						},
-					}
-					return obj
-				}),
+			state: &ReconcileContext{
+				State: &state{
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					tiflash: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiFlash) *v1alpha1.TiFlash {
+						obj.Spec.Volumes = []v1alpha1.Volume{
+							{
+								Name:    "data",
+								Storage: resource.MustParse("10Gi"),
+							},
+						}
+						return obj
+					}),
+				},
 			},
 			pvcs: []*corev1.PersistentVolumeClaim{
 				fake.FakeObj("data-aaa-tiflash-xxx", func(obj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
@@ -132,7 +143,7 @@ func TestTaskPVC(t *testing.T) {
 
 			ctrl := gomock.NewController(tt)
 			vm := volumes.NewMockModifier(ctrl)
-			expectedPVCs := newPVCs(c.state.TiFlash())
+			expectedPVCs := newPVCs(c.state)
 			for _, expected := range expectedPVCs {
 				for _, current := range c.pvcs {
 					if current.Name == expected.Name {

--- a/pkg/controllers/tikv/handler.go
+++ b/pkg/controllers/tikv/handler.go
@@ -41,6 +41,8 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 
 			if newObj.Status.PD != oldObj.Status.PD {
 				r.Logger.Info("pd url is updating", "from", oldObj.Status.PD, "to", newObj.Status.PD)
+			} else if newObj.Status.ID != oldObj.Status.ID {
+				r.Logger.Info("cluster id is updating", "from", oldObj.Status.ID, "to", newObj.Status.ID)
 			} else if !reflect.DeepEqual(oldObj.Spec.SuspendAction, newObj.Spec.SuspendAction) {
 				r.Logger.Info("suspend action is updating", "from", oldObj.Spec.SuspendAction, "to", newObj.Spec.SuspendAction)
 			} else if oldObj.Spec.Paused != newObj.Spec.Paused {

--- a/pkg/controllers/tikv/tasks/pod.go
+++ b/pkg/controllers/tikv/tasks/pod.go
@@ -196,6 +196,7 @@ func newPod(cluster *v1alpha1.Cluster, tikv *v1alpha1.TiKV, configHash string) *
 			Labels: maputil.Merge(tikv.Labels, map[string]string{
 				v1alpha1.LabelKeyInstance:   tikv.Name,
 				v1alpha1.LabelKeyConfigHash: configHash,
+				v1alpha1.LabelKeyClusterID:  cluster.Status.ID,
 			}, k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentTiKV)),
 			Annotations: maputil.Merge(tikv.GetAnnotations(), k8s.AnnoProm(tikv.GetStatusPort(), metricsPath)),
 			OwnerReferences: []metav1.OwnerReference{

--- a/pkg/controllers/tikv/tasks/pod_test.go
+++ b/pkg/controllers/tikv/tasks/pod_test.go
@@ -316,7 +316,7 @@ func TestTaskPod(t *testing.T) {
 			assert.Equal(tt, c.expectedPodIsTerminating, c.state.PodIsTerminating, c.desc)
 
 			if c.expectUpdatedPod {
-				expectedPod := newPod(c.state.Cluster(), c.state.TiKV(), c.state.ConfigHash)
+				expectedPod := newPod(c.state)
 				actual := c.state.Pod().DeepCopy()
 				actual.Kind = ""
 				actual.APIVersion = ""

--- a/pkg/timanager/apis/pd/v1/types.go
+++ b/pkg/timanager/apis/pd/v1/types.go
@@ -119,6 +119,7 @@ type Member struct {
 	// Invalid means pd svc is unavailable and store info is untrusted
 	Invalid bool `json:"invalid,omitempty"`
 
+	ClusterID      string   `json:"cluster_id,omitempty"`
 	ID             string   `json:"id"`
 	PeerUrls       []string `json:"peer_urls,omitempty"`
 	ClientUrls     []string `json:"client_urls,omitempty"`

--- a/pkg/timanager/pd/member.go
+++ b/pkg/timanager/pd/member.go
@@ -91,6 +91,7 @@ func (l *memberLister) List(ctx context.Context) (*pdv1.MemberList, error) {
 				Name:      m.Name,
 				Namespace: l.cluster,
 			},
+			ClusterID:      strconv.FormatUint(info.Header.ClusterId, 10),
 			ID:             strconv.FormatUint(m.MemberId, 10),
 			PeerUrls:       m.PeerUrls,
 			ClientUrls:     m.ClientUrls,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

- add cluster/member/store ID for Pod and PVC
- also add K8s labels for PVC as #6047

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
