### PR TITLE
Delete TiBR StatefulSet PVCs automatically

### DIFF
--- a/pkg/controllers/br/tibr/tasks/sts.go
+++ b/pkg/controllers/br/tibr/tasks/sts.go
@@ -88,6 +88,10 @@ func assembleSts(rtx *ReconcileContext) *appsv1.StatefulSet {
 	volumeClaim := assembleVolumeClaimIfNeeded(tibr)
 	if volumeClaim != nil {
 		sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{*volumeClaim}
+		sts.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+		}
 	}
 
 	return sts

--- a/pkg/controllers/br/tibr/tasks/sts_test.go
+++ b/pkg/controllers/br/tibr/tasks/sts_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,6 +187,14 @@ func TestAssembleSts(t *testing.T) {
 			assert.Equal(t, tc.expectExtraAnnotations, sts.Spec.Template.Annotations)
 
 			assert.Len(t, sts.Spec.VolumeClaimTemplates, tc.expectPVCCount)
+			if tc.expectPVCCount > 0 {
+				assert.Equal(t, &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				}, sts.Spec.PersistentVolumeClaimRetentionPolicy)
+			} else {
+				assert.Nil(t, sts.Spec.PersistentVolumeClaimRetentionPolicy)
+			}
 
 			var containerNames []string
 			for _, c := range sts.Spec.Template.Spec.Containers {


### PR DESCRIPTION
## What changed

Set the TiBR StatefulSet PVC retention policy to delete PVCs created from `volumeClaimTemplates` when the StatefulSet is deleted or scaled down.

## Why it changed

TiBR PVCs created by the StatefulSet were not being removed automatically when the StatefulSet was deleted. This leaves storage behind after cleanup.

## Root cause

The assembled StatefulSet did not set `persistentVolumeClaimRetentionPolicy`, so Kubernetes retained PVCs from the StatefulSet's `volumeClaimTemplates`.

## Impact

TiBR StatefulSet PVCs are now cleaned up automatically during StatefulSet deletion and scale-down.

## Validation

- `env GOROOT=/Users/caiyuanrui/golang/goroot GOTOOLCHAIN=local GOCACHE=/tmp/go-build-cache /Users/caiyuanrui/golang/goroot/bin/go test ./pkg/controllers/br/tibr/tasks -run TestAssembleSts -count=1`
