### PR TITLE
opt: check PD member ready when upgrading

### DIFF
--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -121,6 +121,16 @@ func NewFakePDClient(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster) *
 	return pdClient
 }
 
+// NewFakePDClientForMember creates a fake pdclient that is set as the pd client for a specific PD member.
+func NewFakePDClientForMember(pdControl *pdapi.FakePDControl, member *v1alpha1.PDMember) *pdapi.FakePDClient {
+	if member == nil {
+		return nil
+	}
+	pdClient := pdapi.NewFakePDClient()
+	pdControl.SetPDClientForKey(member.Name, pdClient)
+	return pdClient
+}
+
 // NewFakePDMSClient creates a fake pdmsclient that is set as the pdms client
 func NewFakePDMSClient(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster, curService string) *pdapi.FakePDMSClient {
 	pdmsClient := pdapi.NewFakePDMSClient()

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -73,6 +73,14 @@ func GetPDClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster) p
 	return pdClient
 }
 
+// GetPDClientForMember tries to return a PDClient for a specific PD member.
+func GetPDClientForMember(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster, member *v1alpha1.PDMember) pdapi.PDClient {
+	if member == nil {
+		return nil
+	}
+	return pdControl.GetPDClient(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), tc.IsTLSClusterEnabled(), pdapi.SpecifyClient(member.ClientURL, member.Name))
+}
+
 // GetPDMSClient tries to return an available PDMSClient
 func GetPDMSClient(pdControl pdapi.PDControlInterface, tc *v1alpha1.TidbCluster, serviceName string) pdapi.PDMSClient {
 	pdMSClient := getPDMSClientFromService(pdControl, tc, serviceName)

--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -122,12 +122,12 @@ func NewFakePDClient(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster) *
 }
 
 // NewFakePDClientForMember creates a fake pdclient that is set as the pd client for a specific PD member.
-func NewFakePDClientForMember(pdControl *pdapi.FakePDControl, member *v1alpha1.PDMember) *pdapi.FakePDClient {
+func NewFakePDClientForMember(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster, member *v1alpha1.PDMember) *pdapi.FakePDClient {
 	if member == nil {
 		return nil
 	}
 	pdClient := pdapi.NewFakePDClient()
-	pdControl.SetPDClientForKey(member.Name, pdClient)
+	pdControl.SetPDClientForKey(pdapi.Namespace(tc.GetNamespace()), tc.GetName(), member.Name, pdClient)
 	return pdClient
 }
 

--- a/pkg/controller/pd_control_test.go
+++ b/pkg/controller/pd_control_test.go
@@ -74,7 +74,7 @@ func TestGetPDClient(t *testing.T) {
 				pdClientCluster1.AddReaction(pdapi.GetHealthActionType, func(action *pdapi.Action) (interface{}, error) {
 					return nil, fmt.Errorf("Fake cluster 1 PD crashed")
 				})
-				pdClientCluster2 := NewFakePDClientWithAddress(pdControl, "pd-0")
+				pdClientCluster2 := NewFakePDClientForMember(pdControl, tc, &v1alpha1.PDMember{Name: "pd-0"})
 				pdClientCluster2.AddReaction(pdapi.GetHealthActionType, func(action *pdapi.Action) (interface{}, error) {
 					return &pdapi.HealthInfo{Healths: []pdapi.MemberHealth{
 						{Name: "pd-0", MemberID: uint64(1), ClientUrls: []string{"http://pd-0.pd.pingcap.cluster2.com:2379"}, Health: true},
@@ -98,7 +98,7 @@ func TestGetPDClient(t *testing.T) {
 				pdClientCluster1.AddReaction(pdapi.GetHealthActionType, func(action *pdapi.Action) (interface{}, error) {
 					return nil, fmt.Errorf("Fake cluster 1 PD crashed")
 				})
-				pdClientCluster2 := NewFakePDClientWithAddress(pdControl, "pd-0")
+				pdClientCluster2 := NewFakePDClientForMember(pdControl, tc, &v1alpha1.PDMember{Name: "pd-0"})
 				pdClientCluster2.AddReaction(pdapi.GetHealthActionType, func(action *pdapi.Action) (interface{}, error) {
 					return nil, fmt.Errorf("Fake cluster 2 PD crashed")
 				})

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -96,13 +96,13 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 		})
 
 		for _, member := range tc.Status.PD.Members {
-			pdClientM := controller.NewFakePDClientForMember(pdControl, &member)
+			pdClientM := controller.NewFakePDClientForMember(pdControl, tc, &member)
 			pdClientM.AddReaction(pdapi.GetReadyActionType, func(action *pdapi.Action) (interface{}, error) {
 				return true, nil
 			})
 		}
 		for _, member := range tc.Status.PD.PeerMembers {
-			pdClientM := controller.NewFakePDClientForMember(pdControl, &member)
+			pdClientM := controller.NewFakePDClientForMember(pdControl, tc, &member)
 			pdClientM.AddReaction(pdapi.GetReadyActionType, func(action *pdapi.Action) (interface{}, error) {
 				return true, nil
 			})

--- a/pkg/manager/member/pd_upgrader_test.go
+++ b/pkg/manager/member/pd_upgrader_test.go
@@ -95,6 +95,19 @@ func TestPDUpgraderUpgrade(t *testing.T) {
 			return healthInfo, nil
 		})
 
+		for _, member := range tc.Status.PD.Members {
+			pdClientM := controller.NewFakePDClientForMember(pdControl, &member)
+			pdClientM.AddReaction(pdapi.GetReadyActionType, func(action *pdapi.Action) (interface{}, error) {
+				return true, nil
+			})
+		}
+		for _, member := range tc.Status.PD.PeerMembers {
+			pdClientM := controller.NewFakePDClientForMember(pdControl, &member)
+			pdClientM.AddReaction(pdapi.GetReadyActionType, func(action *pdapi.Action) (interface{}, error) {
+				return true, nil
+			})
+		}
+
 		err := upgrader.Upgrade(tc, oldSet, newSet)
 		test.errExpectFn(g, err)
 		test.expectFn(g, tc, newSet)

--- a/pkg/pdapi/fake_pdapi.go
+++ b/pkg/pdapi/fake_pdapi.go
@@ -46,6 +46,7 @@ const (
 	TransferPDLeaderActionType                  ActionType = "TransferPDLeader"
 	GetAutoscalingPlansActionType               ActionType = "GetAutoscalingPlans"
 	GetRecoveringMarkActionType                 ActionType = "GetRecoveringMark"
+	GetReadyActionType                          ActionType = "GetReady"
 	PDMSTransferPrimaryActionType               ActionType = "PDMSTransferPrimary"
 )
 
@@ -301,6 +302,15 @@ func (c *FakePDClient) GetRecoveringMark() (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (c *FakePDClient) GetReady() (bool, error) {
+	action := &Action{}
+	result, err := c.fakeAPI(GetReadyActionType, action)
+	if err != nil {
+		return false, err
+	}
+	return result.(bool), nil
 }
 
 // FakePDMSClient implements a fake version of PDMSClient.

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -345,6 +345,10 @@ func (fpc *FakePDControl) SetPDClient(namespace Namespace, tcName string, pdclie
 	fpc.defaultPDControl.pdClients[genClientKey("http", namespace, tcName, "")] = pdclient
 }
 
+func (fpc *FakePDControl) SetPDClientForKey(key string, pdclient PDClient) {
+	fpc.defaultPDControl.pdClients[key] = pdclient
+}
+
 func (fpc *FakePDControl) SetPDClientWithClusterDomain(namespace Namespace, tcName string, tcClusterDomain string, pdclient PDClient) {
 	fpc.defaultPDControl.pdClients[genClientKey("http", namespace, tcName, tcClusterDomain)] = pdclient
 }

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -350,7 +350,9 @@ func (fpc *FakePDControl) SetPDClient(namespace Namespace, tcName string, pdclie
 	fpc.defaultPDControl.pdClients[genClientKey("http", namespace, tcName, "")] = pdclient
 }
 
-func (fpc *FakePDControl) SetPDClientForKey(key string, pdclient PDClient) {
+func (fpc *FakePDControl) SetPDClientForKey(namespace Namespace, tcName, key string, pdclient PDClient) {
+	genKey := genClientKey("http", namespace, tcName, "")
+	key = fmt.Sprintf("%s.%s", genKey, key)
 	fpc.defaultPDControl.pdClients[key] = pdclient
 }
 

--- a/pkg/pdapi/pd_control.go
+++ b/pkg/pdapi/pd_control.go
@@ -123,8 +123,13 @@ func (c *clientConfig) completeForPDClient(namespace Namespace, tcName, serviceN
 	if c.clientURL == "" {
 		c.clientURL = genClientUrl(namespace, tcName, scheme, c.clusterDomain, serviceName, c.headlessSvc)
 	}
+	genKey := genClientKey(scheme, namespace, tcName, c.clusterDomain)
 	if c.clientKey == "" {
-		c.clientKey = genClientKey(scheme, namespace, tcName, c.clusterDomain)
+		c.clientKey = genKey
+	} else {
+		// we often pass the PD member name as the clientKey now,
+		// but this is NOT unique, so we need to add the genKey to make it unique
+		c.clientKey = fmt.Sprintf("%s.%s", genKey, c.clientKey)
 	}
 }
 

--- a/pkg/pdapi/pd_control_test.go
+++ b/pkg/pdapi/pd_control_test.go
@@ -135,7 +135,7 @@ func TestPDControl(t *testing.T) {
 				tlsEnable: true,
 				expectConfig: func(pdClient *clientConfig, etcdClient *clientConfig) {
 					g.Expect(pdClient.clientURL).To(Equal("http://test.cluster"))
-					g.Expect(pdClient.clientKey).To(Equal("test.cluster"))
+					g.Expect(pdClient.clientKey).To(Equal("https.target-cluster.target-namespace.cluster.local.test.cluster"))
 
 					g.Expect(etcdClient.clientURL).To(Equal("http://test.cluster"))
 					g.Expect(etcdClient.clientKey).To(Equal("test.cluster"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

Use PD ready API to check if PD members are ready during upgrading/updating, ref https://github.com/tikv/pd/pull/8749


### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
  - upgrade PD from 8.5.0 to 8.5.1 then to 8.5.2 (without mTLS enabled) successfully, and check log
    ```
    I0612 03:40:35.851728       1 pdapi.go:820] ready API is not found, assuming PD is ready
    ```
  - upgrade PD from 8.5.0 to 8.5.1 then to 8.5.2 (without mTLS enabled) successfully, and check log
     ```
     I0612 06:40:23.794992       1 tidb_cluster_controller.go:142] TidbCluster: default/basic, still need sync: tidbcluster: [default/basic]'s pd member: [basic-pd-1] is not ready, error: pd upgrader: failed to check if pd member basic-pd-1 is ready: Get "https://basic-pd-1.basic-pd-peer.default.svc:2379/pd/api/v2/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers), requeuing
     ```
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
