### PR TITLE
fix(e2e): change short time to long when import

### DIFF
--- a/tests/e2e/framework/workload.go
+++ b/tests/e2e/framework/workload.go
@@ -158,7 +158,7 @@ func (w *Workload) MustImportData(ctx context.Context, host string, opts ...work
 	w.f.Must(w.f.Client.Create(ctx, job))
 	w.jobs = append(w.jobs, job)
 
-	w.f.Must(waiter.WaitForJobComplete(ctx, w.f.Client, job, waiter.ShortTaskTimeout))
+	w.f.Must(waiter.WaitForJobComplete(ctx, w.f.Client, job, waiter.LongTaskTimeout))
 }
 
 func (w *Workload) MustRunWorkload(ctx context.Context, host string, opts ...workload.Option) (done chan struct{}) {


### PR DESCRIPTION
- 3min maybe not enough

See https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_tidb-operator/6631/pull-e2e/2004451792384954368