### PR TITLE
CI: update debian image in for E2E

### DIFF
--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ENV KUBECTL_VERSION=v1.28.5
 ENV HELM_VERSION=v3.11.0

--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETARCH
 # python is required by gcloud
 RUN apt-get update && \
     apt-get install -y ca-certificates curl git openssl default-mysql-client unzip && \
-    apt-get install -y python && \
+    apt-get install -y python3 && \
     apt-get autoremove -y && \
     apt-get clean -y
 

--- a/tests/images/kubekins-e2e/Dockerfile
+++ b/tests/images/kubekins-e2e/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION=1.23.4
 # common util tools
 RUN apt-get update && \
     apt-get install -y build-essential ca-certificates curl git openssl default-mysql-client unzip wget && \
-    apt-get install -y python && \
+    apt-get install -y python3 && \
     apt-get autoremove -y && \
     apt-get clean -y
 

--- a/tests/images/kubekins-e2e/Dockerfile
+++ b/tests/images/kubekins-e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG GO_VERSION=1.23.4
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

```
[2025-07-17T03:34:29.074Z]  ---> Running in 774eba915a6b
[2025-07-17T03:34:29.997Z] Ign:1 http://deb.debian.org/debian buster InRelease
[2025-07-17T03:34:29.997Z] Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
[2025-07-17T03:34:29.997Z] Ign:3 http://deb.debian.org/debian buster-updates InRelease
[2025-07-17T03:34:29.997Z] Err:4 http://deb.debian.org/debian buster Release
[2025-07-17T03:34:29.997Z]   404  Not Found [IP: 151.101.194.132 80]
[2025-07-17T03:34:30.252Z] Err:5 http://deb.debian.org/debian-security buster/updates Release
[2025-07-17T03:34:30.252Z]   404  Not Found [IP: 151.101.194.132 80]
[2025-07-17T03:34:30.252Z] Err:6 http://deb.debian.org/debian buster-updates Release
[2025-07-17T03:34:30.252Z]   404  Not Found [IP: 151.101.194.132 80]
[2025-07-17T03:34:30.252Z] Reading package lists...
[2025-07-17T03:34:30.252Z] E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
[2025-07-17T03:34:30.252Z] E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
[2025-07-17T03:34:30.252Z] E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
[2025-07-17T03:34:30.845Z] The command '/bin/sh -c apt-get update &&     apt-get install -y ca-certificates curl git openssl default-mysql-client unzip &&     apt-get install -y python &&     apt-get autoremove -y &&     apt-get clean -y' returned a non-zero code: 100
```

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
