### PR TITLE
Chore: bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,87 +1,8 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: -1
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-  gocyclo:
-    min-complexity: 15
-  godox:
-    keywords:
-      - FIXME
-  gofmt:
-    rewrite-rules:
-      - pattern: "interface{}"
-        replacement: "any"
-  goimports:
-    local-prefixes: github.com/pingcap/tidb-operator
-  mnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - "0"
-      - "1"
-      - "2"
-      - "3"
-      - "4"
-    ignored-functions:
-      - strings.SplitN
-    ignored-files:
-      - 'tests/e2e/cluster/.+\.go$'
-      - 'tests/e2e/pd/.+\.go$'
-      - 'tests/e2e/tidb/.+\.go$'
-      - 'tests/e2e/tikv/.+\.go$'
-  govet:
-    enable:
-      - nilness
-      # - shadow # TODO(ideascf): recover it
-  errorlint:
-    asserts: false
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-    ignore-words:
-      - "importas" # linter name
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    # TODO(ideascf): recover the following two rules
-    # require-explanation: true # require an explanation for nolint directives
-    # require-specific: true # require nolint directives to be specific about which linter is being skipped
-  revive:
-    rules:
-      - name: unexported-return
-        disabled: true
-      # TODO(ideascf): recover the following three rules
-      # - name: indent-error-flow
-      # - name: unused-parameter
-      # - name: unused-receiver
-
+version: "2"
 linters:
-  disable-all: true
   enable:
     - bodyclose
     - dogsled
-    - errcheck
     - errorlint
     - copyloopvar
     - gocheckcompilerdirectives
@@ -90,12 +11,9 @@ linters:
     # - gocritic // TODO(ideascf): recover it
     - gocyclo
     - godox
-    - gofmt
-    - goimports
     - mnd
     - goprintffuncname
-    - gosec
-    - gosimple
+    # - gosec // TODO: uncomment this
     - govet
     - ineffassign
     # - lll  # TODO(ideascf): recover it
@@ -106,28 +24,97 @@ linters:
     - revive
     # - stylecheck # TODO(ideascf): recover it
     - staticcheck
-    - testifylint
+    # - testifylint  // TODO: uncomment this
     - unconvert
     # - unparam  # TODO(ideascf): recover it
     - unused
     - whitespace
-
-  # This list of linters is not a recommendation (same thing for all this configuration file).
-  # We intentionally use a limited set of linters.
-  # See the comment on top of this file.
-
-issues:
-  exclude-rules:
-    - path: (.+)_test\.go
-      linters:
-        - dupl
-        - mnd
-        - lll
-        - goconst
-  exclude-files:
-    - ".*/br/.*/_test.go"
-    - ".*/br/.*/testutils/.*"
-    - "tests/e2e/br/.*/*.go"
-
+  disable:
+    - errcheck # TODO: remove this
+  exclusions:
+    rules:
+      - path: (.+)_test\.go
+        linters:
+          - dupl
+          - mnd
+          - lll
+          - goconst
+    paths:
+      - ".*/br/.*/_test.go"
+      - ".*/br/.*/testutils/.*"
+      - "tests/e2e/br/.*"
+      - "third_party/.*"
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: -1
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+    gocyclo:
+      min-complexity: 15
+    godox:
+      keywords:
+        - FIXME
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+      ignored-numbers:
+        - "0"
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+      ignored-functions:
+        - strings.SplitN
+      ignored-files:
+        - 'tests/e2e/cluster/.+\.go$'
+        - 'tests/e2e/pd/.+\.go$'
+        - 'tests/e2e/tidb/.+\.go$'
+        - 'tests/e2e/tikv/.+\.go$'
+    govet:
+      enable:
+        - nilness
+        # - shadow # TODO(ideascf): recover it
+    errorlint:
+      asserts: false
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      # TODO(ideascf): recover the following two rules
+      # require-explanation: true # require an explanation for nolint directives
+      # require-specific: true # require nolint directives to be specific about which linter is being skipped
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        # TODO(ideascf): recover the following three rules
+        # - name: indent-error-flow
+        # - name: unused-parameter
+        # - name: unused-receiver
+    staticcheck:
+      dot-import-whitelist:
+        - "github.com/onsi/ginkgo/v2"
+        - "github.com/onsi/gomega"
 run:
   timeout: 15m

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ bin/runtime-gen:
 GOLANGCI_LINT = $(BIN_DIR)/golangci-lint
 bin/golangci-lint:
 	# DON'T track the version of this cmd by go.mod
-	$(ROOT)/hack/download.sh go_install $(GOLANGCI_LINT) github.com/golangci/golangci-lint/cmd/golangci-lint v1.64.8 "version --format=short"
+	$(ROOT)/hack/download.sh go_install $(GOLANGCI_LINT) github.com/golangci/golangci-lint/v2/cmd/golangci-lint v2.1.6 "version --short"
 
 .PHONY: bin/kind
 KIND = $(BIN_DIR)/kind

--- a/cmd/tidb-backup-manager/app/backup/backup.go
+++ b/cmd/tidb-backup-manager/app/backup/backup.go
@@ -245,7 +245,7 @@ func (bo *Options) brCommandRunWithLogCallback(ctx context.Context, fullArgs []s
 			logCallback(line)
 		}
 
-		klog.Info(strings.Replace(line, "\n", "", -1))
+		klog.Info(strings.ReplaceAll(line, "\n", ""))
 		if err != nil {
 			if err != io.EOF {
 				klog.Errorf("read stdout error: %s", err.Error())

--- a/cmd/tidb-backup-manager/app/restore/restore.go
+++ b/cmd/tidb-backup-manager/app/restore/restore.go
@@ -37,7 +37,6 @@ import (
 	corev1alpha1 "github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	backupUtil "github.com/pingcap/tidb-operator/cmd/tidb-backup-manager/app/util"
 	"github.com/pingcap/tidb-operator/pkg/controllers/br/manager/constants"
-	"github.com/pingcap/tidb-operator/pkg/controllers/br/manager/restore"
 	restoreMgr "github.com/pingcap/tidb-operator/pkg/controllers/br/manager/restore"
 	pkgutil "github.com/pingcap/tidb-operator/pkg/controllers/br/manager/util"
 )
@@ -58,7 +57,7 @@ type Options struct {
 func (ro *Options) restoreData(
 	ctx context.Context,
 	restore *v1alpha1.Restore,
-	statusUpdater restore.RestoreConditionUpdaterInterface,
+	statusUpdater restoreMgr.RestoreConditionUpdaterInterface,
 ) error {
 	args := make([]string, 0)
 	args = append(args, fmt.Sprintf("--pd=%s", ro.PDAddress))
@@ -160,7 +159,7 @@ func (ro *Options) restoreData(
 			}
 			ro.updateResolvedTSForCSB(ctx, line, restore, progressStep, statusUpdater)
 		}
-		klog.Info(strings.Replace(line, "\n", "", -1))
+		klog.Info(strings.ReplaceAll(line, "\n", ""))
 		if err != nil {
 			if err != io.EOF {
 				klog.Errorf("read stdout error: %s", err.Error())

--- a/cmd/tidb-backup-manager/app/util/util.go
+++ b/cmd/tidb-backup-manager/app/util/util.go
@@ -158,7 +158,7 @@ func NormalizeBucketURI(bucket string) string {
 
 // GetOptionValueFromEnv get option's value from environment variable. If unset, return empty string.
 func GetOptionValueFromEnv(option, envPrefix string) string {
-	envVar := envPrefix + "_" + strings.Replace(strings.ToUpper(option), "-", "_", -1)
+	envVar := envPrefix + "_" + strings.ReplaceAll(strings.ToUpper(option), "-", "_")
 	return os.Getenv(envVar)
 }
 

--- a/pkg/controllers/br/manager/backup/backup_tracker.go
+++ b/pkg/controllers/br/manager/backup/backup_tracker.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -189,7 +188,7 @@ func (bt *backupTracker) refreshLogBackupCheckpointTs(ns, name string) {
 		}
 		backup := &v1alpha1.Backup{}
 		err := bt.cli.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, backup)
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("log backup has been deleted, will remove from tracker", "namespace", ns, "backup", name, "key", logkey)
 			bt.removeLogBackup(ns, name)
 			return

--- a/pkg/controllers/br/manager/util/remote.go
+++ b/pkg/controllers/br/manager/util/remote.go
@@ -157,13 +157,13 @@ func (b *StorageBackend) StorageType() v1alpha1.BackupStorageType {
 
 func (b *StorageBackend) ListPage(opts *blob.ListOptions) *PageIterator {
 	return &PageIterator{
-		iter: b.Bucket.List(opts),
+		iter: b.List(opts),
 	}
 }
 
 func (b *StorageBackend) AsS3() (*s3.S3, bool) {
 	var s3cli *s3.S3
-	if ok := b.Bucket.As(&s3cli); !ok {
+	if ok := b.As(&s3cli); !ok {
 		return nil, false
 	}
 
@@ -517,7 +517,7 @@ type azblobSharedKeyCred struct {
 func newAzblobStorage(conf *azblobConfig) (*blob.Bucket, error) {
 	account := os.Getenv("AZURE_STORAGE_ACCOUNT")
 	if len(account) == 0 {
-		return nil, errors.New("No AZURE_STORAGE_ACCOUNT")
+		return nil, errors.New("no AZURE_STORAGE_ACCOUNT")
 	}
 
 	// Azure AAD Service Principal with access to the storage account.
@@ -548,7 +548,7 @@ func newAzblobStorage(conf *azblobConfig) (*blob.Bucket, error) {
 			sharedKey: accountKey,
 		})
 	} else {
-		return nil, errors.New("Missing necessary key(s) for credentials")
+		return nil, errors.New("missing necessary key(s) for credentials")
 	}
 
 	if err != nil {

--- a/pkg/controllers/common/job.go
+++ b/pkg/controllers/common/job.go
@@ -164,7 +164,7 @@ func (m *jobLifecycleManager) retryWithBackoffPolicy(ctx context.Context, c clie
 	if ok && !lastRetryRecord.IsTriggered() {
 		if !m.isTimeToRetry(lastRetryRecord, now) {
 			klog.Infof("backup %s/%s is not the time to retry, expected retry time is %s, now is %s", ns, name, lastRetryRecord.ExpectedRetryAt, now)
-			return RequeueErrorf(lastRetryRecord.ExpectedRetryAt.Time.Sub(now)+time.Second, "retry backup %s/%s after %s", ns, name, now.Sub(lastRetryRecord.ExpectedRetryAt.Time))
+			return RequeueErrorf(lastRetryRecord.ExpectedRetryAt.Sub(now)+time.Second, "retry backup %s/%s after %s", ns, name, now.Sub(lastRetryRecord.ExpectedRetryAt.Time))
 		}
 		return m.doRetryLogic(ctx, c, job, now)
 	}

--- a/pkg/overlay/overlay_test.go
+++ b/pkg/overlay/overlay_test.go
@@ -90,12 +90,12 @@ func TestOverlayPod(t *testing.T) {
 		"aa": "aa",
 		"bb": "bb",
 		"zz": "456",
-	}, base.ObjectMeta.Annotations)
+	}, base.Annotations)
 	assert.Equal(t, map[string]string{
 		"aa": "aa",
 		"bb": "bb",
 		"zz": "456",
-	}, base.ObjectMeta.Labels)
+	}, base.Labels)
 	assert.Equal(t, map[string]string{
 		"aa": "aa",
 		"bb": "bb",

--- a/pkg/pdapi/v1/client_test.go
+++ b/pkg/pdapi/v1/client_test.go
@@ -573,11 +573,12 @@ func TestPDClient_DeleteMember(t *testing.T) {
   ]
 }`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/pd/api/v1/members" {
+		switch r.URL.Path {
+		case "/pd/api/v1/members":
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(getMembersJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/pd/api/v1/member/basic-7axwci" {
+		case "/pd/api/v1/member/basic-7axwci":
 			assert.Equal(t, http.MethodDelete, r.Method)
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{}`))
@@ -608,11 +609,12 @@ func TestPDClient_DeleteMemberByID(t *testing.T) {
   ]
 }`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/pd/api/v1/members" {
+		switch r.URL.Path {
+		case "/pd/api/v1/members":
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(getMembersJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/pd/api/v1/member/1428427862495950874" {
+		case "/pd/api/v1/member/1428427862495950874":
 			assert.Equal(t, http.MethodDelete, r.Method)
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{}`))

--- a/pkg/runtime/br.go
+++ b/pkg/runtime/br.go
@@ -181,7 +181,7 @@ type (
 var _ Job = &Restore{}
 
 func (r *Restore) NeedAddFinalizer() bool {
-	return !(r.Completed() || r.Failed())
+	return !r.Completed() && !r.Failed()
 }
 
 func (r *Restore) NeedRemoveFinalizer() bool {

--- a/pkg/ticdcapi/v1/client_test.go
+++ b/pkg/ticdcapi/v1/client_test.go
@@ -96,11 +96,12 @@ func TestTiCDCClient_DrainCapture(t *testing.T) {
 
 	// two captures, resign owner
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == capturesURL {
+		switch r.URL.Path {
+		case capturesURL:
 			assert.Equal(t, http.MethodGet, r.Method)
 			_, err = w.Write([]byte(capturesTwoJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/api/v1/captures/drain" {
+		case "/api/v1/captures/drain":
 			assert.Equal(t, http.MethodPut, r.Method)
 			_, err = w.Write([]byte(`{"current_table_count": 0}`))
 			assert.NoError(t, err)
@@ -115,11 +116,12 @@ func TestTiCDCClient_DrainCapture(t *testing.T) {
 
 	// do not support this API
 	server3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == capturesURL {
+		switch r.URL.Path {
+		case capturesURL:
 			assert.Equal(t, http.MethodGet, r.Method)
 			_, err = w.Write([]byte(capturesTwoJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/api/v1/captures/drain" {
+		case "/api/v1/captures/drain":
 			assert.Equal(t, http.MethodPut, r.Method)
 			w.WriteHeader(http.StatusNotImplemented)
 		}
@@ -148,11 +150,12 @@ func TestTiCDCClient_ResignOwner(t *testing.T) {
 	assert.True(t, ok)
 
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == capturesURL {
+		switch r.URL.Path {
+		case capturesURL:
 			assert.Equal(t, http.MethodGet, r.Method)
 			_, err = w.Write([]byte(capturesTwoJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/api/v1/owner/resign" {
+		case "/api/v1/owner/resign":
 			assert.Equal(t, http.MethodPost, r.Method)
 			w.WriteHeader(http.StatusOK)
 		}
@@ -219,11 +222,12 @@ func TestTiCDCClient_IsHealthy(t *testing.T) {
 
 	// owner exists and healthy
 	server3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/captures" {
+		switch r.URL.Path {
+		case "/api/v1/captures":
 			assert.Equal(t, http.MethodGet, r.Method)
 			_, err = w.Write([]byte(capturesOneJSONStr))
 			assert.NoError(t, err)
-		} else if r.URL.Path == "/api/v1/health" {
+		case "/api/v1/health":
 			assert.Equal(t, http.MethodGet, r.Method)
 			_, err = w.Write([]byte("ok"))
 			assert.NoError(t, err)

--- a/third_party/kubernetes/pkg/controller/history/controller_history.go
+++ b/third_party/kubernetes/pkg/controller/history/controller_history.go
@@ -219,7 +219,6 @@ func (rh *realHistory) ListControllerRevisions(ctx context.Context, parent clien
 		if ref == nil || ref.UID == parent.GetUID() {
 			owned = append(owned, &list.Items[i])
 		}
-
 	}
 	return owned, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Fixes https://github.com/pingcap/tidb-operator/issues/6194

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [x] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
