### PR TITLE
feat: support of PodDisruptionBudgets

### DIFF
--- a/api/core/v1alpha1/pd_types.go
+++ b/api/core/v1alpha1/pd_types.go
@@ -97,6 +97,7 @@ type PDList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -238,6 +239,12 @@ type PDSpec struct {
 	// A same pd cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// PDTemplateSpec embedded some fields managed by PDGroup
 	PDTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/resourcemanager_types.go
+++ b/api/core/v1alpha1/resourcemanager_types.go
@@ -80,6 +80,7 @@ type ResourceManagerList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=instance
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Synced",type=string,JSONPath=`.status.conditions[?(@.type=="Synced")].status`
@@ -196,6 +197,12 @@ type ResourceManagerSpec struct {
 	// A same ResourceManager cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// ResourceManagerTemplateSpec embedded some fields managed by ResourceManagerGroup
 	ResourceManagerTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/router_types.go
+++ b/api/core/v1alpha1/router_types.go
@@ -79,6 +79,7 @@ type RouterList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -193,6 +194,12 @@ type RouterSpec struct {
 	// A same Router cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// RouterTemplateSpec embedded some fields managed by RouterGroup
 	RouterTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/scheduler_types.go
+++ b/api/core/v1alpha1/scheduler_types.go
@@ -85,6 +85,7 @@ type SchedulerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -209,6 +210,12 @@ type SchedulerSpec struct {
 	// A same Scheduler cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// SchedulerTemplateSpec embedded some fields managed by SchedulerGroup
 	SchedulerTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/scheduling_types.go
+++ b/api/core/v1alpha1/scheduling_types.go
@@ -79,6 +79,7 @@ type SchedulingList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -194,6 +195,12 @@ type SchedulingSpec struct {
 	// A same Scheduling cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// SchedulingTemplateSpec embedded some fields managed by SchedulingGroup
 	SchedulingTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/ticdc_types.go
+++ b/api/core/v1alpha1/ticdc_types.go
@@ -83,6 +83,7 @@ type TiCDCList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -217,6 +218,12 @@ type TiCDCSpec struct {
 	// A same TiCDC cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// TiCDCTemplateSpec embedded some fields managed by TiCDCGroup
 	TiCDCTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/tidb_types.go
+++ b/api/core/v1alpha1/tidb_types.go
@@ -102,6 +102,7 @@ type TiDBList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -339,6 +340,12 @@ type TiDBSpec struct {
 	// A same TiDB cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// TiDBTemplateSpec embedded some fields managed by TiDBGroup.
 	// +kubebuilder:validation:XValidation:rule="!has(self.mode) || self.mode == 'Normal' || !has(self.keyspace) || self.keyspace.size() == 0",message="keyspace cannot be set if mode is StandBy"

--- a/api/core/v1alpha1/tiflash_types.go
+++ b/api/core/v1alpha1/tiflash_types.go
@@ -93,6 +93,7 @@ type TiFlashList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -240,11 +241,18 @@ type TiFlashSpec struct {
 	// +optional
 	Offline *bool `json:"offline,omitempty"`
 
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
+
 	// TiFlashTemplateSpec embedded some fields managed by TiFlashGroup
 	TiFlashTemplateSpec `json:",inline"`
 }
 
 type TiFlashStatus struct {
 	CommonStatus `json:",inline"`
-	StoreStatus  `json:",inline"`
+
+	StoreStatus `json:",inline"`
 }

--- a/api/core/v1alpha1/tikv_types.go
+++ b/api/core/v1alpha1/tikv_types.go
@@ -118,6 +118,7 @@ type TiKVList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -279,11 +280,17 @@ type TiKVSpec struct {
 	// +optional
 	Offline *bool `json:"offline,omitempty"`
 
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
+
 	// TiKVTemplateSpec embedded some fields managed by TiKVGroup
 	TiKVTemplateSpec `json:",inline"`
 }
 
 type TiKVStatus struct {
 	CommonStatus `json:",inline"`
-	StoreStatus  `json:",inline"`
+	StoreStatus `json:",inline"`
 }

--- a/api/core/v1alpha1/tikv_worker_types.go
+++ b/api/core/v1alpha1/tikv_worker_types.go
@@ -88,6 +88,7 @@ type TiKVWorkerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -194,6 +195,12 @@ type TiKVWorkerSpec struct {
 	// A same tikv-worker cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// TiKVWorkerTemplateSpec embeded some fields managed by TiKVWorkerGroup.
 	TiKVWorkerTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/tiproxy_types.go
+++ b/api/core/v1alpha1/tiproxy_types.go
@@ -89,6 +89,7 @@ type TiProxyList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -276,6 +277,12 @@ type TiProxySpec struct {
 	// A same tiproxy cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// TiProxyTemplateSpec embeded some fields managed by TiProxyGroup.
 	TiProxyTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/tso_types.go
+++ b/api/core/v1alpha1/tso_types.go
@@ -79,6 +79,7 @@ type TSOList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories=instance
 // +kubebuilder:selectablefield:JSONPath=`.spec.cluster.name`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster.name`
@@ -192,6 +193,12 @@ type TSOSpec struct {
 	// A same tso cluster will use a same subdomain
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="subdomain is immutable"
 	Subdomain string `json:"subdomain"`
+
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1
+	// +default:value=1
+	// +optional
+	Replicas *int32 `json:"replicas"`
 
 	// TSOTemplateSpec embedded some fields managed by TSOGroup
 	TSOTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -765,6 +765,11 @@ func (in *PDSpec) DeepCopyInto(out *PDSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.PDTemplateSpec.DeepCopyInto(&out.PDTemplateSpec)
 	return
 }
@@ -1149,6 +1154,11 @@ func (in *ResourceManagerSpec) DeepCopyInto(out *ResourceManagerSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.ResourceManagerTemplateSpec.DeepCopyInto(&out.ResourceManagerTemplateSpec)
 	return
 }
@@ -1498,6 +1508,11 @@ func (in *RouterSpec) DeepCopyInto(out *RouterSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
 	}
 	in.RouterTemplateSpec.DeepCopyInto(&out.RouterTemplateSpec)
 	return
@@ -1912,6 +1927,11 @@ func (in *SchedulerSpec) DeepCopyInto(out *SchedulerSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.SchedulerTemplateSpec.DeepCopyInto(&out.SchedulerTemplateSpec)
 	return
 }
@@ -2235,6 +2255,11 @@ func (in *SchedulingSpec) DeepCopyInto(out *SchedulingSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
 	}
 	in.SchedulingTemplateSpec.DeepCopyInto(&out.SchedulingTemplateSpec)
 	return
@@ -2672,6 +2697,11 @@ func (in *TSOSpec) DeepCopyInto(out *TSOSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.TSOTemplateSpec.DeepCopyInto(&out.TSOTemplateSpec)
 	return
 }
@@ -3016,6 +3046,11 @@ func (in *TiCDCSpec) DeepCopyInto(out *TiCDCSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
 	}
 	in.TiCDCTemplateSpec.DeepCopyInto(&out.TiCDCTemplateSpec)
 	return
@@ -3524,6 +3559,11 @@ func (in *TiDBSpec) DeepCopyInto(out *TiDBSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.TiDBTemplateSpec.DeepCopyInto(&out.TiDBTemplateSpec)
 	return
 }
@@ -3930,6 +3970,11 @@ func (in *TiFlashSpec) DeepCopyInto(out *TiFlashSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.TiFlashTemplateSpec.DeepCopyInto(&out.TiFlashTemplateSpec)
 	return
 }
@@ -4325,6 +4370,11 @@ func (in *TiKVSpec) DeepCopyInto(out *TiKVSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.TiKVTemplateSpec.DeepCopyInto(&out.TiKVTemplateSpec)
 	return
 }
@@ -4659,6 +4709,11 @@ func (in *TiKVWorkerSpec) DeepCopyInto(out *TiKVWorkerSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
 	}
 	in.TiKVWorkerTemplateSpec.DeepCopyInto(&out.TiKVWorkerTemplateSpec)
 	return
@@ -5084,6 +5139,11 @@ func (in *TiProxySpec) DeepCopyInto(out *TiProxySpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
 	}
 	in.TiProxyTemplateSpec.DeepCopyInto(&out.TiProxyTemplateSpec)
 	return

--- a/manifests/crd/core.pingcap.com_pds.yaml
+++ b/manifests/crd/core.pingcap.com_pds.yaml
@@ -8333,6 +8333,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8638,4 +8644,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_resourcemanagers.yaml
+++ b/manifests/crd/core.pingcap.com_resourcemanagers.yaml
@@ -8321,6 +8321,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8600,4 +8606,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_routers.yaml
+++ b/manifests/crd/core.pingcap.com_routers.yaml
@@ -8322,6 +8322,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8600,4 +8606,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_schedulers.yaml
+++ b/manifests/crd/core.pingcap.com_schedulers.yaml
@@ -8330,6 +8330,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8609,4 +8615,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_schedulings.yaml
+++ b/manifests/crd/core.pingcap.com_schedulings.yaml
@@ -8325,6 +8325,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8603,4 +8609,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_ticdcs.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcs.yaml
@@ -8331,6 +8331,12 @@ spec:
                       Default is pingcap/prestop-checker:latest
                     type: string
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8642,4 +8648,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tidbs.yaml
+++ b/manifests/crd/core.pingcap.com_tidbs.yaml
@@ -8369,6 +8369,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: Resources defines resource required by TiDB.
                 properties:
@@ -8794,4 +8800,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tiflashes.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashes.yaml
@@ -8367,6 +8367,12 @@ spec:
               proxyConfig:
                 description: ProxyConfig defines config file of TiFlash proxy
                 type: string
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: Resources defines resource required by TiFlash
                 properties:
@@ -8694,4 +8700,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tikvs.yaml
+++ b/manifests/crd/core.pingcap.com_tikvs.yaml
@@ -8399,6 +8399,12 @@ spec:
                 required:
                 - worker
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: Resources defines resource required by TiKV
                 properties:
@@ -8708,4 +8714,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tikvworkers.yaml
+++ b/manifests/crd/core.pingcap.com_tikvworkers.yaml
@@ -8324,6 +8324,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: Resources defines resource required by TiKV worker.
                 properties:
@@ -8598,4 +8604,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tiproxies.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxies.yaml
@@ -8353,6 +8353,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: Resources defines resource required by TiProxy.
                 properties:
@@ -8767,4 +8773,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/manifests/crd/core.pingcap.com_tsos.yaml
+++ b/manifests/crd/core.pingcap.com_tsos.yaml
@@ -8324,6 +8324,12 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              replicas:
+                default: 1
+                format: int32
+                maximum: 1
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   ResourceRequirements describes the compute resource requirements.
@@ -8608,4 +8614,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}


### PR DESCRIPTION
In order for PodDisruptionBudgets to work on various groups of Pods we need to implement the Scale subresource at the direct owner of the Pod.

Otherwise the PDB will return errors like:

```yaml
status:
  conditions:
    - lastTransitionTime: "2026-04..."
      message: tikvs.core.pingcap.com does not implement the scale subresource
      reason: SyncFailed
      status: "False"
      type: DisruptionAllowed
```

Followup to https://github.com/pingcap/tidb-operator/pull/6213

Closes: https://github.com/pingcap/tidb-operator/issues/6901
Closes: https://github.com/pingcap/tidb-operator/issues/4221