### PR TITLE
fix(group): ensure feature gates should sync before reconciling

### DIFF
--- a/pkg/controllers/common/task.go
+++ b/pkg/controllers/common/task.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/apicall"
+	coreutil "github.com/pingcap/tidb-operator/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client"
 	"github.com/pingcap/tidb-operator/pkg/pdapi/v1"
 	"github.com/pingcap/tidb-operator/pkg/runtime"
@@ -184,6 +185,29 @@ func TaskContextPod[
 
 		state.SetPod(pod)
 		return task.Complete().With("pod is set")
+	})
+}
+
+type ContextFeatureGates[
+	F client.Object,
+] interface {
+	ObjectState[F]
+	ClusterState
+}
+
+// TaskCheckFeatureGates is defined to ensure features are synced before all actions
+func TaskCheckFeatureGates[
+	S scope.Group[F, T],
+	F client.Object,
+	T runtime.Group,
+](state ContextFeatureGates[F], c client.Client) task.Task {
+	return task.NameTaskFunc("CheckFeatureGates", func(ctx context.Context) task.Result {
+		obj := state.Object()
+		cluster := state.Cluster()
+		if !slices.Equal(coreutil.Features[S](obj), coreutil.EnabledFeatures(cluster)) {
+			return task.Wait().With("waiting until features are synced from cluster")
+		}
+		return task.Complete().With("features are synced")
 	})
 }
 

--- a/pkg/controllers/pdgroup/builder.go
+++ b/pkg/controllers/pdgroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.PDGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.PDGroup](state, r.Client),
 
 		// get all pds
 		common.TaskContextSlice[scope.PDGroup](state, r.Client),

--- a/pkg/controllers/replicationworkergroup/builder.go
+++ b/pkg/controllers/replicationworkergroup/builder.go
@@ -31,6 +31,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.ReplicationWorkerGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.ReplicationWorkerGroup](state, r.Client),
 
 		// get all schedulers
 		common.TaskContextSlice[scope.ReplicationWorkerGroup](state, r.Client),

--- a/pkg/controllers/schedulergroup/builder.go
+++ b/pkg/controllers/schedulergroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.SchedulerGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.SchedulerGroup](state, r.Client),
 
 		// get all schedulers
 		common.TaskContextSlice[scope.SchedulerGroup](state, r.Client),

--- a/pkg/controllers/ticdcgroup/builder.go
+++ b/pkg/controllers/ticdcgroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TiCDCGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TiCDCGroup](state, r.Client),
 
 		// get all TiCDCs
 		common.TaskContextSlice[scope.TiCDCGroup](state, r.Client),

--- a/pkg/controllers/tidbgroup/builder.go
+++ b/pkg/controllers/tidbgroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TiDBGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TiDBGroup](state, r.Client),
 
 		// get all tidbs
 		common.TaskContextSlice[scope.TiDBGroup](state, r.Client),

--- a/pkg/controllers/tiflashgroup/builder.go
+++ b/pkg/controllers/tiflashgroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TiFlashGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TiFlashGroup](state, r.Client),
 
 		// get all tiflashes
 		common.TaskContextSlice[scope.TiFlashGroup](state, r.Client),

--- a/pkg/controllers/tikvgroup/builder.go
+++ b/pkg/controllers/tikvgroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TiKVGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TiKVGroup](state, r.Client),
 
 		// get all tikvs
 		common.TaskContextSlice[scope.TiKVGroup](state, r.Client),

--- a/pkg/controllers/tiproxygroup/builder.go
+++ b/pkg/controllers/tiproxygroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TiProxyGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TiProxyGroup](state, r.Client),
 
 		// get all tiproxies
 		common.TaskContextSlice[scope.TiProxyGroup](state, r.Client),

--- a/pkg/controllers/tsogroup/builder.go
+++ b/pkg/controllers/tsogroup/builder.go
@@ -33,6 +33,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextCluster[scope.TSOGroup](state, r.Client),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		common.TaskCheckFeatureGates[scope.TSOGroup](state, r.Client),
 
 		// get all tsos
 		common.TaskContextSlice[scope.TSOGroup](state, r.Client),


### PR DESCRIPTION
Now features in group spec may be unset by users, we should ensure that features have been synced before reconciling.