### PR TITLE
feat(validation): cannot overlay pod labels starting with pingcap.com/

### DIFF
--- a/api/core/v1alpha1/common_types.go
+++ b/api/core/v1alpha1/common_types.go
@@ -194,6 +194,7 @@ type Overlay struct {
 }
 
 type PodOverlay struct {
+	// +kubebuilder:validation:XValidation:rule="self.labels.all(key, !key.startsWith('pingcap.com/'))",message="cannot overlay pod labels starting with 'pingcap.com/'"
 	ObjectMeta `json:"metadata,omitempty"`
 	Spec       *corev1.PodSpec `json:"spec,omitempty"`
 }

--- a/api/core/v1alpha1/common_types.go
+++ b/api/core/v1alpha1/common_types.go
@@ -194,7 +194,7 @@ type Overlay struct {
 }
 
 type PodOverlay struct {
-	// +kubebuilder:validation:XValidation:rule="self.labels.all(key, !key.startsWith('pingcap.com/'))",message="cannot overlay pod labels starting with 'pingcap.com/'"
+	// +kubebuilder:validation:XValidation:rule="!has(self.labels) || self.labels.all(key, !key.startsWith('pingcap.com/'))",message="cannot overlay pod labels starting with 'pingcap.com/'"
 	ObjectMeta `json:"metadata,omitempty"`
 	Spec       *corev1.PodSpec `json:"spec,omitempty"`
 }

--- a/manifests/crd/core.pingcap.com_pdgroups.yaml
+++ b/manifests/crd/core.pingcap.com_pdgroups.yaml
@@ -235,7 +235,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_pdgroups.yaml
+++ b/manifests/crd/core.pingcap.com_pdgroups.yaml
@@ -232,6 +232,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_pds.yaml
+++ b/manifests/crd/core.pingcap.com_pds.yaml
@@ -127,6 +127,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_pds.yaml
+++ b/manifests/crd/core.pingcap.com_pds.yaml
@@ -129,7 +129,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_schedulergroups.yaml
+++ b/manifests/crd/core.pingcap.com_schedulergroups.yaml
@@ -218,6 +218,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_schedulergroups.yaml
+++ b/manifests/crd/core.pingcap.com_schedulergroups.yaml
@@ -221,7 +221,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_schedulers.yaml
+++ b/manifests/crd/core.pingcap.com_schedulers.yaml
@@ -119,6 +119,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_schedulers.yaml
+++ b/manifests/crd/core.pingcap.com_schedulers.yaml
@@ -121,7 +121,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_ticdcgroups.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcgroups.yaml
@@ -213,6 +213,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_ticdcgroups.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcgroups.yaml
@@ -216,7 +216,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_ticdcs.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcs.yaml
@@ -118,7 +118,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_ticdcs.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcs.yaml
@@ -116,6 +116,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tidbgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tidbgroups.yaml
@@ -240,6 +240,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tidbgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tidbgroups.yaml
@@ -243,7 +243,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tidbs.yaml
+++ b/manifests/crd/core.pingcap.com_tidbs.yaml
@@ -117,6 +117,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tidbs.yaml
+++ b/manifests/crd/core.pingcap.com_tidbs.yaml
@@ -119,7 +119,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiflashes.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashes.yaml
@@ -149,6 +149,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiflashes.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashes.yaml
@@ -151,7 +151,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiflashgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashgroups.yaml
@@ -245,7 +245,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tiflashgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashgroups.yaml
@@ -242,6 +242,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tikvgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tikvgroups.yaml
@@ -219,7 +219,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tikvgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tikvgroups.yaml
@@ -216,6 +216,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tikvs.yaml
+++ b/manifests/crd/core.pingcap.com_tikvs.yaml
@@ -123,7 +123,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tikvs.yaml
+++ b/manifests/crd/core.pingcap.com_tikvs.yaml
@@ -121,6 +121,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiproxies.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxies.yaml
@@ -117,6 +117,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiproxies.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxies.yaml
@@ -119,7 +119,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tiproxygroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxygroups.yaml
@@ -219,7 +219,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tiproxygroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxygroups.yaml
@@ -216,6 +216,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tsogroups.yaml
+++ b/manifests/crd/core.pingcap.com_tsogroups.yaml
@@ -218,6 +218,10 @@ spec:
                                       More info: http://kubernetes.io/docs/user-guide/identifiers#names
                                     type: string
                                 type: object
+                                x-kubernetes-validations:
+                                - message: cannot overlay pod labels starting with
+                                    'pingcap.com/'
+                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tsogroups.yaml
+++ b/manifests/crd/core.pingcap.com_tsogroups.yaml
@@ -221,7 +221,8 @@ spec:
                                 x-kubernetes-validations:
                                 - message: cannot overlay pod labels starting with
                                     'pingcap.com/'
-                                  rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                                  rule: '!has(self.labels) || self.labels.all(key,
+                                    !key.startsWith(''pingcap.com/''))'
                               spec:
                                 description: PodSpec is a description of a pod.
                                 properties:

--- a/manifests/crd/core.pingcap.com_tsos.yaml
+++ b/manifests/crd/core.pingcap.com_tsos.yaml
@@ -120,7 +120,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: cannot overlay pod labels starting with 'pingcap.com/'
-                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
+                          rule: '!has(self.labels) || self.labels.all(key, !key.startsWith(''pingcap.com/''))'
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/manifests/crd/core.pingcap.com_tsos.yaml
+++ b/manifests/crd/core.pingcap.com_tsos.yaml
@@ -118,6 +118,9 @@ spec:
                               More info: http://kubernetes.io/docs/user-guide/identifiers#names
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: cannot overlay pod labels starting with 'pingcap.com/'
+                          rule: self.labels.all(key, !key.startsWith('pingcap.com/'))
                       spec:
                         description: PodSpec is a description of a pod.
                         properties:

--- a/tests/validation/common_test.go
+++ b/tests/validation/common_test.go
@@ -174,17 +174,26 @@ func Topology() []Case {
 func PodOverlayLabels() []Case {
 	cases := []Case{
 		{
+			desc:     "no label overlay is ok",
+			isCreate: true,
+			current:  map[string]any{},
+		},
+		{
 			desc:     "ok to overlay normal labels",
 			isCreate: true,
 			current: map[string]any{
-				"component": "bbb",
+				"labels": map[string]any{
+					"component": "bbb",
+				},
 			},
 		},
 		{
 			desc:     "cannot overlay pingcap.com/xxx labels",
 			isCreate: true,
 			current: map[string]any{
-				"pingcap.com/xxx": "bbb",
+				"labels": map[string]any{
+					"pingcap.com/xxx": "bbb",
+				},
 			},
 			wantErrs: []string{
 				`spec.overlay.pod.metadata: Invalid value: "object": cannot overlay pod labels starting with 'pingcap.com/'`,
@@ -194,7 +203,9 @@ func PodOverlayLabels() []Case {
 			desc:     "ok to overlay pingcap.com label",
 			isCreate: true,
 			current: map[string]any{
-				"pingcap.com": "bbb",
+				"labels": map[string]any{
+					"pingcap.com": "bbb",
+				},
 			},
 		},
 	}

--- a/tests/validation/common_test.go
+++ b/tests/validation/common_test.go
@@ -170,3 +170,34 @@ func Topology() []Case {
 
 	return cases
 }
+
+func PodOverlayLabels() []Case {
+	cases := []Case{
+		{
+			desc:     "ok to overlay normal labels",
+			isCreate: true,
+			current: map[string]any{
+				"component": "bbb",
+			},
+		},
+		{
+			desc:     "cannot overlay pingcap.com/xxx labels",
+			isCreate: true,
+			current: map[string]any{
+				"pingcap.com/xxx": "bbb",
+			},
+			wantErrs: []string{
+				`spec.overlay.pod.metadata: Invalid value: "object": cannot overlay pod labels starting with 'pingcap.com/'`,
+			},
+		},
+		{
+			desc:     "ok to overlay pingcap.com label",
+			isCreate: true,
+			current: map[string]any{
+				"pingcap.com": "bbb",
+			},
+		},
+	}
+
+	return cases
+}

--- a/tests/validation/pd_test.go
+++ b/tests/validation/pd_test.go
@@ -30,6 +30,8 @@ func TestPD(t *testing.T) {
 		transferPDCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases,
 		transferPDCases(t, PDMode(), "spec", "mode")...)
+	cases = append(cases,
+		transferPDCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
 
 	Validate(t, "crd/core.pingcap.com_pds.yaml", cases)
 }

--- a/tests/validation/pd_test.go
+++ b/tests/validation/pd_test.go
@@ -31,7 +31,7 @@ func TestPD(t *testing.T) {
 	cases = append(cases,
 		transferPDCases(t, PDMode(), "spec", "mode")...)
 	cases = append(cases,
-		transferPDCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
+		transferPDCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata")...)
 
 	Validate(t, "crd/core.pingcap.com_pds.yaml", cases)
 }

--- a/tests/validation/scheduler_test.go
+++ b/tests/validation/scheduler_test.go
@@ -27,6 +27,8 @@ func TestScheduler(t *testing.T) {
 		transferSchedulerCases(t, Topology(), "spec", "topology"),
 		transferSchedulerCases(t, ClusterReference(), "spec", "cluster")...,
 	)
+	cases = append(cases,
+		transferSchedulerCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
 
 	Validate(t, "crd/core.pingcap.com_schedulers.yaml", cases)
 }

--- a/tests/validation/scheduler_test.go
+++ b/tests/validation/scheduler_test.go
@@ -28,7 +28,7 @@ func TestScheduler(t *testing.T) {
 		transferSchedulerCases(t, ClusterReference(), "spec", "cluster")...,
 	)
 	cases = append(cases,
-		transferSchedulerCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
+		transferSchedulerCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata")...)
 
 	Validate(t, "crd/core.pingcap.com_schedulers.yaml", cases)
 }

--- a/tests/validation/tidb_test.go
+++ b/tests/validation/tidb_test.go
@@ -28,7 +28,7 @@ func TestTiDB(t *testing.T) {
 	cases = append(cases, transferTiDBCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferTiDBCases(t, serverLabels(), "spec", "server", "labels")...)
 	cases = append(cases,
-		transferTiDBCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
+		transferTiDBCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata")...)
 
 	Validate(t, "crd/core.pingcap.com_tidbs.yaml", cases)
 }

--- a/tests/validation/tidb_test.go
+++ b/tests/validation/tidb_test.go
@@ -27,6 +27,8 @@ func TestTiDB(t *testing.T) {
 	cases = append(cases, transferTiDBCases(t, Topology(), "spec", "topology")...)
 	cases = append(cases, transferTiDBCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferTiDBCases(t, serverLabels(), "spec", "server", "labels")...)
+	cases = append(cases,
+		transferTiDBCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
 
 	Validate(t, "crd/core.pingcap.com_tidbs.yaml", cases)
 }

--- a/tests/validation/tso_test.go
+++ b/tests/validation/tso_test.go
@@ -28,7 +28,7 @@ func TestTSO(t *testing.T) {
 		transferTSOCases(t, ClusterReference(), "spec", "cluster")...,
 	)
 	cases = append(cases,
-		transferTSOCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
+		transferTSOCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata")...)
 
 	Validate(t, "crd/core.pingcap.com_tsos.yaml", cases)
 }

--- a/tests/validation/tso_test.go
+++ b/tests/validation/tso_test.go
@@ -27,6 +27,8 @@ func TestTSO(t *testing.T) {
 		transferTSOCases(t, Topology(), "spec", "topology"),
 		transferTSOCases(t, ClusterReference(), "spec", "cluster")...,
 	)
+	cases = append(cases,
+		transferTSOCases(t, PodOverlayLabels(), "spec", "overlay", "pod", "metadata", "labels")...)
 
 	Validate(t, "crd/core.pingcap.com_tsos.yaml", cases)
 }


### PR DESCRIPTION
- add validation rule to forbid overlaying pod labels starting with `pingcap.com/`
