### PR TITLE
Fix: consider the store state `Preparing` as healthy

### DIFF
--- a/api/core/v1alpha1/tikv_types.go
+++ b/api/core/v1alpha1/tikv_types.go
@@ -40,10 +40,14 @@ const (
 const (
 	// store state for both TiKV and TiFlash stores
 
+	// StoreStatePreparing means there are no regions on this store.
+	// In this state, the store is ready to serve.
 	StoreStatePreparing = "Preparing"
-	StoreStateServing   = "Serving"
-	StoreStateRemoving  = "Removing"
-	StoreStateRemoved   = "Removed"
+	// StoreStateServing means the number of regions reaches a certain proportion.
+	// In this state, the store is ready to serve.
+	StoreStateServing  = "Serving"
+	StoreStateRemoving = "Removing"
+	StoreStateRemoved  = "Removed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/core/v1alpha1/tikv_types.go
+++ b/api/core/v1alpha1/tikv_types.go
@@ -40,7 +40,6 @@ const (
 const (
 	// store state for both TiKV and TiFlash stores
 
-	StoreStateUnknown   = "Unknown"
 	StoreStatePreparing = "Preparing"
 	StoreStateServing   = "Serving"
 	StoreStateRemoving  = "Removing"

--- a/pkg/controllers/common/interfaces.go
+++ b/pkg/controllers/common/interfaces.go
@@ -252,5 +252,7 @@ type (
 type StoreState interface {
 	GetStoreState() string
 	SetStoreState(string)
+	// IsStoreUp returns true if the store state is `Preparing` or `Serving`,
+	// which means the store is in the state of providing services.
 	IsStoreUp() bool
 }

--- a/pkg/controllers/common/interfaces.go
+++ b/pkg/controllers/common/interfaces.go
@@ -248,3 +248,9 @@ type (
 		Pod() *corev1.Pod
 	}
 )
+
+type StoreState interface {
+	GetStoreState() string
+	SetStoreState(string)
+	IsStoreUp() bool
+}

--- a/pkg/controllers/tiflash/tasks/ctx.go
+++ b/pkg/controllers/tiflash/tasks/ctx.go
@@ -34,7 +34,6 @@ type ReconcileContext struct {
 
 	Store       *pdv1.Store
 	StoreID     string
-	StoreState  string
 	StoreLabels []*metapb.StoreLabel
 
 	// Pod cannot be updated when call DELETE API, so we have to set this field to indicate
@@ -63,7 +62,8 @@ func TaskContextInfoFromPD(state *ReconcileContext, cm pdm.PDClientManager) task
 			return task.Complete().With("store does not exist")
 		}
 
-		state.Store, state.StoreID, state.StoreState = s, s.ID, string(s.NodeState)
+		state.Store, state.StoreID = s, s.ID
+		state.SetStoreState(string(s.NodeState))
 		state.StoreLabels = make([]*metapb.StoreLabel, len(s.Labels))
 		for k, v := range s.Labels {
 			state.StoreLabels = append(state.StoreLabels, &metapb.StoreLabel{Key: k, Value: v})

--- a/pkg/controllers/tiflash/tasks/finalizer.go
+++ b/pkg/controllers/tiflash/tasks/finalizer.go
@@ -49,11 +49,11 @@ func TaskFinalizerDel(state *ReconcileContext, c client.Client) task.Task {
 				return task.Fail().With("cannot remove finalizer: %w", err)
 			}
 
-		case state.StoreState == v1alpha1.StoreStateRemoving:
+		case state.GetStoreState() == v1alpha1.StoreStateRemoving:
 			// TODO: Complete task and retrigger reconciliation by polling PD
 			return task.Retry(removingWaitInterval).With("wait until the store is removed")
 
-		case state.StoreState == v1alpha1.StoreStateRemoved || state.StoreID == "":
+		case state.GetStoreState() == v1alpha1.StoreStateRemoved || state.StoreID == "":
 			wait, err := EnsureSubResourcesDeleted(ctx, c, state.TiFlash())
 			if err != nil {
 				return task.Fail().With("cannot delete sub resources: %w", err)

--- a/pkg/controllers/tiflash/tasks/finalizer_test.go
+++ b/pkg/controllers/tiflash/tasks/finalizer_test.go
@@ -215,8 +215,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoving,
 				},
-				StoreState: v1alpha1.StoreStateRemoving,
 			},
 
 			expectedStatus: task.SRetry,
@@ -235,8 +235,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 
 			expectedStatus: task.SComplete,
@@ -255,8 +255,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 
 			expectedStatus: task.SComplete,
@@ -276,8 +276,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			unexpectedErr: true,
 
@@ -294,8 +294,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			subresources: fakeSubresources("Pod"),
 
@@ -316,8 +316,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			subresources:  fakeSubresources("Pod"),
 			unexpectedErr: true,

--- a/pkg/controllers/tiflash/tasks/state.go
+++ b/pkg/controllers/tiflash/tasks/state.go
@@ -28,10 +28,10 @@ import (
 type state struct {
 	key types.NamespacedName
 
-	cluster *v1alpha1.Cluster
-	tiflash *v1alpha1.TiFlash
-	pod     *corev1.Pod
-
+	cluster       *v1alpha1.Cluster
+	tiflash       *v1alpha1.TiFlash
+	pod           *corev1.Pod
+	storeState    string
 	statusChanged bool
 }
 
@@ -49,6 +49,8 @@ type State interface {
 
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.TiFlash]
+
+	common.StoreState
 
 	SetPod(*corev1.Pod)
 }
@@ -110,4 +112,16 @@ func (s *state) PodInitializer() common.PodInitializer {
 			return coreutil.PodName[scope.TiFlash](s.tiflash)
 		})).
 		Initializer()
+}
+
+func (s *state) GetStoreState() string {
+	return s.storeState
+}
+
+func (s *state) SetStoreState(state string) {
+	s.storeState = state
+}
+
+func (s *state) IsStoreUp() bool {
+	return s.storeState == v1alpha1.StoreStatePreparing || s.storeState == v1alpha1.StoreStateServing
 }

--- a/pkg/controllers/tiflash/tasks/status.go
+++ b/pkg/controllers/tiflash/tasks/status.go
@@ -44,13 +44,13 @@ func TaskStatus(state *ReconcileContext, c client.Client) task.Task {
 		if pod != nil &&
 			statefulset.IsPodRunningAndReady(pod) &&
 			!state.PodIsTerminating &&
-			state.StoreState == v1alpha1.StoreStateServing {
+			state.IsStoreUp() {
 			healthy = true
 		}
 		needUpdate = syncHealthCond(tiflash, healthy) || needUpdate
 		needUpdate = syncSuspendCond(tiflash) || needUpdate
 		needUpdate = SetIfChanged(&tiflash.Status.ID, state.StoreID) || needUpdate
-		needUpdate = SetIfChanged(&tiflash.Status.State, state.StoreState) || needUpdate
+		needUpdate = SetIfChanged(&tiflash.Status.State, state.GetStoreState()) || needUpdate
 
 		needUpdate = SetIfChanged(&tiflash.Status.ObservedGeneration, tiflash.Generation) || needUpdate
 		needUpdate = SetIfChanged(&tiflash.Status.UpdateRevision, tiflash.Labels[v1alpha1.LabelKeyInstanceRevisionHash]) || needUpdate

--- a/pkg/controllers/tiflash/tasks/status_test.go
+++ b/pkg/controllers/tiflash/tasks/status_test.go
@@ -62,10 +62,10 @@ func TestTaskStatus(t *testing.T) {
 						obj.Status.ObservedGeneration = 3
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateServing,
 				},
-				Store:      &pdv1.Store{},
-				StoreID:    fakeTiFlashName,
-				StoreState: v1alpha1.StoreStateServing,
+				Store:   &pdv1.Store{},
+				StoreID: fakeTiFlashName,
 			},
 
 			expectedStatus: task.SWait,
@@ -122,10 +122,10 @@ func TestTaskStatus(t *testing.T) {
 						})
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateServing,
 				},
-				Store:      &pdv1.Store{},
-				StoreID:    fakeTiFlashName,
-				StoreState: v1alpha1.StoreStateServing,
+				Store:   &pdv1.Store{},
+				StoreID: fakeTiFlashName,
 			},
 
 			expectedStatus: task.SComplete,

--- a/pkg/controllers/tiflash/tasks/store_labels.go
+++ b/pkg/controllers/tiflash/tasks/store_labels.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
 	"github.com/pingcap/tidb-operator/pkg/utils/k8s"
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
@@ -32,7 +31,7 @@ import (
 func TaskStoreLabels(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("StoreLabels", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
-		if state.StoreState != v1alpha1.StoreStateServing || state.PodIsTerminating || state.Pod() == nil {
+		if !state.IsStoreUp() || state.PodIsTerminating || state.Pod() == nil {
 			return task.Complete().With("skip sync store labels as the store is not serving")
 		}
 

--- a/pkg/controllers/tikv/tasks/ctx.go
+++ b/pkg/controllers/tikv/tasks/ctx.go
@@ -32,7 +32,6 @@ type ReconcileContext struct {
 
 	StoreExists    bool
 	StoreID        string
-	StoreState     string
 	LeaderEvicting bool
 
 	Store *pdv1.Store
@@ -65,8 +64,8 @@ func TaskContextInfoFromPD(state *ReconcileContext, cm pdm.PDClientManager) task
 			}
 			return task.Complete().With("store does not exist")
 		}
-		state.Store, state.StoreID, state.StoreState = s, s.ID, string(s.NodeState)
-
+		state.Store, state.StoreID = s, s.ID
+		state.SetStoreState(string(s.NodeState))
 		// TODO: cache evict leader scheduler info, then we don't need to check suspend here
 		if coreutil.ShouldSuspendCompute(state.Cluster()) {
 			return task.Complete().With("cluster is suspending")

--- a/pkg/controllers/tikv/tasks/finalizer.go
+++ b/pkg/controllers/tikv/tasks/finalizer.go
@@ -49,11 +49,11 @@ func TaskFinalizerDel(state *ReconcileContext, c client.Client) task.Task {
 			if err := k8s.RemoveFinalizer(ctx, c, state.TiKV()); err != nil {
 				return task.Fail().With("cannot remove finalizer: %w", err)
 			}
-		case state.StoreState == v1alpha1.StoreStateRemoving:
+		case state.GetStoreState() == v1alpha1.StoreStateRemoving:
 			// TODO: Complete task and retrigger reconciliation by polling PD
 			return task.Retry(removingWaitInterval).With("wait until the store is removed")
 
-		case state.StoreState == v1alpha1.StoreStateRemoved || state.StoreID == "":
+		case state.GetStoreState() == v1alpha1.StoreStateRemoved || state.StoreID == "":
 			wait, err := EnsureSubResourcesDeleted(ctx, c, state.TiKV())
 			if err != nil {
 				return task.Fail().With("cannot delete subresources: %w", err)

--- a/pkg/controllers/tikv/tasks/finalizer_test.go
+++ b/pkg/controllers/tikv/tasks/finalizer_test.go
@@ -215,8 +215,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoving,
 				},
-				StoreState: v1alpha1.StoreStateRemoving,
 			},
 
 			expectedStatus: task.SRetry,
@@ -235,8 +235,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 
 			expectedStatus: task.SComplete,
@@ -255,8 +255,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 
 			expectedStatus: task.SComplete,
@@ -276,8 +276,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			unexpectedErr: true,
 
@@ -294,8 +294,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			subresources: fakeSubresources("Pod"),
 
@@ -316,8 +316,8 @@ func TestTaskFinalizerDel(t *testing.T) {
 					cluster: fake.FakeObj("cluster", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateRemoved,
 				},
-				StoreState: v1alpha1.StoreStateRemoved,
 			},
 			subresources:  fakeSubresources("Pod"),
 			unexpectedErr: true,

--- a/pkg/controllers/tikv/tasks/state.go
+++ b/pkg/controllers/tikv/tasks/state.go
@@ -32,6 +32,7 @@ type state struct {
 	tikv    *v1alpha1.TiKV
 	pod     *corev1.Pod
 
+	storeState    string
 	statusChanged bool
 }
 
@@ -50,6 +51,7 @@ type State interface {
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.TiKV]
 
+	common.StoreState
 	SetPod(*corev1.Pod)
 }
 
@@ -110,4 +112,16 @@ func (s *state) PodInitializer() common.PodInitializer {
 			return coreutil.PodName[scope.TiKV](s.tikv)
 		})).
 		Initializer()
+}
+
+func (s *state) GetStoreState() string {
+	return s.storeState
+}
+
+func (s *state) SetStoreState(state string) {
+	s.storeState = state
+}
+
+func (s *state) IsStoreUp() bool {
+	return s.storeState == v1alpha1.StoreStatePreparing || s.storeState == v1alpha1.StoreStateServing
 }

--- a/pkg/controllers/tikv/tasks/status.go
+++ b/pkg/controllers/tikv/tasks/status.go
@@ -45,14 +45,14 @@ func TaskStatus(state *ReconcileContext, c client.Client) task.Task {
 		if pod != nil &&
 			statefulset.IsPodRunningAndReady(pod) &&
 			!state.PodIsTerminating &&
-			state.StoreState == v1alpha1.StoreStateServing {
+			state.IsStoreUp() {
 			healthy = true
 		}
 		needUpdate = syncHealthCond(tikv, healthy) || needUpdate
 		needUpdate = syncSuspendCond(tikv) || needUpdate
 		needUpdate = syncLeadersEvictedCond(tikv, state.Store, state.LeaderEvicting, state.IsPDAvailable) || needUpdate
 		needUpdate = SetIfChanged(&tikv.Status.ID, state.StoreID) || needUpdate
-		needUpdate = SetIfChanged(&tikv.Status.State, state.StoreState) || needUpdate
+		needUpdate = SetIfChanged(&tikv.Status.State, state.GetStoreState()) || needUpdate
 
 		needUpdate = SetIfChanged(&tikv.Status.ObservedGeneration, tikv.Generation) || needUpdate
 		needUpdate = SetIfChanged(&tikv.Status.UpdateRevision, tikv.Labels[v1alpha1.LabelKeyInstanceRevisionHash]) || needUpdate

--- a/pkg/controllers/tikv/tasks/status_test.go
+++ b/pkg/controllers/tikv/tasks/status_test.go
@@ -62,11 +62,11 @@ func TestTaskStatus(t *testing.T) {
 						obj.Status.ObservedGeneration = 3
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateServing,
 				},
 				IsPDAvailable: true,
 				Store:         &pdv1.Store{},
 				StoreID:       fakeTiKVName,
-				StoreState:    v1alpha1.StoreStateServing,
 			},
 
 			expectedStatus: task.SWait,
@@ -130,11 +130,11 @@ func TestTaskStatus(t *testing.T) {
 						})
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateServing,
 				},
 				IsPDAvailable: true,
 				Store:         &pdv1.Store{},
 				StoreID:       fakeTiKVName,
-				StoreState:    v1alpha1.StoreStateServing,
 			},
 
 			expectedStatus: task.SComplete,
@@ -332,12 +332,12 @@ func TestTaskStatus(t *testing.T) {
 						})
 						return obj
 					}),
+					storeState: v1alpha1.StoreStateServing,
 				},
 				IsPDAvailable:  true,
 				LeaderEvicting: true,
 				Store:          &pdv1.Store{},
 				StoreID:        fakeTiKVName,
-				StoreState:     v1alpha1.StoreStateServing,
 			},
 
 			expectedStatus: task.SWait,

--- a/pkg/controllers/tikv/tasks/store_labels.go
+++ b/pkg/controllers/tikv/tasks/store_labels.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
 	"github.com/pingcap/tidb-operator/pkg/utils/k8s"
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
@@ -32,7 +31,7 @@ import (
 func TaskStoreLabels(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("StoreLabels", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
-		if state.StoreState != v1alpha1.StoreStateServing || state.PodIsTerminating || state.Pod() == nil {
+		if !state.IsStoreUp() || state.PodIsTerminating || state.Pod() == nil {
 			return task.Complete().With("skip sync store labels as the store is not serving")
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [x] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
