### PR TITLE
tici: fix lost common prefix when apply config

### DIFF
--- a/pkg/manager/member/tici_member_manager.go
+++ b/pkg/manager/member/tici_member_manager.go
@@ -715,10 +715,11 @@ access-key = "%s"
 secret-key = "%s"
 use-path-style = %t
 bucket = "%s"
+prefix = "%s"
 
 [shard]
 max-size = "128MB"
-`, tidbHost, tidbPort, pdAddr, s3.Endpoint, s3.Region, s3.AccessKey, s3.SecretKey, s3.UsePathStyle, s3.Bucket)
+`, tidbHost, tidbPort, pdAddr, s3.Endpoint, s3.Region, s3.AccessKey, s3.SecretKey, s3.UsePathStyle, s3.Bucket, s3.Prefix)
 	if tc.Spec.TiCI != nil && tc.Spec.TiCI.Meta != nil {
 		return appendTiCICustomConfig(baseConfig, tc.Spec.TiCI.Meta.Config)
 	}
@@ -742,7 +743,8 @@ access-key = "%s"
 secret-key = "%s"
 use-path-style = %t
 bucket = "%s"
-`, pdAddr, s3.Endpoint, s3.Region, s3.AccessKey, s3.SecretKey, s3.UsePathStyle, s3.Bucket)
+prefix = "%s"
+`, pdAddr, s3.Endpoint, s3.Region, s3.AccessKey, s3.SecretKey, s3.UsePathStyle, s3.Bucket, s3.Prefix)
 	if tc.Spec.TiCI != nil && tc.Spec.TiCI.Worker != nil {
 		return appendTiCICustomConfig(baseConfig, tc.Spec.TiCI.Worker.Config)
 	}

--- a/pkg/manager/member/tici_member_manager_test.go
+++ b/pkg/manager/member/tici_member_manager_test.go
@@ -81,6 +81,35 @@ data-dir = "/data/tici-meta"`
 	}
 }
 
+func TestBuildTiCIConfigIncludesS3Prefix(t *testing.T) {
+	tc := newTidbClusterForTiCIConfig()
+	tc.Spec.TiCI.S3.Prefix = "custom_prefix"
+
+	workerCfg, err := buildTiCIWorkerConfig(tc)
+	if err != nil {
+		t.Fatalf("build worker config failed: %v", err)
+	}
+	assertS3Prefix(t, workerCfg, "worker", "custom_prefix")
+
+	metaCfg, err := buildTiCIMetaConfig(tc)
+	if err != nil {
+		t.Fatalf("build meta config failed: %v", err)
+	}
+	assertS3Prefix(t, metaCfg, "meta", "custom_prefix")
+}
+
+func assertS3Prefix(t *testing.T, cfg, component, expected string) {
+	t.Helper()
+	wrapper := tcconfig.New(map[string]interface{}{})
+	if err := wrapper.UnmarshalTOML([]byte(cfg)); err != nil {
+		t.Fatalf("%s config should be valid TOML, got err: %v, config: %s", component, err, cfg)
+	}
+	prefix := wrapper.Get("s3.prefix")
+	if prefix == nil || prefix.MustString() != expected {
+		t.Fatalf("%s config should include s3.prefix=%q, got: %s", component, expected, cfg)
+	}
+}
+
 func TestAppendTiCICustomConfig(t *testing.T) {
 	base := "[server]\npd-addr = \"x\"\n"
 


### PR DESCRIPTION
## Summary

Fix TiCI config generation to correctly include s3.prefix for both meta and worker components. Previously, the generated TOML contained a prefix = "%s" placeholder but the fmt.Sprintf arguments did not include tc.Spec.TiCI.S3.Prefix, which could lead to missing/invalid s3.prefix in the rendered config.  ￼

This PR also adds a unit test to ensure s3.prefix is present and the generated config is valid TOML.

## What’s Changed

#### Code changes
	•	Include s3.Prefix in config rendering
	•	Update the fmt.Sprintf argument lists so the generated TOML uses tc.Spec.TiCI.S3.Prefix for the prefix = "%s" field in:
	•	buildTiCIMetaConfig(...)
	•	buildTiCIWorkerConfig(...)  ￼

#### Tests
	•	Add TestBuildTiCIConfigIncludesS3Prefix