### PR TITLE
fix(tiproxy): sync graceful delay before rollout

### DIFF
--- a/pkg/controllers/tiproxygroup/tasks/updater.go
+++ b/pkg/controllers/tiproxygroup/tasks/updater.go
@@ -77,7 +77,8 @@ func TaskUpdater(state *ReconcileContext, c client.Client, af tracker.AllocateFa
 			return task.Fail().With("invalid topo policy, it should be validated: %w", err)
 		}
 
-		needUpdate, needRestart := precheckInstances(proxyg, runtime.ToTiProxySlice(proxies), updateRevision)
+		tiproxies := runtime.ToTiProxySlice(proxies)
+		needUpdate, needRestart := precheckInstances(proxyg, tiproxies, updateRevision)
 		if !needUpdate {
 			return task.Complete().With("all instances are synced")
 		}
@@ -85,6 +86,14 @@ func TaskUpdater(state *ReconcileContext, c client.Client, af tracker.AllocateFa
 		maxSurge, maxUnavailable := 0, 1
 		noUpdate := false
 		if needRestart {
+			updated, err := syncGracefulShutdownDeleteDelayForOutdatedTiProxies(ctx, c, proxyg, tiproxies, updateRevision)
+			if err != nil {
+				return task.Fail().With("cannot sync graceful shutdown delete delay before rolling restart: %w", err)
+			}
+			if updated {
+				return task.Wait().With("wait for graceful shutdown delete delay to be synced before rolling restart")
+			}
+
 			maxSurge, maxUnavailable = 1, 0
 			if proxyg.Spec.MaxSurge != nil {
 				maxSurge = int(*proxyg.Spec.MaxSurge)
@@ -153,6 +162,45 @@ func precheckInstances(proxyg *v1alpha1.TiProxyGroup, proxies []*v1alpha1.TiProx
 	}
 
 	return needUpdate, needRestart
+}
+
+func syncGracefulShutdownDeleteDelayForOutdatedTiProxies(
+	ctx context.Context,
+	c client.Client,
+	proxyg *v1alpha1.TiProxyGroup,
+	proxies []*v1alpha1.TiProxy,
+	updateRevision string,
+) (bool, error) {
+	expected, expectedExists := proxyg.Spec.Template.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds]
+	updated := false
+
+	for _, proxy := range proxies {
+		if coreutil.UpdateRevision[scope.TiProxy](proxy) == updateRevision {
+			continue
+		}
+
+		current, currentExists := proxy.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds]
+		if currentExists == expectedExists && current == expected {
+			continue
+		}
+
+		newProxy := proxy.DeepCopy()
+		if newProxy.Annotations == nil {
+			newProxy.Annotations = map[string]string{}
+		}
+		if expectedExists {
+			newProxy.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds] = expected
+		} else {
+			delete(newProxy.Annotations, v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds)
+		}
+
+		if err := c.Patch(ctx, newProxy, client.MergeFrom(proxy)); err != nil {
+			return false, err
+		}
+		updated = true
+	}
+
+	return updated, nil
 }
 
 func TiProxyNewer(proxyg *v1alpha1.TiProxyGroup, rev string, fg features.Gates) updater.NewFactory[*runtime.TiProxy] {

--- a/pkg/controllers/tiproxygroup/tasks/updater_test.go
+++ b/pkg/controllers/tiproxygroup/tasks/updater_test.go
@@ -286,6 +286,113 @@ func TestTaskUpdater(t *testing.T) {
 	}
 }
 
+func TestTaskUpdaterSyncsGracefulShutdownDeleteDelayBeforeRollingRestart(t *testing.T) {
+	const deleteDelaySeconds = "86400"
+
+	cases := []struct {
+		desc                   string
+		groupAnnotation        map[string]string
+		oldProxyAnnotation     map[string]string
+		includeUpdatedTiProxy  bool
+		expectedDelayByTiProxy map[string]struct {
+			value  string
+			exists bool
+		}
+	}{
+		{
+			desc: "sets delay annotation before deleting old instances",
+			groupAnnotation: map[string]string{
+				v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds: deleteDelaySeconds,
+			},
+			includeUpdatedTiProxy: true,
+			expectedDelayByTiProxy: map[string]struct {
+				value  string
+				exists bool
+			}{
+				"aaa-old-1": {value: deleteDelaySeconds, exists: true},
+				"aaa-old-2": {value: deleteDelaySeconds, exists: true},
+				"aaa-new":   {exists: false},
+			},
+		},
+		{
+			desc: "removes stale delay annotation before deleting old instances",
+			oldProxyAnnotation: map[string]string{
+				v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds: deleteDelaySeconds,
+			},
+			expectedDelayByTiProxy: map[string]struct {
+				value  string
+				exists bool
+			}{
+				"aaa-old-1": {exists: false},
+				"aaa-old-2": {exists: false},
+			},
+		},
+	}
+
+	for i := range cases {
+		c := cases[i]
+		t.Run(c.desc, func(t *testing.T) {
+			t.Parallel()
+
+			proxyg := fake.FakeObj("aaa", func(obj *v1alpha1.TiProxyGroup) *v1alpha1.TiProxyGroup {
+				obj.Spec.Replicas = ptr.To[int32](2)
+				obj.Spec.MaxSurge = ptr.To[int32](2)
+				obj.Spec.Template.Annotations = c.groupAnnotation
+				obj.Spec.Template.Spec.Image = ptr.To("pingcap/tiproxy:v8.1.1")
+				return obj
+			})
+			proxies := []*v1alpha1.TiProxy{
+				fakeAvailableTiProxy("aaa-old-1", fake.FakeObj[v1alpha1.TiProxyGroup]("aaa"), oldRevision),
+				fakeAvailableTiProxy("aaa-old-2", fake.FakeObj[v1alpha1.TiProxyGroup]("aaa"), oldRevision),
+			}
+			for _, proxy := range proxies {
+				proxy.Annotations = c.oldProxyAnnotation
+			}
+			if c.includeUpdatedTiProxy {
+				proxies = append(proxies, fakeAvailableTiProxy("aaa-new", fake.FakeObj[v1alpha1.TiProxyGroup]("aaa"), newRevision))
+			}
+
+			s := &state{
+				proxyg:         proxyg,
+				cluster:        fake.FakeObj[v1alpha1.Cluster]("cluster"),
+				proxies:        proxies,
+				updateRevision: newRevision,
+			}
+			s.IFeatureGates = stateutil.NewFeatureGates[scope.TiProxyGroup](s)
+			state := &ReconcileContext{State: s}
+
+			ctx := context.Background()
+			fc := client.NewFakeClient(state.TiProxyGroup(), state.Cluster())
+			for _, proxy := range state.TiProxySlice() {
+				require.NoError(t, fc.Apply(ctx, proxy.DeepCopy()))
+				require.NoError(t, fc.Status().Update(ctx, proxy.DeepCopy()))
+			}
+
+			af := tracker.New().AllocateFactory("tiproxy")
+			res, _ := task.RunTask(ctx, TaskUpdater(state, fc, af))
+			require.Equal(t, task.SWait.String(), res.Status().String())
+
+			var tiproxies v1alpha1.TiProxyList
+			require.NoError(t, fc.List(ctx, &tiproxies))
+			require.Len(t, tiproxies.Items, len(c.expectedDelayByTiProxy))
+			for i := range tiproxies.Items {
+				tiproxy := &tiproxies.Items[i]
+				expected, ok := c.expectedDelayByTiProxy[tiproxy.Name]
+				require.True(t, ok, "unexpected TiProxy %s", tiproxy.Name)
+
+				got, ok := tiproxy.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds]
+				require.Equal(t, expected.exists, ok)
+				if expected.exists {
+					require.Equal(t, expected.value, got)
+				}
+				if tiproxy.Name != "aaa-new" {
+					require.NotContains(t, tiproxy.Annotations, v1alpha1.AnnoKeyDeferDelete)
+				}
+			}
+		})
+	}
+}
+
 func fakeAvailableTiProxy(name string, proxyg *v1alpha1.TiProxyGroup, rev string) *v1alpha1.TiProxy {
 	return fake.FakeObj(name, func(obj *v1alpha1.TiProxy) *v1alpha1.TiProxy {
 		tiproxy := runtime.ToTiProxy(TiProxyNewer(proxyg, rev, features.NewFromFeatures(nil)).New())

--- a/tests/e2e/tiproxy/tiproxy.go
+++ b/tests/e2e/tiproxy/tiproxy.go
@@ -308,6 +308,103 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 			}),
 		)
 
+		ginkgo.It("syncs graceful shutdown delay before same-patch rolling restart", label.Update, func(ctx context.Context) {
+			o := desc.DefaultOptions()
+			const replicas int32 = 2
+			const deleteDelaySeconds = "0"
+
+			pdg := action.MustCreatePD(ctx, f, o)
+			kvg := action.MustCreateTiKV(ctx, f, o)
+			dbg := action.MustCreateTiDB(ctx, f, o)
+			proxyg := action.MustCreateTiProxy(ctx, f, o,
+				data.WithReplicas[scope.TiProxyGroup](replicas),
+				data.WithTiProxyMaxSurge(replicas),
+			)
+
+			f.WaitForPDGroupReady(ctx, pdg)
+			f.WaitForTiKVGroupReady(ctx, kvg)
+			f.WaitForTiDBGroupReady(ctx, dbg)
+			f.WaitForTiProxyGroupReady(ctx, proxyg)
+
+			listTiProxies := func() (*v1alpha1.TiProxyList, error) {
+				tiproxies := &v1alpha1.TiProxyList{}
+				if err := f.Client.List(ctx, tiproxies, client.InNamespace(proxyg.Namespace), client.MatchingLabels{
+					v1alpha1.LabelKeyCluster:   proxyg.Spec.Cluster.Name,
+					v1alpha1.LabelKeyGroup:     proxyg.Name,
+					v1alpha1.LabelKeyComponent: v1alpha1.LabelValComponentTiProxy,
+				}); err != nil {
+					return nil, err
+				}
+				return tiproxies, nil
+			}
+
+			initialTiProxies, err := listTiProxies()
+			f.Must(err)
+			gomega.Expect(initialTiProxies.Items).To(gomega.HaveLen(int(replicas)))
+			outdatedTiProxies := map[string]struct{}{}
+			for i := range initialTiProxies.Items {
+				tiproxy := &initialTiProxies.Items[i]
+				outdatedTiProxies[tiproxy.Name] = struct{}{}
+				gomega.Expect(tiproxy.Annotations).ToNot(gomega.HaveKey(v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds))
+			}
+
+			changeTime, err := waiter.MaxPodsCreateTimestamp[scope.TiProxyGroup](ctx, f.Client, proxyg)
+			f.Must(err)
+
+			ginkgo.By("Patch TiProxyGroup to trigger rolling restart and add graceful shutdown delay at the same time")
+			patch := client.MergeFrom(proxyg.DeepCopy())
+			proxyg.Spec.Template.Spec.Config = changedConfig
+			if proxyg.Spec.Template.Annotations == nil {
+				proxyg.Spec.Template.Annotations = map[string]string{}
+			}
+			proxyg.Spec.Template.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds] = deleteDelaySeconds
+			f.Must(f.Client.Patch(ctx, proxyg, patch))
+
+			var violated error
+			ginkgo.By("Ensure outdated TiProxy instances get graceful shutdown delay before defer deletion")
+			gomega.Eventually(func() error {
+				if violated != nil {
+					return violated
+				}
+
+				tiproxies, err := listTiProxies()
+				if err != nil {
+					return err
+				}
+
+				outdatedSeen := 0
+				outdatedWithDelay := 0
+				for i := range tiproxies.Items {
+					tiproxy := &tiproxies.Items[i]
+					if _, ok := outdatedTiProxies[tiproxy.Name]; !ok {
+						continue
+					}
+
+					outdatedSeen++
+					delay := tiproxy.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownDeleteDelaySeconds]
+					isDeferredDelete := tiproxy.Annotations[v1alpha1.AnnoKeyDeferDelete] == v1alpha1.AnnoValTrue || !tiproxy.DeletionTimestamp.IsZero()
+					if isDeferredDelete && delay != deleteDelaySeconds {
+						violated = fmt.Errorf("outdated TiProxy %s/%s entered deletion before graceful shutdown delay was synced", tiproxy.Namespace, tiproxy.Name)
+						return violated
+					}
+					if delay == deleteDelaySeconds {
+						outdatedWithDelay++
+					}
+				}
+
+				if outdatedSeen != len(outdatedTiProxies) {
+					return fmt.Errorf("observed %d outdated TiProxy instances, want %d", outdatedSeen, len(outdatedTiProxies))
+				}
+				if outdatedWithDelay != len(outdatedTiProxies) {
+					return fmt.Errorf("observed %d outdated TiProxy instances with graceful shutdown delay, want %d", outdatedWithDelay, len(outdatedTiProxies))
+				}
+				return nil
+			}).WithTimeout(waiter.LongTaskTimeout).WithPolling(waiter.Poll).Should(gomega.Succeed())
+
+			f.Must(waiter.WaitForPodsRecreated(ctx, f.Client, runtime.FromTiProxyGroup(proxyg), *changeTime, waiter.LongTaskTimeout))
+			f.WaitForTiProxyGroupReady(ctx, proxyg)
+		})
+
 		ginkgo.It("support scale in from 4 to 2 and rolling update at same time", label.Scale, label.Update, func(ctx context.Context) {
 			pdg := f.MustCreatePD(ctx)
 			kvg := f.MustCreateTiKV(ctx)


### PR DESCRIPTION
For `tiproxy-graceful-shutdown-delete-delay-seconds` annotation, it'd be better to sync it to the `TiProxy` CR before rolling restart them, so that the old `TiProxy` CR without this annotation can keep the behavior.