### PR TITLE
monitor: add fallback scrape protocol for tiflash jobs

### DIFF
--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -38,6 +38,9 @@ const (
 	dmMaster                   = "dm-master"
 	ticiMetaPattern            = "tici-meta"
 	ticiWorkerPattern          = "tici-worker"
+	// Prometheus 3 requires either a valid Content-Type from target metrics endpoints
+	// or an explicit fallback protocol.
+	fallbackScrapeProtocol = "PrometheusText0.0.4"
 )
 
 var (
@@ -329,6 +332,12 @@ func scrapeJob(jobName string, componentPattern string, cmodel *MonitorConfigMod
 			}},
 			{Key: "tls_config", Value: tlsConfigRelabelConfig},
 		}
+		if shouldSetFallbackScrapeProtocol(jobName) {
+			scrapeConfig = append(scrapeConfig, yaml.MapItem{
+				Key:   "fallback_scrape_protocol",
+				Value: fallbackScrapeProtocol,
+			})
+		}
 
 		relabelConfigs := []yaml.MapSlice{}
 		relabelConfigs = append(relabelConfigs, yaml.MapSlice{
@@ -445,6 +454,15 @@ func scrapeJob(jobName string, componentPattern string, cmodel *MonitorConfigMod
 	}
 	return scrapeJobs
 
+}
+
+func shouldSetFallbackScrapeProtocol(jobName string) bool {
+	switch jobName {
+	case "tiflash", "tiflash-proxy":
+		return true
+	default:
+		return false
+	}
 }
 
 func isDMJob(jobName string) bool {

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -527,6 +527,7 @@ scrape_configs:
       - ns1
   tls_config:
     insecure_skip_verify: true
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance
@@ -600,6 +601,7 @@ scrape_configs:
       - ns1
   tls_config:
     insecure_skip_verify: true
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance
@@ -1790,6 +1792,7 @@ scrape_configs:
       - ns1
   tls_config:
     insecure_skip_verify: true
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance
@@ -1863,6 +1866,7 @@ scrape_configs:
       - ns1
   tls_config:
     insecure_skip_verify: true
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance
@@ -3061,6 +3065,7 @@ scrape_configs:
     ca_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_ca.crt
     cert_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_tls.crt
     key_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_tls.key
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance
@@ -3136,6 +3141,7 @@ scrape_configs:
     ca_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_ca.crt
     cert_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_tls.crt
     key_file: /var/lib/cluster-assets-tls/secret_ns1_target-cluster-client-secret_tls.key
+  fallback_scrape_protocol: PrometheusText0.0.4
   relabel_configs:
   - source_labels:
     - __meta_kubernetes_pod_label_app_kubernetes_io_instance


### PR DESCRIPTION
## Background

When monitoring TiCI in a TiDB cluster, `tici-meta`/`tici-worker` dashboards had data, but `tici-reader` stayed empty.

After debugging in a real k8s environment:

- `tici_reader_*` metrics are emitted by TiFlash (`tc-tiflash-*:8234/metrics`) and can be fetched locally from TiFlash pods.
- Prometheus target status for `tiflash`/`tiflash-proxy` jobs was `down` with error:
  - `non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target`
- As a result, TiFlash-side metrics (including `tici_reader_*`) were not ingested into Prometheus.

This behavior is triggered by stricter scrape protocol handling in Prometheus 3 when target `Content-Type` is missing/blank.

## Root Cause

Generated scrape configs for TiFlash jobs did not set `fallback_scrape_protocol`, so Prometheus 3 rejected these targets when response headers were non-compliant.

## Fix

Add fallback scrape protocol for TiFlash-related scrape jobs generated by operator:

- `tiflash`
- `tiflash-proxy`

Specifically, inject the following into those jobs:

```yaml
fallback_scrape_protocol: PrometheusText0.0.4
```

## Code Changes

- `pkg/monitor/monitor/template.go`
  - Add `fallbackScrapeProtocol` constant.
  - Add helper `shouldSetFallbackScrapeProtocol(jobName string) bool`.
  - Append `fallback_scrape_protocol` to scrape config for `tiflash` and `tiflash-proxy` jobs.
- `pkg/monitor/monitor/template_test.go`
  - Update expected rendered prometheus config in existing test cases (normal / rule switch / TLS enabled) to include the new field for TiFlash jobs.

## Compatibility / Scope

- No behavior change for non-TiFlash jobs.
- Only adds an explicit fallback parser for TiFlash jobs, preserving existing scrape labels and addressing logic.

## Verification

Local tests:

- `go test ./pkg/monitor/monitor`
- `go test ./pkg/monitor/...`

Runtime verification in k8s (manual):

- Before fix: `tiflash`/`tiflash-proxy` targets `down` with missing `fallback_scrape_protocol` error.
- After fix: targets recover and `tici_reader_shard_count` is queryable from Prometheus.
