### PR TITLE
Add projected SA token support to controller-manager chart

### DIFF
--- a/charts/tidb-operator/templates/controller-manager-deployment.yaml
+++ b/charts/tidb-operator/templates/controller-manager-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       serviceAccount: {{ .Values.controllerManager.serviceAccount }}
       {{- end }}
     {{- end }}
+      automountServiceAccountToken: {{ .Values.controllerManager.automountServiceAccountToken }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
   {{ toYaml .Values.imagePullSecrets | indent 6 }}
@@ -129,6 +130,12 @@ spec:
           {{- with .Values.controllerManager.env }}
 {{ toYaml . | indent 10 }}
           {{- end }}
+        {{- if not .Values.controllerManager.automountServiceAccountToken }}
+        volumeMounts:
+        - name: sa-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        {{- end }}
       {{- with .Values.controllerManager.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -151,4 +158,22 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
     {{- end}}
+    {{- if not .Values.controllerManager.automountServiceAccountToken }}
+      volumes:
+      - name: sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+          - downwardAPI:
+              items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace
+    {{- end }}
 {{- end }}

--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -56,6 +56,9 @@ controllerManager:
   # With rbac.create=true, this service account will be created
   # Also see rbac.create and clusterScoped
   serviceAccount: tidb-controller-manager
+  # automountServiceAccountToken indicates whether a service account token should be automatically mounted.
+  # When set to false, a projected service account token volume will be mounted instead.
+  automountServiceAccountToken: true
 
   # clusterPermissions are some cluster scoped permissions that will be used even if `clusterScoped: false`.
   # the default value of these fields is `true`. if you want them to be `false`, you MUST set them to `false` explicitly.


### PR DESCRIPTION
### What problem does this PR solve?

FedRAMP Gatekeeper can enforce `block-automount-serviceaccount-token-pod`, requiring controller-manager pods to run with `automountServiceAccountToken: false`.

When automatic service account token mounting is disabled, controller-manager still needs the standard in-cluster credential files under `/var/run/secrets/kubernetes.io/serviceaccount` so client-go can authenticate to the Kubernetes API.

### What is changed and how does it work?

This adds `controllerManager.automountServiceAccountToken` to the tidb-operator chart, defaulting to `true` to preserve current behavior.

When set to `false`, the chart renders:

- `automountServiceAccountToken: false` in the controller-manager pod spec
- a read-only `sa-token` volumeMount at `/var/run/secrets/kubernetes.io/serviceaccount`
- a projected volume containing:
  - service account token at `token`
  - `kube-root-ca.crt` configmap item at `ca.crt`
  - pod namespace via downwardAPI at `namespace`

Example:

```yaml
controllerManager:
  automountServiceAccountToken: false
```

### Check List

Tests

- Manual test (helm template/lint)

Side effects

- No side effects

### Release note

```release-note
Add projected service account token volume support for controller-manager when automountServiceAccountToken is disabled.
```

### Verification

- `helm lint charts/tidb-operator`
- `helm template test charts/tidb-operator --namespace tidb-admin`
- `helm template test charts/tidb-operator --namespace tidb-admin --set controllerManager.automountServiceAccountToken=false`
- `git diff --check`
