### PR TITLE
fix: disable SA token automount for tidbinitializer

### DIFF
--- a/pkg/manager/member/tidb_init_manager.go
+++ b/pkg/manager/member/tidb_init_manager.go
@@ -352,8 +352,9 @@ func (m *tidbInitManager) makeTiDBInitJob(ti *v1alpha1.TidbInitializer) (*batchv
 			Annotations: util.CopyStringMap(ti.Annotations),
 		},
 		Spec: corev1.PodSpec{
-			ImagePullSecrets: ti.Spec.ImagePullSecrets,
-			SecurityContext:  ti.Spec.PodSecurityContext,
+			ImagePullSecrets:             ti.Spec.ImagePullSecrets,
+			SecurityContext:              ti.Spec.PodSecurityContext,
+			AutomountServiceAccountToken: pointer.BoolPtr(false),
 			InitContainers: []corev1.Container{
 				{
 					Name:    initContainerName,

--- a/pkg/manager/member/tidb_init_manager_test.go
+++ b/pkg/manager/member/tidb_init_manager_test.go
@@ -128,6 +128,21 @@ func TestTiDBInitManagerSync(t *testing.T) {
 	}
 }
 
+func TestMakeTiDBInitJobDisablesServiceAccountTokenAutomount(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tim, _, indexers := newFakeTiDBInitManager()
+	ti := newTidbInitializerForTiDB()
+	tc := newTidbClusterForTiDB()
+
+	err := indexers.tc.Add(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	job, err := tim.makeTiDBInitJob(ti)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(job.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+	g.Expect(*job.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+}
+
 func newFakeTiDBInitManager() (*tidbInitManager, *tidbMemberManager, *fakeIndexers) {
 	tmm, _, _, indexers := newFakeTiDBMemberManager()
 	indexers.job = tmm.deps.KubeInformerFactory.Batch().V1().Jobs().Informer().GetIndexer()


### PR DESCRIPTION
## Summary
- set `automountServiceAccountToken: false` explicitly on the generated TidbInitializer job pod
- add a unit test to lock in the pod spec behavior

## Test Plan
- `go test ./pkg/manager/member -run 'TestTiDBInitManagerSync|TestMakeTiDBInitJobDisablesServiceAccountTokenAutomount' -count=1`
- `git diff --check`

This follows up on the FedRAMP/Gatekeeper requirement discussed in #6815.