### PR TITLE
feat(tikv): try to evict leaders before deleting stores

### DIFF
--- a/pkg/apis/label/label.go
+++ b/pkg/apis/label/label.go
@@ -111,7 +111,10 @@ const (
 	AnnoOwnerGeneration = "tidb.pingcap.com/owner-generation"
 
 	// AnnPVCScaleInTime is pvc scaled in time key used in PVC for e2e test only
-	AnnPVCScaleInTime = "tidb.pingcap.com/scale-in-time"
+	AnnPVCScaleInTime = AnnoScaleInTime
+
+	// AnnoScaleInTime is scaled in time
+	AnnoScaleInTime = "tidb.pingcap.com/scale-in-time"
 
 	// AnnForceUpgradeVal is tc annotation value to indicate whether force upgrade should be done
 	AnnForceUpgradeVal = "true"

--- a/pkg/manager/member/tikv_scaler_test.go
+++ b/pkg/manager/member/tikv_scaler_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -1073,7 +1074,6 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				pod.Labels[label.StoreIDLabelKey] = s.storeIdLabel
 			}
 			podIndexer.Add(pod)
-
 		}
 
 		for _, s := range test.pods {
@@ -1189,7 +1189,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 1,
-		}, {
+		},
+		{
 			name:          "1 scaleInParallelism, store state is tombstone, update pvc failed",
 			tikvUpgrading: false,
 			storeFun:      multiTombstoneStoreFun,
@@ -1213,7 +1214,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 1,
-		}, {
+		},
+		{
 			name:          "1 scaleInParallelism, store state is tombstone",
 			tikvUpgrading: false,
 			storeFun:      multiTombstoneStoreFun,
@@ -1237,7 +1239,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 1,
-		}, {
+		},
+		{
 			name:          "2 scaleInParallelism, store is up, delete store failed",
 			tikvUpgrading: false,
 			storeFun:      normalStoreFun,
@@ -1261,7 +1264,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 scaleInParallelism, store is up",
 			tikvUpgrading: false,
 			storeFun:      normalStoreFun,
@@ -1285,7 +1289,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 scaleInParallelism, store state is tombstone",
 			tikvUpgrading: false,
 			storeFun:      multiTombstoneStoreFun,
@@ -1309,7 +1314,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "3 scaleInParallelism, store state is tombstone, scaleInParallelism is bigger than needed",
 			tikvUpgrading: false,
 			storeFun:      multiTombstoneStoreFun,
@@ -1353,7 +1359,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				}
 				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(2))
 			},
-		}, {
+		},
+		{
 			name:          "2 scaleInParallelism, store state is tombstone, scaleInParallelism is smaller than needed",
 			tikvUpgrading: false,
 			storeFun: func(tc *v1alpha1.TidbCluster) {
@@ -1411,7 +1418,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				errExpectNil(g, err)
 				g.Expect(int(*newSet.Spec.Replicas)).To(Equal(3))
 			},
-		}, {
+		},
+		{
 			name:          "2 scaleInParallelism, able to scale in simultaneously while is upgrading",
 			tikvUpgrading: true,
 			storeFun:      multiTombstoneStoreFun,
@@ -1435,7 +1443,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 maxScaleInReplica, tikv pod is not ready now, not sure if the status has been synced",
 			tikvUpgrading: false,
 			storeFun: func(tc *v1alpha1.TidbCluster) {
@@ -1462,7 +1471,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 maxScaleInReplica, tikv pod is not ready now, make sure if the status has been synced",
 			tikvUpgrading: false,
 			storeFun: func(tc *v1alpha1.TidbCluster) {
@@ -1489,7 +1499,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 maxScaleInReplica, store state is tombstone, don't have pvc",
 			tikvUpgrading: false,
 			storeFun:      multiTombstoneStoreFun,
@@ -1513,7 +1524,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				storeIdLabel:  "13",
 			}},
 			scaleInParallelism: 2,
-		}, {
+		},
+		{
 			name:          "2 maxScaleInReplica, 4 up stores, scale in TiKV simultaneously works but only scales one",
 			tikvUpgrading: false,
 			storeFun: func(tc *v1alpha1.TidbCluster) {
@@ -1578,7 +1590,8 @@ func TestTiKVScalerScaleInSimultaneously(t *testing.T) {
 				}
 				g.Expect(len(tc.Status.TiKV.TombstoneStores)).To(Equal(1))
 			},
-		}, {
+		},
+		{
 			name:          "2 maxScaleInReplica, 5 up stores with tiflash store, scale in TiKV simultaneously works but only scales one",
 			tikvUpgrading: false,
 			storeFun: func(tc *v1alpha1.TidbCluster) {
@@ -2060,7 +2073,11 @@ func newFakeTiKVScaler(resyncDuration ...time.Duration) (*tikvScaler, *pdapi.Fak
 	if len(resyncDuration) > 0 {
 		fakeDeps.CLIConfig.ResyncDuration = resyncDuration[0]
 	}
-	fakeDeps.PodControl = &podCtlMock{} // So that UpdateMetaInfo is no-op instead of changing labels.
+	fakeDeps.PodControl = &podCtlMock{
+		updatePod: func(_ runtime.Object, pod *corev1.Pod) (*corev1.Pod, error) {
+			return pod, nil
+		},
+	} // So that UpdateMetaInfo is no-op instead of changing labels.
 	pvcIndexer := fakeDeps.KubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer().GetIndexer()
 	podIndexer := fakeDeps.KubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 	pdControl := fakeDeps.PDControl.(*pdapi.FakePDControl)

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -53,11 +53,9 @@ const (
 	ErrImagePull = "ErrImagePull"
 )
 
-var (
-	// The first version that moves the rocksdb info and raft info log to store and rotate as the TiKV log is v5.0.0
-	// https://github.com/tikv/tikv/pull/7358
-	tikvLessThanV500, _ = semver.NewConstraint("<v5.0.0-0")
-)
+// The first version that moves the rocksdb info and raft info log to store and rotate as the TiKV log is v5.0.0
+// https://github.com/tikv/tikv/pull/7358
+var tikvLessThanV500, _ = semver.NewConstraint("<v5.0.0-0")
 
 func annotationsMountVolume() (corev1.VolumeMount, corev1.Volume) {
 	m := corev1.VolumeMount{Name: "annotations", ReadOnly: true, MountPath: "/etc/podinfo"}
@@ -457,6 +455,24 @@ func addDeferDeletingAnnoToPVC(tc *v1alpha1.TidbCluster, pvc *corev1.PersistentV
 		return err
 	}
 	klog.Infof("set PVC %s/%s annotation %q to %q successfully", tc.Namespace, pvc.Name, label.AnnPVCDeferDeleting, now)
+	return nil
+}
+
+// ensureScaleInTimeAnnoInPod set scale in time to pod annotation
+func ensureScaleInTimeAnnoInPod(tc *v1alpha1.TidbCluster, pod *corev1.Pod, podControl controller.PodControlInterface, scaleInTime string) error {
+	val, ok := pod.Annotations[label.AnnoScaleInTime]
+	if ok && val == scaleInTime {
+		return nil
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[label.AnnoScaleInTime] = scaleInTime
+	if _, err := podControl.UpdatePod(tc, pod); err != nil {
+		klog.Errorf("failed to set pod %s/%s annotation %q to %q", tc.Namespace, pod.Name, label.AnnoScaleInTime, scaleInTime)
+		return err
+	}
+	klog.Infof("set PVC %s/%s annotation %q to %q successfully", tc.Namespace, pod.Name, label.AnnoScaleInTime, scaleInTime)
 	return nil
 }
 

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -472,7 +472,7 @@ func ensureScaleInTimeAnnoInPod(tc *v1alpha1.TidbCluster, pod *corev1.Pod, podCo
 		klog.Errorf("failed to set pod %s/%s annotation %q to %q", tc.Namespace, pod.Name, label.AnnoScaleInTime, scaleInTime)
 		return err
 	}
-	klog.Infof("set PVC %s/%s annotation %q to %q successfully", tc.Namespace, pod.Name, label.AnnoScaleInTime, scaleInTime)
+	klog.Infof("set pod %s/%s annotation %q to %q successfully", tc.Namespace, pod.Name, label.AnnoScaleInTime, scaleInTime)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

- Evict all leaders before deleting store. It can improve the jitter of TiKVs.
- Not all leaders can be evicted. If replicas of a region is all located in these deleting stores, the leader of this region cannot be evicted to other stores. We use an arbitrary timeout(5min) to avoid hanging in this case.

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
