### PR TITLE
opt: improve wait TiKV leader transfer back even lost LeaderCountBeforeUpgrade

### DIFF
--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -941,6 +941,8 @@ func (m *tikvMemberManager) syncTiKVClusterStatus(tc *v1alpha1.TidbCluster, set 
 		}
 
 		if oldStore.LeaderCountBeforeUpgrade != nil {
+			// TODO: if we are using a cached version of oldStore, the LeaderCountBeforeUpgrade maybe lost
+			// we need to find a better way to handle it
 			status.LeaderCountBeforeUpgrade = oldStore.LeaderCountBeforeUpgrade
 		}
 

--- a/pkg/manager/member/utils.go
+++ b/pkg/manager/member/utils.go
@@ -557,6 +557,20 @@ func TiKVStoreIDFromStatus(tc *v1alpha1.TidbCluster, podName string) (uint64, er
 	return storeID, nil
 }
 
+func TiKVStoreAndIDFromStatus(tc *v1alpha1.TidbCluster, podName string) (v1alpha1.TiKVStore, uint64, error) {
+	store, err := TiKVStoreFromStatus(tc, podName)
+	if err != nil {
+		return v1alpha1.TiKVStore{}, 0, err
+	}
+
+	storeID, err := strconv.ParseUint(store.ID, 10, 64)
+	if err != nil {
+		return v1alpha1.TiKVStore{}, 0, err
+	}
+
+	return store, storeID, nil
+}
+
 func TiFlashStoreIDFromStatus(tc *v1alpha1.TidbCluster, podName string) (uint64, error) {
 	store, err := TiFlashStoreFromStatus(tc, podName)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

- `LeaderCountBeforeUpgrade` may lose in some cases, e.g.
  - `if oldStore.LeaderCountBeforeUpgrade != nil {` may be `false` if a stale cached version is used
  - `tc.Status = *status` may drop the `LeaderCountBeforeUpgrade` when conflict occured

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

- Add more logs about `LeaderCountBeforeUpgrade`
- Reset `LeaderCountBeforeUpgrade` if it lost in `evictLeaderBeforeUpgrade` when retrying

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
