### PR TITLE
test(e2e): support specifying max_execution_time when run workload

### DIFF
--- a/cmd/testing-workload/main.go
+++ b/cmd/testing-workload/main.go
@@ -44,6 +44,7 @@ var (
 	longTxnSleepSeconds int
 	maxLifeTimeSeconds  int
 	tiflashReplicas     int
+	maxExecutionTime    int
 
 	// Flags for import action
 	batchSize        int
@@ -72,6 +73,7 @@ const (
 	defaultSleepInterval       = 100
 	defaultLongTxnSleepSeconds = 10
 	defaultMaxLifeTimeSeconds  = 60
+	defaultMaxExecutionTime    = 2000
 
 	defaultBatchSize = 1000
 	defaultTotalRows = 500000
@@ -184,6 +186,7 @@ func parseFlag() {
 	flag.IntVar(&longTxnSleepSeconds, "long-txn-sleep", defaultLongTxnSleepSeconds, "how many seconds to sleep to simulate a long transaction")
 	flag.IntVar(&maxLifeTimeSeconds, "max-life-time", defaultMaxLifeTimeSeconds, "max lifetime in seconds")
 	flag.IntVar(&tiflashReplicas, "tiflash-replicas", 0, "replicas of tiflash")
+	flag.IntVar(&maxExecutionTime, "max-execution-time", defaultMaxExecutionTime, "max_execution_time of tidb")
 
 	// Flags for import action
 	flag.IntVar(&batchSize, "batch-size", defaultBatchSize, "batch size for import action")

--- a/cmd/testing-workload/workload.go
+++ b/cmd/testing-workload/workload.go
@@ -40,13 +40,13 @@ func Workload(ctx context.Context, db *sql.DB) error {
 	db.SetMaxOpenConns(maxConnections)
 	// Set these variable to avoid too long retry time in testing.
 	// Downtime may be short but default timeout is too long.
-	fmt.Println("try to set max_execution_time to 2000ms")
-	if _, err := db.Exec("set global max_execution_time = 2000;"); err != nil {
-		return fmt.Errorf("set max_execute_time failed: %w", err)
+	fmt.Printf("try to set max_execution_time to %dms\n", maxExecutionTime)
+	if _, err := db.Exec(fmt.Sprintf("set global max_execution_time = %d;", maxExecutionTime)); err != nil {
+		return fmt.Errorf("set max_execution_time failed: %w", err)
 	}
 	fmt.Println("try to set tidb_backoff_weight to 1")
 	if _, err := db.Exec("set global tidb_backoff_weight = 1;"); err != nil {
-		return fmt.Errorf("set max_execute_time failed: %w", err)
+		return fmt.Errorf("set tidb_backoff_weight failed: %w", err)
 	}
 
 	table := "test.e2e_test"

--- a/tests/e2e/framework/workload.go
+++ b/tests/e2e/framework/workload.go
@@ -174,6 +174,7 @@ func (w *Workload) MustRunWorkload(ctx context.Context, host string, opts ...wor
 		"--user", o.User,
 		"--password", o.Password,
 		"--max-connections", "30",
+		"--max-execution-time", strconv.Itoa(o.MaxExecutionTime),
 		"--tiflash-replicas", strconv.Itoa(o.TiFlashReplicas),
 		"--max-life-time", strconv.Itoa(o.MaxLifeTime),
 	}

--- a/tests/e2e/framework/workload/options.go
+++ b/tests/e2e/framework/workload/options.go
@@ -29,6 +29,10 @@ type Options struct {
 
 	RegionCount int
 
+	// MaxExecutionTime is max_execution_time of tidb in millisecond
+	// Default is 2000
+	MaxExecutionTime int
+
 	TiFlashReplicas int
 
 	// MaxLifeTime is max life time in seconds of sql connections
@@ -73,6 +77,12 @@ func RegionCount(count int) Option {
 	})
 }
 
+func MaxExecutionTime(ms int) Option {
+	return WithOption(func(opts *Options) {
+		opts.MaxExecutionTime = ms
+	})
+}
+
 func TiFlashReplicas(replicas int) Option {
 	return WithOption(func(opts *Options) {
 		opts.TiFlashReplicas = replicas
@@ -89,6 +99,8 @@ func DefaultOptions() *Options {
 	return &Options{
 		Port: 4000,
 		User: "root",
+
+		MaxExecutionTime: 2000,
 
 		RegionCount: 500,
 		MaxLifeTime: 60,


### PR DESCRIPTION
- support specifying max_execution_time when running workload