### PR TITLE
monitor: gate tiflash fallback scrape protocol on prom v3

### DIFF
--- a/pkg/monitor/monitor/template.go
+++ b/pkg/monitor/monitor/template.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"strings"
 
+	semver "github.com/Masterminds/semver"
 	"github.com/pingcap/tidb-operator/pkg/util"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
@@ -82,6 +83,7 @@ type MonitorConfigModel struct {
 	AlertmanagerURL           string
 	ClusterInfos              []ClusterRegexInfo
 	DMClusterInfos            []ClusterRegexInfo
+	PrometheusVersion         string
 	ExternalLabels            model.LabelSet
 	RemoteWriteCfg            *yaml.MapItem
 	EnableAlertRules          bool
@@ -332,7 +334,7 @@ func scrapeJob(jobName string, componentPattern string, cmodel *MonitorConfigMod
 			}},
 			{Key: "tls_config", Value: tlsConfigRelabelConfig},
 		}
-		if shouldSetFallbackScrapeProtocol(jobName) {
+		if shouldSetFallbackScrapeProtocol(jobName, cmodel.PrometheusVersion) {
 			scrapeConfig = append(scrapeConfig, yaml.MapItem{
 				Key:   "fallback_scrape_protocol",
 				Value: fallbackScrapeProtocol,
@@ -456,10 +458,14 @@ func scrapeJob(jobName string, componentPattern string, cmodel *MonitorConfigMod
 
 }
 
-func shouldSetFallbackScrapeProtocol(jobName string) bool {
+func shouldSetFallbackScrapeProtocol(jobName string, prometheusVersion string) bool {
 	switch jobName {
 	case "tiflash", "tiflash-proxy":
-		return true
+		version, err := semver.NewVersion(prometheusVersion)
+		if err != nil {
+			return false
+		}
+		return version.Major() >= 3
 	default:
 		return false
 	}

--- a/pkg/monitor/monitor/template_test.go
+++ b/pkg/monitor/monitor/template_test.go
@@ -1276,7 +1276,8 @@ rule_files:
 		DMClusterInfos: []ClusterRegexInfo{
 			{Name: "target", Namespace: "ns1"},
 		},
-		AlertmanagerURL: "alert-url",
+		PrometheusVersion: "v3.0.0",
+		AlertmanagerURL:   "alert-url",
 		RemoteWriteCfg: &yaml.MapItem{
 			Key: "remote_write",
 			Value: []yaml.MapSlice{
@@ -2536,6 +2537,7 @@ rule_files:
 		DMClusterInfos: []ClusterRegexInfo{
 			{Name: "target", Namespace: "ns1"},
 		},
+		PrometheusVersion:         "v3.0.0",
 		EnableAlertRules:          true,
 		EnableExternalRuleConfigs: true,
 		RemoteWriteCfg: &yaml.MapItem{
@@ -3809,6 +3811,7 @@ scrape_configs:
 		DMClusterInfos: []ClusterRegexInfo{
 			{Name: "target", Namespace: "ns1", enableTLS: true},
 		},
+		PrometheusVersion: "v3.0.0",
 	}
 	content, err := RenderPrometheusConfig(model)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -3836,6 +3839,17 @@ target_label: __address__
 	bs, err := yaml.Marshal(c)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(string(bs)).Should(Equal(expectedContent))
+}
+
+func TestShouldSetFallbackScrapeProtocol(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(shouldSetFallbackScrapeProtocol("tiflash", "v2.55.1")).To(BeFalse())
+	g.Expect(shouldSetFallbackScrapeProtocol("tiflash-proxy", "v2.55.1")).To(BeFalse())
+	g.Expect(shouldSetFallbackScrapeProtocol("tiflash", "v3.0.0")).To(BeTrue())
+	g.Expect(shouldSetFallbackScrapeProtocol("tiflash-proxy", "v3.0.0-rc.0")).To(BeTrue())
+	g.Expect(shouldSetFallbackScrapeProtocol("pd", "v3.0.0")).To(BeFalse())
+	g.Expect(shouldSetFallbackScrapeProtocol("tiflash", "")).To(BeFalse())
 }
 
 func TestMultipleClusterConfigRender(t *testing.T) {

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -151,12 +151,13 @@ func getAlertManagerRulesVersion(monitor *v1alpha1.TidbMonitor) string {
 // If the namespace in ClusterRef is empty, we would set the TidbMonitor's namespace in the default
 func getPromConfigMap(monitor *v1alpha1.TidbMonitor, monitorClusterInfos []ClusterRegexInfo, dmClusterInfos []ClusterRegexInfo, shard int32, store *Store) (*core.ConfigMap, error) {
 	model := &MonitorConfigModel{
-		AlertmanagerURL:  "",
-		ClusterInfos:     monitorClusterInfos,
-		DMClusterInfos:   dmClusterInfos,
-		ExternalLabels:   buildExternalLabels(monitor),
-		EnableAlertRules: monitor.Spec.EnableAlertRules,
-		shards:           shard,
+		AlertmanagerURL:   "",
+		ClusterInfos:      monitorClusterInfos,
+		DMClusterInfos:    dmClusterInfos,
+		PrometheusVersion: monitor.Spec.Prometheus.Version,
+		ExternalLabels:    buildExternalLabels(monitor),
+		EnableAlertRules:  monitor.Spec.EnableAlertRules,
+		shards:            shard,
 	}
 
 	if monitor.Spec.AlertmanagerURL != nil {


### PR DESCRIPTION
## What is changed

This PR gates `fallback_scrape_protocol` for TiFlash scrape jobs on the configured Prometheus major version.

Before this change, tidb-operator always rendered:

- `fallback_scrape_protocol: PrometheusText0.0.4`

for:

- `tiflash`
- `tiflash-proxy`

That fixes Prometheus 3 scraping TiFlash metrics endpoints which do not return a compliant `Content-Type`, but it also makes Prometheus 2 fail to load the generated config because `fallback_scrape_protocol` is not a valid `scrape_config` field there.

With this change, tidb-operator only emits `fallback_scrape_protocol` when:

- the scrape job is `tiflash` or `tiflash-proxy`, and
- `spec.prometheus.version` is parseable, and
- the Prometheus major version is `>= 3`

For Prometheus 2, the field is omitted, so the generated config remains valid.

## Why this is needed

After the previous TiFlash fallback fix, users deploying monitor with a Prometheus 2 image can hit startup failure like:

```text
level=error ts=... caller=main.go:355 msg="Error loading config (--config.file=/etc/prometheus/config_out/prometheus.yml)" err="parsing YAML file /etc/prometheus/config_out/prometheus.yml: yaml: unmarshal errors:
  line 457: field fallback_scrape_protocol not found in type config.ScrapeConfig
  line 531: field fallback_scrape_protocol not found in type config.ScrapeConfig"
```

So the previous fix solved Prometheus 3 compatibility but regressed Prometheus 2 compatibility.

The correct behavior is version-gated rendering:

- Prometheus 3 needs the fallback protocol for TiFlash scrape targets that return blank `Content-Type`
- Prometheus 2 must not receive this config field at all

## Implementation notes

- Pass `monitor.Spec.Prometheus.Version` into the monitor config rendering model
- Gate `fallback_scrape_protocol` in `scrapeJob(...)`
- Use a strict semver parse and only enable the field when the parsed major version is `>= 3`
- Treat unknown or non-parseable version strings conservatively by omitting the field

## Tests

- updated existing monitor config snapshot tests to explicitly use Prometheus v3 where the fallback field is expected
- added unit coverage for:
  - Prometheus v2 -> disabled
  - Prometheus v3 -> enabled
  - non-TiFlash jobs -> disabled
  - empty / invalid version -> disabled

## Compatibility impact

- Prometheus v2 monitor deployments become valid again
- Prometheus v3 keeps the TiFlash scrape fallback needed for stricter target content-type handling
