### PR TITLE
ms: use PDMSName as the transfer primary param

### DIFF
--- a/pkg/controller/pd_control.go
+++ b/pkg/controller/pd_control.go
@@ -133,7 +133,7 @@ func NewFakePDClientForMember(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbC
 
 // NewFakePDMSClient creates a fake pdmsclient that is set as the pdms client
 func NewFakePDMSClient(pdControl *pdapi.FakePDControl, tc *v1alpha1.TidbCluster, curService string) *pdapi.FakePDMSClient {
-	pdmsClient := pdapi.NewFakePDMSClient()
+	pdmsClient := pdapi.NewFakePDMSClient(tc.Spec.ClusterDomain)
 	if tc.Spec.Cluster != nil {
 		pdControl.SetPDMSClientWithClusterDomain(pdapi.Namespace(tc.Spec.Cluster.Namespace), tc.Spec.Cluster.Name, tc.Spec.Cluster.ClusterDomain, curService, pdmsClient)
 	}

--- a/pkg/manager/member/pd_ms_upgrader.go
+++ b/pkg/manager/member/pd_ms_upgrader.go
@@ -194,12 +194,12 @@ func choosePDMSToTransferFromMembers(tc *v1alpha1.TidbCluster, newSet *apps.Stat
 	// just using pods index for now. TODO: add healthy checker for pdms.
 	// find the maximum ordinal which is larger than ordinal
 	if len(list) > int(ordinal)+1 {
-		targetName = PDMSPodName(tcName, list[len(list)-1], controller.PDMSTrimName(newSet.Name))
+		targetName = PDMSName(tcName, ordinal, tc.Namespace, tc.Spec.ClusterDomain, tc.Spec.AcrossK8s, controller.PDMSTrimName(newSet.Name))
 	}
 
 	if targetName == "" && ordinal != 0 {
 		// find the minimum ordinal which is less than ordinal
-		targetName = PDMSPodName(tcName, list[0], controller.PDMSTrimName(newSet.Name))
+		targetName = PDMSName(tcName, ordinal, tc.Namespace, tc.Spec.ClusterDomain, tc.Spec.AcrossK8s, controller.PDMSTrimName(newSet.Name))
 	}
 
 	klog.Infof("Tidbcluster: [%s/%s]' pdms upgrader: choose pdms to transfer primary from members, targetName: %s", ns, tcName, targetName)

--- a/pkg/manager/member/pd_ms_upgrader_test.go
+++ b/pkg/manager/member/pd_ms_upgrader_test.go
@@ -307,6 +307,7 @@ func newTidbClusterForPDMSUpgrader() *v1alpha1.TidbCluster {
 					StorageClassName: pointer.StringPtr("my-storage-class"),
 				},
 			},
+			ClusterDomain: "cluster.local",
 		},
 		Status: v1alpha1.TidbClusterStatus{
 			PDMS: map[string]*v1alpha1.PDMSStatus{

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -162,7 +162,7 @@ func PdName(tcName string, ordinal int32, namespace string, clusterDomain string
 // See the start script of PDMS in pkg/manager/member/startscript/v2.renderPDMSStartScript
 func PDMSName(tcName string, ordinal int32, namespace, clusterDomain string, acrossK8s bool, component string) string {
 	if len(clusterDomain) > 0 {
-		return fmt.Sprintf("%s.%s-%s-peer.%s.svc.%s", PDMSPodName(tcName, ordinal, component), component, tcName, namespace, clusterDomain)
+		return fmt.Sprintf("%s.%s-%s-peer.%s.svc.%s", PDMSPodName(tcName, ordinal, component), tcName, component, namespace, clusterDomain)
 	}
 
 	// clusterDomain is not set

--- a/pkg/pdapi/fake_pdapi.go
+++ b/pkg/pdapi/fake_pdapi.go
@@ -15,6 +15,7 @@ package pdapi
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -316,10 +317,11 @@ func (c *FakePDClient) GetReady() (bool, error) {
 // FakePDMSClient implements a fake version of PDMSClient.
 type FakePDMSClient struct {
 	reactions map[ActionType]Reaction
+	domain    string
 }
 
-func NewFakePDMSClient() *FakePDMSClient {
-	return &FakePDMSClient{reactions: map[ActionType]Reaction{}}
+func NewFakePDMSClient(domain string) *FakePDMSClient {
+	return &FakePDMSClient{reactions: map[ActionType]Reaction{}, domain: domain}
 }
 
 func (c *FakePDMSClient) AddReaction(actionType ActionType, reaction Reaction) {
@@ -346,6 +348,9 @@ func (c *FakePDMSClient) GetHealth() error {
 
 func (c *FakePDMSClient) TransferPrimary(newPrimary string) error {
 	action := &Action{Name: newPrimary}
+	if len(c.domain) > 0 && !strings.Contains(newPrimary, c.domain) {
+		return fmt.Errorf("new primary %s does not contain domain %s", newPrimary, c.domain)
+	}
 	_, err := c.fakeAPI(PDMSTransferPrimaryActionType, action)
 	return err
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
