### PR TITLE
fix(pd): should delete member by name

### DIFF
--- a/pkg/controllers/pd/tasks/finalizer.go
+++ b/pkg/controllers/pd/tasks/finalizer.go
@@ -32,7 +32,7 @@ func TaskFinalizerDel(state *ReconcileContext, c client.Client) task.Task {
 		// get member info successfully and the member still exists
 		case state.IsAvailable && state.MemberID != "":
 			// TODO: check whether quorum will be lost?
-			if err := state.PDClient.Underlay().DeleteMember(ctx, state.MemberID); err != nil {
+			if err := state.PDClient.Underlay().DeleteMember(ctx, state.PD().Name); err != nil {
 				return task.Fail().With("cannot delete member: %v", err)
 			}
 

--- a/tests/e2e/pd/pd.go
+++ b/tests/e2e/pd/pd.go
@@ -59,6 +59,41 @@ var _ = ginkgo.Describe("PD", label.PD, func() {
 	})
 
 	ginkgo.Context("Scale and Update", label.P0, func() {
+		ginkgo.It("support scale PD from 1 to 3", label.Scale, func(ctx context.Context) {
+			pdg := data.NewPDGroup(
+				f.Namespace.Name,
+			)
+
+			ginkgo.By("Create PDGroup")
+			f.Must(f.Client.Create(ctx, pdg))
+			f.WaitForPDGroupReady(ctx, pdg)
+
+			patch := client.MergeFrom(pdg.DeepCopy())
+			pdg.Spec.Replicas = ptr.To[int32](3)
+
+			ginkgo.By("Change replica of the PDGroup")
+			f.Must(f.Client.Patch(ctx, pdg, patch))
+			f.WaitForPDGroupReady(ctx, pdg)
+		})
+
+		ginkgo.It("support scale PD from 3 to 1", label.Scale, func(ctx context.Context) {
+			pdg := data.NewPDGroup(
+				f.Namespace.Name,
+				data.WithReplicas[*runtime.PDGroup](3),
+			)
+
+			ginkgo.By("Create PDGroup")
+			f.Must(f.Client.Create(ctx, pdg))
+			f.WaitForPDGroupReady(ctx, pdg)
+
+			patch := client.MergeFrom(pdg.DeepCopy())
+			pdg.Spec.Replicas = ptr.To[int32](1)
+
+			ginkgo.By("Change replica of the PDGroup")
+			f.Must(f.Client.Patch(ctx, pdg, patch))
+			f.WaitForPDGroupReady(ctx, pdg)
+		})
+
 		ginkgo.It("support scale PD from 3 to 5", label.Scale, func(ctx context.Context) {
 			pdg := data.NewPDGroup(
 				f.Namespace.Name,


### PR DESCRIPTION
-  Delete member by name not by id.
-  This issue is introduced in https://github.com/pingcap/tidb-operator/pull/6026
