### PR TITLE
fix(client): ignore status to avoid unknown fields when applying spec

### DIFF
--- a/pkg/client/converter.go
+++ b/pkg/client/converter.go
@@ -43,6 +43,10 @@ func convertToUnstructured(gvk schema.GroupVersionKind, obj client.Object) (*uns
 	m["apiVersion"] = gvk.GroupVersion().String()
 	m["kind"] = gvk.Kind
 
+	// Ignore status because we only apply spec
+	// Empty status may also marshal to a object with data
+	delete(m, "status")
+
 	return &unstructured.Unstructured{
 		Object: m,
 	}, nil


### PR DESCRIPTION
Fix

```
cannot update instances: %!w(*fmt.wrapError=&{cannot extract last applied patch: error converting obj to typed: .status.isDefaultPrimary: field not declared in schema
```