### PR TITLE
refactor(common): use ContextObject task

### DIFF
--- a/pkg/controllers/common/interfaces.go
+++ b/pkg/controllers/common/interfaces.go
@@ -33,41 +33,12 @@ type ObjectList[T any] interface {
 }
 
 type (
-	ClusterInitializer = ResourceInitializer[v1alpha1.Cluster]
-
-	PDGroupInitializer = ResourceInitializer[v1alpha1.PDGroup]
-	PDInitializer      = ResourceInitializer[v1alpha1.PD]
-	PDSliceInitializer = ResourceSliceInitializer[v1alpha1.PD]
-
-	TiKVGroupInitializer = ResourceInitializer[v1alpha1.TiKVGroup]
-	TiKVInitializer      = ResourceInitializer[v1alpha1.TiKV]
-	TiKVSliceInitializer = ResourceSliceInitializer[v1alpha1.TiKV]
-
-	TiDBGroupInitializer = ResourceInitializer[v1alpha1.TiDBGroup]
-	TiDBInitializer      = ResourceInitializer[v1alpha1.TiDB]
-	TiDBSliceInitializer = ResourceSliceInitializer[v1alpha1.TiDB]
-
-	TiFlashGroupInitializer = ResourceInitializer[v1alpha1.TiFlashGroup]
-	TiFlashInitializer      = ResourceInitializer[v1alpha1.TiFlash]
+	PDSliceInitializer      = ResourceSliceInitializer[v1alpha1.PD]
+	TiKVSliceInitializer    = ResourceSliceInitializer[v1alpha1.TiKV]
+	TiDBSliceInitializer    = ResourceSliceInitializer[v1alpha1.TiDB]
 	TiFlashSliceInitializer = ResourceSliceInitializer[v1alpha1.TiFlash]
-
-	TiCDCGroupInitializer = ResourceInitializer[v1alpha1.TiCDCGroup]
-	TiCDCInitializer      = ResourceInitializer[v1alpha1.TiCDC]
-	TiCDCSliceInitializer = ResourceSliceInitializer[v1alpha1.TiCDC]
-
-	PodInitializer = ResourceInitializer[corev1.Pod]
+	TiCDCSliceInitializer   = ResourceSliceInitializer[v1alpha1.TiCDC]
 )
-
-type (
-	// DEPRECATED: remove it
-	ClusterStateInitializer interface {
-		ClusterInitializer() ClusterInitializer
-	}
-)
-
-type GroupStateInitializer[G runtime.GroupSet] interface {
-	GroupInitializer() ResourceInitializer[G]
-}
 
 type GroupState[G runtime.Group] interface {
 	Group() G
@@ -125,14 +96,8 @@ type ClusterAndGroupAndInstanceSliceState[
 }
 
 type (
-	PDGroupStateInitializer interface {
-		PDGroupInitializer() PDGroupInitializer
-	}
 	PDGroupState interface {
 		PDGroup() *v1alpha1.PDGroup
-	}
-	PDStateInitializer interface {
-		PDInitializer() PDInitializer
 	}
 	PDState interface {
 		PD() *v1alpha1.PD
@@ -146,14 +111,8 @@ type (
 )
 
 type (
-	TiKVGroupStateInitializer interface {
-		TiKVGroupInitializer() TiKVGroupInitializer
-	}
 	TiKVGroupState interface {
 		TiKVGroup() *v1alpha1.TiKVGroup
-	}
-	TiKVStateInitializer interface {
-		TiKVInitializer() TiKVInitializer
 	}
 	TiKVState interface {
 		TiKV() *v1alpha1.TiKV
@@ -167,14 +126,8 @@ type (
 )
 
 type (
-	TiDBGroupStateInitializer interface {
-		TiDBGroupInitializer() TiDBGroupInitializer
-	}
 	TiDBGroupState interface {
 		TiDBGroup() *v1alpha1.TiDBGroup
-	}
-	TiDBStateInitializer interface {
-		TiDBInitializer() TiDBInitializer
 	}
 	TiDBState interface {
 		TiDB() *v1alpha1.TiDB
@@ -188,14 +141,8 @@ type (
 )
 
 type (
-	TiFlashGroupStateInitializer interface {
-		TiFlashGroupInitializer() TiFlashGroupInitializer
-	}
 	TiFlashGroupState interface {
 		TiFlashGroup() *v1alpha1.TiFlashGroup
-	}
-	TiFlashStateInitializer interface {
-		TiFlashInitializer() TiFlashInitializer
 	}
 	TiFlashState interface {
 		TiFlash() *v1alpha1.TiFlash
@@ -209,14 +156,8 @@ type (
 )
 
 type (
-	TiCDCGroupStateInitializer interface {
-		TiCDCGroupInitializer() TiCDCGroupInitializer
-	}
 	TiCDCGroupState interface {
 		TiCDCGroup() *v1alpha1.TiCDCGroup
-	}
-	TiCDCStateInitializer interface {
-		TiCDCInitializer() TiCDCInitializer
 	}
 	TiCDCState interface {
 		TiCDC() *v1alpha1.TiCDC
@@ -226,13 +167,6 @@ type (
 	}
 	TiCDCSliceState interface {
 		TiCDCSlice() []*v1alpha1.TiCDC
-	}
-)
-
-type (
-	// DEPRECATED: remove it
-	PodStateInitializer interface {
-		PodInitializer() PodInitializer
 	}
 )
 

--- a/pkg/controllers/common/interfaces_test.go
+++ b/pkg/controllers/common/interfaces_test.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
@@ -32,11 +33,15 @@ func (f *fakeState[T]) Object() *T {
 	return f.obj
 }
 
-func (f *fakeState[T]) Initializer() ResourceInitializer[T] {
-	return NewResource(func(obj *T) { f.obj = obj }).
-		WithNamespace(Namespace(f.ns)).
-		WithName(Name(f.name)).
-		Initializer()
+func (f *fakeState[T]) SetObject(obj *T) {
+	f.obj = obj
+}
+
+func (f *fakeState[T]) Key() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: f.ns,
+		Name:      f.name,
+	}
 }
 
 type fakeSliceState[T any] struct {
@@ -56,18 +61,6 @@ func (f *fakeSliceState[T]) Initializer() ResourceSliceInitializer[T] {
 		Initializer()
 }
 
-type fakePDState struct {
-	s *fakeState[v1alpha1.PD]
-}
-
-func (f *fakePDState) PD() *v1alpha1.PD {
-	return f.s.Object()
-}
-
-func (f *fakePDState) PDInitializer() PDInitializer {
-	return f.s.Initializer()
-}
-
 type fakeClusterState struct {
 	s *fakeState[v1alpha1.Cluster]
 }
@@ -76,20 +69,12 @@ func (f *fakeClusterState) Cluster() *v1alpha1.Cluster {
 	return f.s.Object()
 }
 
-func (f *fakeClusterState) ClusterInitializer() ClusterInitializer {
-	return f.s.Initializer()
-}
-
 type fakePodState struct {
 	s *fakeState[corev1.Pod]
 }
 
 func (f *fakePodState) Pod() *corev1.Pod {
 	return f.s.Object()
-}
-
-func (f *fakePodState) PodInitializer() PodInitializer {
-	return f.s.Initializer()
 }
 
 func (f *fakePodState) IsPodTerminating() bool {

--- a/pkg/controllers/common/task.go
+++ b/pkg/controllers/common/task.go
@@ -102,56 +102,6 @@ func taskContextResourceSlice[T any, PT Object[T]](
 	})
 }
 
-func TaskContextPD(state PDStateInitializer, c client.Client) task.Task {
-	w := state.PDInitializer()
-	return taskContextResource("PD", w, c, false)
-}
-
-func TaskContextTiKV(state TiKVStateInitializer, c client.Client) task.Task {
-	w := state.TiKVInitializer()
-	return taskContextResource("TiKV", w, c, false)
-}
-
-func TaskContextTiDB(state TiDBStateInitializer, c client.Client) task.Task {
-	w := state.TiDBInitializer()
-	return taskContextResource("TiDB", w, c, false)
-}
-
-func TaskContextTiFlash(state TiFlashStateInitializer, c client.Client) task.Task {
-	w := state.TiFlashInitializer()
-	return taskContextResource("TiFlash", w, c, false)
-}
-
-func TaskContextTiCDC(state TiCDCStateInitializer, c client.Client) task.Task {
-	w := state.TiCDCInitializer()
-	return taskContextResource("TiCDC", w, c, false)
-}
-
-func TaskContextPDGroup(state PDGroupStateInitializer, c client.Client) task.Task {
-	w := state.PDGroupInitializer()
-	return taskContextResource("PDGroup", w, c, false)
-}
-
-func TaskContextTiKVGroup(state TiKVGroupStateInitializer, c client.Client) task.Task {
-	w := state.TiKVGroupInitializer()
-	return taskContextResource("TiKVGroup", w, c, false)
-}
-
-func TaskContextTiDBGroup(state TiDBGroupStateInitializer, c client.Client) task.Task {
-	w := state.TiDBGroupInitializer()
-	return taskContextResource("TiDBGroup", w, c, false)
-}
-
-func TaskContextTiFlashGroup(state TiFlashGroupStateInitializer, c client.Client) task.Task {
-	w := state.TiFlashGroupInitializer()
-	return taskContextResource("TiFlashGroup", w, c, false)
-}
-
-func TaskContextTiCDCGroup(state TiCDCGroupStateInitializer, c client.Client) task.Task {
-	w := state.TiCDCGroupInitializer()
-	return taskContextResource("TiCDCGroup", w, c, false)
-}
-
 func TaskContextPDSlice(state PDSliceStateInitializer, c client.Client) task.Task {
 	w := state.PDSliceInitializer()
 	return taskContextResourceSlice("PDSlice", w, &v1alpha1.PDList{}, c)

--- a/pkg/controllers/common/task_test.go
+++ b/pkg/controllers/common/task_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/utils/task/v3"
 )
 
-func TestTaskContextPD(t *testing.T) {
+func TestTaskContextObject(t *testing.T) {
 	cases := []struct {
 		desc          string
 		state         *fakeState[v1alpha1.PD]
@@ -87,8 +87,7 @@ func TestTaskContextPD(t *testing.T) {
 				fc.WithError("*", "*", errors.NewInternalError(fmt.Errorf("fake internal err")))
 			}
 
-			s := &fakePDState{s: c.state}
-			res, done := task.RunTask(context.Background(), TaskContextPD(s, fc))
+			res, done := task.RunTask(context.Background(), TaskContextObject[scope.PD](c.state, fc))
 			assert.Equal(tt, c.expectedResult, res.Status(), c.desc)
 			assert.False(tt, done, c.desc)
 			assert.Equal(tt, c.expectedObj, c.state.obj, c.desc)

--- a/pkg/controllers/pd/builder.go
+++ b/pkg/controllers/pd/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get pd
-		common.TaskContextPD(state, r.Client),
+		common.TaskContextObject[scope.PD](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondInstanceHasBeenDeleted(state)),
 

--- a/pkg/controllers/pd/tasks/state.go
+++ b/pkg/controllers/pd/tasks/state.go
@@ -41,7 +41,6 @@ type state struct {
 }
 
 type State interface {
-	common.PDStateInitializer
 	common.PDSliceStateInitializer
 
 	common.PDState
@@ -54,6 +53,7 @@ type State interface {
 	common.InstanceState[*runtime.PD]
 
 	common.ContextClusterNewer[*v1alpha1.PD]
+	common.ContextObjectNewer[*v1alpha1.PD]
 
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.PD]
@@ -69,8 +69,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.PD {
 	return s.pd
+}
+
+func (s *state) SetObject(pd *v1alpha1.PD) {
+	s.pd = pd
 }
 
 func (s *state) PD() *v1alpha1.PD {
@@ -119,13 +127,6 @@ func (s *state) SetStatusChanged() {
 
 func (s *state) PDSlice() []*v1alpha1.PD {
 	return s.pds
-}
-
-func (s *state) PDInitializer() common.PDInitializer {
-	return common.NewResource(func(pd *v1alpha1.PD) { s.pd = pd }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) PDSliceInitializer() common.PDSliceInitializer {

--- a/pkg/controllers/pd/tasks/state_test.go
+++ b/pkg/controllers/pd/tasks/state_test.go
@@ -120,7 +120,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextPD(s, fc),
+				common.TaskContextObject[scope.PD](s, fc),
 				common.TaskContextCluster[scope.PD](s, fc),
 				common.TaskContextPDSlice(s, fc),
 				common.TaskContextPod[scope.PD](s, fc),

--- a/pkg/controllers/pdgroup/builder.go
+++ b/pkg/controllers/pdgroup/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get pdgroup
-		common.TaskContextPDGroup(state, r.Client),
+		common.TaskContextObject[scope.PDGroup](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondGroupHasBeenDeleted(state)),
 

--- a/pkg/controllers/pdgroup/tasks/state.go
+++ b/pkg/controllers/pdgroup/tasks/state.go
@@ -37,7 +37,6 @@ type state struct {
 }
 
 type State interface {
-	common.PDGroupStateInitializer
 	common.PDSliceStateInitializer
 	common.RevisionStateInitializer[*runtime.PDGroup]
 
@@ -49,6 +48,7 @@ type State interface {
 	common.GroupState[*runtime.PDGroup]
 
 	common.ContextClusterNewer[*v1alpha1.PDGroup]
+	common.ContextObjectNewer[*v1alpha1.PDGroup]
 
 	common.InstanceSliceState[*runtime.PD]
 	common.SliceState[*v1alpha1.PD]
@@ -64,8 +64,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.PDGroup {
 	return s.pdg
+}
+
+func (s *state) SetObject(pdg *v1alpha1.PDGroup) {
+	s.pdg = pdg
 }
 
 func (s *state) PDGroup() *v1alpha1.PDGroup {
@@ -102,13 +110,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) PDGroupInitializer() common.PDGroupInitializer {
-	return common.NewResource(func(pdg *v1alpha1.PDGroup) { s.pdg = pdg }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) PDSliceInitializer() common.PDSliceInitializer {

--- a/pkg/controllers/pdgroup/tasks/state_test.go
+++ b/pkg/controllers/pdgroup/tasks/state_test.go
@@ -94,7 +94,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextPDGroup(s, fc),
+				common.TaskContextObject[scope.PDGroup](s, fc),
 				common.TaskContextCluster[scope.PDGroup](s, fc),
 				common.TaskContextPDSlice(s, fc),
 			))

--- a/pkg/controllers/ticdc/builder.go
+++ b/pkg/controllers/ticdc/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get TiCDC
-		common.TaskContextTiCDC(state, r.Client),
+		common.TaskContextObject[scope.TiCDC](state, r.Client),
 		// if it's deleted just return
 		task.IfBreak(common.CondInstanceHasBeenDeleted(state)),
 

--- a/pkg/controllers/ticdc/tasks/state.go
+++ b/pkg/controllers/ticdc/tasks/state.go
@@ -40,8 +40,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiCDCStateInitializer
-
 	common.TiCDCState
 	common.ClusterState
 
@@ -51,6 +49,7 @@ type State interface {
 	common.InstanceState[*runtime.TiCDC]
 
 	common.ContextClusterNewer[*v1alpha1.TiCDC]
+	common.ContextObjectNewer[*v1alpha1.TiCDC]
 
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.TiCDC]
@@ -66,8 +65,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiCDC {
 	return s.ticdc
+}
+
+func (s *state) SetObject(cdc *v1alpha1.TiCDC) {
+	s.ticdc = cdc
 }
 
 func (s *state) TiCDC() *v1alpha1.TiCDC {
@@ -112,13 +119,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiCDCInitializer() common.TiCDCInitializer {
-	return common.NewResource(func(ticdc *v1alpha1.TiCDC) { s.ticdc = ticdc }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) IsHealthy() bool {

--- a/pkg/controllers/ticdc/tasks/state_test.go
+++ b/pkg/controllers/ticdc/tasks/state_test.go
@@ -77,7 +77,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiCDC(s, fc),
+				common.TaskContextObject[scope.TiCDC](s, fc),
 				common.TaskContextCluster[scope.TiCDC](s, fc),
 				common.TaskContextPod[scope.TiCDC](s, fc),
 			))

--- a/pkg/controllers/ticdcgroup/builder.go
+++ b/pkg/controllers/ticdcgroup/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get TiCDCGroup
-		common.TaskContextTiCDCGroup(state, r.Client),
+		common.TaskContextObject[scope.TiCDCGroup](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondGroupHasBeenDeleted(state)),
 

--- a/pkg/controllers/ticdcgroup/tasks/state.go
+++ b/pkg/controllers/ticdcgroup/tasks/state.go
@@ -37,7 +37,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiCDCGroupStateInitializer
 	common.TiCDCSliceStateInitializer
 	common.RevisionStateInitializer[*runtime.TiCDCGroup]
 
@@ -49,6 +48,7 @@ type State interface {
 	common.GroupState[*runtime.TiCDCGroup]
 
 	common.ContextClusterNewer[*v1alpha1.TiCDCGroup]
+	common.ContextObjectNewer[*v1alpha1.TiCDCGroup]
 
 	common.InstanceSliceState[*runtime.TiCDC]
 	common.SliceState[*v1alpha1.TiCDC]
@@ -64,8 +64,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiCDCGroup {
 	return s.cdcg
+}
+
+func (s *state) SetObject(cg *v1alpha1.TiCDCGroup) {
+	s.cdcg = cg
 }
 
 func (s *state) TiCDCGroup() *v1alpha1.TiCDCGroup {
@@ -102,13 +110,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiCDCGroupInitializer() common.TiCDCGroupInitializer {
-	return common.NewResource(func(cdcg *v1alpha1.TiCDCGroup) { s.cdcg = cdcg }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) TiCDCSliceInitializer() common.TiCDCSliceInitializer {

--- a/pkg/controllers/ticdcgroup/tasks/state_test.go
+++ b/pkg/controllers/ticdcgroup/tasks/state_test.go
@@ -97,7 +97,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiCDCGroup(s, fc),
+				common.TaskContextObject[scope.TiCDCGroup](s, fc),
 				common.TaskContextCluster[scope.TiCDCGroup](s, fc),
 				common.TaskContextTiCDCSlice(s, fc),
 				common.TaskRevision[runtime.TiCDCGroupTuple](s, fc),

--- a/pkg/controllers/tidb/builder.go
+++ b/pkg/controllers/tidb/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get tidb
-		common.TaskContextTiDB(state, r.Client),
+		common.TaskContextObject[scope.TiDB](state, r.Client),
 		// if it's deleted just return
 		task.IfBreak(common.CondInstanceHasBeenDeleted(state)),
 

--- a/pkg/controllers/tidb/tasks/state.go
+++ b/pkg/controllers/tidb/tasks/state.go
@@ -40,8 +40,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiDBStateInitializer
-
 	common.TiDBState
 	common.ClusterState
 
@@ -51,6 +49,7 @@ type State interface {
 	common.InstanceState[*runtime.TiDB]
 
 	common.ContextClusterNewer[*v1alpha1.TiDB]
+	common.ContextObjectNewer[*v1alpha1.TiDB]
 
 	common.StatusPersister[*v1alpha1.TiDB]
 	common.StatusUpdater
@@ -64,6 +63,18 @@ func NewState(key types.NamespacedName) State {
 		key: key,
 	}
 	return s
+}
+
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
+func (s *state) Object() *v1alpha1.TiDB {
+	return s.tidb
+}
+
+func (s *state) SetObject(tidb *v1alpha1.TiDB) {
+	s.tidb = tidb
 }
 
 func (s *state) TiDB() *v1alpha1.TiDB {
@@ -84,10 +95,6 @@ func (s *state) IsPodTerminating() bool {
 
 func (s *state) Instance() *runtime.TiDB {
 	return runtime.FromTiDB(s.tidb)
-}
-
-func (s *state) Object() *v1alpha1.TiDB {
-	return s.tidb
 }
 
 func (s *state) IsStatusChanged() bool {
@@ -112,13 +119,6 @@ func (s *state) SetCluster(cluster *v1alpha1.Cluster) {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiDBInitializer() common.TiDBInitializer {
-	return common.NewResource(func(tidb *v1alpha1.TiDB) { s.tidb = tidb }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) IsHealthy() bool {

--- a/pkg/controllers/tidb/tasks/state_test.go
+++ b/pkg/controllers/tidb/tasks/state_test.go
@@ -77,7 +77,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiDB(s, fc),
+				common.TaskContextObject[scope.TiDB](s, fc),
 				common.TaskContextCluster[scope.TiDB](s, fc),
 				common.TaskContextPod[scope.TiDB](s, fc),
 			))

--- a/pkg/controllers/tidbgroup/builder.go
+++ b/pkg/controllers/tidbgroup/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get tidbgroup
-		common.TaskContextTiDBGroup(state, r.Client),
+		common.TaskContextObject[scope.TiDBGroup](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondGroupHasBeenDeleted(state)),
 

--- a/pkg/controllers/tidbgroup/tasks/state.go
+++ b/pkg/controllers/tidbgroup/tasks/state.go
@@ -37,7 +37,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiDBGroupStateInitializer
 	common.TiDBSliceStateInitializer
 	common.RevisionStateInitializer[*runtime.TiDBGroup]
 
@@ -49,6 +48,7 @@ type State interface {
 	common.GroupState[*runtime.TiDBGroup]
 
 	common.ContextClusterNewer[*v1alpha1.TiDBGroup]
+	common.ContextObjectNewer[*v1alpha1.TiDBGroup]
 
 	common.InstanceSliceState[*runtime.TiDB]
 	common.SliceState[*v1alpha1.TiDB]
@@ -64,8 +64,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiDBGroup {
 	return s.dbg
+}
+
+func (s *state) SetObject(dbg *v1alpha1.TiDBGroup) {
+	s.dbg = dbg
 }
 
 func (s *state) TiDBGroup() *v1alpha1.TiDBGroup {
@@ -102,13 +110,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiDBGroupInitializer() common.TiDBGroupInitializer {
-	return common.NewResource(func(dbg *v1alpha1.TiDBGroup) { s.dbg = dbg }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) TiDBSliceInitializer() common.TiDBSliceInitializer {

--- a/pkg/controllers/tidbgroup/tasks/state_test.go
+++ b/pkg/controllers/tidbgroup/tasks/state_test.go
@@ -97,7 +97,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiDBGroup(s, fc),
+				common.TaskContextObject[scope.TiDBGroup](s, fc),
 				common.TaskContextCluster[scope.TiDBGroup](s, fc),
 				common.TaskContextTiDBSlice(s, fc),
 				common.TaskRevision[runtime.TiDBGroupTuple](s, fc),

--- a/pkg/controllers/tiflash/builder.go
+++ b/pkg/controllers/tiflash/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// Get tiflash
-		common.TaskContextTiFlash(state, r.Client),
+		common.TaskContextObject[scope.TiFlash](state, r.Client),
 		// if it's deleted just return
 		task.IfBreak(common.CondInstanceHasBeenDeleted(state)),
 

--- a/pkg/controllers/tiflash/tasks/state.go
+++ b/pkg/controllers/tiflash/tasks/state.go
@@ -39,8 +39,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiFlashStateInitializer
-
 	common.TiFlashState
 	common.ClusterState
 
@@ -50,6 +48,7 @@ type State interface {
 	common.InstanceState[*runtime.TiFlash]
 
 	common.ContextClusterNewer[*v1alpha1.TiFlash]
+	common.ContextObjectNewer[*v1alpha1.TiFlash]
 
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.TiFlash]
@@ -67,8 +66,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiFlash {
 	return s.tiflash
+}
+
+func (s *state) SetObject(f *v1alpha1.TiFlash) {
+	s.tiflash = f
 }
 
 func (s *state) TiFlash() *v1alpha1.TiFlash {
@@ -113,13 +120,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiFlashInitializer() common.TiFlashInitializer {
-	return common.NewResource(func(tiflash *v1alpha1.TiFlash) { s.tiflash = tiflash }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) GetStoreState() string {

--- a/pkg/controllers/tiflash/tasks/state_test.go
+++ b/pkg/controllers/tiflash/tasks/state_test.go
@@ -77,7 +77,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiFlash(s, fc),
+				common.TaskContextObject[scope.TiFlash](s, fc),
 				common.TaskContextCluster[scope.TiFlash](s, fc),
 				common.TaskContextPod[scope.TiFlash](s, fc),
 			))

--- a/pkg/controllers/tiflashgroup/builder.go
+++ b/pkg/controllers/tiflashgroup/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get tiflashgroup
-		common.TaskContextTiFlashGroup(state, r.Client),
+		common.TaskContextObject[scope.TiFlashGroup](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondGroupHasBeenDeleted(state)),
 

--- a/pkg/controllers/tiflashgroup/tasks/state.go
+++ b/pkg/controllers/tiflashgroup/tasks/state.go
@@ -37,7 +37,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiFlashGroupStateInitializer
 	common.TiFlashSliceStateInitializer
 	common.RevisionStateInitializer[*runtime.TiFlashGroup]
 
@@ -49,6 +48,7 @@ type State interface {
 	common.GroupState[*runtime.TiFlashGroup]
 
 	common.ContextClusterNewer[*v1alpha1.TiFlashGroup]
+	common.ContextObjectNewer[*v1alpha1.TiFlashGroup]
 
 	common.InstanceSliceState[*runtime.TiFlash]
 	common.SliceState[*v1alpha1.TiFlash]
@@ -64,8 +64,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiFlashGroup {
 	return s.fg
+}
+
+func (s *state) SetObject(fg *v1alpha1.TiFlashGroup) {
+	s.fg = fg
 }
 
 func (s *state) TiFlashGroup() *v1alpha1.TiFlashGroup {
@@ -102,13 +110,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiFlashGroupInitializer() common.TiFlashGroupInitializer {
-	return common.NewResource(func(fg *v1alpha1.TiFlashGroup) { s.fg = fg }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) TiFlashSliceInitializer() common.TiFlashSliceInitializer {

--- a/pkg/controllers/tiflashgroup/tasks/state_test.go
+++ b/pkg/controllers/tiflashgroup/tasks/state_test.go
@@ -97,7 +97,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiFlashGroup(s, fc),
+				common.TaskContextObject[scope.TiFlashGroup](s, fc),
 				common.TaskContextCluster[scope.TiFlashGroup](s, fc),
 				common.TaskContextTiFlashSlice(s, fc),
 				common.TaskRevision[runtime.TiFlashGroupTuple](s, fc),

--- a/pkg/controllers/tikv/builder.go
+++ b/pkg/controllers/tikv/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get tikv
-		common.TaskContextTiKV(state, r.Client),
+		common.TaskContextObject[scope.TiKV](state, r.Client),
 		// if it's deleted just return
 		task.IfBreak(common.CondInstanceHasBeenDeleted(state)),
 

--- a/pkg/controllers/tikv/tasks/state.go
+++ b/pkg/controllers/tikv/tasks/state.go
@@ -39,8 +39,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiKVStateInitializer
-
 	common.TiKVState
 	common.ClusterState
 
@@ -50,6 +48,7 @@ type State interface {
 	common.InstanceState[*runtime.TiKV]
 
 	common.ContextClusterNewer[*v1alpha1.TiKV]
+	common.ContextObjectNewer[*v1alpha1.TiKV]
 
 	common.StatusUpdater
 	common.StatusPersister[*v1alpha1.TiKV]
@@ -67,8 +66,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiKV {
 	return s.tikv
+}
+
+func (s *state) SetObject(tikv *v1alpha1.TiKV) {
+	s.tikv = tikv
 }
 
 func (s *state) TiKV() *v1alpha1.TiKV {
@@ -113,13 +120,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiKVInitializer() common.TiKVInitializer {
-	return common.NewResource(func(tikv *v1alpha1.TiKV) { s.tikv = tikv }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) GetStoreState() string {

--- a/pkg/controllers/tikv/tasks/state_test.go
+++ b/pkg/controllers/tikv/tasks/state_test.go
@@ -77,7 +77,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiKV(s, fc),
+				common.TaskContextObject[scope.TiKV](s, fc),
 				common.TaskContextCluster[scope.TiKV](s, fc),
 				common.TaskContextPod[scope.TiKV](s, fc),
 			))

--- a/pkg/controllers/tikvgroup/builder.go
+++ b/pkg/controllers/tikvgroup/builder.go
@@ -25,7 +25,7 @@ import (
 func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.TaskReporter) task.TaskRunner {
 	runner := task.NewTaskRunner(reporter,
 		// get tikvgroup
-		common.TaskContextTiKVGroup(state, r.Client),
+		common.TaskContextObject[scope.TiKVGroup](state, r.Client),
 		// if it's gone just return
 		task.IfBreak(common.CondGroupHasBeenDeleted(state)),
 

--- a/pkg/controllers/tikvgroup/tasks/state.go
+++ b/pkg/controllers/tikvgroup/tasks/state.go
@@ -37,7 +37,6 @@ type state struct {
 }
 
 type State interface {
-	common.TiKVGroupStateInitializer
 	common.TiKVSliceStateInitializer
 	common.RevisionStateInitializer[*runtime.TiKVGroup]
 
@@ -49,6 +48,7 @@ type State interface {
 	common.GroupState[*runtime.TiKVGroup]
 
 	common.ContextClusterNewer[*v1alpha1.TiKVGroup]
+	common.ContextObjectNewer[*v1alpha1.TiKVGroup]
 
 	common.InstanceSliceState[*runtime.TiKV]
 	common.SliceState[*v1alpha1.TiKV]
@@ -64,8 +64,16 @@ func NewState(key types.NamespacedName) State {
 	return s
 }
 
+func (s *state) Key() types.NamespacedName {
+	return s.key
+}
+
 func (s *state) Object() *v1alpha1.TiKVGroup {
 	return s.kvg
+}
+
+func (s *state) SetObject(kvg *v1alpha1.TiKVGroup) {
+	s.kvg = kvg
 }
 
 func (s *state) TiKVGroup() *v1alpha1.TiKVGroup {
@@ -102,13 +110,6 @@ func (s *state) IsStatusChanged() bool {
 
 func (s *state) SetStatusChanged() {
 	s.statusChanged = true
-}
-
-func (s *state) TiKVGroupInitializer() common.TiKVGroupInitializer {
-	return common.NewResource(func(kvg *v1alpha1.TiKVGroup) { s.kvg = kvg }).
-		WithNamespace(common.Namespace(s.key.Namespace)).
-		WithName(common.Name(s.key.Name)).
-		Initializer()
 }
 
 func (s *state) TiKVSliceInitializer() common.TiKVSliceInitializer {

--- a/pkg/controllers/tikvgroup/tasks/state_test.go
+++ b/pkg/controllers/tikvgroup/tasks/state_test.go
@@ -94,7 +94,7 @@ func TestState(t *testing.T) {
 
 			ctx := context.Background()
 			res, done := task.RunTask(ctx, task.Block(
-				common.TaskContextTiKVGroup(s, fc),
+				common.TaskContextObject[scope.TiKVGroup](s, fc),
 				common.TaskContextCluster[scope.TiKVGroup](s, fc),
 				common.TaskContextTiKVSlice(s, fc),
 			))


### PR DESCRIPTION
- remove unused interface in common pkg
- use ContextObject to replace ContextXXX task