### PR TITLE
br: clean up compact data and allow user to disable

### DIFF
--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -215,6 +215,13 @@ func (bo *Options) doTruncateLogBackup(ctx context.Context, backup *v1alpha1.Bac
 		"log",
 		"truncate",
 	}
+	
+	// Check for clean-up-compactions annotation
+	// Default behavior: add --clean-up-compactions unless explicitly set to false
+	if value, exists := backup.Annotations["backup.pingcap.com/clean-up-compactions"]; !exists || value != "false" {
+		specificArgs = append(specificArgs, "--clean-up-compactions")
+	}
+	
 	if bo.TruncateUntil != "" && bo.TruncateUntil != "0" {
 		specificArgs = append(specificArgs, fmt.Sprintf("--until=%s", bo.TruncateUntil))
 	} else {

--- a/cmd/backup-manager/app/backup/backup.go
+++ b/cmd/backup-manager/app/backup/backup.go
@@ -215,13 +215,11 @@ func (bo *Options) doTruncateLogBackup(ctx context.Context, backup *v1alpha1.Bac
 		"log",
 		"truncate",
 	}
-	
 	// Check for clean-up-compactions annotation
-	// Default behavior: add --clean-up-compactions unless explicitly set to false
-	if value, exists := backup.Annotations["backup.pingcap.com/clean-up-compactions"]; !exists || value != "false" {
+	// Default behavior: not add --clean-up-compactions unless explicitly set to true
+	if value, exists := backup.Annotations["backup.pingcap.com/clean-up-compactions"]; exists && value == "true" {
 		specificArgs = append(specificArgs, "--clean-up-compactions")
 	}
-	
 	if bo.TruncateUntil != "" && bo.TruncateUntil != "0" {
 		specificArgs = append(specificArgs, fmt.Sprintf("--until=%s", bo.TruncateUntil))
 	} else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

    Close #6306

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
