### PR TITLE
fix(updater): fix executor if outdated is unavailable

### DIFF
--- a/pkg/updater/executor.go
+++ b/pkg/updater/executor.go
@@ -131,7 +131,8 @@ func (ex *executor) Do(ctx context.Context) (bool, error) {
 				// => ex.update + ex.outdated >= ex.desired + ex.outdated
 				// => ex.update == ex.desired
 				// => ex.outdated != 0 (ex.update != ex.desired || ex.outdated != 0 in for loop condition)
-				if available <= minimum {
+				if available <= minimum && ex.unavailableUpdate > 0 {
+					// not all available are update
 					return true, nil
 				}
 

--- a/pkg/updater/executor_test.go
+++ b/pkg/updater/executor_test.go
@@ -849,6 +849,37 @@ func TestExecutor(t *testing.T) {
 			},
 			expectedWait: true,
 		},
+		{
+			desc:                "outdated is unavailable",
+			update:              1,
+			outdated:            1,
+			desired:             1,
+			unavailableUpdate:   0,
+			unavailableOutdated: 1,
+			maxSurge:            1,
+			maxUnavailable:      0,
+			expectedActions: []action{
+				actionScaleInOutdated,
+				actionCleanup,
+			},
+			expectedWait: false,
+		},
+		{
+			desc:                "2 outdated are both unavailable",
+			update:              2,
+			outdated:            2,
+			desired:             2,
+			unavailableUpdate:   0,
+			unavailableOutdated: 2,
+			maxSurge:            1,
+			maxUnavailable:      0,
+			expectedActions: []action{
+				actionScaleInOutdated,
+				actionScaleInOutdated,
+				actionCleanup,
+			},
+			expectedWait: false,
+		},
 	}
 
 	for i := range cases {


### PR DESCRIPTION
- wait forever if `update == desired` and there are still unavailable outdated