### PR TITLE
Pause DDL during eligible TiDB upgrades

### DIFF
--- a/docs/design-proposals/2026-05-14-pause-ddl-during-tidb-upgrade.md
+++ b/docs/design-proposals/2026-05-14-pause-ddl-during-tidb-upgrade.md
@@ -104,7 +104,7 @@ POST /upgrade/start
 POST /upgrade/finish
 ```
 
-The calls are bodyless. TiDB returns HTTP 400 for non-POST requests and for handler/session errors. Successful and idempotent responses are HTTP 200 with one of these bodies:
+The calls are bodyless. TiDB returns HTTP 400 for non-POST requests and for handler/session errors. Successful and idempotent responses are HTTP 200 with one of these string bodies, encoded by TiDB's JSON response helper:
 
 ```text
 "success!"
@@ -112,7 +112,7 @@ The calls are bodyless. TiDB returns HTTP 400 for non-POST requests and for hand
 "It's a duplicated operation and the cluster is already in normal state."
 ```
 
-Implementation should treat these HTTP 200 bodies as success and return errors that include HTTP status and response body for non-200 or unexpected responses. A 200 response from `/upgrade/start` is the point where it is safe to start replacing TiDB pods: TiDB waits up to 10 seconds for the DDL owner to observe and sync the cluster into upgrading state before returning success. Set the client HTTP timeout above 10 seconds; use 30 seconds to allow network/proxy overhead.
+Implementation should decode the response as a JSON string, treat these HTTP 200 bodies as success, and return errors that include HTTP status and response body for non-200 or unexpected responses. A 200 response from `/upgrade/start` is the point where it is safe to start replacing TiDB pods: TiDB waits up to 10 seconds for the DDL owner to observe and sync the cluster into upgrading state before returning success. Set the client HTTP timeout above 10 seconds; use 30 seconds to allow network/proxy overhead.
 
 The existing shared `http.Client` in `defaultTiDBControl` uses a 5-second timeout and must not be used for `StartUpgrade`. `StartUpgrade` must construct a dedicated `http.Client` with a 30-second timeout (or use a per-request `context.WithTimeout`) for this call only. `FinishUpgrade` can use the shared client since TiDB returns immediately for that operation.
 
@@ -211,11 +211,11 @@ Call `maybefinishSmoothUpgrade(tc)` at the end of `tidbMemberManager.Sync()`, af
 
 1. Check whether the pause annotation is active.
 2. If not active, do nothing.
-3. If active, wait until `tc.Status.TiDB.StatefulSet.UpdatedReplicas == tc.Status.TiDB.StatefulSet.Replicas` and `tc.Status.TiDB.Phase == NormalPhase`. Use these StatefulSet status fields rather than pod-level labels to avoid races between pod label updates and StatefulSet controller reconciliation.
+3. If active, wait until `tc.Status.TiDB.StatefulSet.UpdatedReplicas == tc.Status.TiDB.StatefulSet.Replicas`, `tc.Status.TiDB.Phase == NormalPhase`, and all TiDB members are healthy. Use StatefulSet status fields plus TiDB member health to avoid races between pod label updates, health sync, and StatefulSet controller reconciliation.
 4. Select one healthy TiDB endpoint.
 5. Call `POST /upgrade/finish`.
 6. If finish fails, keep annotations and requeue.
-7. If finish succeeds, remove all smooth-upgrade annotations.
+7. If finish succeeds, remove all smooth-upgrade annotations using JSON merge-patch `null` values so the persisted Kubernetes annotations are deleted, not merely omitted from the local object.
 
 ### Controller API changes
 

--- a/docs/design-proposals/2026-05-14-pause-ddl-during-tidb-upgrade.md
+++ b/docs/design-proposals/2026-05-14-pause-ddl-during-tidb-upgrade.md
@@ -1,0 +1,311 @@
+# Pause user DDL during TiDB version upgrade
+
+## Summary
+
+TiDB Operator currently upgrades TiDB by reconciling `spec.version` into a Kubernetes StatefulSet rolling update. This replaces TiDB pods safely at the Kubernetes level, but it does not coordinate TiDB's smooth-upgrade mode, so users still need to avoid user-initiated DDL during the upgrade window.
+
+This proposal adds TiDB smooth-upgrade orchestration for tidb-operator v1 classic TiDB clusters. For TiDB version pairs that require the HTTP switch, TiDB Operator will call `POST /upgrade/start` before the first TiDB pod is rolled and `POST /upgrade/finish` after every TiDB pod is upgraded and healthy. The active pause state is persisted in controller-owned `TidbCluster` annotations so the controller can recover after restarts and always finish a pause window that it started.
+
+## Motivation
+
+TiDB smooth upgrade is designed to reduce DDL-related risk during TiDB binary upgrades. The HTTP API flips TiDB global cluster upgrade state; the DDL subsystem reacts to that state by pausing non-system/user DDL while allowing system DB DDL, then resuming paused user jobs on finish. TiUP already uses this mechanism during `tiup cluster upgrade`, but TiDB Operator does not. In Kubernetes deployments, especially managed environments, users expect TiDB Operator to provide a comparable upgrade experience without requiring a separate manual script to pause and resume user DDL.
+
+### Goals
+
+- Pause user DDL automatically during eligible TiDB Server version upgrades managed by TiDB Operator.
+- Call TiDB's bodyless HTTP API `POST /upgrade/start` before TiDB rolling upgrade starts.
+- Call `POST /upgrade/finish` after all TiDB pods are upgraded and healthy.
+- Apply only to TiDB version upgrades, not scale, config, resource, restart, failover, or volume operations.
+- Apply only to tidb-operator v1 classic TiDB kernel clusters.
+- Persist the active pause state so operator restart does not lose the obligation to call `/upgrade/finish`.
+- Preserve existing rolling-upgrade behavior for unsupported or no-switch-needed version pairs.
+
+### Non-Goals
+
+- Supporting Premium/keyspace-specific behavior. tidb-operator v1 supports classic TiDB kernel only.
+- Pausing DDL for TiKV, PD, TiFlash, TiCDC, TiProxy, Pump, TiCI, scale operations, or config-only rollouts.
+- Preventing all risky user operations listed in TiDB smooth-upgrade limitations. TiDB enforces its own smooth-upgrade mode semantics after `/upgrade/start`.
+- Introducing a new user-facing CRD field for this behavior.
+- Using `POST /upgrade/show` as a required reconcile gate. It can be useful during rollout to confirm consistency or for diagnostics, but start/finish and persisted controller state are sufficient for reconciliation.
+
+## Proposal
+
+### User Stories
+
+#### Story 1: supported switch-controlled TiDB upgrade
+
+A user runs a TiDB cluster at `v7.4.x` and updates `spec.version` to a later supported version. TiDB Operator detects that this is a TiDB image version upgrade and that the source/target pair requires smooth-upgrade HTTP switching. Before updating the TiDB StatefulSet in a way that can replace a pod, the operator sends:
+
+```bash
+curl -X POST http://{TiDBIP}:10080/upgrade/start
+```
+
+TiDB returns:
+
+```text
+"success!"
+```
+
+The operator then persists controller-owned annotations on the `TidbCluster` and proceeds with the existing TiDB rolling upgrade. After all TiDB pods are upgraded, available, and healthy, the operator sends:
+
+```bash
+curl -X POST http://{TiDBIP}:10080/upgrade/finish
+```
+
+After finish succeeds, the operator removes the annotations.
+
+#### Story 2: unsupported smooth-upgrade version pair
+
+A user upgrades from `v7.3.0` to `v7.4.0`. TiDB's smooth-upgrade matrix marks this pair as unsupported. TiDB Operator does not call `/upgrade/start` or `/upgrade/finish`; it proceeds with the existing rolling-upgrade behavior and emits a warning event indicating that TiDB smooth upgrade is not available for the source/target pair.
+
+#### Story 3: operator restart during upgrade
+
+TiDB Operator calls `/upgrade/start` successfully and then restarts while TiDB pods are still rolling. When reconciliation resumes, the operator reads `tidb.pingcap.com/smooth-upgrade-ddl-paused: "true"` from the `TidbCluster`, skips duplicate start, waits for TiDB upgrade completion, calls `/upgrade/finish`, and removes the annotations after finish succeeds.
+
+### Risks and Mitigations
+
+- **TiDB handler/session errors return HTTP 400**: preserve response body/status in operator errors and requeue without advancing rollout on start failure. `/upgrade/start` can legitimately take almost 10 seconds while waiting for DDL owner sync, so use a 30-second timeout. Duplicate start/finish HTTP 200 responses are success and should not block recovery after client timeout or operator restart.
+- **Source version is not available from `spec.version` after the user updates the CR**: derive the source version from the old TiDB StatefulSet image tag and the target version from the new TiDB StatefulSet image tag.
+- **Operator crash after `/upgrade/start`**: persist the pause window in annotations immediately after start succeeds.
+- **Annotation update conflict**: annotation updates modify the main `TidbCluster` object. Mitigation: use retry-on-conflict and keep annotation changes small and deterministic.
+- **User manually removes controller annotations**: document these annotations as controller-owned. Emit warnings when metadata is missing or inconsistent.
+- **Custom image tags cannot be parsed as TiDB versions**: treat them as unsupported for smooth-upgrade API calls and preserve existing rolling-upgrade behavior.
+
+## Design Details
+
+### Existing upgrade flow
+
+The current TiDB flow already has a natural gate for smooth-upgrade start:
+
+- TiDB member reconciliation builds a desired StatefulSet and calls the TiDB upgrader when the pod template differs or TiDB is already in `UpgradePhase`.
+- The TiDB upgrader blocks TiDB upgrade while other components are upgrading/scaling or TiDB is scaling.
+- The TiDB upgrader then advances StatefulSet rolling partitions one pod at a time.
+
+The smooth-upgrade start call should happen after existing blockers pass and before the first StatefulSet update/partition change can replace a TiDB pod. Finish should happen after status sync proves the TiDB rolling upgrade has completed.
+
+### TiDB HTTP API
+
+The classic TiDB smooth-upgrade API is wired at `pkg/server/http_status.go` to `pkg/server/handler/upgrade_handler.go`:
+
+```text
+POST /upgrade/{op}
+```
+
+Supported operations include:
+
+- `start`
+- `finish`
+- `show`
+
+For this feature, TiDB Operator uses only:
+
+```text
+POST /upgrade/start
+POST /upgrade/finish
+```
+
+The calls are bodyless. TiDB returns HTTP 400 for non-POST requests and for handler/session errors. Successful and idempotent responses are HTTP 200 with one of these bodies:
+
+```text
+"success!"
+"It's a duplicated operation and the cluster is already in upgrading state."
+"It's a duplicated operation and the cluster is already in normal state."
+```
+
+Implementation should treat these HTTP 200 bodies as success and return errors that include HTTP status and response body for non-200 or unexpected responses. A 200 response from `/upgrade/start` is the point where it is safe to start replacing TiDB pods: TiDB waits up to 10 seconds for the DDL owner to observe and sync the cluster into upgrading state before returning success. Set the client HTTP timeout above 10 seconds; use 30 seconds to allow network/proxy overhead.
+
+The existing shared `http.Client` in `defaultTiDBControl` uses a 5-second timeout and must not be used for `StartUpgrade`. `StartUpgrade` must construct a dedicated `http.Client` with a 30-second timeout (or use a per-request `context.WithTimeout`) for this call only. `FinishUpgrade` can use the shared client since TiDB returns immediately for that operation.
+
+### Version matrix
+
+TiDB Operator should classify TiDB version upgrades into three categories.
+
+#### Unsupported
+
+- Source `< v7.1.0` to any target.
+- Source `v7.1.0`, `v7.1.1`, `v7.2.0`, or `v7.3.0` to target `>= v7.4.0`.
+- Any version pair that cannot be parsed as semantic TiDB versions.
+- Any pair not matched by the auto-supported or HTTP switch-controlled categories below (catch-all default).
+
+For unsupported pairs, do not call `/upgrade/start` or `/upgrade/finish`. Keep existing rolling-upgrade behavior and emit a warning event.
+
+#### Auto-supported, no HTTP switch needed
+
+- `v7.1.0` to `v7.1.1`, `v7.2.0`, or `v7.3.0`.
+- `v7.1.1` to `v7.2.0` or `v7.3.0`.
+- `v7.2.0` to `v7.3.0`.
+
+For these pairs, do not call `/upgrade/start` or `/upgrade/finish`; smooth upgrade is automatic in TiDB.
+
+#### HTTP switch-controlled
+
+- Source in `[v7.1.2, v7.2.0)` to target in `[v7.1.2, v7.2.0)`.
+- Source in `[v7.1.2, v7.2.0)` or `>= v7.4.0` to target `>= v7.4.0`.
+
+Only these pairs require TiDB Operator to call `/upgrade/start` and `/upgrade/finish`.
+
+### Detecting version upgrades
+
+Add shared helper logic, for example in `pkg/manager/member/smooth_upgrade.go`:
+
+```go
+type smoothUpgradeSupport string
+
+const (
+    smoothUpgradeUnsupported      smoothUpgradeSupport = "Unsupported"
+    smoothUpgradeAutoSupported    smoothUpgradeSupport = "AutoSupportedNoop"
+    smoothUpgradeSwitchControlled smoothUpgradeSupport = "SwitchControlled"
+)
+```
+
+The helper should:
+
+1. Compare only the main TiDB container image tag in the old and new StatefulSet templates.
+2. Return `not a version upgrade` when the tag is unchanged, even if other parts of the pod template changed.
+3. Classify the source and target versions using the matrix above.
+4. Treat invalid/custom tags as unsupported for smooth-upgrade API calls.
+
+This prevents smooth-upgrade API calls for scale-only, config-only, resource-only, annotation-only, restart, failover, and volume-change reconciliations.
+
+### Persisted controller state
+
+Use controller-owned annotations on the `TidbCluster` as the source of truth for an active pause window:
+
+```text
+tidb.pingcap.com/smooth-upgrade-ddl-paused: "true"
+tidb.pingcap.com/smooth-upgrade-source-version: "<source>"
+tidb.pingcap.com/smooth-upgrade-target-version: "<target>"
+tidb.pingcap.com/smooth-upgrade-started-at: "<RFC3339 timestamp>"
+```
+
+Rules:
+
+1. Set annotations only after `/upgrade/start` succeeds.
+2. Treat `smooth-upgrade-ddl-paused=true` as meaning `/upgrade/start` has succeeded and `/upgrade/finish` is still owed.
+3. Do not call `/upgrade/start` again while the annotation is active.
+4. Remove all smooth-upgrade annotations only after `/upgrade/finish` succeeds.
+5. If annotations are present after operator restart, continue waiting for TiDB upgrade completion and then call finish.
+6. If annotation metadata conflicts with the current source/target pair, emit a warning, call `/upgrade/finish` (which is idempotent and safe to call even if TiDB is already in normal state), and remove annotations after finish succeeds. Do not silently drop the annotation without calling finish.
+
+Status conditions may be added for visibility, but must not be the source of truth. Events and logs should be emitted for start, finish, skip, and failure cases.
+
+### Reconcile flow
+
+#### Start gate
+
+When TiDB upgrader is about to start an eligible TiDB version rolling upgrade:
+
+1. Run existing blockers first: do not start while PD/TiKV/TiFlash/Pump are upgrading/scaling or TiDB is scaling.
+2. Detect whether old/new TiDB StatefulSet images represent a version upgrade.
+3. Classify the source/target pair.
+4. If the pair is not switch-controlled, skip HTTP API calls and proceed with existing behavior.
+5. If the pause annotation is already active, skip duplicate start and proceed with rolling upgrade.
+6. Select one healthy TiDB endpoint, preferably the lowest healthy ordinal.
+7. Call `POST /upgrade/start` with a 30-second client timeout.
+8. If start fails or the client times out, do not advance the rolling update; return an error/requeue. Retry is safe because duplicate start returns HTTP 200.
+9. If start returns HTTP 200 success or duplicate-upgrading, persist the annotations and proceed with existing rolling-upgrade logic; the DDL owner has synced the upgrading state before the first-success response returns.
+
+#### Finish gate
+
+Call `maybefinishSmoothUpgrade(tc)` at the end of `tidbMemberManager.Sync()`, after `syncTidbClusterStatus` has run. This ensures the phase and StatefulSet status fields reflect the current state before the check.
+
+1. Check whether the pause annotation is active.
+2. If not active, do nothing.
+3. If active, wait until `tc.Status.TiDB.StatefulSet.UpdatedReplicas == tc.Status.TiDB.StatefulSet.Replicas` and `tc.Status.TiDB.Phase == NormalPhase`. Use these StatefulSet status fields rather than pod-level labels to avoid races between pod label updates and StatefulSet controller reconciliation.
+4. Select one healthy TiDB endpoint.
+5. Call `POST /upgrade/finish`.
+6. If finish fails, keep annotations and requeue.
+7. If finish succeeds, remove all smooth-upgrade annotations.
+
+### Controller API changes
+
+Extend `TiDBControlInterface`:
+
+```go
+type TiDBControlInterface interface {
+    GetHealth(tc *v1alpha1.TidbCluster, ordinal int32) (bool, error)
+    GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error)
+    SetServerLabels(tc *v1alpha1.TidbCluster, ordinal int32, labels map[string]string) error
+    StartUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error
+    FinishUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error
+}
+```
+
+`defaultTiDBControl` should reuse the existing TiDB HTTP client and base URL logic, except `StartUpgrade` must use a dedicated 30-second-timeout client as noted above. `FakeTiDBControl` should record the ordinal passed to each start/finish call (not just a call count) so unit tests can assert that the lowest healthy ordinal was selected, and support injected errors per method.
+
+### Events
+
+Suggested event reasons:
+
+- `SmoothUpgradeStarted`
+- `SmoothUpgradeFinished`
+- `SmoothUpgradeStartFailed`
+- `SmoothUpgradeFinishFailed`
+- `SmoothUpgradeUnsupported`
+- `SmoothUpgradeSkipped`
+
+### Test Plan
+
+#### Unit tests
+
+- `pkg/controller/tidb_control_test.go`
+  - `StartUpgrade` sends bodyless `POST /upgrade/start`.
+  - `StartUpgrade` accepts `"success!"` and the duplicate-upgrading HTTP 200 body.
+  - `FinishUpgrade` sends bodyless `POST /upgrade/finish`.
+  - `FinishUpgrade` accepts `"success!"` and the duplicate-normal HTTP 200 body.
+  - HTTP 400/5xx, client timeout, and unexpected response bodies return useful errors.
+  - `StartUpgrade` uses a timeout greater than TiDB server-side 10-second owner-sync timeout; recommended 30 seconds.
+  - TLS-enabled clusters reuse existing TiDB HTTP client behavior.
+- `pkg/manager/member/smooth_upgrade_test.go`
+  - Detect version upgrade by image tag change only.
+  - Ignore config/resource/annotation-only template changes.
+  - Classify every row in the TiDB version matrix.
+  - Treat invalid/custom tags as unsupported.
+  - Read/write/clear smooth-upgrade annotations.
+  - Detect active, stale, and mismatched annotation states.
+- `pkg/manager/member/tidb_upgrader_test.go`
+  - Call start before first partition decrement for switch-controlled version upgrades.
+  - Start failure blocks StatefulSet rollout.
+  - Active annotation avoids duplicate start.
+  - Auto-supported and unsupported pairs skip start.
+- `pkg/manager/member/tidb_member_manager_test.go`
+  - Call finish only after all TiDB pods are updated and healthy.
+  - Finish failure requeues and keeps annotations.
+  - Finish success removes annotations.
+  - Scale-only and config-only changes do not call start or finish.
+
+#### Integration or manual tests
+
+1. Deploy a switch-controlled source version, for example `v7.4.x` or later.
+2. Start a long-running user DDL workload.
+3. Update `spec.version` to a supported target.
+4. Verify `/upgrade/start` is called before the first TiDB pod replacement.
+5. Verify the smooth-upgrade annotations are present during rolling upgrade.
+6. Verify `/upgrade/finish` is called after all TiDB pods are upgraded.
+7. Verify annotations are removed after finish succeeds.
+8. Restart the operator after start and before finish; verify finish still happens.
+
+## Drawbacks
+
+- The controller must update `TidbCluster` annotations in addition to status and StatefulSet reconciliation, which introduces conflict/retry handling.
+- If TiDB's repeated start/finish behavior is not fully idempotent, the controller must be careful to avoid duplicate start and to classify finish responses safely.
+- Unsupported version pairs still rely on users avoiding DDL manually; the operator can only warn and preserve existing behavior.
+- A stalled upgrade (pod crashloop, image pull failure, etc.) holds the DDL pause indefinitely. The operator does not call `/upgrade/finish` until all pods are on the new revision and healthy, so user DDL remains blocked for the full duration of any stuck upgrade. Users must resolve the underlying pod issue to unblock DDL.
+
+## Alternatives
+
+### Use status conditions as the source of truth
+
+Status conditions are useful for visibility, but they are observations and can be recalculated or overwritten by status-sync paths. The active pause window is controller workflow state: after `/upgrade/start` succeeds, the controller owes a future `/upgrade/finish`. Annotations are a better fit for this durable lock-like state.
+
+### Always call `/upgrade/start` for every TiDB version upgrade
+
+This is simpler but incorrect for unsupported versions and unnecessary for auto-supported versions. It could fail upgrades that currently work and would not follow TiDB's documented version matrix.
+
+### Let users call the API manually
+
+This preserves current behavior but does not provide a TiUP-like operator experience. It is error-prone because users must coordinate API calls precisely with Kubernetes rolling updates.
+
+### Use `/upgrade/show` as the reconciliation source of truth
+
+`/upgrade/show` can help diagnostics, but relying on live TiDB state alone does not solve operator restart and in-flight workflow tracking as cleanly as controller-owned annotations. It can be added later as a defensive check if needed.

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -145,11 +145,14 @@ func (c *defaultTiDBControl) upgradeClientTimeout(op string) time.Duration {
 }
 
 func (c *defaultTiDBControl) upgrade(tc *v1alpha1.TidbCluster, ordinal int32, op string, requestTimeout time.Duration, duplicateSuccessBody string) error {
-	httpClient, err := c.getHTTPClient(tc)
+	baseClient, err := c.getHTTPClient(tc)
 	if err != nil {
 		return err
 	}
-	httpClient.Timeout = requestTimeout
+	httpClient := &http.Client{
+		Transport: baseClient.Transport,
+		Timeout:   requestTimeout,
+	}
 
 	url := fmt.Sprintf("%s/upgrade/%s", c.getBaseURL(tc, ordinal), op)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
@@ -167,7 +170,7 @@ func (c *defaultTiDBControl) upgrade(tc *v1alpha1.TidbCluster, ordinal int32, op
 	}
 	bodyText := string(body)
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("tidb upgrade %s error response %s:%v URL: %s", op, bodyText, res.StatusCode, url)
+		return fmt.Errorf("tidb upgrade %s error response %q:%v URL: %s", op, bodyText, res.StatusCode, url)
 	}
 	successText := normalizeTiDBUpgradeResponse(body)
 	if successText == tidbUpgradeSuccessBody || successText == duplicateSuccessBody {

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -29,8 +29,12 @@ import (
 const (
 	// https://github.com/pingcap/tidb/blob/master/owner/manager.go#L183
 	// NotDDLOwnerError is the error message which was returned when the tidb node is not a ddl owner
-	NotDDLOwnerError = "This node is not a ddl owner, can't be resigned."
-	timeout          = 5 * time.Second
+	NotDDLOwnerError               = "This node is not a ddl owner, can't be resigned."
+	timeout                        = 5 * time.Second
+	startUpgradeTimeout            = 30 * time.Second
+	tidbUpgradeSuccessBody         = "success!"
+	tidbUpgradeDuplicateStartBody  = "It's a duplicated operation and the cluster is already in upgrading state."
+	tidbUpgradeDuplicateFinishBody = "It's a duplicated operation and the cluster is already in normal state."
 )
 
 type DBInfo struct {
@@ -45,6 +49,10 @@ type TiDBControlInterface interface {
 	GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBInfo, error)
 	// SetServerLabels update TiDB's labels config
 	SetServerLabels(tc *v1alpha1.TidbCluster, ordinal int32, labels map[string]string) error
+	// StartUpgrade switches TiDB into upgrade state.
+	StartUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error
+	// FinishUpgrade switches TiDB back to normal state.
+	FinishUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error
 }
 
 // defaultTiDBControl is default implementation of TiDBControlInterface.
@@ -121,6 +129,61 @@ func (c *defaultTiDBControl) SetServerLabels(tc *v1alpha1.TidbCluster, ordinal i
 	return err
 }
 
+func (c *defaultTiDBControl) StartUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	return c.upgrade(tc, ordinal, "start", c.upgradeClientTimeout("start"), tidbUpgradeDuplicateStartBody)
+}
+
+func (c *defaultTiDBControl) FinishUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	return c.upgrade(tc, ordinal, "finish", c.upgradeClientTimeout("finish"), tidbUpgradeDuplicateFinishBody)
+}
+
+func (c *defaultTiDBControl) upgradeClientTimeout(op string) time.Duration {
+	if op == "start" {
+		return startUpgradeTimeout
+	}
+	return timeout
+}
+
+func (c *defaultTiDBControl) upgrade(tc *v1alpha1.TidbCluster, ordinal int32, op string, requestTimeout time.Duration, duplicateSuccessBody string) error {
+	httpClient, err := c.getHTTPClient(tc)
+	if err != nil {
+		return err
+	}
+	httpClient.Timeout = requestTimeout
+
+	url := fmt.Sprintf("%s/upgrade/%s", c.getBaseURL(tc, ordinal), op)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer httputil.DeferClose(res.Body)
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	bodyText := string(body)
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("tidb upgrade %s error response %s:%v URL: %s", op, bodyText, res.StatusCode, url)
+	}
+	successText := normalizeTiDBUpgradeResponse(body)
+	if successText == tidbUpgradeSuccessBody || successText == duplicateSuccessBody {
+		return nil
+	}
+	return fmt.Errorf("tidb upgrade %s unexpected response %q:%v URL: %s", op, bodyText, res.StatusCode, url)
+}
+
+func normalizeTiDBUpgradeResponse(body []byte) string {
+	var text string
+	if err := json.Unmarshal(body, &text); err == nil {
+		return text
+	}
+	return string(body)
+}
+
 func getBodyOK(httpClient *http.Client, apiURL string) ([]byte, error) {
 	res, err := httpClient.Get(apiURL)
 	if err != nil {
@@ -158,10 +221,14 @@ func (c *defaultTiDBControl) getBaseURL(tc *v1alpha1.TidbCluster, ordinal int32)
 
 // FakeTiDBControl is a fake implementation of TiDBControlInterface.
 type FakeTiDBControl struct {
-	healthInfo     map[string]bool
-	tiDBInfo       *DBInfo
-	getInfoError   error
-	setLabelsError error
+	healthInfo            map[string]bool
+	tiDBInfo              *DBInfo
+	getInfoError          error
+	setLabelsError        error
+	startUpgradeError     error
+	finishUpgradeError    error
+	StartUpgradeOrdinals  []int32
+	FinishUpgradeOrdinals []int32
 }
 
 // NewFakeTiDBControl returns a FakeTiDBControl instance
@@ -195,4 +262,22 @@ func (c *FakeTiDBControl) GetInfo(tc *v1alpha1.TidbCluster, ordinal int32) (*DBI
 
 func (c *FakeTiDBControl) SetServerLabels(tc *v1alpha1.TidbCluster, ordinal int32, labels map[string]string) error {
 	return c.setLabelsError
+}
+
+func (c *FakeTiDBControl) SetStartUpgradeError(err error) {
+	c.startUpgradeError = err
+}
+
+func (c *FakeTiDBControl) SetFinishUpgradeError(err error) {
+	c.finishUpgradeError = err
+}
+
+func (c *FakeTiDBControl) StartUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	c.StartUpgradeOrdinals = append(c.StartUpgradeOrdinals, ordinal)
+	return c.startUpgradeError
+}
+
+func (c *FakeTiDBControl) FinishUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	c.FinishUpgradeOrdinals = append(c.FinishUpgradeOrdinals, ordinal)
+	return c.finishUpgradeError
 }

--- a/pkg/controller/tidb_control.go
+++ b/pkg/controller/tidb_control.go
@@ -170,13 +170,13 @@ func (c *defaultTiDBControl) upgrade(tc *v1alpha1.TidbCluster, ordinal int32, op
 	}
 	bodyText := string(body)
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("tidb upgrade %s error response %q:%v URL: %s", op, bodyText, res.StatusCode, url)
+		return fmt.Errorf("tidb upgrade %s error response %d %q URL: %s", op, res.StatusCode, bodyText, url)
 	}
 	successText := normalizeTiDBUpgradeResponse(body)
 	if successText == tidbUpgradeSuccessBody || successText == duplicateSuccessBody {
 		return nil
 	}
-	return fmt.Errorf("tidb upgrade %s unexpected response %q:%v URL: %s", op, bodyText, res.StatusCode, url)
+	return fmt.Errorf("tidb upgrade %s unexpected response %d %q URL: %s", op, res.StatusCode, bodyText, url)
 }
 
 func normalizeTiDBUpgradeResponse(body []byte) string {

--- a/pkg/controller/tidb_control_test.go
+++ b/pkg/controller/tidb_control_test.go
@@ -318,6 +318,65 @@ func TestSetLabels(t *testing.T) {
 	}
 }
 
+func TestUpgradeAPI(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cases := []struct {
+		name    string
+		method  func(*defaultTiDBControl, *v1alpha1.TidbCluster) error
+		path    string
+		body    string
+		status  int
+		wantErr bool
+	}{
+		{name: "start success", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.StartUpgrade(tc, 0) }, path: "/upgrade/start", body: tidbUpgradeSuccessBody, status: http.StatusOK},
+		{name: "start duplicate", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.StartUpgrade(tc, 0) }, path: "/upgrade/start", body: tidbUpgradeDuplicateStartBody, status: http.StatusOK},
+		{name: "finish success", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.FinishUpgrade(tc, 0) }, path: "/upgrade/finish", body: tidbUpgradeSuccessBody, status: http.StatusOK},
+		{name: "finish duplicate", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.FinishUpgrade(tc, 0) }, path: "/upgrade/finish", body: tidbUpgradeDuplicateFinishBody, status: http.StatusOK},
+		{name: "error response", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.StartUpgrade(tc, 0) }, path: "/upgrade/start", body: "handler failed", status: http.StatusBadRequest, wantErr: true},
+		{name: "unexpected body", method: func(c *defaultTiDBControl, tc *v1alpha1.TidbCluster) error { return c.FinishUpgrade(tc, 0) }, path: "/upgrade/finish", body: "unknown", status: http.StatusOK, wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := getClientServer(func(w http.ResponseWriter, request *http.Request) {
+				g.Expect(request.Method).To(Equal(http.MethodPost))
+				g.Expect(request.URL.Path).To(Equal(c.path))
+				body, err := io.ReadAll(request.Body)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(body).To(BeEmpty())
+				w.WriteHeader(c.status)
+				if c.status == http.StatusOK {
+					data, err := json.Marshal(c.body)
+					g.Expect(err).NotTo(HaveOccurred())
+					_, _ = w.Write(data)
+				} else {
+					_, _ = w.Write([]byte(c.body))
+				}
+			})
+			defer svc.Close()
+
+			informer := kubeinformers.NewSharedInformerFactory(&fake.Clientset{}, 0)
+			control := NewDefaultTiDBControl(informer.Core().V1().Secrets().Lister())
+			control.testURL = svc.URL
+			err := c.method(control, getTidbCluster())
+			if c.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(c.body))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestStartUpgradeTimeout(t *testing.T) {
+	g := NewGomegaWithT(t)
+	control := NewDefaultTiDBControl(nil)
+	g.Expect(control.upgradeClientTimeout("start")).To(Equal(startUpgradeTimeout))
+	g.Expect(control.upgradeClientTimeout("finish")).To(Equal(timeout))
+}
+
 func getTidbCluster() *v1alpha1.TidbCluster {
 	return &v1alpha1.TidbCluster{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/manager/member/smooth_upgrade.go
+++ b/pkg/manager/member/smooth_upgrade.go
@@ -1,0 +1,276 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/util/cmpver"
+
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
+)
+
+type smoothUpgradeSupport string
+
+const (
+	smoothUpgradeUnsupported      smoothUpgradeSupport = "Unsupported"
+	smoothUpgradeAutoSupported    smoothUpgradeSupport = "AutoSupportedNoop"
+	smoothUpgradeSwitchControlled smoothUpgradeSupport = "SwitchControlled"
+
+	annSmoothUpgradeDDLPaused     = "tidb.pingcap.com/smooth-upgrade-ddl-paused"
+	annSmoothUpgradeSourceVersion = "tidb.pingcap.com/smooth-upgrade-source-version"
+	annSmoothUpgradeTargetVersion = "tidb.pingcap.com/smooth-upgrade-target-version"
+	annSmoothUpgradeStartedAt     = "tidb.pingcap.com/smooth-upgrade-started-at"
+)
+
+func detectTiDBVersionUpgrade(oldSet, newSet *apps.StatefulSet) (string, string, bool) {
+	oldImage, ok := mainContainerImage(oldSet, v1alpha1.TiDBMemberType.String())
+	if !ok {
+		return "", "", false
+	}
+	newImage, ok := mainContainerImage(newSet, v1alpha1.TiDBMemberType.String())
+	if !ok {
+		return "", "", false
+	}
+	source := imageTag(oldImage)
+	target := imageTag(newImage)
+	return source, target, source != "" && target != "" && source != target
+}
+
+func classifySmoothUpgrade(source, target string) smoothUpgradeSupport {
+	if !validTiDBVersion(source) || !validTiDBVersion(target) {
+		return smoothUpgradeUnsupported
+	}
+
+	sourceBefore710, _ := cmpver.Compare(source, cmpver.Less, "v7.1.0")
+	if sourceBefore710 {
+		return smoothUpgradeUnsupported
+	}
+
+	if isAutoSmoothUpgradePair(source, target) {
+		return smoothUpgradeAutoSupported
+	}
+	if isSwitchControlledSmoothUpgradePair(source, target) {
+		return smoothUpgradeSwitchControlled
+	}
+	return smoothUpgradeUnsupported
+}
+
+func isAutoSmoothUpgradePair(source, target string) bool {
+	return (versionEqual(source, "v7.1.0") && (versionEqual(target, "v7.1.1") || versionEqual(target, "v7.2.0") || versionEqual(target, "v7.3.0"))) ||
+		(versionEqual(source, "v7.1.1") && (versionEqual(target, "v7.2.0") || versionEqual(target, "v7.3.0"))) ||
+		(versionEqual(source, "v7.2.0") && versionEqual(target, "v7.3.0"))
+}
+
+func isSwitchControlledSmoothUpgradePair(source, target string) bool {
+	sourceIn712To720 := versionGTE(source, "v7.1.2") && versionLT(source, "v7.2.0")
+	targetIn712To720 := versionGTE(target, "v7.1.2") && versionLT(target, "v7.2.0")
+	sourceGTE740 := versionGTE(source, "v7.4.0")
+	targetGTE740 := versionGTE(target, "v7.4.0")
+	return (sourceIn712To720 && targetIn712To720) || ((sourceIn712To720 || sourceGTE740) && targetGTE740)
+}
+
+func versionEqual(version, target string) bool {
+	gte, err := cmpver.Compare(version, cmpver.GreaterOrEqual, target)
+	if err != nil || !gte {
+		return false
+	}
+	lte, err := cmpver.Compare(version, cmpver.LessOrEqual, target)
+	return err == nil && lte
+}
+
+func versionGTE(version, target string) bool {
+	ok, err := cmpver.Compare(version, cmpver.GreaterOrEqual, target)
+	return err == nil && ok
+}
+
+func versionLT(version, target string) bool {
+	ok, err := cmpver.Compare(version, cmpver.Less, target)
+	return err == nil && ok
+}
+
+func validTiDBVersion(version string) bool {
+	if !strings.HasPrefix(version, "v") {
+		return false
+	}
+	_, err := cmpver.Compare(version, cmpver.GreaterOrEqual, "v0.0.0")
+	return err == nil
+}
+
+func mainContainerImage(set *apps.StatefulSet, name string) (string, bool) {
+	if set == nil {
+		return "", false
+	}
+	for _, c := range set.Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return c.Image, true
+		}
+	}
+	return "", false
+}
+
+func imageTag(image string) string {
+	if image == "" || strings.Contains(image, "@") {
+		return ""
+	}
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 || idx == len(image)-1 {
+		return ""
+	}
+	return image[idx+1:]
+}
+
+func isSmoothUpgradePaused(tc *v1alpha1.TidbCluster) bool {
+	return tc.Annotations != nil && tc.Annotations[annSmoothUpgradeDDLPaused] == "true"
+}
+
+func setSmoothUpgradeAnnotations(tc *v1alpha1.TidbCluster, source, target string) {
+	if tc.Annotations == nil {
+		tc.Annotations = map[string]string{}
+	}
+	tc.Annotations[annSmoothUpgradeDDLPaused] = "true"
+	tc.Annotations[annSmoothUpgradeSourceVersion] = source
+	tc.Annotations[annSmoothUpgradeTargetVersion] = target
+	tc.Annotations[annSmoothUpgradeStartedAt] = time.Now().UTC().Format(time.RFC3339)
+}
+
+func smoothUpgradeAnnotationKeys() []string {
+	return []string{
+		annSmoothUpgradeDDLPaused,
+		annSmoothUpgradeSourceVersion,
+		annSmoothUpgradeTargetVersion,
+		annSmoothUpgradeStartedAt,
+	}
+}
+
+func clearSmoothUpgradeAnnotations(tc *v1alpha1.TidbCluster) {
+	if tc.Annotations == nil {
+		return
+	}
+	delete(tc.Annotations, annSmoothUpgradeDDLPaused)
+	delete(tc.Annotations, annSmoothUpgradeSourceVersion)
+	delete(tc.Annotations, annSmoothUpgradeTargetVersion)
+	delete(tc.Annotations, annSmoothUpgradeStartedAt)
+}
+
+func smoothUpgradeAnnotationsMatch(tc *v1alpha1.TidbCluster, source, target string) bool {
+	if !isSmoothUpgradePaused(tc) {
+		return false
+	}
+	return tc.Annotations[annSmoothUpgradeSourceVersion] == source && tc.Annotations[annSmoothUpgradeTargetVersion] == target
+}
+
+func (u *tidbUpgrader) ensureSmoothUpgradeStarted(tc *v1alpha1.TidbCluster, oldSet, newSet *apps.StatefulSet) error {
+	source, target, versionUpgrade := detectTiDBVersionUpgrade(oldSet, newSet)
+	if !versionUpgrade {
+		return nil
+	}
+	if isSmoothUpgradePaused(tc) {
+		if smoothUpgradeAnnotationsMatch(tc, source, target) {
+			return nil
+		}
+		ordinal, err := chooseHealthyTiDBOrdinal(tc)
+		if err != nil {
+			return err
+		}
+		if err := u.deps.TiDBControl.FinishUpgrade(tc, ordinal); err != nil {
+			return fmt.Errorf("finish stale TiDB smooth upgrade for %s/%s failed: %v", tc.Namespace, tc.Name, err)
+		}
+		if err := clearSmoothUpgradeAnnotationsPersisted(u.deps, tc); err != nil {
+			return err
+		}
+		return controller.RequeueErrorf("tidbcluster: [%s/%s] cleared stale TiDB smooth upgrade annotations, retry upgrade start", tc.Namespace, tc.Name)
+	}
+	if support := classifySmoothUpgrade(source, target); support != smoothUpgradeSwitchControlled {
+		klog.Warningf("TidbCluster: [%s/%s] TiDB smooth upgrade is %s for version pair %s -> %s, skip DDL pause API", tc.Namespace, tc.Name, support, source, target)
+		return nil
+	}
+
+	ordinal, err := chooseHealthyTiDBOrdinal(tc)
+	if err != nil {
+		return err
+	}
+	if err := u.deps.TiDBControl.StartUpgrade(tc, ordinal); err != nil {
+		return fmt.Errorf("start TiDB smooth upgrade for %s/%s from %s to %s failed: %v", tc.Namespace, tc.Name, source, target, err)
+	}
+	setSmoothUpgradeAnnotations(tc, source, target)
+	return patchTidbClusterAnnotations(u.deps, tc)
+}
+
+func (m *tidbMemberManager) maybeFinishSmoothUpgrade(tc *v1alpha1.TidbCluster) error {
+	if !isSmoothUpgradePaused(tc) {
+		return nil
+	}
+	if tc.Status.TiDB.StatefulSet == nil || tc.Status.TiDB.StatefulSet.UpdatedReplicas != tc.Status.TiDB.StatefulSet.Replicas || tc.Status.TiDB.Phase != v1alpha1.NormalPhase || !tc.TiDBAllMembersReady() {
+		return nil
+	}
+	ordinal, err := chooseHealthyTiDBOrdinal(tc)
+	if err != nil {
+		return err
+	}
+	if err := m.deps.TiDBControl.FinishUpgrade(tc, ordinal); err != nil {
+		return fmt.Errorf("finish TiDB smooth upgrade for %s/%s failed: %v", tc.Namespace, tc.Name, err)
+	}
+	return clearSmoothUpgradeAnnotationsPersisted(m.deps, tc)
+}
+
+func chooseHealthyTiDBOrdinal(tc *v1alpha1.TidbCluster) (int32, error) {
+	if tc.Status.TiDB.StatefulSet == nil {
+		return 0, controller.RequeueErrorf("tidbcluster: [%s/%s] has no TiDB StatefulSet status for smooth upgrade", tc.Namespace, tc.Name)
+	}
+	for i := int32(0); i < tc.Status.TiDB.StatefulSet.Replicas; i++ {
+		name := tidbPodName(tc.Name, i)
+		if member, ok := tc.Status.TiDB.Members[name]; ok && member.Health {
+			return i, nil
+		}
+	}
+	return 0, controller.RequeueErrorf("tidbcluster: [%s/%s] has no healthy TiDB pod for smooth upgrade", tc.Namespace, tc.Name)
+}
+
+func patchTidbClusterAnnotations(deps *controller.Dependencies, tc *v1alpha1.TidbCluster) error {
+	patch, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": tc.Annotations,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = deps.TiDBClusterControl.Patch(tc, patch)
+	return err
+}
+
+func clearSmoothUpgradeAnnotationsPersisted(deps *controller.Dependencies, tc *v1alpha1.TidbCluster) error {
+	clearSmoothUpgradeAnnotations(tc)
+	annotations := map[string]interface{}{}
+	for _, key := range smoothUpgradeAnnotationKeys() {
+		annotations[key] = nil
+	}
+	patch, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = deps.TiDBClusterControl.Patch(tc, patch)
+	return err
+}

--- a/pkg/manager/member/smooth_upgrade.go
+++ b/pkg/manager/member/smooth_upgrade.go
@@ -65,6 +65,11 @@ func classifySmoothUpgrade(source, target string) smoothUpgradeSupport {
 		return smoothUpgradeUnsupported
 	}
 
+	targetNotGreater, _ := cmpver.Compare(target, cmpver.LessOrEqual, source)
+	if targetNotGreater {
+		return smoothUpgradeUnsupported
+	}
+
 	if isAutoSmoothUpgradePair(source, target) {
 		return smoothUpgradeAutoSupported
 	}

--- a/pkg/manager/member/smooth_upgrade.go
+++ b/pkg/manager/member/smooth_upgrade.go
@@ -16,6 +16,7 @@ package member
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -235,19 +236,37 @@ func chooseHealthyTiDBOrdinal(tc *v1alpha1.TidbCluster) (int32, error) {
 	if tc.Status.TiDB.StatefulSet == nil {
 		return 0, controller.RequeueErrorf("tidbcluster: [%s/%s] has no TiDB StatefulSet status for smooth upgrade", tc.Namespace, tc.Name)
 	}
-	for i := int32(0); i < tc.Status.TiDB.StatefulSet.Replicas; i++ {
-		name := tidbPodName(tc.Name, i)
-		if member, ok := tc.Status.TiDB.Members[name]; ok && member.Health {
-			return i, nil
+	prefix := controller.TiDBMemberName(tc.Name) + "-"
+	chosen := int32(-1)
+	for name, member := range tc.Status.TiDB.Members {
+		if !member.Health || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		ord64, err := strconv.ParseInt(name[len(prefix):], 10, 32)
+		if err != nil {
+			continue
+		}
+		ord := int32(ord64)
+		if chosen < 0 || ord < chosen {
+			chosen = ord
 		}
 	}
-	return 0, controller.RequeueErrorf("tidbcluster: [%s/%s] has no healthy TiDB pod for smooth upgrade", tc.Namespace, tc.Name)
+	if chosen < 0 {
+		return 0, controller.RequeueErrorf("tidbcluster: [%s/%s] has no healthy TiDB pod for smooth upgrade", tc.Namespace, tc.Name)
+	}
+	return chosen, nil
 }
 
 func patchTidbClusterAnnotations(deps *controller.Dependencies, tc *v1alpha1.TidbCluster) error {
-	patch, err := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": tc.Annotations,
+	annotations := map[string]any{
+		annSmoothUpgradeDDLPaused:     tc.Annotations[annSmoothUpgradeDDLPaused],
+		annSmoothUpgradeSourceVersion: tc.Annotations[annSmoothUpgradeSourceVersion],
+		annSmoothUpgradeTargetVersion: tc.Annotations[annSmoothUpgradeTargetVersion],
+		annSmoothUpgradeStartedAt:     tc.Annotations[annSmoothUpgradeStartedAt],
+	}
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": annotations,
 		},
 	})
 	if err != nil {
@@ -259,12 +278,12 @@ func patchTidbClusterAnnotations(deps *controller.Dependencies, tc *v1alpha1.Tid
 
 func clearSmoothUpgradeAnnotationsPersisted(deps *controller.Dependencies, tc *v1alpha1.TidbCluster) error {
 	clearSmoothUpgradeAnnotations(tc)
-	annotations := map[string]interface{}{}
+	annotations := map[string]any{}
 	for _, key := range smoothUpgradeAnnotationKeys() {
 		annotations[key] = nil
 	}
-	patch, err := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
 			"annotations": annotations,
 		},
 	})

--- a/pkg/manager/member/smooth_upgrade_test.go
+++ b/pkg/manager/member/smooth_upgrade_test.go
@@ -41,6 +41,9 @@ func TestSmoothUpgradeMatrix(t *testing.T) {
 		{"v7.4.0", "v7.5.0", smoothUpgradeSwitchControlled},
 		{"v7.3.0", "v7.4.0", smoothUpgradeUnsupported},
 		{"nightly", "v7.4.0", smoothUpgradeUnsupported},
+		// downgrade pairs must never trigger smooth upgrade
+		{"v7.5.0", "v7.4.0", smoothUpgradeUnsupported},
+		{"v7.1.3", "v7.1.2", smoothUpgradeUnsupported},
 	}
 	for _, c := range cases {
 		g.Expect(classifySmoothUpgrade(c.source, c.target)).To(Equal(c.want), "%s -> %s", c.source, c.target)

--- a/pkg/manager/member/smooth_upgrade_test.go
+++ b/pkg/manager/member/smooth_upgrade_test.go
@@ -82,6 +82,23 @@ func TestSmoothUpgradeAnnotations(t *testing.T) {
 	g.Expect(tc.Annotations).NotTo(HaveKey(annSmoothUpgradeSourceVersion))
 }
 
+func TestImageTag(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cases := []struct {
+		image string
+		want  string
+	}{
+		{"pingcap/tidb:v7.5.0", "v7.5.0"},
+		{"pingcap/tidb@sha256:abc123", ""},
+		{"pingcap/tidb", ""},
+		{"pingcap/tidb:", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		g.Expect(imageTag(c.image)).To(Equal(c.want), "image=%q", c.image)
+	}
+}
+
 func smoothUpgradeStatefulSet(image string) *apps.StatefulSet {
 	return &apps.StatefulSet{Spec: apps.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: v1alpha1.TiDBMemberType.String(), Image: image}}}}}}
 }

--- a/pkg/manager/member/smooth_upgrade_test.go
+++ b/pkg/manager/member/smooth_upgrade_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+
+	. "github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSmoothUpgradeMatrix(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cases := []struct {
+		source string
+		target string
+		want   smoothUpgradeSupport
+	}{
+		{"v7.0.9", "v7.1.0", smoothUpgradeUnsupported},
+		{"v7.1.0", "v7.1.1", smoothUpgradeAutoSupported},
+		{"v7.1.0", "v7.2.0", smoothUpgradeAutoSupported},
+		{"v7.1.1", "v7.3.0", smoothUpgradeAutoSupported},
+		{"v7.2.0", "v7.3.0", smoothUpgradeAutoSupported},
+		{"v7.1.2", "v7.1.3", smoothUpgradeSwitchControlled},
+		{"v7.1.9", "v7.4.0", smoothUpgradeSwitchControlled},
+		{"v7.4.0", "v7.5.0", smoothUpgradeSwitchControlled},
+		{"v7.3.0", "v7.4.0", smoothUpgradeUnsupported},
+		{"nightly", "v7.4.0", smoothUpgradeUnsupported},
+	}
+	for _, c := range cases {
+		g.Expect(classifySmoothUpgrade(c.source, c.target)).To(Equal(c.want), "%s -> %s", c.source, c.target)
+	}
+}
+
+func TestDetectTiDBVersionUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	oldSet := smoothUpgradeStatefulSet("pingcap/tidb:v7.4.0")
+	newSet := smoothUpgradeStatefulSet("pingcap/tidb:v7.5.0")
+	source, target, ok := detectTiDBVersionUpgrade(oldSet, newSet)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(source).To(Equal("v7.4.0"))
+	g.Expect(target).To(Equal("v7.5.0"))
+
+	newSet = smoothUpgradeStatefulSet("pingcap/tidb:v7.4.0")
+	newSet.Spec.Template.Annotations = map[string]string{"config": "changed"}
+	_, _, ok = detectTiDBVersionUpgrade(oldSet, newSet)
+	g.Expect(ok).To(BeFalse())
+
+	newSet = smoothUpgradeStatefulSet("custom")
+	_, _, ok = detectTiDBVersionUpgrade(oldSet, newSet)
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestSmoothUpgradeAnnotations(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tc := &v1alpha1.TidbCluster{ObjectMeta: metav1.ObjectMeta{Name: "tc"}}
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeFalse())
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+	g.Expect(smoothUpgradeAnnotationsMatch(tc, "v7.4.0", "v7.5.0")).To(BeTrue())
+	g.Expect(smoothUpgradeAnnotationsMatch(tc, "v7.4.0", "v7.6.0")).To(BeFalse())
+	clearSmoothUpgradeAnnotations(tc)
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeFalse())
+	g.Expect(tc.Annotations).NotTo(HaveKey(annSmoothUpgradeSourceVersion))
+}
+
+func smoothUpgradeStatefulSet(image string) *apps.StatefulSet {
+	return &apps.StatefulSet{Spec: apps.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: v1alpha1.TiDBMemberType.String(), Image: image}}}}}}
+}

--- a/pkg/manager/member/tidb_member_manager.go
+++ b/pkg/manager/member/tidb_member_manager.go
@@ -163,7 +163,10 @@ func (m *tidbMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	}
 
 	// Sync TiDB StatefulSet
-	return m.syncTiDBStatefulSetForTidbCluster(tc)
+	if err := m.syncTiDBStatefulSetForTidbCluster(tc); err != nil {
+		return err
+	}
+	return m.maybeFinishSmoothUpgrade(tc)
 }
 
 func (m *tidbMemberManager) syncRecoveryForTidbCluster(tc *v1alpha1.TidbCluster) error {

--- a/pkg/manager/member/tidb_member_manager_test.go
+++ b/pkg/manager/member/tidb_member_manager_test.go
@@ -2939,3 +2939,101 @@ func TestTiDBMemberManagerSetServerLabels(t *testing.T) {
 		testFn(&tests[i], t)
 	}
 }
+
+func TestTiDBMemberManagerMaybeFinishSmoothUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m, _, tidbControl, _ := newFakeTiDBMemberManager()
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "finish", Namespace: corev1.NamespaceDefault},
+		Spec:       v1alpha1.TidbClusterSpec{TiDB: &v1alpha1.TiDBSpec{Replicas: 2}},
+		Status: v1alpha1.TidbClusterStatus{TiDB: v1alpha1.TiDBStatus{
+			Phase: v1alpha1.NormalPhase,
+			StatefulSet: &apps.StatefulSetStatus{
+				Replicas:        2,
+				UpdatedReplicas: 2,
+			},
+			Members: map[string]v1alpha1.TiDBMember{
+				"finish-tidb-0": {Name: "finish-tidb-0", Health: true},
+				"finish-tidb-1": {Name: "finish-tidb-1", Health: true},
+			},
+		}},
+	}
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+
+	err := m.maybeFinishSmoothUpgrade(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.FinishUpgradeOrdinals).To(Equal([]int32{0}))
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeFalse())
+}
+
+func TestTiDBMemberManagerMaybeFinishSmoothUpgradeWaitsUntilNormal(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m, _, tidbControl, _ := newFakeTiDBMemberManager()
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "finish", Namespace: corev1.NamespaceDefault},
+		Status: v1alpha1.TidbClusterStatus{TiDB: v1alpha1.TiDBStatus{
+			Phase: v1alpha1.UpgradePhase,
+			StatefulSet: &apps.StatefulSetStatus{
+				Replicas:        2,
+				UpdatedReplicas: 1,
+			},
+			Members: map[string]v1alpha1.TiDBMember{"finish-tidb-0": {Name: "finish-tidb-0", Health: true}},
+		}},
+	}
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+
+	err := m.maybeFinishSmoothUpgrade(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.FinishUpgradeOrdinals).To(BeEmpty())
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+}
+
+func TestTiDBMemberManagerMaybeFinishSmoothUpgradeWaitsForAllMembersHealthy(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m, _, tidbControl, _ := newFakeTiDBMemberManager()
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "finish", Namespace: corev1.NamespaceDefault},
+		Spec:       v1alpha1.TidbClusterSpec{TiDB: &v1alpha1.TiDBSpec{Replicas: 2}},
+		Status: v1alpha1.TidbClusterStatus{TiDB: v1alpha1.TiDBStatus{
+			Phase: v1alpha1.NormalPhase,
+			StatefulSet: &apps.StatefulSetStatus{
+				Replicas:        2,
+				UpdatedReplicas: 2,
+			},
+			Members: map[string]v1alpha1.TiDBMember{
+				"finish-tidb-0": {Name: "finish-tidb-0", Health: true},
+				"finish-tidb-1": {Name: "finish-tidb-1", Health: false},
+			},
+		}},
+	}
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+
+	err := m.maybeFinishSmoothUpgrade(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.FinishUpgradeOrdinals).To(BeEmpty())
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+}
+
+func TestTiDBMemberManagerMaybeFinishSmoothUpgradeFailureKeepsAnnotations(t *testing.T) {
+	g := NewGomegaWithT(t)
+	m, _, tidbControl, _ := newFakeTiDBMemberManager()
+	tidbControl.SetFinishUpgradeError(fmt.Errorf("boom"))
+	tc := &v1alpha1.TidbCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "finish", Namespace: corev1.NamespaceDefault},
+		Spec:       v1alpha1.TidbClusterSpec{TiDB: &v1alpha1.TiDBSpec{Replicas: 1}},
+		Status: v1alpha1.TidbClusterStatus{TiDB: v1alpha1.TiDBStatus{
+			Phase: v1alpha1.NormalPhase,
+			StatefulSet: &apps.StatefulSetStatus{
+				Replicas:        1,
+				UpdatedReplicas: 1,
+			},
+			Members: map[string]v1alpha1.TiDBMember{"finish-tidb-0": {Name: "finish-tidb-0", Health: true}},
+		}},
+	}
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+
+	err := m.maybeFinishSmoothUpgrade(tc)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(tidbControl.FinishUpgradeOrdinals).To(Equal([]int32{0}))
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+}

--- a/pkg/manager/member/tidb_upgrader.go
+++ b/pkg/manager/member/tidb_upgrader.go
@@ -76,6 +76,9 @@ func (u *tidbUpgrader) Upgrade(tc *v1alpha1.TidbCluster, oldSet *apps.StatefulSe
 	}
 
 	tc.Status.TiDB.Phase = v1alpha1.UpgradePhase
+	if err := u.ensureSmoothUpgradeStarted(tc, oldSet, newSet); err != nil {
+		return err
+	}
 	if !templateEqual(newSet, oldSet) {
 		return nil
 	}

--- a/pkg/manager/member/tidb_upgrader_test.go
+++ b/pkg/manager/member/tidb_upgrader_test.go
@@ -464,6 +464,30 @@ func TestTiDBUpgraderSmoothUpgradeActiveAnnotationSkipsDuplicate(t *testing.T) {
 	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
 }
 
+func TestTiDBUpgraderSmoothUpgradeStaleAnnotationRecovery(t *testing.T) {
+	g := NewGomegaWithT(t)
+	upgrader, tidbControl, podInformer := newTiDBUpgrader()
+	tc := newTidbClusterForTiDBUpgrader()
+	tc.Status.PD.Phase = v1alpha1.NormalPhase
+	tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	for _, pod := range getTiDBPods() {
+		g.Expect(podInformer.Informer().GetIndexer().Add(pod)).To(Succeed())
+	}
+	oldSet := newStatefulSetForTiDBUpgrader()
+	oldSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.4.0"
+	newSet := oldSet.DeepCopy()
+	newSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.5.0"
+	g.Expect(mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)).To(Succeed())
+	// stale annotations from a prior upgrade to a different target
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.4.1")
+
+	err := upgrader.Upgrade(tc, oldSet, newSet)
+	g.Expect(err).To(HaveOccurred()) // requeue error
+	g.Expect(tidbControl.FinishUpgradeOrdinals).To(Equal([]int32{0}))
+	g.Expect(tidbControl.StartUpgradeOrdinals).To(BeEmpty())
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeFalse())
+}
+
 func TestTiDBUpgraderSmoothUpgradeSkipsNonSwitchPairs(t *testing.T) {
 	g := NewGomegaWithT(t)
 	upgrader, tidbControl, podInformer := newTiDBUpgrader()

--- a/pkg/manager/member/tidb_upgrader_test.go
+++ b/pkg/manager/member/tidb_upgrader_test.go
@@ -442,6 +442,28 @@ func TestTiDBUpgraderSmoothUpgradeStartFailureBlocksRollout(t *testing.T) {
 	g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
 }
 
+func TestTiDBUpgraderSmoothUpgradeActiveAnnotationSkipsDuplicate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	upgrader, tidbControl, podInformer := newTiDBUpgrader()
+	tc := newTidbClusterForTiDBUpgrader()
+	tc.Status.PD.Phase = v1alpha1.NormalPhase
+	tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	for _, pod := range getTiDBPods() {
+		g.Expect(podInformer.Informer().GetIndexer().Add(pod)).To(Succeed())
+	}
+	oldSet := newStatefulSetForTiDBUpgrader()
+	oldSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.4.0"
+	newSet := oldSet.DeepCopy()
+	newSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.5.0"
+	g.Expect(mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)).To(Succeed())
+	setSmoothUpgradeAnnotations(tc, "v7.4.0", "v7.5.0")
+
+	err := upgrader.Upgrade(tc, oldSet, newSet)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.StartUpgradeOrdinals).To(BeEmpty())
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+}
+
 func TestTiDBUpgraderSmoothUpgradeSkipsNonSwitchPairs(t *testing.T) {
 	g := NewGomegaWithT(t)
 	upgrader, tidbControl, podInformer := newTiDBUpgrader()

--- a/pkg/manager/member/tidb_upgrader_test.go
+++ b/pkg/manager/member/tidb_upgrader_test.go
@@ -14,6 +14,7 @@
 package member
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
@@ -394,4 +395,69 @@ func getTiDBPods() []*corev1.Pod {
 		},
 	}
 	return pods
+}
+
+func TestTiDBUpgraderSmoothUpgradeStart(t *testing.T) {
+	g := NewGomegaWithT(t)
+	upgrader, tidbControl, podInformer := newTiDBUpgrader()
+	tc := newTidbClusterForTiDBUpgrader()
+	tc.Status.PD.Phase = v1alpha1.NormalPhase
+	tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	for _, pod := range getTiDBPods() {
+		g.Expect(podInformer.Informer().GetIndexer().Add(pod)).To(Succeed())
+	}
+	oldSet := newStatefulSetForTiDBUpgrader()
+	oldSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.4.0"
+	newSet := oldSet.DeepCopy()
+	newSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.5.0"
+	g.Expect(mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)).To(Succeed())
+
+	err := upgrader.Upgrade(tc, oldSet, newSet)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.StartUpgradeOrdinals).To(Equal([]int32{0}))
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeTrue())
+	g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
+}
+
+func TestTiDBUpgraderSmoothUpgradeStartFailureBlocksRollout(t *testing.T) {
+	g := NewGomegaWithT(t)
+	upgrader, tidbControl, podInformer := newTiDBUpgrader()
+	tidbControl.SetStartUpgradeError(fmt.Errorf("boom"))
+	tc := newTidbClusterForTiDBUpgrader()
+	tc.Status.PD.Phase = v1alpha1.NormalPhase
+	tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	for _, pod := range getTiDBPods() {
+		g.Expect(podInformer.Informer().GetIndexer().Add(pod)).To(Succeed())
+	}
+	oldSet := newStatefulSetForTiDBUpgrader()
+	oldSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.4.0"
+	newSet := oldSet.DeepCopy()
+	newSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.5.0"
+	g.Expect(mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)).To(Succeed())
+
+	err := upgrader.Upgrade(tc, oldSet, newSet)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(tidbControl.StartUpgradeOrdinals).To(Equal([]int32{0}))
+	g.Expect(isSmoothUpgradePaused(tc)).To(BeFalse())
+	g.Expect(newSet.Spec.UpdateStrategy.RollingUpdate.Partition).To(Equal(pointer.Int32Ptr(1)))
+}
+
+func TestTiDBUpgraderSmoothUpgradeSkipsNonSwitchPairs(t *testing.T) {
+	g := NewGomegaWithT(t)
+	upgrader, tidbControl, podInformer := newTiDBUpgrader()
+	tc := newTidbClusterForTiDBUpgrader()
+	tc.Status.PD.Phase = v1alpha1.NormalPhase
+	tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+	for _, pod := range getTiDBPods() {
+		g.Expect(podInformer.Informer().GetIndexer().Add(pod)).To(Succeed())
+	}
+	oldSet := newStatefulSetForTiDBUpgrader()
+	oldSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.3.0"
+	newSet := oldSet.DeepCopy()
+	newSet.Spec.Template.Spec.Containers[0].Image = "pingcap/tidb:v7.4.0"
+	g.Expect(mngerutils.SetStatefulSetLastAppliedConfigAnnotation(oldSet)).To(Succeed())
+
+	err := upgrader.Upgrade(tc, oldSet, newSet)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tidbControl.StartUpgradeOrdinals).To(BeEmpty())
 }

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -3519,6 +3519,126 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 			framework.ExpectNoError(err, "Expected tidbcluster is ready")
 		})
 	})
+
+	ginkgo.Context("[TiDBCluster: Smooth Upgrade DDL Pause]", func() {
+		const (
+			annSmoothUpgradeDDLPaused     = "tidb.pingcap.com/smooth-upgrade-ddl-paused"
+			annSmoothUpgradeSourceVersion = "tidb.pingcap.com/smooth-upgrade-source-version"
+			annSmoothUpgradeTargetVersion = "tidb.pingcap.com/smooth-upgrade-target-version"
+		)
+
+		smoothUpgradePaused := func(tc *v1alpha1.TidbCluster) (bool, error) {
+			return tc.Annotations[annSmoothUpgradeDDLPaused] == "true", nil
+		}
+		smoothUpgradeCleared := func(tc *v1alpha1.TidbCluster) (bool, error) {
+			_, has := tc.Annotations[annSmoothUpgradeDDLPaused]
+			return !has, nil
+		}
+
+		ginkgo.It("should set and clear smooth-upgrade annotations for switch-controlled version pair", func() {
+			tcName := "smooth-upgrade-happy"
+			ginkgo.By(fmt.Sprintf("Deploy cluster at %s", utilimage.TiDBV7x5x0))
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV7x5x0)
+			tc.Spec.PD.Replicas = 1
+			tc.Spec.TiKV.Replicas = 1
+			tc.Spec.TiDB.Replicas = 2
+			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc, 15*time.Minute, 10*time.Second)
+
+			ginkgo.By(fmt.Sprintf("Upgrade to %s", utilimage.TiDBV7x5x3))
+			err := controller.GuaranteedUpdate(genericCli, tc, func() error {
+				tc.Spec.Version = utilimage.TiDBV7x5x3
+				return nil
+			})
+			framework.ExpectNoError(err, "failed to update tc version")
+
+			ginkgo.By("Wait for smooth-upgrade-ddl-paused annotation to appear")
+			err = utiltc.WaitForTCCondition(cli, ns, tcName, 3*time.Minute, 5*time.Second, smoothUpgradePaused)
+			framework.ExpectNoError(err, "smooth-upgrade-ddl-paused annotation did not appear during upgrade")
+
+			ginkgo.By("Verify source and target version annotations")
+			latest, err := cli.PingcapV1alpha1().TidbClusters(ns).Get(context.TODO(), tcName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get TidbCluster")
+			framework.ExpectEqual(latest.Annotations[annSmoothUpgradeSourceVersion], utilimage.TiDBV7x5x0, "source version annotation mismatch")
+			framework.ExpectEqual(latest.Annotations[annSmoothUpgradeTargetVersion], utilimage.TiDBV7x5x3, "target version annotation mismatch")
+
+			ginkgo.By("Wait for cluster upgrade to complete")
+			err = oa.WaitForTidbClusterReady(tc, 15*time.Minute, 10*time.Second)
+			framework.ExpectNoError(err, "cluster did not become ready after upgrade")
+
+			ginkgo.By("Verify smooth-upgrade annotations are cleared after finish")
+			err = utiltc.WaitForTCCondition(cli, ns, tcName, 2*time.Minute, 5*time.Second, smoothUpgradeCleared)
+			framework.ExpectNoError(err, "smooth-upgrade annotations were not cleared after upgrade finish")
+		})
+
+		ginkgo.It("should skip smooth-upgrade annotations for unsupported version pair", func() {
+			tcName := "smooth-upgrade-unsupported"
+			oldVersion := utilimage.TiDBPreviousVersions[0] // v6.5.10, source < v7.1.0 → unsupported
+			ginkgo.By(fmt.Sprintf("Deploy cluster at %s", oldVersion))
+			tc := fixture.GetTidbCluster(ns, tcName, oldVersion)
+			tc.Spec.PD.Replicas = 1
+			tc.Spec.TiKV.Replicas = 1
+			tc.Spec.TiDB.Replicas = 1
+			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc, 15*time.Minute, 10*time.Second)
+
+			ginkgo.By(fmt.Sprintf("Upgrade to %s", utilimage.TiDBLatest))
+			err := controller.GuaranteedUpdate(genericCli, tc, func() error {
+				tc.Spec.Version = utilimage.TiDBLatest
+				return nil
+			})
+			framework.ExpectNoError(err, "failed to update tc version")
+
+			ginkgo.By("Wait for TiDB UpgradePhase")
+			utiltc.MustWaitForComponentPhase(cli, tc, v1alpha1.TiDBMemberType, v1alpha1.UpgradePhase, 3*time.Minute, 5*time.Second)
+
+			ginkgo.By("Assert smooth-upgrade-ddl-paused annotation is absent during upgrade")
+			latest, err := cli.PingcapV1alpha1().TidbClusters(ns).Get(context.TODO(), tcName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get TidbCluster")
+			_, hasPausedAnn := latest.Annotations[annSmoothUpgradeDDLPaused]
+			framework.ExpectEqual(hasPausedAnn, false, "smooth-upgrade-ddl-paused should not be set for unsupported version pair")
+
+			ginkgo.By("Wait for cluster upgrade to complete")
+			err = oa.WaitForTidbClusterReady(tc, 15*time.Minute, 10*time.Second)
+			framework.ExpectNoError(err, "cluster did not become ready after upgrade")
+		})
+
+		ginkgo.It("should finish smooth upgrade after operator restart", func() {
+			tcName := "smooth-upgrade-restart"
+			ginkgo.By(fmt.Sprintf("Deploy cluster at %s", utilimage.TiDBV7x5x0))
+			tc := fixture.GetTidbCluster(ns, tcName, utilimage.TiDBV7x5x0)
+			tc.Spec.PD.Replicas = 1
+			tc.Spec.TiKV.Replicas = 1
+			tc.Spec.TiDB.Replicas = 2
+			utiltc.MustCreateTCWithComponentsReady(genericCli, oa, tc, 15*time.Minute, 10*time.Second)
+
+			ginkgo.By(fmt.Sprintf("Upgrade to %s", utilimage.TiDBV7x5x3))
+			err := controller.GuaranteedUpdate(genericCli, tc, func() error {
+				tc.Spec.Version = utilimage.TiDBV7x5x3
+				return nil
+			})
+			framework.ExpectNoError(err, "failed to update tc version")
+
+			ginkgo.By("Wait for smooth-upgrade start annotation")
+			err = utiltc.WaitForTCCondition(cli, ns, tcName, 3*time.Minute, 5*time.Second, smoothUpgradePaused)
+			framework.ExpectNoError(err, "smooth-upgrade-ddl-paused annotation did not appear")
+
+			ginkgo.By("Delete the tidb-controller-manager pod to simulate operator restart")
+			podList, err := c.CoreV1().Pods(ocfg.Namespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/component=controller-manager",
+			})
+			framework.ExpectNoError(err, "failed to list controller-manager pods")
+			framework.ExpectNotEqual(len(podList.Items), 0, "expected at least one controller-manager pod")
+			err = c.CoreV1().Pods(ocfg.Namespace).Delete(context.TODO(), podList.Items[0].Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete controller-manager pod")
+
+			ginkgo.By("Wait for cluster upgrade to complete after operator restart")
+			err = oa.WaitForTidbClusterReady(tc, 20*time.Minute, 10*time.Second)
+			framework.ExpectNoError(err, "cluster did not become ready after operator restart during upgrade")
+
+			ginkgo.By("Verify smooth-upgrade annotations are cleared after finish")
+			err = utiltc.WaitForTCCondition(cli, ns, tcName, 2*time.Minute, 5*time.Second, smoothUpgradeCleared)
+			framework.ExpectNoError(err, "smooth-upgrade annotations were not cleared after operator restart recovery")
+		})
+	})
 })
 
 // checkAllPDMSStatus check there are onlineNum online pdms instance running now.

--- a/tests/e2e/tidbcluster/tidbcluster.go
+++ b/tests/e2e/tidbcluster/tidbcluster.go
@@ -3521,6 +3521,7 @@ var _ = ginkgo.Describe("TiDBCluster", func() {
 	})
 
 	ginkgo.Context("[TiDBCluster: Smooth Upgrade DDL Pause]", func() {
+		// These must match pkg/manager/member/smooth_upgrade.go ann* constants.
 		const (
 			annSmoothUpgradeDDLPaused     = "tidb.pingcap.com/smooth-upgrade-ddl-paused"
 			annSmoothUpgradeSourceVersion = "tidb.pingcap.com/smooth-upgrade-source-version"

--- a/tests/e2e/util/proxiedtidbclient/proxiedtidbclient.go
+++ b/tests/e2e/util/proxiedtidbclient/proxiedtidbclient.go
@@ -42,6 +42,14 @@ func (p *proxiedTiDBClient) SetServerLabels(tc *v1alpha1.TidbCluster, ordinal in
 	panic("implement when necessary")
 }
 
+func (p *proxiedTiDBClient) StartUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	panic("implement when necessary")
+}
+
+func (p *proxiedTiDBClient) FinishUpgrade(tc *v1alpha1.TidbCluster, ordinal int32) error {
+	panic("implement when necessary")
+}
+
 func NewProxiedTiDBClient(fw portforward.PortForward, caCert []byte) controller.TiDBControlInterface {
 	return &proxiedTiDBClient{fw: fw, httpClient: &http.Client{Timeout: 5 * time.Second}, caCert: caCert}
 }


### PR DESCRIPTION
## What is changed

This PR adds TiDB smooth-upgrade coordination to TiDB Operator v1 classic TiDB upgrades on `release-1.x`:

- call TiDB `POST /upgrade/start` before eligible TiDB rolling version upgrades begin
- wait for the `200` start response before allowing TiDB pods to roll
- persist the active pause window in `TidbCluster` annotations
- call `POST /upgrade/finish` after the upgraded TiDB StatefulSet is fully updated, Normal, and members are healthy
- clear smooth-upgrade annotations only after finish succeeds
- skip unsupported and auto-supported smooth-upgrade version pairs

## Design notes

The implementation follows `docs/design-proposals/2026-05-14-pause-ddl-during-tidb-upgrade.md`.

Important behavior:

- `/upgrade/start` uses a 30s client timeout because TiDB waits up to 10s for the DDL owner to sync upgrading state before returning success.
- TiDB's success responses are JSON string bodies, so the client decodes them before matching `success!` and duplicate-success responses.
- Active pause state is stored in annotations:
  - `tidb.pingcap.com/smooth-upgrade-ddl-paused`
  - `tidb.pingcap.com/smooth-upgrade-source-version`
  - `tidb.pingcap.com/smooth-upgrade-target-version`
  - `tidb.pingcap.com/smooth-upgrade-started-at`
- Stale/mismatched annotations are handled by idempotently calling `/upgrade/finish`, deleting the annotation keys, and requeueing.

## Tests

```text
PASS git diff --check
PASS go test ./pkg/controller ./pkg/manager/member ./tests/e2e/util/proxiedtidbclient -count=1
```
