### PR TITLE
Revert "Volume Replacement causes excessive CPU and IO usage on the p…

### DIFF
--- a/pkg/manager/volumes/pvc_replacer.go
+++ b/pkg/manager/volumes/pvc_replacer.go
@@ -163,25 +163,11 @@ func isVolumeReplacing(pod *corev1.Pod) bool {
 	return exist
 }
 
-func (p *pvcReplacer) startVolumeReplace(ctx *componentVolumeContext, pod *corev1.Pod) error {
+func (p *pvcReplacer) startVolumeReplace(pod *corev1.Pod) error {
 	pod = pod.DeepCopy()
 
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
-	}
-
-	// try to evict leader
-	isEvicted := isLeaderEvictedOrTimeout(ctx.tc, pod)
-	if !isEvicted {
-		if ensureTiKVLeaderEvictionCondition(ctx.tc, metav1.ConditionTrue) {
-			// return to sync tc
-			return fmt.Errorf("try to evict leader for tidbcluster %s/%s", ctx.tc.Namespace, ctx.tc.Name)
-		}
-		// evict leader
-		if err := p.evictLeader(ctx.tc, pod); err != nil {
-			return err
-		}
-		return fmt.Errorf("wait for leader eviction of %s/%s completed", pod.Namespace, pod.Name)
 	}
 
 	pod.Annotations[v1alpha1.ReplaceVolumeAnnKey] = v1alpha1.ReplaceVolumeValueTrue
@@ -207,29 +193,11 @@ func (p *pvcReplacer) tryToReplacePVC(ctx *componentVolumeContext) error {
 		if podSynced {
 			continue
 		}
-		if err := p.startVolumeReplace(ctx, pod); err != nil {
+		if err := p.startVolumeReplace(pod); err != nil {
 			return err
 		}
 		return fmt.Errorf("started volume replace for pod %s, waiting", pod.Name)
 	}
-	return nil
-}
-
-func (p *pvcReplacer) evictLeader(tc *v1alpha1.TidbCluster, pod *corev1.Pod) error {
-	if isLeaderEvicting(pod) {
-		return nil
-	}
-	pod = pod.DeepCopy()
-
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
-	}
-
-	pod.Annotations[v1alpha1.EvictLeaderAnnKey] = v1alpha1.EvictLeaderValueDeletePod
-	if _, err := p.deps.KubeClientset.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("add leader eviction annotation to pod %s/%s failed: %s", pod.Namespace, pod.Name, err)
-	}
-
 	return nil
 }
 

--- a/pkg/manager/volumes/pvc_replacer_test.go
+++ b/pkg/manager/volumes/pvc_replacer_test.go
@@ -316,29 +316,7 @@ func TestPvcReplacerSync(t *testing.T) {
 		if tt.isScale {
 			tc.Status.TiKV.Phase = v1alpha1.ScalePhase
 		}
-		tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{
-			"1": {ID: "1", State: v1alpha1.TiKVStateUp, PodName: "test-cluster-tikv-1", LeaderCount: 5},
-		}
 		syncErr := replacer.Sync(tc)
-		if tt.expectAnnotationOnPod1 {
-			g.Expect(syncErr == nil)
-			// another iteration
-			syncErr = replacer.Sync(tc)
-			g.Expect(syncErr == nil)
-			deps.KubeInformerFactory.WaitForCacheSync(stop)
-			// simulate eviction of all leaders now
-			tc.Status.TiKV.EvictLeader = make(map[string]*v1alpha1.EvictLeaderStatus)
-			tc.Status.TiKV.EvictLeader["test-cluster-tikv-1"] = &v1alpha1.EvictLeaderStatus{
-				PodCreateTime: metav1.Now(),
-				BeginTime:     metav1.Now(),
-				//Value:         value,
-			}
-			store := tc.Status.TiKV.Stores["1"] // Retrieve the struct
-			store.LeaderCount = 0               // Set LeaderCount to 0 now
-			tc.Status.TiKV.Stores["1"] = store  // Reassign the modified struct
-			// call again, it should now proceed with replacing volumes
-			syncErr = replacer.Sync(tc)
-		}
 		deps.KubeInformerFactory.WaitForCacheSync(stop)
 		if tt.expectStsDeleted {
 			g.Eventually(func() error {
@@ -353,11 +331,7 @@ func TestPvcReplacerSync(t *testing.T) {
 			g.Eventually(func() map[string]string {
 				pod1, _ := deps.PodLister.Pods(tc.Namespace).Get("test-cluster-tikv-1")
 				return pod1.Annotations
-			}, testMatchTimeout, testMatchInterval).Should(
-				SatisfyAll(
-					HaveKeyWithValue(v1alpha1.ReplaceVolumeAnnKey, v1alpha1.ReplaceVolumeValueTrue),
-					HaveKeyWithValue(v1alpha1.EvictLeaderAnnKey, v1alpha1.EvictLeaderValueDeletePod),
-				), "Expected both annotations to be present in pod annotations")
+			}, testMatchTimeout, testMatchInterval).Should(HaveKeyWithValue(v1alpha1.ReplaceVolumeAnnKey, v1alpha1.ReplaceVolumeValueTrue))
 			g.Expect(syncErr.Error()).To(ContainSubstring("started volume replace"))
 		} else if syncErr != nil {
 			g.Expect(syncErr.Error()).To(Not(ContainSubstring("started volume replace")))


### PR DESCRIPTION
…ods being deleted because schedule.store-limit.xyz.remove-peer limit is being set to unlimited. Effectively the limit becomes num_available_tikv_pods *  schedule.store-limit.xyz.add-peer. The problem is the TIKV store is still serving active leaders causing a high latency impact to clients. (#6069)"

This reverts commit e84b19cf93e787a4d3adc9de94d9004f1df944aa.

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
VolumeReplacement is broken for PD, TICDC, and TIDB components (except for TIKV) as it tries to evict leaders from the store/pod.
https://github.com/pingcap/tidb-operator/issues/6252

### What is changed and how does it work?
This reverts https://github.com/pingcap/tidb-operator/pull/6069

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
