### PR TITLE
ebs br: fail the ebs volume backup when some backup member tc is invalid

### DIFF
--- a/pkg/backup/backup/backup_manager.go
+++ b/pkg/backup/backup/backup_manager.go
@@ -116,7 +116,7 @@ func (bm *backupManager) syncBackupJob(backup *v1alpha1.Backup) error {
 		}
 	}
 
-	if v1alpha1.IsBackupComplete(backup) || v1alpha1.IsBackupFailed(backup) {
+	if v1alpha1.IsBackupComplete(backup) || v1alpha1.IsBackupFailed(backup) || v1alpha1.IsBackupInvalid(backup) {
 		return nil
 	}
 
@@ -1161,8 +1161,8 @@ func (bm *backupManager) teardownVolumeBackup(backup *v1alpha1.Backup) (err erro
 			return
 		}
 
-		// if backup is failed or complete, just delete job, not modify status
-		if v1alpha1.IsBackupFailed(backup) || v1alpha1.IsBackupComplete(backup) {
+		// if backup is failed, complete or invalid, just delete job, not modify status
+		if v1alpha1.IsBackupFailed(backup) || v1alpha1.IsBackupComplete(backup) || v1alpha1.IsBackupInvalid(backup) {
 			return
 		}
 		backupCondition := v1alpha1.BackupComplete

--- a/pkg/backup/backupschedule/backup_schedule_manager.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager.go
@@ -237,7 +237,7 @@ func (bm *backupScheduleManager) canPerformNextBackup(bs *v1alpha1.BackupSchedul
 			return fmt.Errorf("backup schedule %s/%s, get backup %s failed, err: %v", ns, bsName, bs.Status.LastBackup, err)
 		}
 
-		if v1alpha1.IsBackupComplete(backup) || (v1alpha1.IsBackupScheduled(backup) && v1alpha1.IsBackupFailed(backup)) {
+		if v1alpha1.IsBackupComplete(backup) || (v1alpha1.IsBackupScheduled(backup) && v1alpha1.IsBackupFailed(backup)) || v1alpha1.IsBackupInvalid(backup) {
 			return nil
 		}
 		// skip this sync round of the backup schedule and waiting the last backup.
@@ -752,8 +752,8 @@ func separateSnapshotBackupsAndLogBackup(backupsList []*v1alpha1.Backup) ([]*v1a
 			logBackup = backup
 			continue
 		}
-		// Completed or failed backups will be GC'ed
-		if !(v1alpha1.IsBackupFailed(backup) || v1alpha1.IsBackupComplete(backup)) {
+		// Completed, failed or invalid backups will be GC'ed
+		if !(v1alpha1.IsBackupFailed(backup) || v1alpha1.IsBackupComplete(backup) || v1alpha1.IsBackupInvalid(backup)) {
 			continue
 		}
 		ascBackupList = append(ascBackupList, backup)

--- a/pkg/backup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/backup/backupschedule/backup_schedule_manager_test.go
@@ -70,6 +70,17 @@ func TestManager(t *testing.T) {
 	g.Expect(err).Should(BeNil())
 	helper.deleteBackup(bk)
 
+	// test last backup invalid state
+	bk.Status.Conditions = nil
+	bk.Status.Conditions = append(bk.Status.Conditions, v1alpha1.BackupCondition{
+		Type:   v1alpha1.BackupInvalid,
+		Status: v1.ConditionTrue,
+	})
+	helper.createBackup(bk)
+	err = m.canPerformNextBackup(bs)
+	g.Expect(err).Should(BeNil())
+	helper.deleteBackup(bk)
+
 	// test last backup failed state and not scheduled yet
 	bk.Status.Conditions = nil
 	bk.Status.Conditions = append(bk.Status.Conditions, v1alpha1.BackupCondition{

--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -234,8 +234,8 @@ func (c *Controller) updateBackup(cur interface{}) {
 		return
 	}
 
-	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsBackupFailed(newBackup) {
-		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing or Failed, skipping.", ns, name)
+	if v1alpha1.IsBackupScheduled(newBackup) || v1alpha1.IsBackupRunning(newBackup) || v1alpha1.IsBackupPrepared(newBackup) || v1alpha1.IsBackupFailed(newBackup) || v1alpha1.IsBackupInvalid(newBackup) {
+		klog.V(4).Infof("backup %s/%s is already Scheduled, Running, Preparing, Failed or InValid, skipping.", ns, name)
 		return
 	}
 

--- a/pkg/fedvolumebackup/backup/backup_manager.go
+++ b/pkg/fedvolumebackup/backup/backup_manager.go
@@ -263,7 +263,7 @@ func (bm *backupManager) waitBackupMemberInitialized(ctx context.Context, volume
 				Message: errMsg,
 			}
 		}
-		if pingcapv1alpha1.IsBackupFailed(backupMember.backup) {
+		if pingcapv1alpha1.IsBackupFailed(backupMember.backup) || pingcapv1alpha1.IsBackupInvalid(backupMember.backup) {
 			errMsg := fmt.Sprintf("backup member %s of cluster %s failed", backupMember.backup.Name, backupMember.k8sClusterName)
 			return &fedvolumebackup.BRDataPlaneFailedError{
 				Reason:  reasonVolumeBackupMemberFailed,
@@ -343,7 +343,8 @@ func (bm *backupManager) waitVolumeSnapshotsCreated(backupMembers []*volumeBacku
 	for _, backupMember := range backupMembers {
 		if pingcapv1alpha1.IsVolumeBackupInitializeFailed(backupMember.backup) ||
 			pingcapv1alpha1.IsVolumeBackupFailed(backupMember.backup) ||
-			pingcapv1alpha1.IsBackupFailed(backupMember.backup) {
+			pingcapv1alpha1.IsBackupFailed(backupMember.backup) ||
+			pingcapv1alpha1.IsBackupInvalid(backupMember.backup) {
 			errMsg := fmt.Sprintf("backup member %s of cluster %s failed", backupMember.backup.Name, backupMember.k8sClusterName)
 			return &fedvolumebackup.BRDataPlaneFailedError{
 				Reason:  reasonVolumeBackupMemberFailed,
@@ -363,7 +364,8 @@ func (bm *backupManager) waitBackupMemberInitializeComplete(volumeBackup *v1alph
 	for _, backupMember := range backupMembers {
 		if pingcapv1alpha1.IsVolumeBackupInitializeFailed(backupMember.backup) ||
 			pingcapv1alpha1.IsVolumeBackupFailed(backupMember.backup) ||
-			pingcapv1alpha1.IsBackupFailed(backupMember.backup) {
+			pingcapv1alpha1.IsBackupFailed(backupMember.backup) ||
+			pingcapv1alpha1.IsBackupInvalid(backupMember.backup) {
 			errMsg := fmt.Sprintf("backup member %s of cluster %s failed", backupMember.backup.Name, backupMember.k8sClusterName)
 			return &fedvolumebackup.BRDataPlaneFailedError{
 				Reason:  reasonVolumeBackupMemberFailed,
@@ -385,7 +387,8 @@ func (bm *backupManager) waitVolumeSnapshotsComplete(backupMembers []*volumeBack
 	for _, backupMember := range backupMembers {
 		if pingcapv1alpha1.IsVolumeBackupInitializeFailed(backupMember.backup) ||
 			pingcapv1alpha1.IsVolumeBackupFailed(backupMember.backup) ||
-			pingcapv1alpha1.IsBackupFailed(backupMember.backup) {
+			pingcapv1alpha1.IsBackupFailed(backupMember.backup) ||
+			pingcapv1alpha1.IsBackupInvalid(backupMember.backup) {
 			errMsg := fmt.Sprintf("backup member %s of cluster %s failed", backupMember.backup.Name, backupMember.k8sClusterName)
 			return &fedvolumebackup.BRDataPlaneFailedError{
 				Reason:  reasonVolumeBackupMemberFailed,
@@ -436,6 +439,10 @@ func (bm *backupManager) waitVolumeBackupComplete(ctx context.Context, volumeBac
 		} else if pingcapv1alpha1.IsBackupFailed(backupMember.backup) {
 			failedBackups = append(failedBackups, backupMember)
 			klog.Errorf("VolumeBackup %s/%s backup member %s of cluster %s is failed",
+				volumeBackup.Namespace, volumeBackup.Name, backupMember.backup.Name, backupMember.k8sClusterName)
+		} else if pingcapv1alpha1.IsBackupInvalid(backupMember.backup) {
+			failedBackups = append(failedBackups, backupMember)
+			klog.Errorf("VolumeBackup %s/%s backup member %s of cluster %s is invalid",
 				volumeBackup.Namespace, volumeBackup.Name, backupMember.backup.Name, backupMember.k8sClusterName)
 		} else if !pingcapv1alpha1.IsBackupComplete(backupMember.backup) {
 			isBackupRunning = true

--- a/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
+++ b/pkg/fedvolumebackup/backupschedule/backup_schedule_manager_test.go
@@ -398,7 +398,7 @@ func TestCalculateExpiredBackups(t *testing.T) {
 		// 3 backups should be deleted
 		{
 			backups: []*v1alpha1.VolumeBackup{
-				fakeBackup(&last3Day),
+				fakeFailedBackup(&last3Day),
 				fakeBackup(&last2Day),
 				fakeBackup(&last1Day),
 				fakeBackup(&last10Min),
@@ -568,6 +568,19 @@ func fakeBackup(ts *time.Time) *v1alpha1.VolumeBackup {
 	backup.CreationTimestamp = metav1.Time{Time: *ts}
 	backup.Status.Conditions = append(backup.Status.Conditions, v1alpha1.VolumeBackupCondition{
 		Type:   v1alpha1.VolumeBackupComplete,
+		Status: v1.ConditionTrue,
+	})
+	return backup
+}
+
+func fakeFailedBackup(ts *time.Time) *v1alpha1.VolumeBackup {
+	backup := &v1alpha1.VolumeBackup{}
+	if ts == nil {
+		return backup
+	}
+	backup.CreationTimestamp = metav1.Time{Time: *ts}
+	backup.Status.Conditions = append(backup.Status.Conditions, v1alpha1.VolumeBackupCondition{
+		Type:   v1alpha1.VolumeBackupFailed,
 		Status: v1.ConditionTrue,
 	})
 	return backup


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Closes #6090 

When some tidb cluster TC is invalid, its backup member goes into InvalidSpec status and fails. While the volumebackup status keeps as running.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->
Let volume backup detect the failure of the backup member due to invalid tc and fail itself.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
