### PR TITLE
fix(br): return if object is not found

### DIFF
--- a/pkg/controllers/br/backup/controller.go
+++ b/pkg/controllers/br/backup/controller.go
@@ -99,6 +99,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	backup := &v1alpha1.Backup{}
 	if err := r.Client.Get(ctx, req.NamespacedName, backup); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	err := common.JobLifecycleManager.Sync(ctx, runtime.FromBackup(backup), r.Client)

--- a/pkg/controllers/br/restore/controller.go
+++ b/pkg/controllers/br/restore/controller.go
@@ -92,6 +92,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	restore := &v1alpha1.Restore{}
 	if err := r.Client.Get(ctx, req.NamespacedName, restore); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	err := common.JobLifecycleManager.Sync(ctx, runtime.FromRestore(restore), r.Client)


### PR DESCRIPTION
If object has been deleted, just stop the reconcile with no error.