### PR TITLE
tici: preserve zero replicas in defaulting

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster.go
@@ -183,13 +183,6 @@ func setTiCISpecDefault(tc *v1alpha1.TidbCluster) {
 		tc.Spec.TiCI.Worker = &v1alpha1.TiCIWorkerSpec{}
 	}
 
-	if tc.Spec.TiCI.Meta.Replicas == 0 {
-		tc.Spec.TiCI.Meta.Replicas = 1
-	}
-	if tc.Spec.TiCI.Worker.Replicas == 0 {
-		tc.Spec.TiCI.Worker.Replicas = 1
-	}
-
 	if len(tc.Spec.Version) > 0 || tc.Spec.TiCI.Meta.Version != nil {
 		if tc.Spec.TiCI.Meta.BaseImage == "" {
 			tc.Spec.TiCI.Meta.BaseImage = defaultTiCIImage

--- a/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster_test.go
+++ b/pkg/apis/pingcap/v1alpha1/defaulting/tidbcluster_test.go
@@ -79,6 +79,33 @@ func TestSetTidbSpecDefault(t *testing.T) {
 
 }
 
+func TestSetTiCISpecDefaultPreservesZeroReplicas(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tc := &v1alpha1.TidbCluster{
+		Spec: v1alpha1.TidbClusterSpec{
+			TiCI: &v1alpha1.TiCISpec{},
+		},
+	}
+	setTiCISpecDefault(tc)
+	g.Expect(tc.Spec.TiCI.Meta).ShouldNot(BeNil())
+	g.Expect(tc.Spec.TiCI.Meta.Replicas).Should(Equal(int32(0)))
+	g.Expect(tc.Spec.TiCI.Worker).ShouldNot(BeNil())
+	g.Expect(tc.Spec.TiCI.Worker.Replicas).Should(Equal(int32(0)))
+
+	tc = &v1alpha1.TidbCluster{
+		Spec: v1alpha1.TidbClusterSpec{
+			TiCI: &v1alpha1.TiCISpec{
+				Meta:   &v1alpha1.TiCIMetaSpec{Replicas: 2},
+				Worker: &v1alpha1.TiCIWorkerSpec{Replicas: 3},
+			},
+		},
+	}
+	setTiCISpecDefault(tc)
+	g.Expect(tc.Spec.TiCI.Meta.Replicas).Should(Equal(int32(2)))
+	g.Expect(tc.Spec.TiCI.Worker.Replicas).Should(Equal(int32(3)))
+}
+
 func newTidbCluster() *v1alpha1.TidbCluster {
 	return &v1alpha1.TidbCluster{
 		Spec: v1alpha1.TidbClusterSpec{


### PR DESCRIPTION
## What changed

Removed the TiCI defaulting logic that rewrote `spec.tici.meta.replicas: 0` and `spec.tici.worker.replicas: 0` to `1`.

Added a defaulting unit test to cover both zero replicas and non-zero replicas for TiCI meta/worker.

## Why

TiCI replicas use the same `int32` pattern as the other TidbCluster components. A zero value should remain a valid desired replica count, matching components like PD, TiKV, TiFlash, TiDB, TiCDC, and TiProxy.

The previous TiCI-specific defaulting treated zero as unspecified, which prevented users from scaling TiCI meta/worker to zero.

## Impact

Users can now set TiCI meta/worker replicas to `0` without the admission defaulting path forcing them back to `1`.

CRD schema still requires the `replicas` field, so manifests should explicitly set `replicas: 0` when scale-to-zero is desired.

## Validation

- `go test github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1/defaulting`
- `go test github.com/pingcap/tidb-operator/pkg/manager/member -run 'Test.*TiCI|TestScaleOne|TestScaleMulti'`
- `git diff --check`
