### PR TITLE
Add serviceAccountName to TidbInitializer

### DIFF
--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -2664,6 +2664,18 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run TiDB initializer Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>permitHost</code></br>
 <em>
 string
@@ -27269,6 +27281,18 @@ Kubernetes core/v1.PullPolicy
 <td>
 <em>(Optional)</em>
 <p>ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run TiDB initializer Pods.</p>
 </td>
 </tr>
 <tr>

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -63536,6 +63536,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              serviceAccountName:
+                type: string
               timezone:
                 type: string
               tlsClientSecretName:

--- a/manifests/crd/v1/pingcap.com_tidbinitializers.yaml
+++ b/manifests/crd/v1/pingcap.com_tidbinitializers.yaml
@@ -158,6 +158,8 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              serviceAccountName:
+                type: string
               timezone:
                 type: string
               tlsClientSecretName:

--- a/pkg/apis/pingcap/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pingcap/v1alpha1/openapi_generated.go
@@ -16775,6 +16775,13 @@ func schema_pkg_apis_pingcap_v1alpha1_TidbInitializerSpec(ref common.ReferenceCa
 							},
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName is the name of the ServiceAccount to use to run TiDB initializer Pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"permitHost": {
 						SchemaProps: spec.SchemaProps{
 							Description: "permitHost is the host which will only be allowed to connect to the TiDB.",

--- a/pkg/apis/pingcap/v1alpha1/tidbinitializer_types.go
+++ b/pkg/apis/pingcap/v1alpha1/tidbinitializer_types.go
@@ -73,6 +73,10 @@ type TidbInitializerSpec struct {
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
+	// ServiceAccountName is the name of the ServiceAccount to use to run TiDB initializer Pods.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
 	// permitHost is the host which will only be allowed to connect to the TiDB.
 	// +optional
 	PermitHost *string `json:"permitHost,omitempty"`

--- a/pkg/manager/member/tidb_init_manager.go
+++ b/pkg/manager/member/tidb_init_manager.go
@@ -353,6 +353,7 @@ func (m *tidbInitManager) makeTiDBInitJob(ti *v1alpha1.TidbInitializer) (*batchv
 		},
 		Spec: corev1.PodSpec{
 			ImagePullSecrets:             ti.Spec.ImagePullSecrets,
+			ServiceAccountName:           ti.Spec.ServiceAccountName,
 			SecurityContext:              ti.Spec.PodSecurityContext,
 			AutomountServiceAccountToken: pointer.BoolPtr(false),
 			InitContainers: []corev1.Container{

--- a/pkg/manager/member/tidb_init_manager_test.go
+++ b/pkg/manager/member/tidb_init_manager_test.go
@@ -143,6 +143,21 @@ func TestMakeTiDBInitJobDisablesServiceAccountTokenAutomount(t *testing.T) {
 	g.Expect(*job.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 }
 
+func TestMakeTiDBInitJobUsesServiceAccountName(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tim, _, indexers := newFakeTiDBInitManager()
+	ti := newTidbInitializerForTiDB()
+	ti.Spec.ServiceAccountName = "tidb-initializer"
+	tc := newTidbClusterForTiDB()
+
+	err := indexers.tc.Add(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	job, err := tim.makeTiDBInitJob(ti)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("tidb-initializer"))
+}
+
 func newFakeTiDBInitManager() (*tidbInitManager, *tidbMemberManager, *fakeIndexers) {
 	tmm, _, _, indexers := newFakeTiDBMemberManager()
 	indexers.job = tmm.deps.KubeInformerFactory.Batch().V1().Jobs().Informer().GetIndexer()


### PR DESCRIPTION
### What problem does this PR solve?

FedRAMP Gatekeeper `block-default-service-account` policy rejects pods that use the default ServiceAccount. The TidbInitializer Job pod did not expose a way to set `spec.serviceAccountName`, so users had to patch operator code or rely on the default ServiceAccount.

### What is changed and how does it work?

This adds `spec.serviceAccountName` to `TidbInitializerSpec` and passes it through to the generated initializer Job pod template.

The CRD/OpenAPI schema is updated so users can configure:

```yaml
spec:
  serviceAccountName: tidb-initializer
```

### Check List

Tests

- Unit test

Side effects

- No side effects

### Release note

```release-note
Add serviceAccountName support to TidbInitializer.
```

### Verification

- `go test ./pkg/manager/member`
- `cd pkg/apis && go test ./pingcap/v1alpha1`
- `git diff --check`
