### PR TITLE
fix(timanager): fix lost event issue

### DIFF
--- a/pkg/timanager/manager.go
+++ b/pkg/timanager/manager.go
@@ -69,6 +69,8 @@ type ManagerBuilder[Object client.Object, UnderlayClient, Client any] interface 
 	WithNewUnderlayClientFunc(f NewUnderlayClientFunc[Object, UnderlayClient]) ManagerBuilder[Object, UnderlayClient, Client]
 	WithNewClientFunc(f NewClientFunc[Object, UnderlayClient, Client]) ManagerBuilder[Object, UnderlayClient, Client]
 	WithNewPollerFunc(obj runtime.Object, f NewPollerFunc[UnderlayClient]) ManagerBuilder[Object, UnderlayClient, Client]
+	WithResyncPeriod(time.Duration) ManagerBuilder[Object, UnderlayClient, Client]
+
 	Build() Manager[Object, Client]
 }
 
@@ -77,6 +79,7 @@ type builder[Object client.Object, UnderlayClient, Client any] struct {
 	newUnderlayClientFunc NewUnderlayClientFunc[Object, UnderlayClient]
 	newClientFunc         NewClientFunc[Object, UnderlayClient, Client]
 	cacheKeysFunc         CacheKeysFunc[Object]
+	resyncPeriod          time.Duration
 
 	newPollerFuncMap map[reflect.Type]NewPollerFunc[UnderlayClient]
 }
@@ -122,6 +125,11 @@ func (b *builder[Object, UnderlayClient, Client]) WithNewPollerFunc(
 	return b
 }
 
+func (b *builder[Object, UnderlayClient, Client]) WithResyncPeriod(d time.Duration) ManagerBuilder[Object, UnderlayClient, Client] {
+	b.resyncPeriod = d
+	return b
+}
+
 func (b *builder[Object, UnderlayClient, Client]) Build() Manager[Object, Client] {
 	s := runtime.NewScheme()
 	if err := pdv1.Install(s); err != nil {
@@ -136,6 +144,7 @@ func (b *builder[Object, UnderlayClient, Client]) Build() Manager[Object, Client
 		cacheKeysFunc:         b.cacheKeysFunc,
 		newPollerFuncMap:      b.newPollerFuncMap,
 		sources:               map[reflect.Type][]EventSource{},
+		resyncPeriod:          b.resyncPeriod,
 	}
 }
 
@@ -151,6 +160,8 @@ type clientManager[Object client.Object, UnderlayClient, Client any] struct {
 
 	newPollerFuncMap map[reflect.Type]NewPollerFunc[UnderlayClient]
 	sources          map[reflect.Type][]EventSource
+
+	resyncPeriod time.Duration
 
 	ctx     context.Context
 	started bool
@@ -184,7 +195,7 @@ func (m *clientManager[Object, UnderlayClient, Client]) Register(obj Object) err
 
 	var f SharedInformerFactory[UnderlayClient]
 	if len(m.newPollerFuncMap) != 0 {
-		f = NewSharedInformerFactory(keys[0], m.logger, m.scheme, underlay, m.newPollerFuncMap, time.Hour)
+		f = NewSharedInformerFactory(keys[0], m.logger, m.scheme, underlay, m.newPollerFuncMap, m.resyncPeriod)
 	}
 
 	c, err := m.newClientFunc(obj, underlay, f)

--- a/pkg/timanager/pd/member.go
+++ b/pkg/timanager/pd/member.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -88,8 +89,9 @@ func (l *memberLister) List(ctx context.Context) (*pdv1.MemberList, error) {
 	for _, m := range info.Members {
 		mm[m.MemberId] = &pdv1.Member{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      m.Name,
-				Namespace: l.cluster,
+				Name:            m.Name,
+				Namespace:       l.cluster,
+				ResourceVersion: uuid.NewString(),
 			},
 			ClusterID:      strconv.FormatUint(info.Header.ClusterId, 10),
 			ID:             strconv.FormatUint(m.MemberId, 10),

--- a/pkg/timanager/pd/store.go
+++ b/pkg/timanager/pd/store.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -108,9 +109,10 @@ func (*storeLister) convert(cluster string, s *pdapi.StoreInfo) *pdv1.Store {
 
 	return &pdv1.Store{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    ls,
-			Name:      s.Store.Address,
-			Namespace: cluster,
+			Labels:          ls,
+			Name:            s.Store.Address,
+			Namespace:       cluster,
+			ResourceVersion: uuid.NewString(),
 		},
 		ID: strconv.FormatUint(s.Store.Id, 10),
 		// Address:             s.Store.Address,

--- a/pkg/timanager/pd/tso.go
+++ b/pkg/timanager/pd/tso.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -80,8 +81,9 @@ func (l *tsoMemberLister) List(ctx context.Context) (*pdv1.TSOMemberList, error)
 	for _, m := range info {
 		list.Items = append(list.Items, pdv1.TSOMember{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      m.Name,
-				Namespace: l.cluster,
+				Name:            m.Name,
+				Namespace:       l.cluster,
+				ResourceVersion: uuid.NewString(),
 			},
 			ServiceAddr:    m.ServiceAddr,
 			Version:        m.Version,

--- a/pkg/timanager/poller.go
+++ b/pkg/timanager/poller.go
@@ -17,12 +17,10 @@ package timanager
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -250,29 +248,5 @@ func (p *poller[T, PT, L]) sendEvent(ctx context.Context, e *watch.Event) {
 	case p.resultCh <- *e:
 		p.logger.Info("poller sent event", "type", e.Type, "object", e.Object, "kind", p.typeName)
 	case <-ctx.Done():
-	}
-}
-
-type deepEquality[T any, PT Object[T]] struct {
-	logger logr.Logger
-}
-
-func (e *deepEquality[T, PT]) Equal(preObj, curObj PT) bool {
-	if reflect.DeepEqual(preObj, curObj) {
-		return true
-	}
-
-	e.logger.Info("poll obj is changed",
-		"namespace", curObj.GetNamespace(),
-		"name", curObj.GetName(),
-		"diff", cmp.Diff(preObj, curObj),
-	)
-
-	return false
-}
-
-func NewDeepEquality[T any, PT Object[T]](logger logr.Logger) Equality[T, PT] {
-	return &deepEquality[T, PT]{
-		logger: logger,
 	}
 }

--- a/pkg/timanager/poller_test.go
+++ b/pkg/timanager/poller_test.go
@@ -66,6 +66,16 @@ func (l *FakeLister[T, PT]) UpdateItems(items []T) {
 	l.L.Items = items
 }
 
+func NewFakeLister[T any, PT Object[T]](items []T) *FakeLister[T, PT] {
+	l := &FakeLister[T, PT]{
+		L: List[T, PT]{},
+	}
+
+	l.UpdateItems(items)
+
+	return l
+}
+
 func TestPoller(t *testing.T) {
 	cases := []struct {
 		desc     string

--- a/pkg/utils/fake/fake.go
+++ b/pkg/utils/fake/fake.go
@@ -133,6 +133,14 @@ func UID[T any, PT Object[T]](uid string) ChangeFunc[T, PT] {
 	}
 }
 
+func ResourceVersion[T any, PT Object[T]](rv string) ChangeFunc[T, PT] {
+	return func(obj PT) PT {
+		obj.SetResourceVersion(rv)
+
+		return obj
+	}
+}
+
 func InstanceOwner[
 	S scope.Instance[F, T],
 	O any, PO Object[O],


### PR DESCRIPTION
Fix https://github.com/pingcap/tidb-operator/issues/6461

- reset default resync period to 0
- use uuid as resource version
- add ut to replay the issue

## What happens

- Informer will ignore events if rv is changed or `isSyncing` is true. See https://github.com/kubernetes/client-go/blob/v0.32.6/tools/cache/shared_informer.go#L657-L676 and https://github.com/kubernetes/client-go/blob/v0.32.6/tools/cache/shared_informer.go#L779-L795
- `isSyncing` will be false only when `shouldResync` is called. See https://github.com/kubernetes/client-go/blob/v0.32.6/tools/cache/shared_informer.go#L837
- `shouldResync` will be called in reflector at `resyncPeriod` later after informer is started.
- If `addListener` is called after informer is started, `shouldResync` will be false at first resync. And then `isSyncing` will be true at second resync.
- If resync period is 0. `isSyncing` will always be true.
