### PR TITLE
fix(tidb): fix topology spread issue of tidb

### DIFF
--- a/pkg/controllers/tiflashgroup/tasks/updater.go
+++ b/pkg/controllers/tiflashgroup/tasks/updater.go
@@ -61,13 +61,13 @@ func TaskUpdater(state *ReconcileContext, c client.Client) task.Task {
 			}
 		}
 
+		updateRevision, _, _ := state.Revision()
+
 		fs := state.Slice()
-		topoPolicy, err := policy.NewTopologyPolicy(topos, fs...)
+		topoPolicy, err := policy.NewTopologyPolicy(topos, updateRevision, fs...)
 		if err != nil {
 			return task.Fail().With("invalid topo policy, it should be validated: %w", err)
 		}
-
-		updateRevision, _, _ := state.Revision()
 
 		wait, err := updater.New[runtime.TiFlashTuple]().
 			WithInstances(fs...).
@@ -79,6 +79,7 @@ func TaskUpdater(state *ReconcileContext, c client.Client) task.Task {
 			WithNewFactory(TiFlashNewer(fg, updateRevision)).
 			WithAddHooks(topoPolicy).
 			WithDelHooks(topoPolicy).
+			WithUpdateHooks(topoPolicy).
 			WithScaleInPreferPolicy(
 				topoPolicy,
 			).

--- a/pkg/updater/policy/topology.go
+++ b/pkg/updater/policy/topology.go
@@ -15,6 +15,8 @@
 package policy
 
 import (
+	"maps"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/runtime"
 	"github.com/pingcap/tidb-operator/pkg/updater"
@@ -22,43 +24,77 @@ import (
 )
 
 type topologyPolicy[R runtime.Instance] struct {
-	scheduler topology.Scheduler
+	all     topology.Scheduler
+	updated topology.Scheduler
+
+	rev string
 }
 
 type TopologyPolicy[R runtime.Instance] interface {
 	updater.AddHook[R]
 	updater.DelHook[R]
+	updater.UpdateHook[R]
 	updater.PreferPolicy[R]
 }
 
-func NewTopologyPolicy[R runtime.Instance](ts []v1alpha1.ScheduleTopology, rs ...R) (TopologyPolicy[R], error) {
-	s, err := topology.New(ts)
+func NewTopologyPolicy[R runtime.Instance](ts []v1alpha1.ScheduleTopology, rev string, rs ...R) (TopologyPolicy[R], error) {
+	all, err := topology.New(ts)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := topology.New(ts)
 	if err != nil {
 		return nil, err
 	}
 	p := &topologyPolicy[R]{
-		scheduler: s,
+		all:     all,
+		updated: updated,
+		rev:     rev,
 	}
 	for _, r := range rs {
-		p.scheduler.Add(r.GetName(), r.GetTopology())
+		p.all.Add(r.GetName(), r.GetTopology())
+		if r.GetUpdateRevision() == rev {
+			p.updated.Add(r.GetName(), r.GetTopology())
+		}
 	}
 	return p, nil
 }
 
 func (p *topologyPolicy[R]) Add(update R) R {
-	topo := p.scheduler.NextAdd()
+	all := p.all.NextAdd()
+	updated := p.updated.NextAdd()
+	topo := choose(all, updated)
+
 	update.SetTopology(topo)
-	p.scheduler.Add(update.GetName(), update.GetTopology())
+	p.all.Add(update.GetName(), update.GetTopology())
+	if update.GetUpdateRevision() == p.rev {
+		p.updated.Add(update.GetName(), update.GetTopology())
+	}
+
+	return update
+}
+
+func (p *topologyPolicy[R]) Update(update, outdated R) R {
+	update.SetTopology(outdated.GetTopology())
+
+	p.all.Add(update.GetName(), update.GetTopology())
+	if update.GetUpdateRevision() == p.rev {
+		p.updated.Add(update.GetName(), update.GetTopology())
+	}
 
 	return update
 }
 
 func (p *topologyPolicy[R]) Delete(name string) {
-	p.scheduler.Del(name)
+	p.all.Del(name)
+	p.updated.Del(name)
 }
 
 func (p *topologyPolicy[R]) Prefer(allowed []R) []R {
-	names := p.scheduler.NextDel()
+	if len(allowed) == 0 {
+		return nil
+	}
+	names := p.all.NextDel()
 	preferred := make([]R, 0, len(allowed))
 	for _, item := range allowed {
 		for _, name := range names {
@@ -69,4 +105,33 @@ func (p *topologyPolicy[R]) Prefer(allowed []R) []R {
 	}
 
 	return preferred
+}
+
+// choose a preferred topology
+// - prefer all instances are well spreaded
+// - if no
+func choose(all, update []v1alpha1.Topology) v1alpha1.Topology {
+	// No topology is preferred
+	// Normally because of no topology policy is specified
+	if len(all) == 0 {
+		return nil
+	}
+	// Only one topology can be choosen
+	if len(all) == 1 {
+		return all[0]
+	}
+
+	// More than one topologies can be choosen
+	// Try to find the first topology which is in both all and update
+	for _, at := range all {
+		for _, bt := range update {
+			if maps.Equal(at, bt) {
+				return at
+			}
+		}
+	}
+
+	// No intersection of prefered topologies of all and update
+	// just return the first prefered topology of all
+	return all[0]
 }

--- a/pkg/updater/policy/topology.go
+++ b/pkg/updater/policy/topology.go
@@ -108,7 +108,7 @@ func (p *topologyPolicy[R]) Prefer(allowed []R) []R {
 }
 
 // choose a preferred topology
-// - prefer all instances are well spreaded
+// - prefer all instances are well spread
 // - if no
 func choose(all, update []v1alpha1.Topology) v1alpha1.Topology {
 	// No topology is preferred
@@ -116,12 +116,12 @@ func choose(all, update []v1alpha1.Topology) v1alpha1.Topology {
 	if len(all) == 0 {
 		return nil
 	}
-	// Only one topology can be choosen
+	// Only one topology can be chosen
 	if len(all) == 1 {
 		return all[0]
 	}
 
-	// More than one topologies can be choosen
+	// More than one topologies can be chosen
 	// Try to find the first topology which is in both all and update
 	for _, at := range all {
 		for _, bt := range update {
@@ -131,7 +131,7 @@ func choose(all, update []v1alpha1.Topology) v1alpha1.Topology {
 		}
 	}
 
-	// No intersection of prefered topologies of all and update
-	// just return the first prefered topology of all
+	// No intersection of preferred topologies of all and update
+	// just return the first preferred topology of all
 	return all[0]
 }

--- a/pkg/updater/policy/topology_test.go
+++ b/pkg/updater/policy/topology_test.go
@@ -19,60 +19,191 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/runtime"
+	"github.com/pingcap/tidb-operator/pkg/utils/fake"
 )
 
 func TestTopologyPolicy(t *testing.T) {
-	policy, err := NewTopologyPolicy[*runtime.PD]([]v1alpha1.ScheduleTopology{
-		{
-			Topology: v1alpha1.Topology{
-				"zone": "us-west-1a",
-			},
-		},
-		{
-			Topology: v1alpha1.Topology{
-				"zone": "us-west-1b",
-			},
-		},
-		{
-			Topology: v1alpha1.Topology{
-				"zone": "us-west-1c",
-			},
-		},
-	})
-	require.NoError(t, err)
+	const newRev = "new"
+	const oldRev = "old"
+	cases := []struct {
+		desc     string
+		existing []*v1alpha1.PD
+		add      *v1alpha1.PD
+		update   *v1alpha1.PD
+		del      string
 
-	pd0 := &v1alpha1.PD{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pd-0",
+		expectedAdd      *v1alpha1.PD
+		expectedUpdate   *v1alpha1.PD
+		expectedPrefered []*v1alpha1.PD
+	}{
+		{
+			desc:        "no existsing, add a new instance, will set topology",
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1a"),
 		},
-		Spec: v1alpha1.PDSpec{
-			Topology: v1alpha1.Topology{},
+
+		{
+			desc: "existsing updated a, add a new will be scheduled to b",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+			},
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1b"),
+		},
+
+		{
+			desc: "existsing updated ab, add a new will be scheduled to c",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", newRev, "us-west-1b"),
+			},
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1c"),
+		},
+
+		{
+			desc: "existsing updated abc, add a new will be scheduled to a",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", newRev, "us-west-1b"),
+				fakePD("2", newRev, "us-west-1c"),
+			},
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1a"),
+		},
+
+		{
+			// two new instance will be scheduled to a different zone
+			desc: "existsing updated a and old bc, add a new will be scheduled to b",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", oldRev, "us-west-1b"),
+				fakePD("2", oldRev, "us-west-1c"),
+			},
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1b"),
+
+			expectedPrefered: []*v1alpha1.PD{
+				fakePD("1", oldRev, "us-west-1b"),
+			},
+		},
+
+		{
+			desc: "existsing updated ab and old c, add a new will be scheduled to c",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", newRev, "us-west-1b"),
+				fakePD("2", oldRev, "us-west-1c"),
+			},
+			add:         fakePD("add", newRev, ""),
+			expectedAdd: fakePD("add", newRev, "us-west-1c"),
+
+			expectedPrefered: []*v1alpha1.PD{
+				fakePD("2", oldRev, "us-west-1c"),
+			},
+		},
+
+		{
+			desc: "update will keep topology",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", oldRev, "us-west-1b"),
+				fakePD("2", oldRev, "us-west-1c"),
+			},
+			update:         fakePD("2", newRev, ""),
+			expectedUpdate: fakePD("2", newRev, "us-west-1c"),
+
+			expectedPrefered: []*v1alpha1.PD{
+				fakePD("1", oldRev, "us-west-1b"),
+			},
+		},
+
+		{
+			desc: "del an existing obj",
+			existing: []*v1alpha1.PD{
+				fakePD("0", newRev, "us-west-1a"),
+				fakePD("1", oldRev, "us-west-1b"),
+				fakePD("2", oldRev, "us-west-1c"),
+			},
+			del: "0",
+
+			expectedPrefered: []*v1alpha1.PD{
+				fakePD("1", oldRev, "us-west-1b"),
+				fakePD("2", oldRev, "us-west-1c"),
+			},
 		},
 	}
-	pd0r := policy.Add(runtime.FromPD(pd0))
-	require.Equal(t, pd0, runtime.ToPD(pd0r)) // in-place update
-	assert.Equal(t, v1alpha1.Topology{"zone": "us-west-1a"}, pd0r.Spec.Topology)
 
-	pd1 := &v1alpha1.PD{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pd-1",
-		},
-		Spec: v1alpha1.PDSpec{
-			Topology: v1alpha1.Topology{},
-		},
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.desc, func(tt *testing.T) {
+			tt.Parallel()
+			policy, err := NewTopologyPolicy([]v1alpha1.ScheduleTopology{
+				{
+					Topology: v1alpha1.Topology{
+						"zone": "us-west-1a",
+					},
+				},
+				{
+					Topology: v1alpha1.Topology{
+						"zone": "us-west-1b",
+					},
+				},
+				{
+					Topology: v1alpha1.Topology{
+						"zone": "us-west-1c",
+					},
+				},
+			}, newRev, runtime.FromPDSlice(c.existing)...)
+			require.NoError(tt, err)
+
+			instances := map[string]*v1alpha1.PD{}
+			for _, in := range c.existing {
+				instances[in.GetName()] = in
+			}
+
+			if c.add != nil {
+				actualAdd := policy.Add(runtime.FromPD(c.add))
+				require.Equal(t, c.add, runtime.ToPD(actualAdd)) // in-place update
+				assert.Equal(t, c.expectedAdd, c.add)
+				instances[c.add.GetName()] = c.add
+			}
+
+			if c.update != nil {
+				actualUpdate := policy.Update(runtime.FromPD(c.update), runtime.FromPD(instances[c.update.GetName()]))
+				require.Equal(t, c.update, runtime.ToPD(actualUpdate)) // in-place update
+				assert.Equal(t, c.expectedUpdate, c.update)
+				instances[c.update.GetName()] = c.update
+			}
+
+			if c.del != "" {
+				policy.Delete(c.del)
+				delete(instances, c.del)
+			}
+
+			var outdated []*v1alpha1.PD
+			for _, in := range instances {
+				rev, ok := in.Labels[v1alpha1.LabelKeyInstanceRevisionHash]
+				if !ok || rev != newRev {
+					outdated = append(outdated, in)
+				}
+			}
+
+			preferred := policy.Prefer(runtime.FromPDSlice(outdated))
+			assert.Equal(tt, c.expectedPrefered, runtime.ToPDSlice(preferred))
+		})
 	}
-	pd1r := policy.Add(runtime.FromPD(pd1))
-	require.Equal(t, pd1, runtime.ToPD(pd1r)) // in-place update
-	assert.Equal(t, v1alpha1.Topology{"zone": "us-west-1b"}, pd1r.Spec.Topology)
+}
 
-	perfer := policy.Prefer([]*runtime.PD{pd0r, pd1r})
-	assert.Equal(t, "pd-0", perfer[0].Name)
-
-	policy.Delete("pd-0")
-	perfer = policy.Prefer([]*runtime.PD{pd0r, pd1r})
-	assert.Equal(t, "pd-1", perfer[0].Name)
+func fakePD(name string, rev string, zone string) *v1alpha1.PD {
+	pd := fake.FakeObj(name, fake.Label[v1alpha1.PD](v1alpha1.LabelKeyInstanceRevisionHash, rev))
+	if zone != "" {
+		pd.Spec.Topology = v1alpha1.Topology{
+			"zone": zone,
+		}
+	}
+	return pd
 }

--- a/pkg/updater/state.go
+++ b/pkg/updater/state.go
@@ -15,6 +15,9 @@
 package updater
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/pingcap/tidb-operator/pkg/runtime"
 )
 
@@ -59,6 +62,9 @@ func (s *state[R]) List() []R {
 	for _, obj := range s.nameToObj {
 		l = append(l, obj)
 	}
+	slices.SortFunc(l, func(a, b R) int {
+		return cmp.Compare(a.GetName(), b.GetName())
+	})
 	return l
 }
 

--- a/tests/e2e/data/tidb.go
+++ b/tests/e2e/data/tidb.go
@@ -124,3 +124,31 @@ func WithEphemeralVolume() GroupPatch[*runtime.TiDBGroup] {
 		})
 	}
 }
+
+// TODO: combine with WithTiKVEvenlySpreadPolicy
+func WithTiDBEvenlySpreadPolicy() GroupPatch[*runtime.TiDBGroup] {
+	return func(obj *runtime.TiDBGroup) {
+		obj.Spec.SchedulePolicies = append(obj.Spec.SchedulePolicies, v1alpha1.SchedulePolicy{
+			Type: v1alpha1.SchedulePolicyTypeEvenlySpread,
+			EvenlySpread: &v1alpha1.SchedulePolicyEvenlySpread{
+				Topologies: []v1alpha1.ScheduleTopology{
+					{
+						Topology: v1alpha1.Topology{
+							"zone": "zone-a",
+						},
+					},
+					{
+						Topology: v1alpha1.Topology{
+							"zone": "zone-b",
+						},
+					},
+					{
+						Topology: v1alpha1.Topology{
+							"zone": "zone-c",
+						},
+					},
+				},
+			},
+		})
+	}
+}

--- a/tests/e2e/data/tikv.go
+++ b/tests/e2e/data/tikv.go
@@ -54,7 +54,8 @@ func NewTiKVGroup(ns string, patches ...GroupPatch[*runtime.TiKVGroup]) *v1alpha
 	return runtime.ToTiKVGroup(kvg)
 }
 
-func WithEvenlySpreadPolicy() GroupPatch[*runtime.TiKVGroup] {
+// TODO: combine with WithTiDBEvenlySpreadPolicy
+func WithTiKVEvenlySpreadPolicy() GroupPatch[*runtime.TiKVGroup] {
 	return func(obj *runtime.TiKVGroup) {
 		obj.Spec.SchedulePolicies = append(obj.Spec.SchedulePolicies, v1alpha1.SchedulePolicy{
 			Type: v1alpha1.SchedulePolicyTypeEvenlySpread,

--- a/tests/e2e/tidb/topology.go
+++ b/tests/e2e/tidb/topology.go
@@ -1,0 +1,101 @@
+package tidb
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/pingcap/tidb-operator/pkg/runtime"
+	"github.com/pingcap/tidb-operator/tests/e2e/data"
+	"github.com/pingcap/tidb-operator/tests/e2e/framework"
+	"github.com/pingcap/tidb-operator/tests/e2e/label"
+	"github.com/pingcap/tidb-operator/tests/e2e/utils/waiter"
+)
+
+var _ = ginkgo.Describe("Topology", label.TiDB, label.MultipleAZ, label.P0, func() {
+	f := framework.New()
+	f.Setup()
+
+	ginkgo.It("Create tidb evenly spread in multiple azs", func(ctx context.Context) {
+		ginkgo.By("Creating cluster")
+		pdg := f.MustCreatePD(ctx)
+		kvg := f.MustCreateTiKV(ctx)
+		dbg := f.MustCreateTiDB(ctx,
+			data.WithReplicas[*runtime.TiDBGroup](3),
+			data.WithTiDBEvenlySpreadPolicy(),
+		)
+
+		f.WaitForPDGroupReady(ctx, pdg)
+		f.WaitForTiKVGroupReady(ctx, kvg)
+		f.WaitForTiDBGroupReady(ctx, dbg)
+
+		f.MustEvenlySpreadTiDB(ctx, dbg)
+	})
+
+	ginkgo.It("rolling update and scale + rolling update", label.Scale, label.Update, func(ctx context.Context) {
+		ginkgo.By("Creating cluster")
+		pdg := f.MustCreatePD(ctx)
+		kvg := f.MustCreateTiKV(ctx)
+		dbg := f.MustCreateTiDB(ctx,
+			data.WithReplicas[*runtime.TiDBGroup](2),
+			data.WithTiDBEvenlySpreadPolicy(),
+		)
+
+		f.WaitForPDGroupReady(ctx, pdg)
+		f.WaitForTiKVGroupReady(ctx, kvg)
+		f.WaitForTiDBGroupReady(ctx, dbg)
+
+		f.MustEvenlySpreadTiDB(ctx, dbg)
+
+		patch := client.MergeFrom(dbg.DeepCopy())
+		dbg.Spec.Template.Spec.Config = `log.level = 'warn'`
+
+		nctx, cancel := context.WithCancel(ctx)
+		ch := make(chan struct{})
+		go func() {
+			defer close(ch)
+			defer ginkgo.GinkgoRecover()
+			f.Must(waiter.WaitPodsRollingUpdateOnce(nctx, f.Client, runtime.FromTiDBGroup(dbg), 2, 1, waiter.LongTaskTimeout))
+		}()
+
+		maxTime, err := waiter.MaxPodsCreateTimestamp(ctx, f.Client, runtime.FromTiDBGroup(dbg))
+		f.Must(err)
+		changeTime := maxTime.Add(time.Second)
+
+		ginkgo.By("rolling update once")
+		f.Must(f.Client.Patch(ctx, dbg, patch))
+		f.Must(waiter.WaitForPodsRecreated(ctx, f.Client, runtime.FromTiDBGroup(dbg), changeTime, waiter.LongTaskTimeout))
+		f.WaitForTiDBGroupReady(ctx, dbg)
+		cancel()
+		<-ch
+		f.MustEvenlySpreadTiDB(ctx, dbg)
+
+		patch = client.MergeFrom(dbg.DeepCopy())
+		dbg.Spec.Template.Spec.Config = `log.level = 'info'`
+		dbg.Spec.Replicas = ptr.To[int32](3)
+
+		nctx, cancel = context.WithCancel(ctx)
+		ch = make(chan struct{})
+		go func() {
+			defer close(ch)
+			defer ginkgo.GinkgoRecover()
+			f.Must(waiter.WaitPodsRollingUpdateOnce(nctx, f.Client, runtime.FromTiDBGroup(dbg), 2, 1, waiter.LongTaskTimeout))
+		}()
+
+		maxTime, err = waiter.MaxPodsCreateTimestamp(ctx, f.Client, runtime.FromTiDBGroup(dbg))
+		f.Must(err)
+		changeTime = maxTime.Add(time.Second)
+
+		ginkgo.By("rolling update again")
+		f.Must(f.Client.Patch(ctx, dbg, patch))
+		f.Must(waiter.WaitForPodsRecreated(ctx, f.Client, runtime.FromTiDBGroup(dbg), changeTime, waiter.LongTaskTimeout))
+		f.WaitForTiDBGroupReady(ctx, dbg)
+		cancel()
+		<-ch
+
+		f.MustEvenlySpreadTiDB(ctx, dbg)
+	})
+})

--- a/tests/e2e/tidb/topology.go
+++ b/tests/e2e/tidb/topology.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tidb
 
 import (

--- a/tests/e2e/tikv/topology.go
+++ b/tests/e2e/tikv/topology.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("Topology", label.TiKV, label.MultipleAZ, label.P0, func
 		pdg := f.MustCreatePD(ctx)
 		kvg := f.MustCreateTiKV(ctx,
 			data.WithReplicas[*runtime.TiKVGroup](6),
-			data.WithEvenlySpreadPolicy(),
+			data.WithTiKVEvenlySpreadPolicy(),
 		)
 
 		f.WaitForPDGroupReady(ctx, pdg)
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Topology", label.TiKV, label.MultipleAZ, label.P0, func
 		pdg := f.MustCreatePD(ctx)
 		kvg := f.MustCreateTiKV(ctx,
 			data.WithReplicas[*runtime.TiKVGroup](3),
-			data.WithEvenlySpreadPolicy(),
+			data.WithTiKVEvenlySpreadPolicy(),
 		)
 
 		f.WaitForPDGroupReady(ctx, pdg)


### PR DESCRIPTION
- prefer evenly spread updated instances if there are more than one choices of topology. 

See https://github.com/pingcap/tidb-operator/issues/6136

It is not fully fixed because we always prefer scale in unavailable instances which may be not the best choice for topology spread.