### PR TITLE
tici-meta: remove default shard max-size

### DIFF
--- a/pkg/manager/member/tici_member_manager.go
+++ b/pkg/manager/member/tici_member_manager.go
@@ -716,9 +716,6 @@ secret-key = "%s"
 use-path-style = %t
 bucket = "%s"
 prefix = "%s"
-
-[shard]
-max-size = "128MB"
 `, tidbHost, tidbPort, pdAddr, s3.Endpoint, s3.Region, s3.AccessKey, s3.SecretKey, s3.UsePathStyle, s3.Bucket, s3.Prefix)
 	if tc.Spec.TiCI != nil && tc.Spec.TiCI.Meta != nil {
 		return appendTiCICustomConfig(baseConfig, tc.Spec.TiCI.Meta.Config)

--- a/pkg/manager/member/tici_member_manager_test.go
+++ b/pkg/manager/member/tici_member_manager_test.go
@@ -72,9 +72,6 @@ data-dir = "/data/tici-meta"`
 	if dsns == nil || len(dsns.MustStringSlice()) == 0 {
 		t.Fatalf("meta config should include generated tidb-server section, got: %s", cfg)
 	}
-	if wrapper.Get("shard.max-size") == nil {
-		t.Fatalf("meta config should include generated shard section, got: %s", cfg)
-	}
 	dataDir := wrapper.Get("storage.data-dir")
 	if dataDir == nil || dataDir.MustString() != "/data/tici-meta" {
 		t.Fatalf("meta config should merge custom storage.data-dir, got: %s", cfg)


### PR DESCRIPTION
## What
- remove default `[shard] max-size = "128MB"` from generated tici-meta config
- update related unit test accordingly

## Test
- go test ./pkg/manager/member -run 'TestBuildTiCI(MetaConfigWithCustomConfig|ConfigIncludesS3Prefix|WorkerConfigWithCustomConfig)$'