### PR TITLE
fix: preserve legacy DM app label

### DIFF
--- a/pkg/controllers/dm/tasks/pod.go
+++ b/pkg/controllers/dm/tasks/pod.go
@@ -161,6 +161,10 @@ func newPod(cluster *v1alpha1.Cluster, dm *v1alpha1.DM) *corev1.Pod {
 				},
 				// TODO: remove it
 				k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentDMMaster),
+				map[string]string{
+					// Keep the legacy DM app name for user monitoring collectors that select DM metrics by this label.
+					k8s.LabelKeyK8sAppName: k8s.LabelValK8sAppNameDMCluster,
+				},
 			),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(dm, v1alpha1.SchemeGroupVersion.WithKind("DM")),

--- a/pkg/controllers/dm/tasks/pod_test.go
+++ b/pkg/controllers/dm/tasks/pod_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/fake"
+	"github.com/pingcap/tidb-operator/v2/pkg/utils/k8s"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
 )
 
@@ -118,6 +119,7 @@ func TestTaskPod(t *testing.T) {
 			require.Len(t, pod.Spec.Containers, 1)
 			assert.Equal(t, []string{"/dm-master", "--config", "/etc/dm-master/config.toml"}, pod.Spec.Containers[0].Command)
 			assert.Equal(t, v1alpha1.LabelValComponentDMMaster, pod.Labels[v1alpha1.LabelKeyComponent])
+			assert.Equal(t, k8s.LabelValK8sAppNameDMCluster, pod.Labels[k8s.LabelKeyK8sAppName])
 			assert.Len(t, pod.Spec.Containers[0].Ports, 2)
 			assert.Equal(t, int32(8261), pod.Spec.Containers[0].Ports[0].ContainerPort)
 			assert.Equal(t, int32(8291), pod.Spec.Containers[0].Ports[1].ContainerPort)

--- a/pkg/controllers/dmworker/tasks/pod.go
+++ b/pkg/controllers/dmworker/tasks/pod.go
@@ -161,6 +161,10 @@ func newPod(cluster *v1alpha1.Cluster, dw *v1alpha1.DMWorker) *corev1.Pod {
 					v1alpha1.LabelKeyClusterID: cluster.Status.ID,
 				},
 				k8s.LabelsK8sApp(cluster.Name, v1alpha1.LabelValComponentDMWorker),
+				map[string]string{
+					// Keep the legacy DM app name for user monitoring collectors that select DM metrics by this label.
+					k8s.LabelKeyK8sAppName: k8s.LabelValK8sAppNameDMCluster,
+				},
 			),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(dw, v1alpha1.SchemeGroupVersion.WithKind("DMWorker")),

--- a/pkg/controllers/dmworker/tasks/pod_test.go
+++ b/pkg/controllers/dmworker/tasks/pod_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/fake"
+	"github.com/pingcap/tidb-operator/v2/pkg/utils/k8s"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
 )
 
@@ -93,6 +94,7 @@ func TestTaskPod(t *testing.T) {
 			require.Len(t, pod.Spec.Containers, 1)
 			assert.Equal(t, []string{"/dm-worker", "--config", "/etc/dm-worker/config.toml"}, pod.Spec.Containers[0].Command)
 			assert.Equal(t, v1alpha1.LabelValComponentDMWorker, pod.Labels[v1alpha1.LabelKeyComponent])
+			assert.Equal(t, k8s.LabelValK8sAppNameDMCluster, pod.Labels[k8s.LabelKeyK8sAppName])
 			require.Len(t, pod.Spec.Containers[0].Ports, 1)
 			assert.Equal(t, int32(8262), pod.Spec.Containers[0].Ports[0].ContainerPort)
 		})

--- a/pkg/utils/k8s/pod.go
+++ b/pkg/utils/k8s/pod.go
@@ -23,6 +23,12 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 )
 
+const (
+	LabelKeyK8sAppName          = "app.kubernetes.io/name"
+	LabelValK8sAppNameTiDB      = "tidb-cluster"
+	LabelValK8sAppNameDMCluster = "dm-cluster"
+)
+
 func GetResourceRequirements(req v1alpha1.ResourceRequirements) corev1.ResourceRequirements {
 	if req.CPU == nil && req.Memory == nil {
 		return corev1.ResourceRequirements{}
@@ -68,6 +74,6 @@ func LabelsK8sApp(cluster, component string) map[string]string {
 		"app.kubernetes.io/component":  component,
 		"app.kubernetes.io/instance":   cluster,
 		"app.kubernetes.io/managed-by": "tidb-operator",
-		"app.kubernetes.io/name":       "tidb-cluster",
+		LabelKeyK8sAppName:             LabelValK8sAppNameTiDB,
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve `app.kubernetes.io/name=dm-cluster` on DM and DMWorker pods for legacy monitoring collectors.
- Add shared k8s app label constants and focused pod label assertions.

## Test plan
- [x] `go test ./pkg/controllers/dm/tasks ./pkg/controllers/dmworker/tasks ./pkg/utils/k8s`
- [x] IDE lints checked for edited files


Made with [Cursor](https://cursor.com)