### PR TITLE
Volume Replacement causes high latency/jitter to the clients due to excessive IO and CPU usage

### DIFF
--- a/pkg/manager/volumes/pvc_replacer.go
+++ b/pkg/manager/volumes/pvc_replacer.go
@@ -163,11 +163,25 @@ func isVolumeReplacing(pod *corev1.Pod) bool {
 	return exist
 }
 
-func (p *pvcReplacer) startVolumeReplace(pod *corev1.Pod) error {
+func (p *pvcReplacer) startVolumeReplace(ctx *componentVolumeContext, pod *corev1.Pod) error {
 	pod = pod.DeepCopy()
 
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
+	}
+
+	// try to evict leader
+	isEvicted := isLeaderEvictedOrTimeout(ctx.tc, pod)
+	if !isEvicted {
+		if ensureTiKVLeaderEvictionCondition(ctx.tc, metav1.ConditionTrue) {
+			// return to sync tc
+			return fmt.Errorf("try to evict leader for tidbcluster %s/%s", ctx.tc.Namespace, ctx.tc.Name)
+		}
+		// evict leader
+		if err := p.evictLeader(ctx.tc, pod); err != nil {
+			return err
+		}
+		return fmt.Errorf("wait for leader eviction of %s/%s completed", pod.Namespace, pod.Name)
 	}
 
 	pod.Annotations[v1alpha1.ReplaceVolumeAnnKey] = v1alpha1.ReplaceVolumeValueTrue
@@ -193,11 +207,29 @@ func (p *pvcReplacer) tryToReplacePVC(ctx *componentVolumeContext) error {
 		if podSynced {
 			continue
 		}
-		if err := p.startVolumeReplace(pod); err != nil {
+		if err := p.startVolumeReplace(ctx, pod); err != nil {
 			return err
 		}
 		return fmt.Errorf("started volume replace for pod %s, waiting", pod.Name)
 	}
+	return nil
+}
+
+func (p *pvcReplacer) evictLeader(tc *v1alpha1.TidbCluster, pod *corev1.Pod) error {
+	if isLeaderEvicting(pod) {
+		return nil
+	}
+	pod = pod.DeepCopy()
+
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	pod.Annotations[v1alpha1.EvictLeaderAnnKey] = v1alpha1.EvictLeaderValueDeletePod
+	if _, err := p.deps.KubeClientset.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("add leader eviction annotation to pod %s/%s failed: %s", pod.Namespace, pod.Name, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION


### What problem does this PR solve?
Volume Replacement causes high latency/jitter to the clients due to excessive IO and CPU usage  because schedule.store-limit.xyz.remove-peer limit is being set to unlimited. Effectively the limit becomes num_available_tikv_pods *  schedule.store-limit.xyz.add-peer. The problem is the TIKV store is still serving active leaders causing a high latency impact to clients.

This fix evicts the leaders from the TIKV pod/store before proceeding with volume replacement on the pod.

Ref: https://github.com/tikv/pd/issues/4099

### What is changed and how does it work?
Evict region leaders from the TIKV store before proceeding with volume replacement

### Code changes

- [X ] Has Go code change
- [ ] Has CI related scripts change

### Tests


- [X] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes

Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix high latency/jitter due to excessive IO and CPU usage during Volume Replacement.
```
