### PR TITLE
Support setting Server Labels for tidb and tiproxy via spec

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -18497,6 +18497,22 @@ The probe binary in the image should be placed under the root directory, i.e., <
 <p>Arguments is the extra command line arguments for TiDB server.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>serverLabels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>ServerLabels defines the server labels of the TiDB server.
+Using both this field and config file to manage the labels is an undefined behavior.
+Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:
+- region, topology.kubernetes.io/region
+- zone, topology.kubernetes.io/zone
+- host</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tidbstatus">TiDBStatus</h3>
@@ -24233,6 +24249,22 @@ string
 <em>(Optional)</em>
 <p>The storageClassName of the persistent volume for TiProxy data storage.
 Defaults to Kubernetes default storage class.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverLabels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>ServerLabels defines the server labels of the TiProxy.
+Using both this field and config file to manage the labels is an undefined behavior.
+Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:
+- region, topology.kubernetes.io/region
+- zone, topology.kubernetes.io/zone
+- host</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -41303,6 +41303,10 @@ spec:
                     type: string
                   separateSlowLog:
                     type: boolean
+                  serverLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   service:
                     properties:
                       additionalPorts:
@@ -49633,6 +49637,10 @@ spec:
                     type: object
                   schedulerName:
                     type: string
+                  serverLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   serviceAccount:
                     type: string
                   sslEnableTiDB:

--- a/manifests/crd/v1/pingcap.com_tidbclusters.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbclusters.yaml
@@ -16863,6 +16863,10 @@ spec:
                     type: string
                   separateSlowLog:
                     type: boolean
+                  serverLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   service:
                     properties:
                       additionalPorts:
@@ -25193,6 +25197,10 @@ spec:
                     type: object
                   schedulerName:
                     type: string
+                  serverLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   serviceAccount:
                     type: string
                   sslEnableTiDB:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -10492,6 +10492,22 @@ func schema_pkg_apis_pingcap_v1alpha1_TiDBSpec(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"serverLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServerLabels defines the server labels of the TiDB server. Using both this field and config file to manage the labels is an undefined behavior. Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:\n - region, topology.kubernetes.io/region\n - zone, topology.kubernetes.io/zone\n - host",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"replicas"},
 			},
@@ -14191,6 +14207,22 @@ func schema_pkg_apis_pingcap_v1alpha1_TiProxySpec(ref common.ReferenceCallback) 
 							Description: "The storageClassName of the persistent volume for TiProxy data storage. Defaults to Kubernetes default storage class.",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"serverLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServerLabels defines the server labels of the TiProxy. Using both this field and config file to manage the labels is an undefined behavior. Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:\n - region, topology.kubernetes.io/region\n - zone, topology.kubernetes.io/zone\n - host",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -968,6 +968,14 @@ type TiProxySpec struct {
 	// Defaults to Kubernetes default storage class.
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
+
+	// ServerLabels defines the server labels of the TiProxy.
+	// Using both this field and config file to manage the labels is an undefined behavior.
+	// Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:
+	//  - region, topology.kubernetes.io/region
+	//  - zone, topology.kubernetes.io/zone
+	//  - host
+	ServerLabels map[string]string `json:"serverLabels,omitempty"`
 }
 
 // LogTailerSpec represents an optional log tailer sidecar container
@@ -1106,6 +1114,14 @@ type TiDBSpec struct {
 	// Arguments is the extra command line arguments for TiDB server.
 	// +optional
 	Arguments []string `json:"arguments,omitempty"`
+
+	// ServerLabels defines the server labels of the TiDB server.
+	// Using both this field and config file to manage the labels is an undefined behavior.
+	// Note these label keys are managed by TiDB Operator, it will be set automatically and you can not modify them:
+	//  - region, topology.kubernetes.io/region
+	//  - zone, topology.kubernetes.io/zone
+	//  - host
+	ServerLabels map[string]string `json:"serverLabels,omitempty"`
 }
 
 type CustomizedProbe struct {

--- a/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pingcap/v1alpha1/zz_generated.deepcopy.go
@@ -6259,6 +6259,13 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServerLabels != nil {
+		in, out := &in.ServerLabels, &out.ServerLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -8820,6 +8827,13 @@ func (in *TiProxySpec) DeepCopyInto(out *TiProxySpec) {
 		in, out := &in.StorageClassName, &out.StorageClassName
 		*out = new(string)
 		**out = **in
+	}
+	if in.ServerLabels != nil {
+		in, out := &in.ServerLabels, &out.ServerLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/pkg/manager/member/node.go
+++ b/pkg/manager/member/node.go
@@ -38,6 +38,10 @@ func getNodeLabels(nodeLister corelisterv1.NodeLister, nodeName string, storeLab
 	if err != nil {
 		return nil, err
 	}
+	return getLabelsFromNode(node, storeLabels), nil
+}
+
+func getLabelsFromNode(node *corev1.Node, storeLabels []string) map[string]string {
 	labels := map[string]string{}
 	ls := node.GetLabels()
 	for _, storeLabel := range storeLabels {
@@ -55,7 +59,7 @@ func getNodeLabels(nodeLister corelisterv1.NodeLister, nodeName string, storeLab
 			}
 		}
 	}
-	return labels, nil
+	return labels
 }
 
 // IsNodeReadyConditionFalseOrUnknown returns true if a pod is not ready; false otherwise.

--- a/pkg/util/map/map.go
+++ b/pkg/util/map/map.go
@@ -1,0 +1,60 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maputil
+
+import "maps"
+
+// Merge merges all maps to a new one.
+func Merge[K comparable, V any](maps ...map[K]V) map[K]V {
+	return MergeTo(nil, maps...)
+}
+
+// MergeTo merges all maps to the original one.
+func MergeTo[K comparable, V any](original map[K]V, ms ...map[K]V) map[K]V {
+	if original == nil {
+		original = make(map[K]V)
+	}
+	for _, m := range ms {
+		maps.Copy(original, m)
+	}
+	return original
+}
+
+// AreEqual checks if two maps are equal.
+func AreEqual[K comparable](map1, map2 map[K]string) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+	for k, v1 := range map1 {
+		v2, ok := map2[k]
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
+// Select returns a new map with selected keys and values of the originalMap
+func Select[K comparable, V any](originalMap map[K]V, keys ...K) map[K]V {
+	ret := make(map[K]V)
+
+	for _, k := range keys {
+		v, ok := originalMap[k]
+		if ok {
+			ret[k] = v
+		}
+	}
+
+	return ret
+}

--- a/pkg/util/map/map_test.go
+++ b/pkg/util/map/map_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerge(t *testing.T) {
+	cases := []struct {
+		desc     string
+		maps     []map[string]string
+		expected map[string]string
+	}{
+		{
+			desc:     "nil",
+			maps:     nil,
+			expected: map[string]string{},
+		},
+		{
+			desc: "overwrite",
+			maps: []map[string]string{
+				{
+					"aa": "aa",
+				},
+				{
+					"bb": "bb",
+				},
+				{
+					"aa": "cc",
+				},
+			},
+			expected: map[string]string{
+				"aa": "cc",
+				"bb": "bb",
+			},
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.desc, func(tt *testing.T) {
+			tt.Parallel()
+
+			res := Merge(c.maps...)
+			assert.Equal(tt, c.expected, res)
+		})
+	}
+}
+
+func TestAreEqual(t *testing.T) {
+	cases := []struct {
+		desc     string
+		map1     map[string]string
+		map2     map[string]string
+		expected bool
+	}{
+		{
+			desc:     "nil",
+			map1:     nil,
+			map2:     nil,
+			expected: true,
+		},
+		{
+			desc:     "empty",
+			map1:     map[string]string{},
+			map2:     map[string]string{},
+			expected: true,
+		},
+		{
+			desc: "equal",
+			map1: map[string]string{
+				"aa": "aa",
+				"bb": "bb",
+			},
+			map2: map[string]string{
+				"aa": "aa",
+				"bb": "bb",
+			},
+			expected: true,
+		},
+		{
+			desc: "not equal",
+			map1: map[string]string{
+				"aa": "aa",
+				"bb": "bb",
+			},
+			map2: map[string]string{
+				"aa": "aa",
+				"bb": "cc",
+			},
+			expected: false,
+		},
+		{
+			desc: "not equal",
+			map1: map[string]string{
+				"aa": "aa",
+				"bb": "bb",
+			},
+			map2: map[string]string{
+				"aa": "aa",
+			},
+			expected: false,
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.desc, func(tt *testing.T) {
+			tt.Parallel()
+
+			res := AreEqual(c.map1, c.map2)
+			assert.Equal(tt, c.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
Support to set Server Labels for tidb and tiproxy by adding a spec field for both tiproxy and tidb.

Newly added spec files
* .spec.tidb.serverLabels
* .spec.tiproxy.serverLabels

Reserved keys:
* tiproxy: zone, topology.kubernetes.io/zone
* tidb: zone, topology.kubernetes.io/zone

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

#### Preparation
* Create a TC
* Update the TC CRD `k replace -f ./manifests/crd/v1/pingcap.com_tidbclusters.yaml`
* Deploy new tidb-operator binary, NO existing pods of this TC would be restarted or impacted

#### Test for TiProxy
* Edit TC to set `.spec.tiproxy.serverLabels` with `group: db`, the label kv should be labeled and tiproxy pods shouldn't be restarted
```bash
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tiproxy-0.db-tiproxy-peer:3080/api/admin/config/ | grep labels -C 7
max-size = 300
max-days = 3
max-backups = 3

[balance]
policy = 'resource'

[labels]
group = 'db'
host = 'ip-172-16-2-127.us-west-2.compute.internal'
region = 'us-west-2'
zone = 'us-west-2b'
```
* Edit TC to change label kv `group = 'db'` to `group = 'g1'`, the labels on tiproxy should be changed
```bash
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tiproxy-0.db-tiproxy-peer:3080/api/admin/config/ | grep labels -C 7
max-size = 300
max-days = 3
max-backups = 3

[balance]
policy = 'resource'

[labels]
group = 'g1'
host = 'ip-172-16-2-127.us-west-2.compute.internal'
key1 = 'value2'
region = 'us-west-2'
zone = 'us-west-2b'
```
* Edit TC to remove `.spec.tiproxy.serverLabels`, the label kv `group = 'g1'` should be **kept** and others keep unchanged
```bash
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tiproxy-1.db-tiproxy-peer:3080/api/admin/config/ | grep labels -C 7
max-size = 300
max-days = 3
max-backups = 3

[balance]
policy = 'resource'

[labels]
group = 'g1'
host = 'ip-172-16-0-254.us-west-2.compute.internal'
key1 = 'value2'
region = 'us-west-2'
zone = 'us-west-2a
```

#### Test for tidb
* Edit TC to set `.spec.tidb.serverLabels` with `group: g1`, the label kv should be labeled and tidb pods shouldn't be restarted
```bash
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tidb-1.db-tidb-peer:10080/config | jq '.labels'
{
  "group": "g1",
  "host": "ip-172-16-0-55.us-west-2.compute.internal",
  "region": "us-west-2",
  "zone": "us-west-2a"
}
```
* Edit TC to change label kv `group = 'g1'` to `group = 'g2'`, the labels on tiproxy should be changed
```bash
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tidb-1.db-tidb-peer:10080/config | jq '.labels'
{
  "group": "g2",
  "host": "ip-172-16-0-55.us-west-2.compute.internal",
  "region": "us-west-2",
  "zone": "us-west-2a"
}
```
* Edit TC to remove `.spec.tiproxy.serverLabels`, the label kv `group = 'g2'` should be **kept** and others keep unchanged
```
curl -k --cert ./tls.crt --key ./tls.key --cacert ca.crt https://db-tidb-1.db-tidb-peer:10080/config | jq '.labels'
{
  "group": "g2",
  "host": "ip-172-16-0-55.us-west-2.compute.internal",
  "region": "us-west-2",
  "zone": "us-west-2a"
}
```
### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
