### PR TITLE
fix(updater): defer delete instance should not be counted as update

### DIFF
--- a/pkg/updater/builder.go
+++ b/pkg/updater/builder.go
@@ -162,10 +162,13 @@ func split[R runtime.Instance](all []R, rev string) (update, outdated, deleted [
 		if !instance.GetDeletionTimestamp().IsZero() {
 			continue
 		}
+		if _, ok := instance.GetAnnotations()[v1alpha1.AnnoKeyDeferDelete]; ok {
+			deleted = append(deleted, instance)
+			continue
+		}
+
 		if instance.GetUpdateRevision() == rev {
 			update = append(update, instance)
-		} else if _, ok := instance.GetAnnotations()[v1alpha1.AnnoKeyDeferDelete]; ok {
-			deleted = append(deleted, instance)
 		} else {
 			outdated = append(outdated, instance)
 		}


### PR DESCRIPTION
If an instance is marked to defer delete, it just like an deleting instance. Defer deletion is not revertible now.

A defer delete instance should not be counted into the update set.