### PR TITLE
Add comment for passwordSecret

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2616,6 +2616,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
+<p>passwordSecret is the name of the Kubernetes secret that is used to initialize the cluster.</p>
 </td>
 </tr>
 <tr>
@@ -26000,6 +26001,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
+<p>passwordSecret is the name of the Kubernetes secret that is used to initialize the cluster.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -15457,8 +15457,9 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbInitializerSpec(ref common.ReferenceCa
 					},
 					"passwordSecret": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "passwordSecret is the name of the Kubernetes secret that is used to initialize the cluster.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"resources": {

--- a/pkg/apis/pingcap/v1alpha1/tidbinitializer_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbinitializer_types.go
@@ -85,6 +85,7 @@ type TidbInitializerSpec struct {
 	// +optional
 	InitSqlConfigMap *string `json:"initSqlConfigMap,omitempty"`
 
+	// passwordSecret is the name of the Kubernetes secret that is used to initialize the cluster.
 	// +optional
 	PasswordSecret *string `json:"passwordSecret,omitempty"`
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

https://github.com/pingcap/tidb-operator/blob/v1.6.3/docs/api-references/docs.md#tidbinitializer currently doesn't explain what this field does. 

I added a comment to make it more obvious that this isn't a literal secret, but the name of the Kubernetes secret that is used to initialize the cluster.

Note that the `tidb-secret` can store a list of secrets as demonstrated on https://docs.pingcap.com/tidb-in-kubernetes/stable/initialize-a-cluster/#set-initial-account-and-password so it is not restricted to the root account.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
