### PR TITLE
tidb-scheduler now supports kubescheduler.config.k8s.io/v1 in tidb-operator helm charts

### DIFF
--- a/charts/tidb-operator/templates/_helpers.tpl
+++ b/charts/tidb-operator/templates/_helpers.tpl
@@ -57,5 +57,5 @@ By default, we extract the v<major>.<minor>.<patch> part from the KubeVersion, e
 - v1.15.11-gke.15 -> v1.15.11 (GKE)
 */}}
 {{- define "kube-scheduler.image_tag" -}}
-{{- default (regexFind "^v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.GitVersion) .Values.scheduler.kubeSchedulerImageTag -}}
+{{- default (regexFind "^v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version) .Values.scheduler.kubeSchedulerImageTag -}}
 {{- end -}}

--- a/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
+++ b/charts/tidb-operator/templates/config/_scheduler-config-yaml.tpl
@@ -1,4 +1,24 @@
-{{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.25.0-0" .Capabilities.KubeVersion.Version }}
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: true
+  resourceNamespace: {{ .Release.Namespace }}
+  {{- if eq .Values.appendReleaseSuffix true}}
+  resourceName: {{ .Values.scheduler.schedulerName }}-{{.Release.Name}}
+  {{- else }}
+  resourceName: {{ .Values.scheduler.schedulerName }}
+  {{- end }}
+profiles:
+  - schedulerName: tidb-scheduler
+extenders:
+  - urlPrefix: http://127.0.0.1:10262/scheduler
+    filterVerb: filter
+    preemptVerb: preempt
+    weight: 1
+    enableHTTPS: false
+    httpTimeout: 30s
+{{- else if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 leaderElection:

--- a/charts/tidb-operator/templates/config/_scheduler-policy-json.tpl
+++ b/charts/tidb-operator/templates/config/_scheduler-policy-json.tpl
@@ -11,10 +11,10 @@
     {"name": "CheckVolumeBinding"},
     {"name": "MaxGCEPDVolumeCount"},
     {"name": "MatchInterPodAffinity"},
-{{- if semverCompare "~1.11.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "~1.11.0" .Capabilities.KubeVersion.Version }}
     {"name": "CheckNodePIDPressure"},
 {{- end }}
-{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.Version }}
     {"name": "CheckNodeCondition"},
     {"name": "CheckNodeMemoryPressure"},
     {"name": "CheckNodeDiskPressure"},

--- a/charts/tidb-operator/templates/scheduler-config-configmap.yaml
+++ b/charts/tidb-operator/templates/scheduler-config-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tidb-operator/templates/scheduler-deployment.yaml
+++ b/charts/tidb-operator/templates/scheduler-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) }}
-{{- $lgK8sV119 := (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- $lgK8sV119 := (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/tidb-operator/templates/scheduler-policy-configmap.yaml
+++ b/charts/tidb-operator/templates/scheduler-policy-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare "<1.19.0-0" .Capabilities.KubeVersion.GitVersion)  }}
+{{- if (hasKey .Values.scheduler "create" | ternary .Values.scheduler.create true) | and (semverCompare "<1.19.0-0" .Capabilities.KubeVersion.Version)  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
### What problem does this PR solve?
- tidb-scheduler crashes when deployed on Kubernetes clusters with version 1.28 or higher because `kubescheduler.config.k8s.io/v1beta2` was removed from 1.28.

```
$ kubectl version
Client Version: v1.31.2
Kustomize Version: v5.4.2
Server Version: v1.31.4

$ kubectl get pod
NAME                                      READY   STATUS             RESTARTS        AGE
tidb-controller-manager-8c464f99d-h6phh   1/1     Running            0               15m
tidb-scheduler-f8b4568f8-rjbzv            1/2     CrashLoopBackOff   7 (4m22s ago)   15m

$ kubectl logs tidb-scheduler-f8b4568f8-rjbzv -c kube-scheduler
...
I0220 09:45:24.146211       1 serving.go:386] Generated self-signed cert in-memory
E0220 09:45:24.146505       1 run.go:72] "command failed" err="no kind \"KubeSchedulerConfiguration\" is registered for version \"kubescheduler.config.k8s.io/v1beta2\" in scheme \"pkg/scheduler/apis/config/scheme/scheme.go:29\""
```

- Use `Capabilities.KubeVersion.Version` instead of `Capabilities.KubeVersion.GitVersion`
  - `Capabilities.KubeVersion.GitVersion` was already removed in [helm docs](https://helm.sh/docs/chart_template_guide/builtin_objects/).

### What is changed and how does it work?

Use `kubescheduler.config.k8s.io/v1` in tidb-operator helm charts template when Kubernetes version 1.25 or higher.
(`kubescheduler.config.k8s.io/v1` was GA at [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#v1250))

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
tidb-scheduler now supports kubescheduler.config.k8s.io/v1 in tidb-operator helm charts
```
