### PR TITLE
fix(tikv): adjust timeout to get store in prestop hook

### DIFF
--- a/pkg/controllers/tikv/tasks/finalizer.go
+++ b/pkg/controllers/tikv/tasks/finalizer.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// for deleted store, we'll set grace period to the default
-	defaultGracePeriod = 30
+	// 30s for prestop hook and 30s for tikv
+	defaultGracePeriod = 60
 )
 
 // TaskFinalizerDel deletes sub-resources and remove the finalizer from the instance CR.


### PR DESCRIPTION
When the whole cluster is deleted, the default graceful terminating seconds(30s) are all wasted by getting store.

- adjust default terminationGracePeriod to 60s
- adjust default get store timeout to 15s
- limit retry times of getting leader count to 5