### PR TITLE
feat(tiproxy): support readiness probe

### DIFF
--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -907,7 +907,7 @@ outer:
 }
 
 // buildTiProxyReadinessProbeHandler builds the readiness probe handler for TiProxy.
-// For compatibility, it doesn't provide any probe handler if `Type` or `InitialDelaySeconds` is not set.
+// For compatibility, it doesn't provide any probe handler if `readinessProbe` or `readinessProbe.type` is not set.
 func buildTiProxyReadinessProbeHandler(tc *v1alpha1.TidbCluster) *corev1.ProbeHandler {
 	if tc.Spec.TiProxy.ReadinessProbe == nil {
 		return nil

--- a/pkg/manager/member/tiproxy_member_manager.go
+++ b/pkg/manager/member/tiproxy_member_manager.go
@@ -532,6 +532,13 @@ func (m *tiproxyMemberManager) getNewStatefulSet(tc *v1alpha1.TidbCluster, cm *c
 		Env:          util.AppendEnv(envs, baseTiProxySpec.Env()),
 		EnvFrom:      baseTiProxySpec.EnvFrom(),
 	}
+	if probeHander := buildTiProxyReadinessProbeHandler(tc); probeHander != nil {
+		tiproxyContainer.ReadinessProbe = &corev1.Probe{
+			ProbeHandler:        *probeHander,
+			InitialDelaySeconds: pointer.Int32Deref(tc.Spec.TiProxy.ReadinessProbe.InitialDelaySeconds, 10),
+			PeriodSeconds:       pointer.Int32Deref(tc.Spec.TiProxy.ReadinessProbe.PeriodSeconds, 10),
+		}
+	}
 
 	podSpec := baseTiProxySpec.BuildPodSpec()
 
@@ -897,6 +904,65 @@ outer:
 	}
 
 	return setCount, nil
+}
+
+// buildTiProxyReadinessProbeHandler builds the readiness probe handler for TiProxy.
+// For compatibility, it doesn't provide any probe handler if `Type` or `InitialDelaySeconds` is not set.
+func buildTiProxyReadinessProbeHandler(tc *v1alpha1.TidbCluster) *corev1.ProbeHandler {
+	if tc.Spec.TiProxy.ReadinessProbe == nil {
+		return nil
+	}
+	tp := tc.Spec.TiProxy.ReadinessProbe.Type
+	if tp == nil {
+		return nil
+	}
+
+	switch *tp {
+	case v1alpha1.CommandProbeType:
+		command := buildTiProxyProbeCommand(tc)
+		return &corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: command,
+			},
+		}
+	case v1alpha1.TCPProbeType:
+		return &corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(int(v1alpha1.DefaultTiProxyServerPort)),
+			},
+		}
+	}
+
+	return nil
+}
+
+func buildTiProxyProbeCommand(tc *v1alpha1.TidbCluster) (command []string) {
+	const (
+		host    = "127.0.0.1"
+		apiPath = "/api/debug/health"
+	)
+
+	readinessURL := fmt.Sprintf("%s://%s:%d%s", tc.Scheme(), host, v1alpha1.DefaultTiProxyStatusPort, apiPath)
+	command = append(command, "curl")
+	command = append(command, readinessURL)
+
+	// Fail silently (no output at all) on server errors
+	// without this if the server return 500, the exist code will be 0
+	// and probe is success.
+	command = append(command, "--fail")
+	// follow 301 or 302 redirect
+	command = append(command, "--location")
+
+	if tc.IsTLSClusterEnabled() {
+		// The following code is compatible with cert layout both `legacy` and `v1`.
+		cacert := path.Join(util.ClusterClientTLSPath, tlsSecretRootCAKey)
+		cert := path.Join(util.ClusterClientTLSPath, corev1.TLSCertKey)
+		key := path.Join(util.ClusterClientTLSPath, corev1.TLSPrivateKeyKey)
+		command = append(command, "--cacert", cacert)
+		command = append(command, "--cert", cert)
+		command = append(command, "--key", key)
+	}
+	return
 }
 
 type FakeTiProxyMemberManager struct {

--- a/pkg/manager/member/tiproxy_member_manager_test.go
+++ b/pkg/manager/member/tiproxy_member_manager_test.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestTiProxyMemberManagerSetLabels(t *testing.T) {
@@ -442,7 +442,7 @@ func TestBuildTiProxyReadinessProbeHandler(t *testing.T) {
 					TiProxy: &v1alpha1.TiProxySpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
 							ReadinessProbe: &v1alpha1.Probe{
-								Type: pointer.StringPtr(string(v1alpha1.CommandProbeType)),
+								Type: ptr.To(string(v1alpha1.CommandProbeType)),
 							},
 						},
 					},
@@ -466,7 +466,7 @@ func TestBuildTiProxyReadinessProbeHandler(t *testing.T) {
 					TiProxy: &v1alpha1.TiProxySpec{
 						ComponentSpec: v1alpha1.ComponentSpec{
 							ReadinessProbe: &v1alpha1.Probe{
-								Type: pointer.StringPtr(string(v1alpha1.TCPProbeType)),
+								Type: ptr.To(string(v1alpha1.TCPProbeType)),
 							},
 						},
 					},


### PR DESCRIPTION
Currently, tiproxy spec has field `readinessProbe` but operator doesn't implement it yet. This PR addresses this.

<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [x] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

Manual test cases
- [x] Create a TC with tiproxy enabled
- [x] Deploy new operator, tiproxy pods shouldn't restart
- [x] Set `tc.spec.tiproxy.readinessProbe` with the following spec, the tiproxy pods should restart and recreated with readiness probe
  - spec
```yaml
tiproxy:
  readinessProbe:
  type: command
```
  -  pod spec
```yaml
readinessProbe:
      exec:
        command:
        - curl
        - https://127.0.0.1:3080/api/debug/health
        - --fail
        - --location
        - --cacert
        - /var/lib/cluster-client-tls/ca.crt
        - --cert
        - /var/lib/cluster-client-tls/tls.crt
        - --key
        - /var/lib/cluster-client-tls/tls.key
      failureThreshold: 3
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 1
```
- [x] Set `tc.spec.tiproxy.readinessProbe` with the following spec, the tiproxy pods should restart and recreated with new readiness probe
  - spec
```yaml
tiproxy:
  readinessProbe:
  type: tcp
```
  -  pod spec
```yaml
readinessProbe:
      failureThreshold: 3
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      tcpSocket:
        port: 6000
      timeoutSeconds: 1
```


### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
