### PR TITLE
fix(cluster): fix deletion when pd addr is not updated

### DIFF
--- a/pkg/controllers/scheduler/builder.go
+++ b/pkg/controllers/scheduler/builder.go
@@ -31,10 +31,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster
 		common.TaskContextCluster[scope.Scheduler](state, r.Client),
-		// return if cluster's status is not updated
-		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		// if the cluster is deleting, del all subresources and remove the finalizer directly
+		task.IfBreak(common.CondClusterIsDeleting(state),
+			tasks.TaskFinalizerDel(state, r.Client),
+		),
+		// return if cluster's status is not updated
+		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 
 		// get info from pd
 		// tasks.TaskContextInfoFromPD(state, r.PDClientManager),

--- a/pkg/controllers/ticdc/builder.go
+++ b/pkg/controllers/ticdc/builder.go
@@ -31,10 +31,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster info, FinalizerDel will use it
 		common.TaskContextCluster[scope.TiCDC](state, r.Client),
+		// if it's paused just return
+		task.IfBreak(common.CondClusterIsPaused(state)),
+		// if the cluster is deleting, del all subresources and remove the finalizer directly
+		task.IfBreak(common.CondClusterIsDeleting(state),
+			tasks.TaskFinalizerDel(state, r.Client),
+		),
 		// return if cluster's status is not updated
 		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
-		// check whether it's paused
-		task.IfBreak(common.CondClusterIsPaused(state)),
 
 		task.IfBreak(common.CondObjectIsDeleting[scope.TiCDC](state),
 			tasks.TaskFinalizerDel(state, r.Client),

--- a/pkg/controllers/tidb/builder.go
+++ b/pkg/controllers/tidb/builder.go
@@ -35,10 +35,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster info, FinalizerDel will use it
 		common.TaskContextCluster[scope.TiDB](state, r.Client),
+		// if it's paused just return
+		task.IfBreak(common.CondClusterIsPaused(state)),
+		// if the cluster is deleting, del all subresources and remove the finalizer directly
+		task.IfBreak(common.CondClusterIsDeleting(state),
+			tasks.TaskFinalizerDel(state, r.Client),
+		),
 		// return if cluster's status is not updated
 		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
-		// check whether it's paused
-		task.IfBreak(common.CondClusterIsPaused(state)),
 
 		task.IfBreak(common.CondObjectIsDeleting[scope.TiDB](state),
 			tasks.TaskFinalizerDel(state, r.Client),

--- a/pkg/controllers/tiflash/builder.go
+++ b/pkg/controllers/tiflash/builder.go
@@ -32,8 +32,6 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster info, FinalizerDel will use it
 		common.TaskContextCluster[scope.TiFlash](state, r.Client),
-		// return if cluster's status is not updated
-		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 		// check whether it's paused
 		task.IfBreak(common.CondClusterIsPaused(state)),
 
@@ -41,6 +39,8 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		task.IfBreak(common.CondClusterIsDeleting(state),
 			tasks.TaskFinalizerDel(state, r.Client, r.TiFlashClientManager),
 		),
+		// return if cluster's status is not updated
+		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.TiFlash](state, r.Client),

--- a/pkg/controllers/tikv/builder.go
+++ b/pkg/controllers/tikv/builder.go
@@ -32,8 +32,6 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster info, FinalizerDel will use it
 		common.TaskContextCluster[scope.TiKV](state, r.Client),
-		// return if cluster's status is not updated
-		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 
 		// check whether it's paused
 		task.IfBreak(common.CondClusterIsPaused(state)),
@@ -42,6 +40,9 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		task.IfBreak(common.CondClusterIsDeleting(state),
 			tasks.TaskFinalizerDel(state, r.Client),
 		),
+
+		// return if cluster's status is not updated
+		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 
 		// if instance is not deleting but store is offlined
 		task.IfBreak(common.CondObjectIsNotDeletingButOfflined[scope.TiKV](state),

--- a/pkg/controllers/tiproxy/builder.go
+++ b/pkg/controllers/tiproxy/builder.go
@@ -33,10 +33,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster info, FinalizerDel will use it
 		common.TaskContextCluster[scope.TiProxy](state, r.Client),
+		// if it's paused just return
+		task.IfBreak(common.CondClusterIsPaused(state)),
+		// if the cluster is deleting, del all subresources and remove the finalizer directly
+		task.IfBreak(common.CondClusterIsDeleting(state),
+			tasks.TaskFinalizerDel(state, r.Client),
+		),
 		// return if cluster's status is not updated
 		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
-		// check whether it's paused
-		task.IfBreak(common.CondClusterIsPaused(state)),
 
 		task.IfBreak(common.CondObjectIsDeleting[scope.TiProxy](state),
 			tasks.TaskFinalizerDel(state, r.Client),

--- a/pkg/controllers/tso/builder.go
+++ b/pkg/controllers/tso/builder.go
@@ -31,10 +31,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get cluster
 		common.TaskContextCluster[scope.TSO](state, r.Client),
-		// return if cluster's status is not updated
-		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 		// if it's paused just return
 		task.IfBreak(common.CondClusterIsPaused(state)),
+		// if the cluster is deleting, del all subresources and remove the finalizer directly
+		task.IfBreak(common.CondClusterIsDeleting(state),
+			tasks.TaskFinalizerDel(state, r.Client),
+		),
+		// return if cluster's status is not updated
+		task.IfBreak(common.CondClusterPDAddrIsNotRegistered(state)),
 
 		// get info from pd
 		// tasks.TaskContextInfoFromPD(state, r.PDClientManager),


### PR DESCRIPTION
If pd addr is not updated, instances cannot be deleted even if the whole cluster is deleting.