### PR TITLE
feat: add ci script for e2e tests 

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -172,7 +172,7 @@ function install_dependencies() {
     echo "Docker daemon is responsive."
 }
 
-# Build binaries, e2e image, and load-side helpers (gocovmerge, codecov patch).
+# Build binaries, e2e image, and build-side helpers (gocovmerge, codecov patch).
 function build_and_prepare() {
     local githash image_tag
     ./hack/e2e-patch-codecov.sh >&2 || true
@@ -248,7 +248,11 @@ function run_tests() {
     local e2e_extra=()
     e2e_extra+=(--ginkgo.focus="${GINKGO_FOCUS}")
     [ -n "$GINKGO_SKIP" ] && e2e_extra+=(--ginkgo.skip="${GINKGO_SKIP}")
-    [ -n "$E2E_EXTRA_ARGS" ] && e2e_extra+=($E2E_EXTRA_ARGS)
+    if [ -n "$E2E_EXTRA_ARGS" ]; then
+        set -f
+        e2e_extra+=($E2E_EXTRA_ARGS)
+        set +f
+    fi
 
     timeout "${TEST_TIMEOUT}" env \
         E2E=y \


### PR DESCRIPTION
add run-e2e-kind.sh script for e2e kind test 
ref: https://github.com/PingCAP-QE/ci/pull/4165
test pr: https://github.com/pingcap/tidb-operator/pull/6702
test result(Take pull-e2e-kind-tngm as an example. https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_tidb-operator/6702/pull-e2e-kind-tngm/2026663457146802176)：

<img width="1262" height="419" alt="image" src="https://github.com/user-attachments/assets/96292bb1-895a-48f7-8d37-8b2be609949d" />

<img width="1480" height="842" alt="image" src="https://github.com/user-attachments/assets/d79eb2e3-020b-4634-af37-fa690aa1fdbb" />


