### PR TITLE
feat(updater): defer scale in after rolling update is done

### DIFF
--- a/apis/core/v1alpha1/common_types.go
+++ b/apis/core/v1alpha1/common_types.go
@@ -35,9 +35,15 @@ const (
 const (
 	// Finalizer is the finalizer used by all resources managed by TiDB Operator.
 	Finalizer = "core.pingcap.com/finalizer"
+)
 
+const (
+	KeyPrefix = "pingcap.com/"
+)
+
+const (
 	// LabelKeyPrefix defines key prefix of well known labels
-	LabelKeyPrefix = "pingcap.com/"
+	LabelKeyPrefix = KeyPrefix
 
 	// LabelKeyManagedBy means resources are managed by tidb operator
 	LabelKeyManagedBy         = LabelKeyPrefix + "managed-by"
@@ -81,6 +87,17 @@ const (
 	// LabelKeyStoreID is the unique identifier of a TiKV or TiFlash store.
 	// This label is used for backward compatibility with TiDB Operator v1, so it has a different prefix.
 	LabelKeyStoreID = "tidb.pingcap.com/store-id"
+)
+
+const (
+	// AnnoKeyPrefix defines key prefix of well known annotations
+	AnnoKeyPrefix = "pingcap.com/"
+
+	// all bool anno will use this val as default
+	AnnoValTrue = "true"
+
+	// means the instance is marked as deleted and will be deleted later
+	AnnoKeyDeferDelete = AnnoKeyPrefix + "defer-delete"
 )
 
 const (

--- a/pkg/client/alias.go
+++ b/pkg/client/alias.go
@@ -44,3 +44,7 @@ var ObjectKeyFromObject = client.ObjectKeyFromObject
 var IgnoreNotFound = client.IgnoreNotFound
 
 type GracePeriodSeconds = client.GracePeriodSeconds
+
+type MergeFromOption = client.MergeFromOption
+
+var RawPatch = client.RawPatch

--- a/pkg/controllers/pdgroup/tasks/updater_test.go
+++ b/pkg/controllers/pdgroup/tasks/updater_test.go
@@ -55,7 +55,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus: task.SComplete,
+			expectedStatus: task.SWait,
 			expectedPDNum:  1,
 		},
 		{
@@ -103,7 +103,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus: task.SComplete,
+			expectedStatus: task.SWait,
 			expectedPDNum:  2,
 		},
 		{
@@ -236,7 +236,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus: task.SComplete,
+			expectedStatus: task.SWait,
 			expectedPDNum:  3,
 		},
 	}

--- a/pkg/controllers/tidbgroup/tasks/updater_test.go
+++ b/pkg/controllers/tidbgroup/tasks/updater_test.go
@@ -55,7 +55,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiDBNum: 1,
 		},
 		{
@@ -103,7 +103,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiDBNum: 2,
 		},
 		{
@@ -236,7 +236,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiDBNum: 3,
 		},
 	}

--- a/pkg/controllers/tiflashgroup/tasks/updater_test.go
+++ b/pkg/controllers/tiflashgroup/tasks/updater_test.go
@@ -55,7 +55,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:     task.SComplete,
+			expectedStatus:     task.SWait,
 			expectedTiFlashNum: 1,
 		},
 		{
@@ -103,7 +103,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:     task.SComplete,
+			expectedStatus:     task.SWait,
 			expectedTiFlashNum: 2,
 		},
 		{
@@ -236,7 +236,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:     task.SComplete,
+			expectedStatus:     task.SWait,
 			expectedTiFlashNum: 3,
 		},
 	}

--- a/pkg/controllers/tikvgroup/tasks/updater_test.go
+++ b/pkg/controllers/tikvgroup/tasks/updater_test.go
@@ -55,7 +55,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiKVNum: 1,
 		},
 		{
@@ -103,7 +103,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiKVNum: 2,
 		},
 		{
@@ -236,7 +236,7 @@ func TestTaskUpdater(t *testing.T) {
 				},
 			},
 
-			expectedStatus:  task.SComplete,
+			expectedStatus:  task.SWait,
 			expectedTiKVNum: 3,
 		},
 	}

--- a/pkg/updater/builder_test.go
+++ b/pkg/updater/builder_test.go
@@ -50,12 +50,12 @@ func TestBuilder(t *testing.T) {
 		{
 			desc:         "scale out",
 			desired:      3,
-			expectedWait: false,
+			expectedWait: true,
 		},
 		{
 			desc:         "scale in",
 			desired:      1,
-			expectedWait: false,
+			expectedWait: true,
 		},
 	}
 


### PR DESCRIPTION
- add annotation to mark outdated instances when scale in
- delete marked instances until the whole rolling update process is done

This change is used to avoid the corner case when users scale up and scale in at the same time.  The cluster may be unavailable after scaling in some instances because of the lack of resources, but it can be worked when all instances are updated.