### PR TITLE
feat(pd): add feature to disable pd's default readiness probe

### DIFF
--- a/api/meta/v1alpha1/feature.go
+++ b/api/meta/v1alpha1/feature.go
@@ -38,4 +38,10 @@ const (
 	// Support modify volume by VolumeAttributeClass
 	VolumeAttributeClass      Feature      = "VolumeAttributeClass"
 	VolumeAttributeClassStage FeatureStage = FeatureStageAlpha
+
+	// Disable PD's default readiness probe
+	// Now the pd's default readiness probe use TCP to probe client port
+	// It's not usefull and will print so many warn logs in PD's stdout/stderr
+	DisablePDDefaultReadinessProbe      Feature      = "DisablePDDefaultReadinessProbe"
+	DisablePDDefaultReadinessProbeStage FeatureStage = FeatureStageAlpha
 )

--- a/pkg/controllers/pd/tasks/pod_test.go
+++ b/pkg/controllers/pd/tasks/pod_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
+	"github.com/pingcap/tidb-operator/pkg/features"
 	"github.com/pingcap/tidb-operator/pkg/pdapi/v1"
 	pdv1 "github.com/pingcap/tidb-operator/pkg/timanager/apis/pd/v1"
 	pdm "github.com/pingcap/tidb-operator/pkg/timanager/pd"
@@ -42,6 +43,9 @@ const (
 )
 
 func TestTaskPod(t *testing.T) {
+	// TODO(liubo02): register feature gates per case
+	features.Register(fake.FakeObj[v1alpha1.Cluster]("aaa"))
+
 	cases := []struct {
 		desc          string
 		state         *ReconcileContext
@@ -553,6 +557,7 @@ func TestTaskPod(t *testing.T) {
 			}
 
 			res, done := task.RunTask(ctx, TaskPod(c.state, fc))
+
 			assert.Equal(tt, c.expectedStatus.String(), res.Status().String(), res.Message())
 			assert.False(tt, done, c.desc)
 

--- a/tests/e2e/data/cluster.go
+++ b/tests/e2e/data/cluster.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
+	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 )
 
 const (
@@ -33,6 +34,12 @@ func NewCluster(namespace string, patches ...ClusterPatch) *v1alpha1.Cluster {
 		},
 		Spec: v1alpha1.ClusterSpec{
 			UpgradePolicy: v1alpha1.UpgradePolicyDefault,
+			FeatureGates: []metav1alpha1.FeatureGate{
+				{
+					// Disable PD Probe by default in e2e
+					Name: metav1alpha1.DisablePDDefaultReadinessProbe,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
- add a feature to disable pd's default readiness probe

It's not useful and produce too many wan logs in pd's stdout/stderr