### PR TITLE
tiproxy: delete drained pods early when the connection drops to zero

### DIFF
--- a/pkg/controllers/tiproxy/tasks/finalizer.go
+++ b/pkg/controllers/tiproxy/tasks/finalizer.go
@@ -79,14 +79,19 @@ func drainOrDeletePod(ctx context.Context, c client.Client, state State, pod *co
 	}
 
 	remaining := time.Until(startAt.Add(time.Duration(seconds) * time.Second))
+	if remaining <= 0 {
+		return deleteTiProxyPod(ctx, c, pod)
+	}
+
+	if tiProxyConnectionsDrained(ctx, state, c, logger) {
+		return deleteTiProxyPod(ctx, c, pod)
+	}
+
 	if remaining > task.DefaultRequeueAfter {
 		remaining = task.DefaultRequeueAfter
 	}
-	if remaining > 0 {
-		return remaining, nil
-	}
 
-	return deleteTiProxyPod(ctx, c, pod)
+	return remaining, nil
 }
 
 func gracefulShutdownDeleteDelaySeconds(tiproxy *v1alpha1.TiProxy) (seconds int32, ok bool, err error) {
@@ -129,6 +134,48 @@ func deleteTiProxyPod(ctx context.Context, c client.Client, pod *corev1.Pod) (ti
 		return 0, err
 	}
 	return task.DefaultRequeueAfter, nil
+}
+
+func tiProxyConnectionsDrained(ctx context.Context, state State, c client.Client, logger logr.Logger) bool {
+	tiproxy := state.Object()
+
+	tpClient, err := newTiProxyDeleteClient(ctx, state, c)
+	if err != nil {
+		logger.Info(
+			"failed to build TiProxy API client before checking connections, continue waiting",
+			"namespace", tiproxy.Namespace,
+			"name", tiproxy.Name,
+			"error", err,
+		)
+		return false
+	}
+
+	connectionCount, err := tpClient.ConnectionCount(ctx)
+	if err != nil {
+		logger.Info(
+			"failed to query TiProxy connections before graceful delete, continue waiting",
+			"namespace", tiproxy.Namespace,
+			"name", tiproxy.Name,
+			"error", err,
+		)
+		return false
+	}
+	if connectionCount > 0 {
+		logger.V(2).Info(
+			"TiProxy still has active connections, continue waiting",
+			"namespace", tiproxy.Namespace,
+			"name", tiproxy.Name,
+			"connectionCount", connectionCount,
+		)
+		return false
+	}
+
+	logger.Info(
+		"TiProxy has no active connections, delete pod without waiting for the remaining graceful delay",
+		"namespace", tiproxy.Namespace,
+		"name", tiproxy.Name,
+	)
+	return true
 }
 
 func ensureTiProxyMarkedUnhealthy(ctx context.Context, state State, c client.Client, logger logr.Logger) bool {

--- a/pkg/controllers/tiproxy/tasks/finalizer.go
+++ b/pkg/controllers/tiproxy/tasks/finalizer.go
@@ -161,7 +161,7 @@ func tiProxyConnectionsDrained(ctx context.Context, state State, c client.Client
 		return false
 	}
 	if connectionCount > 0 {
-		logger.V(2).Info(
+		logger.Info(
 			"TiProxy still has active connections, continue waiting",
 			"namespace", tiproxy.Namespace,
 			"name", tiproxy.Name,

--- a/pkg/controllers/tiproxy/tasks/finalizer_test.go
+++ b/pkg/controllers/tiproxy/tasks/finalizer_test.go
@@ -56,8 +56,11 @@ type testTiProxyHealthServer struct {
 	mu                  sync.Mutex
 	healthStatus        int
 	markUnhealthyStatus int
+	metricsStatus       int
+	connectionCount     int
 	healthCalls         int
 	markUnhealthyCalls  int
+	metricsCalls        int
 }
 
 func newTestTiProxyHealthServer(t *testing.T, healthStatus, markUnhealthyStatus int) *testTiProxyHealthServer {
@@ -66,6 +69,8 @@ func newTestTiProxyHealthServer(t *testing.T, healthStatus, markUnhealthyStatus 
 	s := &testTiProxyHealthServer{
 		healthStatus:        healthStatus,
 		markUnhealthyStatus: markUnhealthyStatus,
+		metricsStatus:       http.StatusOK,
+		connectionCount:     1,
 	}
 
 	mux := http.NewServeMux()
@@ -84,11 +89,33 @@ func newTestTiProxyHealthServer(t *testing.T, healthStatus, markUnhealthyStatus 
 		w.WriteHeader(s.healthStatus)
 		_, _ = w.Write([]byte(`{"config_checksum":1}`))
 	})
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.metricsCalls++
+		w.WriteHeader(s.metricsStatus)
+		_, _ = w.Write([]byte(`# HELP tiproxy_server_connections Number of connections.
+# TYPE tiproxy_server_connections gauge
+tiproxy_server_connections ` + strconv.Itoa(s.connectionCount) + `
+`))
+	})
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
 	s.server = server
 	return s
+}
+
+func (s *testTiProxyHealthServer) setConnectionCount(connectionCount int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connectionCount = connectionCount
+}
+
+func (s *testTiProxyHealthServer) setMetricsStatus(status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metricsStatus = status
 }
 
 func (s *testTiProxyHealthServer) port(t *testing.T) int32 {
@@ -105,6 +132,12 @@ func (s *testTiProxyHealthServer) counts() (health, markUnhealthy int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.healthCalls, s.markUnhealthyCalls
+}
+
+func (s *testTiProxyHealthServer) metricsCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.metricsCalls
 }
 
 func runDrainPodForDeleteTask(t *testing.T, ctx context.Context, s State, c client.Client) (task.Result, bool) {
@@ -255,6 +288,55 @@ func TestTaskDrainPodForDeleteWaitForDeleteDelayAfterGracefulShutdownStarted(t *
 	healthCalls, markUnhealthyCalls := server.counts()
 	assert.Equal(t, 0, healthCalls)
 	assert.Equal(t, 0, markUnhealthyCalls)
+
+	actual := &corev1.Pod{}
+	require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(pod), actual))
+	assert.True(t, actual.GetDeletionTimestamp().IsZero())
+}
+
+func TestTaskDrainPodForDeleteDeletePodWhenConnectionsDropToZero(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := newTestTiProxyHealthServer(t, http.StatusBadGateway, http.StatusOK)
+	server.setConnectionCount(0)
+	cluster := localTestCluster()
+	tiproxy := deletingTiProxyWithAPIAddress("3600", server.port(t))
+	pod := fakePod(cluster, tiproxy)
+	pod.Annotations = map[string]string{
+		v1alpha1.AnnoKeyTiProxyGracefulShutdownBeginTime: time.Now().Add(-10 * time.Second).Format(time.RFC3339Nano),
+	}
+
+	fc := client.NewFakeClient(cluster, tiproxy, pod)
+	res, done := runDrainPodForDeleteTask(t, ctx, &state{cluster: cluster, tiproxy: tiproxy}, fc)
+
+	assert.Equal(t, task.SRetry.String(), res.Status().String())
+	assert.False(t, done)
+	assert.Equal(t, 1, server.metricsCount())
+
+	err := fc.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestTaskDrainPodForDeleteContinueDeleteDelayWhenConnectionMetricFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := newTestTiProxyHealthServer(t, http.StatusBadGateway, http.StatusOK)
+	server.setMetricsStatus(http.StatusInternalServerError)
+	cluster := localTestCluster()
+	tiproxy := deletingTiProxyWithAPIAddress("3600", server.port(t))
+	pod := fakePod(cluster, tiproxy)
+	pod.Annotations = map[string]string{
+		v1alpha1.AnnoKeyTiProxyGracefulShutdownBeginTime: time.Now().Add(-10 * time.Second).Format(time.RFC3339Nano),
+	}
+
+	fc := client.NewFakeClient(cluster, tiproxy, pod)
+	res, done := runDrainPodForDeleteTask(t, ctx, &state{cluster: cluster, tiproxy: tiproxy}, fc)
+
+	assert.Equal(t, task.SRetry.String(), res.Status().String())
+	assert.False(t, done)
+	assert.Equal(t, 1, server.metricsCount())
 
 	actual := &corev1.Pod{}
 	require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(pod), actual))

--- a/pkg/tiproxyapi/v1/client.go
+++ b/pkg/tiproxyapi/v1/client.go
@@ -20,18 +20,22 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/prometheus/common/expfmt"
 
 	httputil "github.com/pingcap/tidb-operator/v2/pkg/utils/http"
 )
 
 const (
-	healthPath = "api/debug/health"
-	configPath = "api/admin/config"
+	healthPath                   = "api/debug/health"
+	configPath                   = "api/admin/config"
+	metricsPath                  = "metrics"
+	tiproxyConnectionsMetricName = "tiproxy_server_connections"
 )
 
 type healthOverrideRequest struct {
@@ -45,6 +49,8 @@ type TiProxyClient interface {
 	IsHealthy(ctx context.Context) (bool, error)
 	// MarkUnhealthy makes the TiProxy health endpoint report unhealthy.
 	MarkUnhealthy(ctx context.Context) error
+	// ConnectionCount returns the current number of TiProxy SQL client connections.
+	ConnectionCount(ctx context.Context) (float64, error)
 	// SetLabels sets the labels for TiProxy.
 	SetLabels(ctx context.Context, labels map[string]string) error
 }
@@ -113,6 +119,55 @@ func (c *tiproxyClient) MarkUnhealthy(ctx context.Context) error {
 	apiURL := fmt.Sprintf("%s/%s", c.url, healthPath)
 	_, err := httputil.PutBodyOK(ctx, c.httpClient, apiURL, &buffer)
 	return err
+}
+
+func (c *tiproxyClient) ConnectionCount(ctx context.Context) (float64, error) {
+	apiURL := fmt.Sprintf("%s/%s", c.url, metricsPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
+	if err != nil {
+		return 0, err
+	}
+
+	//nolint:bodyclose,gosec // bodyclose: has been handled; gosec: URL is constructed from trusted internal config
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer httputil.DeferClose(resp.Body)
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return 0, fmt.Errorf("get TiProxy metrics failed: status %d", resp.StatusCode)
+	}
+
+	return parseConnectionCount(resp.Body)
+}
+
+func parseConnectionCount(metrics io.Reader) (float64, error) {
+	parser := expfmt.TextParser{}
+	metricFamilies, err := parser.TextToMetricFamilies(metrics)
+	if err != nil {
+		return 0, fmt.Errorf("parse TiProxy metrics failed: %w", err)
+	}
+
+	mf, ok := metricFamilies[tiproxyConnectionsMetricName]
+	if !ok {
+		return 0, fmt.Errorf("metric %s not found", tiproxyConnectionsMetricName)
+	}
+
+	var count float64
+	var found bool
+	for _, metric := range mf.GetMetric() {
+		if metric.Gauge == nil {
+			continue
+		}
+		count += metric.Gauge.GetValue()
+		found = true
+	}
+	if !found {
+		return 0, fmt.Errorf("metric %s has no gauge value", tiproxyConnectionsMetricName)
+	}
+
+	return count, nil
 }
 
 func (c *tiproxyClient) SetLabels(ctx context.Context, labels map[string]string) error {

--- a/pkg/tiproxyapi/v1/client_test.go
+++ b/pkg/tiproxyapi/v1/client_test.go
@@ -173,5 +173,5 @@ tiproxy_server_connections 7
 	client := NewTiProxyClient(addr, 5*time.Second, nil)
 	count, err := client.ConnectionCount(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, float64(7), count)
+	assert.InDelta(t, 7, count, 0)
 }

--- a/pkg/tiproxyapi/v1/client_test.go
+++ b/pkg/tiproxyapi/v1/client_test.go
@@ -156,3 +156,22 @@ func TestTiProxyClient_MarkUnhealthy(t *testing.T) {
 	err := client.MarkUnhealthy(context.Background())
 	require.NoError(t, err)
 }
+
+func TestTiProxyClient_ConnectionCount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/metrics", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		_, err := w.Write([]byte(`# HELP tiproxy_server_connections Number of connections.
+# TYPE tiproxy_server_connections gauge
+tiproxy_server_connections 7
+`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	addr := stringutil.RemoveHTTPPrefix(server.URL)
+	client := NewTiProxyClient(addr, 5*time.Second, nil)
+	count, err := client.ConnectionCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, float64(7), count)
+}

--- a/tests/e2e/tiproxy/tiproxy.go
+++ b/tests/e2e/tiproxy/tiproxy.go
@@ -16,11 +16,13 @@ package tiproxy
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +32,7 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
+	tiproxyapi "github.com/pingcap/tidb-operator/v2/pkg/tiproxyapi/v1"
 	"github.com/pingcap/tidb-operator/v2/tests/e2e/data"
 	"github.com/pingcap/tidb-operator/v2/tests/e2e/framework"
 	"github.com/pingcap/tidb-operator/v2/tests/e2e/framework/action"
@@ -81,6 +84,47 @@ func tiproxyHealthStatusCode(ctx context.Context, f *framework.Framework, pod *c
 	defer resp.Body.Close()
 
 	return resp.StatusCode, nil
+}
+
+func tiproxyConnectionCount(ctx context.Context, f *framework.Framework, pod *corev1.Pod) (float64, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	ports := f.PortForwardPod(probeCtx, pod, []string{fmt.Sprintf(":%d", v1alpha1.DefaultTiProxyPortAPI)})
+	tpClient := tiproxyapi.NewTiProxyClient(fmt.Sprintf("127.0.0.1:%d", ports[0].Local), 10*time.Second, nil)
+	return tpClient.ConnectionCount(probeCtx)
+}
+
+func holdTiProxySQLConnection(ctx context.Context, f *framework.Framework, pod *corev1.Pod) (func(), error) {
+	forwardCtx, cancel := context.WithCancel(ctx)
+	ports := f.PortForwardPod(forwardCtx, pod, []string{fmt.Sprintf(":%d", v1alpha1.DefaultTiProxyPortClient)})
+
+	db, err := sql.Open("mysql", fmt.Sprintf("root:@tcp(127.0.0.1:%d)/?timeout=10s", ports[0].Local))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		_ = db.Close()
+		cancel()
+		return nil, err
+	}
+	if err := conn.PingContext(ctx); err != nil {
+		_ = conn.Close()
+		_ = db.Close()
+		cancel()
+		return nil, err
+	}
+
+	return func() {
+		_ = conn.Close()
+		_ = db.Close()
+		cancel()
+	}, nil
 }
 
 func tiproxySupportsHealthOverrideAPI(ctx context.Context, f *framework.Framework, pod *corev1.Pod) (bool, error) {
@@ -342,7 +386,7 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 		ginkgo.It("keep service backends during graceful rolling update with large maxSurge", label.Update, func(ctx context.Context) {
 			o := desc.DefaultOptions()
 			const replicas int32 = 3
-			const deleteDelaySeconds int32 = 20
+			const deleteDelaySeconds int32 = 3600
 
 			pdg := action.MustCreatePD(ctx, f, o)
 			kvg := action.MustCreateTiKV(ctx, f, o)
@@ -386,6 +430,7 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 			initialPods, err := listTiProxyPods()
 			f.Must(err)
 			gomega.Expect(initialPods.Items).To(gomega.HaveLen(int(replicas)))
+			targetOldPod := initialPods.Items[0].DeepCopy()
 			initialPodUIDs := map[string]string{}
 			for i := range initialPods.Items {
 				initialPodUIDs[initialPods.Items[i].Name] = string(initialPods.Items[i].UID)
@@ -446,6 +491,25 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 			f.Must(err)
 			manualTiProxyUnhealthyTrigger := !supportsHealthOverrideAPI
 
+			ginkgo.By("Hold one SQL connection on an old TiProxy pod")
+			releaseTargetOldPodConnection, err := holdTiProxySQLConnection(ctx, f, targetOldPod)
+			f.Must(err)
+			defer func() {
+				if releaseTargetOldPodConnection != nil {
+					releaseTargetOldPodConnection()
+				}
+			}()
+			gomega.Eventually(func() error {
+				connectionCount, err := tiproxyConnectionCount(ctx, f, targetOldPod)
+				if err != nil {
+					return err
+				}
+				if connectionCount <= 0 {
+					return fmt.Errorf("target old tiproxy pod %s/%s has %v connections, want > 0", targetOldPod.Namespace, targetOldPod.Name, connectionCount)
+				}
+				return nil
+			}).WithTimeout(waiter.ShortTaskTimeout).WithPolling(waiter.Poll).Should(gomega.Succeed())
+
 			changeTime, err := waiter.MaxPodsCreateTimestamp[scope.TiProxyGroup](ctx, f.Client, proxyg)
 			f.Must(err)
 
@@ -456,7 +520,8 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 
 			var violated error
 			terminatedPods := map[string]struct{}{}
-			ginkgo.By("Ensure old pods are marked unhealthy only after enough new TiProxy backends are ready")
+			var targetDrainingPod *corev1.Pod
+			ginkgo.By("Ensure old pods start graceful shutdown only after enough new TiProxy backends are ready")
 			gomega.Eventually(func() error {
 				if violated != nil {
 					return violated
@@ -483,14 +548,21 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 					return err
 				}
 
-				drained := 0
+				oldPodDraining := false
 				for i := range pods.Items {
 					pod := &pods.Items[i]
 					if _, ok := initialPodUIDs[pod.Name]; !ok {
 						continue
 					}
-					if pod.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownBeginTime] == "" {
+					rawStartTime := pod.Annotations[v1alpha1.AnnoKeyTiProxyGracefulShutdownBeginTime]
+					if rawStartTime == "" {
 						continue
+					}
+					oldPodDraining = true
+
+					if backends < int(replicas) {
+						violated = fmt.Errorf("tiproxy service backends dropped below desired replicas after drain started: got %d, want >= %d", backends, replicas)
+						return violated
 					}
 
 					statusCode, err := tiproxyHealthStatusCode(ctx, f, pod)
@@ -500,31 +572,39 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 					if statusCode == http.StatusOK {
 						return fmt.Errorf("draining tiproxy pod %s/%s is still healthy after graceful shutdown begins", pod.Namespace, pod.Name)
 					}
-					drained++
-				}
-				if drained == 0 {
-					if backends < int(replicas) {
-						return fmt.Errorf("only %d tiproxy service backends are ready before drain starts, want >= %d", backends, replicas)
+
+					if pod.Name != targetOldPod.Name {
+						continue
 					}
-					if len(pods.Items) < int(replicas)+2 {
-						return fmt.Errorf("only %d tiproxy pods exist during graceful rolling update, want at least %d", len(pods.Items), int(replicas)+2)
+
+					connectionCount, err := tiproxyConnectionCount(ctx, f, pod)
+					if err != nil {
+						return fmt.Errorf("cannot query connection count of target draining tiproxy pod %s/%s: %w", pod.Namespace, pod.Name, err)
 					}
-					if err := manuallyTriggerTiProxyUnhealthy(ctx, f, manualTiProxyUnhealthyTrigger, pods.Items, initialPodUIDs, deletingTiProxies, terminatedPods); err != nil {
-						return err
+					if connectionCount <= 0 {
+						return fmt.Errorf("target draining tiproxy pod %s/%s has %v connections before releasing the held connection, want > 0", pod.Namespace, pod.Name, connectionCount)
 					}
-					return fmt.Errorf("no unhealthy tiproxy pod observed yet")
+
+					targetDrainingPod = pod.DeepCopy()
+					return nil
 				}
 
-				if backends < int(replicas) {
-					violated = fmt.Errorf("tiproxy service backends dropped below desired replicas after drain started: got %d, want >= %d", backends, replicas)
-					return violated
+				if !oldPodDraining && backends < int(replicas) {
+					return fmt.Errorf("only %d tiproxy service backends are ready before drain starts, want >= %d", backends, replicas)
 				}
-				if len(pods.Items) < int(replicas)+2 {
-					return fmt.Errorf("only %d tiproxy pods exist during graceful rolling update, want at least %d", len(pods.Items), int(replicas)+2)
+				if err := manuallyTriggerTiProxyUnhealthy(ctx, f, manualTiProxyUnhealthyTrigger, pods.Items, initialPodUIDs, deletingTiProxies, terminatedPods); err != nil {
+					return err
 				}
 
-				return nil
+				return fmt.Errorf("target old tiproxy pod %s/%s has not started graceful shutdown yet", targetOldPod.Namespace, targetOldPod.Name)
 			}).WithTimeout(waiter.LongTaskTimeout).WithPolling(waiter.Poll).Should(gomega.Succeed())
+
+			ginkgo.By("Release the held SQL connection and ensure the old TiProxy pod is deleted before the graceful delay limit")
+			releaseTargetOldPodConnection()
+			releaseTargetOldPodConnection = nil
+			const earlyDeleteTimeout = time.Minute
+			gomega.Expect(time.Duration(deleteDelaySeconds) * time.Second).To(gomega.BeNumerically(">", waiter.LongTaskTimeout+earlyDeleteTimeout))
+			f.Must(waiter.WaitForObjectDeleted(ctx, f.Client, targetDrainingPod, earlyDeleteTimeout))
 
 			f.Must(waiter.WaitForPodsRecreated(ctx, f.Client, runtime.FromTiProxyGroup(proxyg), *changeTime, waiter.LongTaskTimeout))
 			f.WaitForTiProxyGroupReady(ctx, proxyg)


### PR DESCRIPTION
If the connection on a specific tiproxy pod has already dropped to zero, we can delete it earlier. It'll optimize the total time consumed by rolling update / scaling in.