### PR TITLE
opt: delete sts and reset status when the tiproxy is scaled to 0

### DIFF
--- a/pkg/manager/member/tiproxy_scaler.go
+++ b/pkg/manager/member/tiproxy_scaler.go
@@ -76,7 +76,7 @@ func (s *tiproxyScaler) ScaleIn(meta metav1.Object, oldSet *apps.StatefulSet, ne
 	resetReplicas(newSet, oldSet)
 
 	if !tc.Status.TiProxy.Synced {
-		return fmt.Errorf("TidbCluster: %s/%s's pd status sync failed, can't scale in now", ns, tcName)
+		return fmt.Errorf("TidbCluster: %s/%s's tiproxy status sync failed, can't scale in now", ns, tcName)
 	}
 
 	klog.Infof("scaling in tiproxy statefulset %s/%s, ordinal: %d (replicas: %d, delete slots: %v)", oldSet.Namespace, oldSet.Name, ordinal, replicas, deleteSlots.List())

--- a/pkg/manager/volumes/pvc_modifier.go
+++ b/pkg/manager/volumes/pvc_modifier.go
@@ -70,6 +70,11 @@ func (p *pvcModifier) Sync(tc *v1alpha1.TidbCluster) error {
 			// not need storage
 			continue
 		}
+		// skip if tiproxy is already scaled to zero
+		if comp.MemberType() == v1alpha1.TiProxyMemberType && tc.TiProxyStsDesiredReplicas() == 0 {
+			continue
+		}
+
 		ctx, err := p.utils.BuildContextForTC(tc, comp)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("build ctx used by modifier for %s/%s:%s failed: %w", tc.Namespace, tc.Name, comp.MemberType(), err))


### PR DESCRIPTION
Note: the corresponding k8s services, configmaps will remain unchanged.

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
