### PR TITLE
feat: check resource exists before CreateOrUpdate

### DIFF
--- a/pkg/controller/generic_control.go
+++ b/pkg/controller/generic_control.go
@@ -461,8 +461,11 @@ func (c *realGenericControlInterface) CreateOrUpdate(controller, obj client.Obje
 	}
 
 	// 1. try to create and see if there is any conflicts
-	err := c.client.Create(context.TODO(), desired)
-	if errors.IsAlreadyExists(err) {
+	exist, err := c.Exist(client.ObjectKeyFromObject(desired), obj)
+	if err != nil {
+		return nil, err
+	}
+	if exist {
 
 		// 2. object has already existed, merge our desired changes to it
 		existing, err := EmptyClone(obj)
@@ -498,6 +501,7 @@ func (c *realGenericControlInterface) CreateOrUpdate(controller, obj client.Obje
 	}
 
 	// object do not exist, return the creation result
+	err = c.client.Create(context.TODO(), desired)
 	if err == nil {
 		c.RecordControllerEvent("create", controller, desired, err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->
There will be a large number of 409 errors when confirming the existence of resources through creation operations in CreateOrUpdate
Modify the logic to confirm the existence of resources through Exist.

Closes #6234 #6322



### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
Fix the issue that instead of creating the resource in every sync cycle, first check whether it already exists because just use create-api will cause many 409 responses.
```
