### PR TITLE
br: allow user to customize tikv image in compact

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -5324,9 +5324,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>BrImage specifies the br image used in compact <code>Backup</code>.
-For examples <code>spec.brImage: pingcap/br:v4.0.8</code>
-For BR image, if it does not contain tag, Pod will use image &lsquo;BrImage:${TiKV_Version}&rsquo;.</p>
+<p>ToolImage specifies the br image used in compact <code>Backup</code>.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code>
+For BR image, if it does not contain tag, Pod will use the same version in tc &lsquo;BrImage:${TiKV_Version}&rsquo;.</p>
 </td>
 </tr>
 <tr>
@@ -5338,6 +5338,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
+<p>TikvImage specifies the tikv image used in compact <code>Backup</code>.
+For examples <code>spec.tikvImage: pingcap/tikv:v9.0.0</code>
+For TiKV image, if it does not contain tag, Pod will use the same version in tc &lsquo;TiKVImage:${TiKV_Version}&rsquo;.</p>
 </td>
 </tr>
 <tr>
@@ -5676,9 +5679,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>BrImage specifies the br image used in compact <code>Backup</code>.
-For examples <code>spec.brImage: pingcap/br:v4.0.8</code>
-For BR image, if it does not contain tag, Pod will use image &lsquo;BrImage:${TiKV_Version}&rsquo;.</p>
+<p>ToolImage specifies the br image used in compact <code>Backup</code>.
+For examples <code>spec.toolImage: pingcap/br:v4.0.8</code>
+For BR image, if it does not contain tag, Pod will use the same version in tc &lsquo;BrImage:${TiKV_Version}&rsquo;.</p>
 </td>
 </tr>
 <tr>
@@ -5690,6 +5693,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
+<p>TikvImage specifies the tikv image used in compact <code>Backup</code>.
+For examples <code>spec.tikvImage: pingcap/tikv:v9.0.0</code>
+For TiKV image, if it does not contain tag, Pod will use the same version in tc &lsquo;TiKVImage:${TiKV_Version}&rsquo;.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -5331,6 +5331,17 @@ For BR image, if it does not contain tag, Pod will use image &lsquo;BrImage:${Ti
 </tr>
 <tr>
 <td>
+<code>tikvImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
 <code>br</code></br>
 <em>
 <a href="#brconfig">
@@ -5668,6 +5679,17 @@ string
 <p>BrImage specifies the br image used in compact <code>Backup</code>.
 For examples <code>spec.brImage: pingcap/br:v4.0.8</code>
 For BR image, if it does not contain tag, Pod will use image &lsquo;BrImage:${TiKV_Version}&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tikvImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
 </td>
 </tr>
 <tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4470,6 +4470,8 @@ spec:
                     type: string
                   startTs:
                     type: string
+                  tikvImage:
+                    type: string
                   tolerations:
                     items:
                       properties:
@@ -12206,6 +12208,8 @@ spec:
               serviceAccount:
                 type: string
               startTs:
+                type: string
+              tikvImage:
                 type: string
               tolerations:
                 items:

--- a/manifests/crd/v1/pingcap.com_backupschedules.yaml
+++ b/manifests/crd/v1/pingcap.com_backupschedules.yaml
@@ -4470,6 +4470,8 @@ spec:
                     type: string
                   startTs:
                     type: string
+                  tikvImage:
+                    type: string
                   tolerations:
                     items:
                       properties:

--- a/manifests/crd/v1/pingcap.com_compactbackups.yaml
+++ b/manifests/crd/v1/pingcap.com_compactbackups.yaml
@@ -2163,6 +2163,8 @@ spec:
                 type: string
               startTs:
                 type: string
+              tikvImage:
+                type: string
               tolerations:
                 items:
                   properties:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1634,15 +1634,16 @@ func schema_pkg_apis_pingcap_v1alpha1_CompactSpec(ref common.ReferenceCallback) 
 					},
 					"toolImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BrImage specifies the br image used in compact `Backup`. For examples `spec.brImage: pingcap/br:v4.0.8` For BR image, if it does not contain tag, Pod will use image 'BrImage:${TiKV_Version}'.",
+							Description: "ToolImage specifies the br image used in compact `Backup`. For examples `spec.toolImage: pingcap/br:v4.0.8` For BR image, if it does not contain tag, Pod will use the same version in tc 'BrImage:${TiKV_Version}'.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tikvImage": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "TikvImage specifies the tikv image used in compact `Backup`. For examples `spec.tikvImage: pingcap/tikv:v9.0.0` For TiKV image, if it does not contain tag, Pod will use the same version in tc 'TiKVImage:${TiKV_Version}'.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"br": {

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -1639,6 +1639,12 @@ func schema_pkg_apis_pingcap_v1alpha1_CompactSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"tikvImage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"br": {
 						SchemaProps: spec.SchemaProps{
 							Description: "BRConfig is the configs for BR *** Note: This field should generally not be left empty, unless you are certain the BR config *** can be obtained from another source, such as a schedule CR.",

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -3552,6 +3552,8 @@ type CompactSpec struct {
 	// For BR image, if it does not contain tag, Pod will use image 'BrImage:${TiKV_Version}'.
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
+	// +optional
+	TiKVImage string `json:"tikvImage,omitempty"`
 	// BRConfig is the configs for BR
 	// *** Note: This field should generally not be left empty, unless you are certain the BR config
 	// *** can be obtained from another source, such as a schedule CR.

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -3547,11 +3547,14 @@ type CompactSpec struct {
 	// Base tolerations of backup Pods, components may add more tolerations upon this respectively
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// BrImage specifies the br image used in compact `Backup`.
-	// For examples `spec.brImage: pingcap/br:v4.0.8`
-	// For BR image, if it does not contain tag, Pod will use image 'BrImage:${TiKV_Version}'.
+	// ToolImage specifies the br image used in compact `Backup`.
+	// For examples `spec.toolImage: pingcap/br:v4.0.8`
+	// For BR image, if it does not contain tag, Pod will use the same version in tc 'BrImage:${TiKV_Version}'.
 	// +optional
 	ToolImage string `json:"toolImage,omitempty"`
+	// TikvImage specifies the tikv image used in compact `Backup`.
+	// For examples `spec.tikvImage: pingcap/tikv:v9.0.0`
+	// For TiKV image, if it does not contain tag, Pod will use the same version in tc 'TiKVImage:${TiKV_Version}'.
 	// +optional
 	TiKVImage string `json:"tikvImage,omitempty"`
 	// BRConfig is the configs for BR

--- a/pkg/controller/compactbackup/compact_backup_controller.go
+++ b/pkg/controller/compactbackup/compact_backup_controller.go
@@ -354,18 +354,24 @@ func (c *Controller) makeCompactJob(compact *v1alpha1.CompactBackup) (*batchv1.J
 		return nil, fmt.Sprintf("failed to fetch tidbcluster %s/%s", ns, compact.Spec.BR.Cluster), err
 	}
 	tikvImage := tc.TiKVImage()
-	_, tikvVersion := backuputil.ParseImage(tikvImage)
-	brImage := "pingcap/br:" + tikvVersion
+	_, tcVersion := backuputil.ParseImage(tikvImage)
+	brImage := "pingcap/br:" + tcVersion
 	if compact.Spec.ToolImage != "" {
-		brImage, toolVersion := backuputil.ParseImage(compact.Spec.ToolImage)
-		if toolVersion == "" {
-			brImage = fmt.Sprintf("%s:%s", brImage, tikvVersion)
+		var brVersion string
+		brImage, brVersion = backuputil.ParseImage(compact.Spec.ToolImage)
+		if brVersion != "" {
+			brImage = fmt.Sprintf("%s:%s", brImage, brVersion)
+		} else {
+			brImage = fmt.Sprintf("%s:%s", brImage, tcVersion)
 		}
 	}
 	if compact.Spec.TiKVImage != "" {
-		tikvImage, ctlVersion := backuputil.ParseImage(compact.Spec.TiKVImage)
-		if ctlVersion == "" {
+		var tikvVersion string
+		tikvImage, tikvVersion = backuputil.ParseImage(compact.Spec.TiKVImage)
+		if tikvVersion != "" {
 			tikvImage = fmt.Sprintf("%s:%s", tikvImage, tikvVersion)
+		} else {
+			tikvImage = fmt.Sprintf("%s:%s", tikvImage, tcVersion)
 		}
 	}
 	klog.Infof("Compact %s/%s use br image %s and tikv image %s", ns, name, brImage, tikvImage)

--- a/pkg/controller/compactbackup/compact_backup_controller.go
+++ b/pkg/controller/compactbackup/compact_backup_controller.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -358,12 +357,16 @@ func (c *Controller) makeCompactJob(compact *v1alpha1.CompactBackup) (*batchv1.J
 	_, tikvVersion := backuputil.ParseImage(tikvImage)
 	brImage := "pingcap/br:" + tikvVersion
 	if compact.Spec.ToolImage != "" {
-		toolImage := compact.Spec.ToolImage
-		if !strings.ContainsRune(compact.Spec.ToolImage, ':') {
-			toolImage = fmt.Sprintf("%s:%s", toolImage, tikvVersion)
+		brImage, toolVersion := backuputil.ParseImage(compact.Spec.ToolImage)
+		if toolVersion == "" {
+			brImage = fmt.Sprintf("%s:%s", brImage, tikvVersion)
 		}
-
-		brImage = toolImage
+	}
+	if compact.Spec.TiKVImage != "" {
+		tikvImage, ctlVersion := backuputil.ParseImage(compact.Spec.TiKVImage)
+		if ctlVersion == "" {
+			tikvImage = fmt.Sprintf("%s:%s", tikvImage, tikvVersion)
+		}
 	}
 	klog.Infof("Compact %s/%s use br image %s and tikv image %s", ns, name, brImage, tikvImage)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.


For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

Allow user use a new field named `tikvImage` to customize their own tikv image in compact.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
