### PR TITLE
Update monitor versions

### DIFF
--- a/cmd/http-service/examples/create-cluster.json
+++ b/cmd/http-service/examples/create-cluster.json
@@ -49,7 +49,7 @@
       "port":4000
    },
    "prometheus":{
-      "version":"v2.27.1",
+      "version":"v3.5.0",
       "resource":{
          "cpu":2,
          "memory":4

--- a/cmd/http-service/idl/api/service.proto
+++ b/cmd/http-service/idl/api/service.proto
@@ -240,7 +240,7 @@ message Prometheus {
 
   string version = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "The version of the Prometheus. Only official versions are supported now.",
-    example: "\"v2.27.1\""
+    example: "\"v3.5.0\""
   }];
   Resource resource = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The resource of the Prometheus."}];
   map<string, string> config = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
@@ -679,7 +679,7 @@ message PrometheusStatus {
 
   string version = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "The version of the Prometheus component.",
-    example: "\"v2.27.1\""
+    example: "\"v3.5.0\""
   }];
   Resource resource = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The resource of the Prometheus component."}];
   map<string, string> config = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The command options config of the Prometheus. ref https://prometheus.io/docs/prometheus/latest/command-line/prometheus/"}];

--- a/cmd/http-service/pbgen/oas/openapi-spec.swagger.json
+++ b/cmd/http-service/pbgen/oas/openapi-spec.swagger.json
@@ -1094,7 +1094,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "example": "v2.27.1",
+          "example": "v3.5.0",
           "description": "The version of the Prometheus. Only official versions are supported now."
         },
         "resource": {

--- a/deploy/aliyun/manifests/db-monitor.yaml.example
+++ b/deploy/aliyun/manifests/db-monitor.yaml.example
@@ -65,7 +65,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -82,7 +82,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi
   storageClassName: alicloud-disk-available
   tolerations: []

--- a/deploy/aws/manifests/db-monitor.yaml.example
+++ b/deploy/aws/manifests/db-monitor.yaml.example
@@ -63,7 +63,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -80,7 +80,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi
   storageClassName: ebs-gp2
   tolerations: []

--- a/deploy/gcp/manifests/db-monitor.yaml.example
+++ b/deploy/gcp/manifests/db-monitor.yaml.example
@@ -63,7 +63,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -80,7 +80,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi
   storageClassName: pd-ssd
   tolerations: []

--- a/examples/Runbooks/EKS/tidb-monitor.yaml
+++ b/examples/Runbooks/EKS/tidb-monitor.yaml
@@ -43,7 +43,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -53,6 +53,6 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 10Gi
   storageClassName: gp2

--- a/examples/Runbooks/GKE/tidb-monitor.yaml
+++ b/examples/Runbooks/GKE/tidb-monitor.yaml
@@ -43,7 +43,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -53,6 +53,6 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 10Gi
   storageClassName: gp2

--- a/examples/Runbooks/K8s/tidb-monitor.yaml
+++ b/examples/Runbooks/K8s/tidb-monitor.yaml
@@ -43,7 +43,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -53,6 +53,6 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 10Gi
   storageClassName: gp2

--- a/examples/advanced/tidb-monitor.yaml
+++ b/examples/advanced/tidb-monitor.yaml
@@ -142,7 +142,7 @@ spec:
     ## ImagePullPolicy of prometheus.
     # imagePullPolicy: IfNotPresent
     ## Prometheus version.
-    version: v2.27.1
+    version: v3.5.0
 
     ## Describes the compute resource requirements and limits of Prometheus.
     ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -402,7 +402,7 @@ spec:
   ##  ImagePullPolicy of prometheusReloader.
   #   ImagePullPolicy: IfNotPresent
   #   PrometheusReloader version.
-  #   version: v0.49.0
+  #   version: v0.85.0
   ##  Describes the compute resource requirements and limits of prometheusReloader.
   ##  Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   #   requests:
@@ -453,7 +453,7 @@ spec:
   #   # ImagePullPolicy of thanos.
   #   imagePullPolicy: IfNotPresent
   #   # Thanos version.
-  #   version: v0.17.2
+  #   version: v0.39.2
 
   ##  Describes the compute resource requirements and limits of thanos.
   ##  Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/examples/aks/tidb-monitor.yaml
+++ b/examples/aks/tidb-monitor.yaml
@@ -40,7 +40,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -50,5 +50,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi

--- a/examples/aws/tidb-monitor.yaml
+++ b/examples/aws/tidb-monitor.yaml
@@ -43,7 +43,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -53,5 +53,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi

--- a/examples/basic-cn/tidb-monitor.yaml
+++ b/examples/basic-cn/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -19,5 +19,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/basic-storagevolumes/tidb-monitor.yaml
+++ b/examples/basic-storagevolumes/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -19,5 +19,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/basic-tls/tidb-monitor.yaml
+++ b/examples/basic-tls/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic-tls
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -19,5 +19,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/basic/tidb-monitor.yaml
+++ b/examples/basic/tidb-monitor.yaml
@@ -8,7 +8,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,5 +20,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/dm/dm-monitor.yaml
+++ b/examples/dm/dm-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -17,7 +17,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   dm:
     clusters:
     - name: basic

--- a/examples/gcp/tidb-monitor.yaml
+++ b/examples/gcp/tidb-monitor.yaml
@@ -41,7 +41,7 @@ spec:
     service:
       portName: http-prometheus
       type: NodePort
-    version: v2.27.1
+    version: v3.5.0
   reloader:
     baseImage: pingcap/tidb-monitor-reloader
     imagePullPolicy: IfNotPresent
@@ -51,5 +51,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   storage: 100Gi

--- a/examples/heterogeneous-tls/tidb-monitor.yaml
+++ b/examples/heterogeneous-tls/tidb-monitor.yaml
@@ -8,7 +8,7 @@ spec:
     - name: heterogeneous
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,6 +20,6 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent
 

--- a/examples/heterogeneous/tidb-monitor.yaml
+++ b/examples/heterogeneous/tidb-monitor.yaml
@@ -8,7 +8,7 @@ spec:
     - name: basic-heterogeneous
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,5 +20,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/istio/tidb-monitor.yaml
+++ b/examples/istio/tidb-monitor.yaml
@@ -8,7 +8,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,5 +20,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-dynamic-configmap/tidb-monitor.yaml
+++ b/examples/monitor-dynamic-configmap/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
       namespace: ns2
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -23,5 +23,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-grafana-secret/tidb-monitor.yaml
+++ b/examples/monitor-grafana-secret/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
     - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -25,5 +25,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
       namespace: ns2
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -23,5 +23,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
+++ b/examples/monitor-multiple-cluster-tls/tidb-monitor.yaml
@@ -11,7 +11,7 @@ spec:
       namespace: ns2
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -23,5 +23,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-prom-remotewrite/tidb-monitor.yaml
+++ b/examples/monitor-prom-remotewrite/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
     remoteWrite:
       - url: "http://thanos-receiver-0.thanos-receiver.default.svc:19291/api/v1/receive"
         queueConfig:
@@ -26,5 +26,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-shards/tidb-monitor.yaml
+++ b/examples/monitor-shards/tidb-monitor.yaml
@@ -9,7 +9,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   initializer:
     baseImage: pingcap/tidb-monitor-initializer
     version: v8.5.2
@@ -18,5 +18,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/grafana/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
     - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -22,7 +22,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent
   additionalVolumes:
     - name: customdashboard

--- a/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
+++ b/examples/monitor-with-externalConfigMap/prometheus/tidb-monitor.yaml
@@ -14,7 +14,7 @@ spec:
         - --web.max-connections=512
         - --storage.remote.read-concurrent-limit=10
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -26,5 +26,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-with-externalRules/tidb-monitor.yaml
+++ b/examples/monitor-with-externalRules/tidb-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       ruleConfigRef:
         name: external-config
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -22,5 +22,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/monitor-with-thanos/README.md
+++ b/examples/monitor-with-thanos/README.md
@@ -34,7 +34,7 @@ spec:
   - name: basic
   thanos:
     baseImage: thanosio/thanos
-    version: v0.17.2
+    version: v0.39.2
     objectStorageConfig:
       key: objectstorage.yaml
       name: thanos-objectstorage

--- a/examples/monitor-with-thanos/thanos-query.yaml
+++ b/examples/monitor-with-thanos/thanos-query.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.17.2
+    app.kubernetes.io/version: v0.39.2
   name: thanos-query
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.17.2
+        app.kubernetes.io/version: v0.39.2
     spec:
       containers:
         - args:
@@ -40,7 +40,7 @@ spec:
                 "sampler_type": "ratelimiting"
                 "service_name": "thanos-query"
               "type": "JAEGER"
-          image: quay.io/thanos/thanos:v0.17.2
+          image: quay.io/thanos/thanos:v0.39.2
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -73,7 +73,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.17.2
+    app.kubernetes.io/version: v0.39.2
   name: thanos-query
 spec:
   ports:

--- a/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor-with-additional-volumes.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic
   thanos:
     baseImage: thanosio/thanos
-    version: v0.17.2
+    version: v0.39.2
     objectStorageConfigFile: /etc/thanos/objectstorage.yaml
     additionalVolumeMounts:
       - name: objectstorage
@@ -15,7 +15,7 @@ spec:
         readOnly: true
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -27,7 +27,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent
   additionalVolumes:
     - name: objectstorage

--- a/examples/monitor-with-thanos/tidb-monitor.yaml
+++ b/examples/monitor-with-thanos/tidb-monitor.yaml
@@ -7,10 +7,10 @@ spec:
   - name: basic
   thanos:
     baseImage: thanosio/thanos
-    version: v0.17.2
+    version: v0.39.2
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -22,5 +22,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/namespaced/tidb-monitor.yaml
+++ b/examples/namespaced/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -19,5 +19,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/examples/podpatch/tidb-monitor.yaml
+++ b/examples/podpatch/tidb-monitor.yaml
@@ -8,7 +8,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,7 +20,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent
   additionalContainers:
     - name: test

--- a/examples/prometheus-operator/prometheus.yaml
+++ b/examples/prometheus-operator/prometheus.yaml
@@ -12,7 +12,7 @@ spec:
       namespace: monitoring
       port: web
   baseImage: prom/prometheus
-  version: v2.27.1
+  version: v3.5.0
   nodeSelector:
     kubernetes.io/os: linux
   podMonitorSelector: {}

--- a/examples/tiflash/tidb-monitor.yaml
+++ b/examples/tiflash/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: demo
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -21,7 +21,7 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   persistent: true
   imagePullPolicy: IfNotPresent
   storage: 10Gi

--- a/hack/localtest/monitor.yaml
+++ b/hack/localtest/monitor.yaml
@@ -8,7 +8,7 @@ spec:
   - name: basic
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
   grafana:
     baseImage: grafana/grafana
     version: 7.5.11
@@ -20,5 +20,5 @@ spec:
     version: v1.0.1
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
-    version: v0.49.0
+    version: v0.85.0
   imagePullPolicy: IfNotPresent

--- a/manifests/monitor/tidb-monitor.yaml
+++ b/manifests/monitor/tidb-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   - name: demo
   prometheus:
     baseImage: prom/prometheus
-    version: v2.27.1
+    version: v3.5.0
     #limits:
     #  cpu: 8000m
     #  memory: 8Gi
@@ -71,7 +71,7 @@ spec:
   prometheusReloader:
     baseImage: quay.io/prometheus-operator/prometheus-config-reloader
     ImagePullPolicy: IfNotPresent
-    version: v0.49.0
+    version: v0.85.0
     #limits:
     #  cpu: 50m
     #  memory: 64Mi

--- a/pkg/monitor/monitor/monitor_manager_test.go
+++ b/pkg/monitor/monitor/monitor_manager_test.go
@@ -206,7 +206,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 				monitor.Spec.PrometheusReloader = &v1alpha1.PrometheusReloaderSpec{
 					MonitorContainer: v1alpha1.MonitorContainer{
 						BaseImage: "quay.io/prometheus-operator/prometheus-config-reloaders",
-						Version:   "v0.49.0",
+						Version:   "v0.85.0",
 					},
 				}
 			},
@@ -257,7 +257,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 				monitor.Spec.Thanos = &v1alpha1.ThanosSpec{
 					MonitorContainer: v1alpha1.MonitorContainer{
 						BaseImage: "thanosio/thanos",
-						Version:   "v0.17.2",
+						Version:   "v0.39.2",
 					},
 				}
 			},
@@ -300,7 +300,7 @@ func TestTidbMonitorSyncCreate(t *testing.T) {
 				monitor.Spec.Thanos = &v1alpha1.ThanosSpec{
 					MonitorContainer: v1alpha1.MonitorContainer{
 						BaseImage: "thanosio/thanos",
-						Version:   "v0.17.2",
+						Version:   "v0.39.2",
 					},
 				}
 			},

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -1493,7 +1493,7 @@ func TestGetMonitorThanosSidecarContainer(t *testing.T) {
 					Thanos: &v1alpha1.ThanosSpec{
 						MonitorContainer: v1alpha1.MonitorContainer{
 							BaseImage: "thanosio/thanos",
-							Version:   "v0.17.2",
+							Version:   "v0.39.2",
 						},
 						ObjectStorageConfig: &corev1.SecretKeySelector{
 							Key: "objectstorage.yaml",
@@ -1506,7 +1506,7 @@ func TestGetMonitorThanosSidecarContainer(t *testing.T) {
 			},
 			expected: &corev1.Container{
 				Name:  "thanos-sidecar",
-				Image: "thanosio/thanos:v0.17.2",
+				Image: "thanosio/thanos:v0.39.2",
 				Args: []string{
 					"sidecar",
 					"--prometheus.url=http://localhost:9090/.",
@@ -1611,7 +1611,7 @@ func TestBuildExternalLabels(t *testing.T) {
 					Thanos: &v1alpha1.ThanosSpec{
 						MonitorContainer: v1alpha1.MonitorContainer{
 							BaseImage: "thanosio/thanos",
-							Version:   "v0.17.2",
+							Version:   "v0.39.2",
 						},
 					},
 				},

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -563,7 +563,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			tm.Spec.PrometheusReloader = &v1alpha1.PrometheusReloaderSpec{
 				MonitorContainer: v1alpha1.MonitorContainer{
 					BaseImage: "quay.io/prometheus-operator/prometheus-config-reloader",
-					Version:   "v0.49.0",
+					Version:   "v0.85.0",
 				},
 			}
 			return nil

--- a/tests/e2e/util/image/image.go
+++ b/tests/e2e/util/image/image.go
@@ -41,7 +41,7 @@ const (
 	TiDBV7x5x3 = "v7.5.3"
 
 	PrometheusImage               = "prom/prometheus"
-	PrometheusVersion             = "v2.27.1"
+	PrometheusVersion             = "v3.5.0"
 	TiDBMonitorReloaderImage      = "pingcap/tidb-monitor-reloader"
 	TiDBMonitorReloaderVersion    = "v1.0.1"
 	TiDBMonitorInitializerImage   = "pingcap/tidb-monitor-initializer"
@@ -49,7 +49,7 @@ const (
 	GrafanaImage                  = "grafana/grafana"
 	GrafanaVersion                = "7.5.11"
 	ThanosImage                   = "thanosio/thanos"
-	ThanosVersion                 = "v0.17.2"
+	ThanosVersion                 = "v0.39.2"
 	DMV2Prev                      = TiDBLatestPrev
 	DMV2                          = TiDBLatest
 	TiDBNGMonitoringLatest        = TiDBLatest


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

Monitoring component versions are years out of date.

### What is changed and how does it work?

Update several monitoring component versions to current releases.
* Prometheus v2.27.1 -> v3.5.0
* Thanos v0.17.2 -> v0.39.2
* Prometheus Config Reloader v0.49.0 -> v0.85.0

This imports countless bug fixes and feature improvements. For example, Prometheus is over 2x as memory efficient as the previous versions, has support for native histograms, and full container memory/cpu limit awareness.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
