### PR TITLE
fix(features): reimplement verify api and rename to use

### DIFF
--- a/pkg/controllers/common/task.go
+++ b/pkg/controllers/common/task.go
@@ -148,8 +148,8 @@ func TaskSuspendPod(state PodState, c client.Client) task.Task {
 }
 
 func TaskFeatureGates(state ClusterState) task.Task {
-	return task.NameTaskFunc("FeatureGates", func(context.Context) task.Result {
-		if err := features.Verify(state.Cluster()); err != nil {
+	return task.NameTaskFunc("FeatureGates", func(ctx context.Context) task.Result {
+		if err := features.Use(ctx, state.Cluster()); err != nil {
 			return task.Fail().With("feature gates are not up to date: %v", err)
 		}
 

--- a/pkg/controllers/pd/controller.go
+++ b/pkg/controllers/pd/controller.go
@@ -63,6 +63,9 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm vo
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("pd", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/pdgroup/controller.go
+++ b/pkg/controllers/pdgroup/controller.go
@@ -90,6 +90,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("pdgroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/ticdc/controller.go
+++ b/pkg/controllers/ticdc/controller.go
@@ -54,6 +54,9 @@ func Setup(mgr manager.Manager, c client.Client, vm volumes.ModifierFactory) err
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("ticdc", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/ticdcgroup/controller.go
+++ b/pkg/controllers/ticdcgroup/controller.go
@@ -87,6 +87,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("ticdcgroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tidb/controller.go
+++ b/pkg/controllers/tidb/controller.go
@@ -57,6 +57,9 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm vo
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tidb", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tidbgroup/controller.go
+++ b/pkg/controllers/tidbgroup/controller.go
@@ -87,6 +87,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tidbgroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tiflash/controller.go
+++ b/pkg/controllers/tiflash/controller.go
@@ -59,6 +59,9 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm vo
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tiflash", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tiflashgroup/controller.go
+++ b/pkg/controllers/tiflashgroup/controller.go
@@ -87,6 +87,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tiflashgroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tikv/controller.go
+++ b/pkg/controllers/tikv/controller.go
@@ -60,6 +60,9 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm vo
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tikv", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tikvgroup/controller.go
+++ b/pkg/controllers/tikvgroup/controller.go
@@ -87,6 +87,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tikvgroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tso/controller.go
+++ b/pkg/controllers/tso/controller.go
@@ -57,6 +57,9 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm vo
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tso", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/controllers/tsogroup/controller.go
+++ b/pkg/controllers/tsogroup/controller.go
@@ -87,6 +87,9 @@ func (r *Reconciler) ClusterEventHandler() handler.TypedEventHandler[client.Obje
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	logger := r.Logger.WithValues("tsogroup", req.NamespacedName)
 	reporter := task.NewTableTaskReporter()
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -16,7 +16,6 @@ package features
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	meta "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 )
 
+// nolint: gocyclo // refactor later
 func TestFeatureGates(t *testing.T) {
 	const (
 		uid1 = "aaa"
@@ -221,7 +221,7 @@ func TestFeatureGates(t *testing.T) {
 	for i := range cases {
 		c := &cases[i]
 		defer func() {
-			recover()
+			_ = recover()
 		}()
 
 		func() {
@@ -237,7 +237,6 @@ func TestFeatureGates(t *testing.T) {
 					err := fg.Use(ctx, cluster)
 					if ctrl.failToUse {
 						require.Error(t, err, format, c.desc, ctrl.desc)
-						fmt.Println("fail to use:", "desc:", c.desc, "ctrl:", ctrl.desc, "err:", err)
 					} else {
 						require.NoError(t, err, format, c.desc, ctrl.desc)
 					}
@@ -273,7 +272,6 @@ func TestFeatureGates(t *testing.T) {
 					err := fg.Use(ctx, cluster)
 					if ctrl.failToUse {
 						require.Error(t, err, format, c.desc, ctrl.desc)
-						fmt.Println("fail to use after:", "desc:", c.desc, "ctrl:", ctrl.desc, "err:", err)
 					} else {
 						require.NoError(t, err, format, c.desc, ctrl.desc)
 					}


### PR DESCRIPTION
- reimplement `Verify` and rename to `Use`

Verify cannot ensure all running tasks of one reconcile use a same version of feature gates.

- A controller calls `Verify` and OK to run next tasks.
- `Register` is called and feature gates are changed.
- Some tasks may use a different version of feature gates and do some unexpected things.

After this change, all controllers will wait until all tasks use the outdated feature gates finished.
