### PR TITLE
fix: field name error

### DIFF
--- a/examples/monitor-grafana-secret/tidb-monitor.yaml
+++ b/examples/monitor-grafana-secret/tidb-monitor.yaml
@@ -11,10 +11,10 @@ spec:
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
-    UserSecret:
+    usernameSecret:
       name: basic-grafana
       key: username
-    PasswordSecret:
+    passwordSecret:
       name: basic-grafana
       key: password
   initializer:


### PR DESCRIPTION
### What problem does this PR solve?

fix the field name error for monitor-grafana-secret example.

### What is changed and how does it work?

according to https://github.com/pingcap/tidb-operator/blob/master/pkg/apis/pingcap/v1alpha1/tidbmonitor_types.go#L273 (line 273 and 277), the field names should be `usernameSecret` and `passwordSecret`

### Code changes

- [ ] Has Go code change
- [ x] Has CI related scripts change

### Tests

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
