### PR TITLE
fix log backup state query failure handling

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -188,6 +188,8 @@ const (
 const (
 	// AnnoKeySkipFlushLogBackup when set to a `TidbCluster`, during restarting the cluster, log backup tasks won't be flushed.
 	AnnoKeySkipFlushLogBackup = "tidb.pingcap.com/tikv-restart-without-flush-log-backup"
+	// AnnoKeyLogBackupStateQueryFailureGracePeriod when set to a log `Backup`, overrides how long the tracker waits before failing the backup after continuous state query failures.
+	AnnoKeyLogBackupStateQueryFailureGracePeriod = "tidb.pingcap.com/log-backup-state-query-failure-grace-period"
 )
 
 // +genclient

--- a/pkg/backup/backup/backup_tracker.go
+++ b/pkg/backup/backup/backup_tracker.go
@@ -16,6 +16,7 @@ package backup
 import (
 	"context"
 	"encoding/binary"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -27,20 +28,23 @@ import (
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	"github.com/pingcap/tidb-operator/pkg/pdapi"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
 var (
-	refreshCheckpointTsPeriod = time.Minute * 1
-	streamKeyPrefix           = "/tidb/br-stream"
-	taskInfoPath              = "/info"
-	taskCheckpointPath        = "/checkpoint"
-	taskLastErrorPath         = "/last-error"
-	taskPausePath             = "/pause"
+	refreshCheckpointTsPeriod             = time.Minute * 1
+	logBackupStateQueryFailureGracePeriod = time.Minute * 10
+	streamKeyPrefix                       = "/tidb/br-stream"
+	taskInfoPath                          = "/info"
+	taskCheckpointPath                    = "/checkpoint"
+	taskLastErrorPath                     = "/last-error"
+	taskPausePath                         = "/pause"
 )
+
+var errLogBackupPauseKeyQueryFailed = stderrors.New("query log backup pause key failed")
 
 // LogBackupKernelState represents the actual state of log backup in the kernel (etcd)
 type LogBackupKernelState string
@@ -66,7 +70,7 @@ type LogBackupState struct {
 
 	// Metadata
 	LastQueryTime time.Time // last query timestamp
-	QueryError    error     // query error if any
+	QueryError    error     // non-fatal partial query error, currently used when pause state is unknown
 }
 
 // BackupTracker implements the logic for tracking log backup progress
@@ -95,13 +99,15 @@ type backupTracker struct {
 
 // trackDepends is the tracker depends, such as tidb cluster info.
 type trackDepends struct {
-	tc                    *v1alpha1.TidbCluster
-	state                 *LogBackupState            // cached state
-	etcdClient            pdapi.PDEtcdClient         // reused etcd client
-	lastRefresh           time.Time                  // last refresh timestamp
-	inconsistencyDetected bool                       // flag to track if inconsistency was detected in previous reconcile
-	lastCommand           v1alpha1.LogSubCommandType // last synced command to avoid cross-command interference
-	mutex                 sync.RWMutex               // protect concurrent access
+	tc                         *v1alpha1.TidbCluster
+	state                      *LogBackupState            // cached state
+	etcdClient                 pdapi.PDEtcdClient         // reused etcd client
+	lastRefresh                time.Time                  // last refresh timestamp
+	stateQueryFailureStartTime time.Time                  // timestamp when continuous state query failure starts
+	stateQueryFailureReported  bool                       // whether current continuous state query failure has been reported
+	inconsistencyDetected      bool                       // flag to track if inconsistency was detected in previous reconcile
+	lastCommand                v1alpha1.LogSubCommandType // last synced command to avoid cross-command interference
+	mutex                      sync.RWMutex               // protect concurrent access
 }
 
 // NewBackupTracker returns a BackupTracker
@@ -238,7 +244,7 @@ func (bt *backupTracker) refreshLogBackupProgress(ns, name string) {
 
 		// Get Backup CR
 		backup, err := bt.deps.BackupLister.Backups(ns).Get(name)
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			klog.Infof("log backup %s/%s has been deleted, will remove %s from tracker", ns, name, logkey)
 			bt.removeLogBackup(ns, name)
 			return
@@ -278,6 +284,7 @@ func (bt *backupTracker) doRefreshLogBackupState(backup *v1alpha1.Backup, dep *t
 			dep.tc.IsTLSClusterEnabled(), pdapi.ClusterRef(dep.tc.Spec.ClusterDomain))
 		if err != nil {
 			klog.Errorf("get log backup %s/%s etcd client error %v", ns, name, err)
+			bt.recordLogBackupStateQueryFailure(backup, dep, fmt.Errorf("get etcd client failed: %v", err))
 			return
 		}
 		dep.etcdClient = etcdCli
@@ -287,6 +294,7 @@ func (bt *backupTracker) doRefreshLogBackupState(backup *v1alpha1.Backup, dep *t
 	state, err := bt.queryAllLogBackupKeys(dep.etcdClient, name)
 	if err != nil {
 		klog.Errorf("refresh log backup %s/%s state failed: %v", ns, name, err)
+		bt.recordLogBackupStateQueryFailure(backup, dep, err)
 		return
 	}
 
@@ -294,9 +302,11 @@ func (bt *backupTracker) doRefreshLogBackupState(backup *v1alpha1.Backup, dep *t
 	dep.mutex.Lock()
 	dep.state = state
 	dep.lastRefresh = time.Now()
+	dep.stateQueryFailureStartTime = time.Time{}
+	dep.stateQueryFailureReported = false
 
 	// Check if previously marked inconsistency has been resolved
-	if dep.inconsistencyDetected && dep.lastCommand != "" {
+	if dep.inconsistencyDetected && dep.lastCommand != "" && !stderrors.Is(state.QueryError, errLogBackupPauseKeyQueryFailed) {
 		// Verify if current state is consistent with the recorded command
 		isConsistent := isCommandConsistentWithKernelState(dep.lastCommand, state.KernelState)
 		if isConsistent {
@@ -415,6 +425,8 @@ func (bt *backupTracker) RefreshLogBackupState(backup *v1alpha1.Backup) (*LogBac
 	dep.mutex.Lock()
 	dep.state = state
 	dep.lastRefresh = time.Now()
+	dep.stateQueryFailureStartTime = time.Time{}
+	dep.stateQueryFailureReported = false
 	dep.mutex.Unlock()
 
 	return state, nil
@@ -443,6 +455,7 @@ func (bt *backupTracker) SyncLogBackupState(backup *v1alpha1.Backup) (bool, erro
 	// Get the current state
 	state, err := bt.GetLogBackupState(backup, shouldForceRefresh)
 	if err != nil {
+		bt.recordLogBackupStateQueryFailure(backup, dep, err)
 		return false, err
 	}
 
@@ -463,6 +476,11 @@ func (bt *backupTracker) SyncLogBackupState(backup *v1alpha1.Backup) (bool, erro
 			Message: "Log backup task not found in TiKV, the task may have been deleted or cluster state is inconsistent",
 		}, nil)
 		return false, fmt.Errorf("log backup key not found")
+	}
+
+	if stderrors.Is(state.QueryError, errLogBackupPauseKeyQueryFailed) {
+		klog.Warningf("log backup %s/%s pause state is unknown, skip kernel state sync: %v", ns, name, state.QueryError)
+		return true, nil
 	}
 
 	// Handle error pause
@@ -541,6 +559,50 @@ func (bt *backupTracker) SyncLogBackupState(backup *v1alpha1.Backup) (bool, erro
 	return true, nil
 }
 
+func (bt *backupTracker) recordLogBackupStateQueryFailure(backup *v1alpha1.Backup, dep *trackDepends, err error) {
+	now := time.Now()
+
+	dep.mutex.Lock()
+	failureStart := dep.stateQueryFailureStartTime
+	if failureStart.IsZero() {
+		dep.stateQueryFailureStartTime = now
+		dep.stateQueryFailureReported = false
+		dep.mutex.Unlock()
+		return
+	}
+	if now.Sub(failureStart) < logBackupStateQueryFailureGracePeriod {
+		dep.mutex.Unlock()
+		return
+	}
+	if dep.stateQueryFailureReported {
+		dep.mutex.Unlock()
+		return
+	}
+	dep.stateQueryFailureReported = true
+	dep.mutex.Unlock()
+
+	ns := backup.Namespace
+	name := backup.Name
+	command := v1alpha1.ParseLogBackupSubcommand(backup)
+	klog.Errorf("log backup %s/%s state query has not succeeded for %s, marking as failed: %v",
+		ns, name, now.Sub(failureStart).Round(time.Second), err)
+	err = bt.statusUpdater.Update(backup, &v1alpha1.BackupCondition{
+		Command: command,
+		Type:    v1alpha1.BackupFailed,
+		Status:  corev1.ConditionTrue,
+		Reason:  "LogBackupStateQueryFailed",
+		Message: fmt.Sprintf("Failed to query log backup task state from PD etcd for the last %s; task existence is unknown: %v",
+			now.Sub(failureStart).Round(time.Second), err),
+	}, nil)
+	if err != nil {
+		klog.Errorf("update log backup %s/%s state query failure status failed: %v", ns, name, err)
+		dep.mutex.Lock()
+		dep.stateQueryFailureReported = false
+		dep.mutex.Unlock()
+		return
+	}
+}
+
 // StopTrackLogBackupProgress stops tracking a log backup
 func (bt *backupTracker) StopTrackLogBackupProgress(backup *v1alpha1.Backup) {
 	ns := backup.Namespace
@@ -605,10 +667,21 @@ func (bt *backupTracker) queryAllLogBackupKeys(client pdapi.PDEtcdClient, name s
 	wg.Wait()
 	close(resultCh)
 
+	var infoQueryErr error
+	var pauseQueryErr error
+
 	// Process query results
 	for result := range resultCh {
 		if result.err != nil {
 			klog.Warningf("query etcd key type %s failed: %v", result.key, result.err)
+			if result.key == "info" {
+				infoQueryErr = result.err
+				continue
+			}
+			if result.key == "pause" {
+				pauseQueryErr = result.err
+				continue
+			}
 			// Don't fail on individual key errors, continue processing
 			continue
 		}
@@ -623,7 +696,6 @@ func (bt *backupTracker) queryAllLogBackupKeys(client pdapi.PDEtcdClient, name s
 		case "pause":
 			if len(result.kvs) > 0 {
 				state.IsPaused = true
-				// Parse pause reason - this will need to be implemented based on pause info structure
 				state.PauseReason = bt.parsePauseReason(result.kvs[0].Value)
 			}
 		case "error":
@@ -631,6 +703,15 @@ func (bt *backupTracker) queryAllLogBackupKeys(client pdapi.PDEtcdClient, name s
 				state.LastError = string(result.kvs[0].Value)
 			}
 		}
+	}
+
+	if infoQueryErr != nil {
+		return nil, fmt.Errorf("query log backup info key failed: %v", infoQueryErr)
+	}
+
+	if pauseQueryErr != nil {
+		state.QueryError = fmt.Errorf("%w: %v", errLogBackupPauseKeyQueryFailed, pauseQueryErr)
+		return state, nil
 	}
 
 	// Derive kernel state

--- a/pkg/backup/backup/backup_tracker.go
+++ b/pkg/backup/backup/backup_tracker.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,7 +37,7 @@ import (
 
 var (
 	refreshCheckpointTsPeriod             = time.Minute * 1
-	logBackupStateQueryFailureGracePeriod = time.Minute * 10
+	logBackupStateQueryFailureGracePeriod = 168 * time.Hour
 	streamKeyPrefix                       = "/tidb/br-stream"
 	taskInfoPath                          = "/info"
 	taskCheckpointPath                    = "/checkpoint"
@@ -561,6 +562,7 @@ func (bt *backupTracker) SyncLogBackupState(backup *v1alpha1.Backup) (bool, erro
 
 func (bt *backupTracker) recordLogBackupStateQueryFailure(backup *v1alpha1.Backup, dep *trackDepends, err error) {
 	now := time.Now()
+	gracePeriod := getLogBackupStateQueryFailureGracePeriod(backup)
 
 	dep.mutex.Lock()
 	failureStart := dep.stateQueryFailureStartTime
@@ -570,7 +572,7 @@ func (bt *backupTracker) recordLogBackupStateQueryFailure(backup *v1alpha1.Backu
 		dep.mutex.Unlock()
 		return
 	}
-	if now.Sub(failureStart) < logBackupStateQueryFailureGracePeriod {
+	if now.Sub(failureStart) < gracePeriod {
 		dep.mutex.Unlock()
 		return
 	}
@@ -601,6 +603,27 @@ func (bt *backupTracker) recordLogBackupStateQueryFailure(backup *v1alpha1.Backu
 		dep.mutex.Unlock()
 		return
 	}
+}
+
+func getLogBackupStateQueryFailureGracePeriod(backup *v1alpha1.Backup) time.Duration {
+	if backup == nil || backup.Annotations == nil {
+		return logBackupStateQueryFailureGracePeriod
+	}
+
+	value := strings.TrimSpace(backup.Annotations[v1alpha1.AnnoKeyLogBackupStateQueryFailureGracePeriod])
+	if value == "" {
+		return logBackupStateQueryFailureGracePeriod
+	}
+
+	gracePeriod, err := time.ParseDuration(value)
+	if err != nil || gracePeriod <= 0 {
+		klog.Warningf("invalid annotation %s=%q on log backup %s/%s, using default grace period %s",
+			v1alpha1.AnnoKeyLogBackupStateQueryFailureGracePeriod, value, backup.Namespace, backup.Name,
+			logBackupStateQueryFailureGracePeriod)
+		return logBackupStateQueryFailureGracePeriod
+	}
+
+	return gracePeriod
 }
 
 // StopTrackLogBackupProgress stops tracking a log backup

--- a/pkg/backup/backup/backup_tracker_test.go
+++ b/pkg/backup/backup/backup_tracker_test.go
@@ -630,6 +630,77 @@ func TestSyncLogBackupStateStartsQueryFailureCountdownBeforeGracePeriod(t *testi
 	}
 }
 
+func TestLogBackupStateQueryFailureGracePeriodUsesAnnotation(t *testing.T) {
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+			Annotations: map[string]string{
+				v1alpha1.AnnoKeyLogBackupStateQueryFailureGracePeriod: "30m",
+			},
+		},
+	}
+
+	gracePeriod := getLogBackupStateQueryFailureGracePeriod(backup)
+	if gracePeriod != 30*time.Minute {
+		t.Fatalf("expected annotation grace period 30m, got %s", gracePeriod)
+	}
+}
+
+func TestSyncLogBackupStateUsesAnnotatedQueryFailureGracePeriod(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+			Annotations: map[string]string{
+				v1alpha1.AnnoKeyLogBackupStateQueryFailureGracePeriod: "336h",
+			},
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getErrors: map[string]error{
+				"/tidb/br-stream/info/test-backup": queryErr,
+			},
+		},
+		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Hour),
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err == nil {
+		t.Fatal("expected query failure error, got nil")
+	}
+	if canSkip {
+		t.Error("expected sync not to skip when query fails")
+	}
+	if updatedCondition != nil {
+		t.Fatalf("expected no status update before annotated grace period, got %#v", updatedCondition)
+	}
+}
+
 func TestSyncLogBackupStateMarksInfoMissingAsTaskNotFound(t *testing.T) {
 	bt := &backupTracker{
 		logBackups: make(map[string]*trackDepends),

--- a/pkg/backup/backup/backup_tracker_test.go
+++ b/pkg/backup/backup/backup_tracker_test.go
@@ -321,12 +321,8 @@ func TestQueryAllLogBackupKeysReturnsPartialStateWhenPauseQueryFails(t *testing.
 	}
 }
 
-func TestSyncLogBackupStateDoesNotStartQueryFailureCountdownWhenPauseQueryFails(t *testing.T) {
+func TestPauseQueryFailureSkipsKernelSyncButKeepsCheckpointUpdate(t *testing.T) {
 	queryErr := errors.New("pd etcd unavailable")
-	bt := &backupTracker{
-		logBackups: make(map[string]*trackDepends),
-	}
-
 	backup := &v1alpha1.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-backup",
@@ -341,47 +337,93 @@ func TestSyncLogBackupStateDoesNotStartQueryFailureCountdownWhenPauseQueryFails(
 		},
 	}
 
-	logkey := genLogBackupKey("default", "test-backup")
-	bt.logBackups[logkey] = &trackDepends{
-		tc: &v1alpha1.TidbCluster{},
-		etcdClient: &mockPDEtcdClient{
-			getResponse: map[string][]*pdapi.KeyValue{
-				"/tidb/br-stream/info/test-backup": {
-					{Value: []byte("info")},
+	t.Run("sync skips kernel state update", func(t *testing.T) {
+		bt := &backupTracker{
+			logBackups: make(map[string]*trackDepends),
+		}
+
+		logkey := genLogBackupKey("default", "test-backup")
+		bt.logBackups[logkey] = &trackDepends{
+			tc: &v1alpha1.TidbCluster{},
+			etcdClient: &mockPDEtcdClient{
+				getResponse: map[string][]*pdapi.KeyValue{
+					"/tidb/br-stream/info/test-backup": {
+						{Value: []byte("info")},
+					},
+					"/tidb/br-stream/checkpoint/test-backup": {
+						{Value: encodeUint64(123)},
+					},
+				},
+				getErrors: map[string]error{
+					"/tidb/br-stream/pause/test-backup": queryErr,
 				},
 			},
-			getErrors: map[string]error{
-				"/tidb/br-stream/pause/test-backup": queryErr,
+		}
+
+		var updatedCondition *v1alpha1.BackupCondition
+		bt.statusUpdater = &mockStatusUpdater{
+			updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+				updatedCondition = condition
+				return nil
 			},
-		},
-	}
+		}
 
-	var updatedCondition *v1alpha1.BackupCondition
-	bt.statusUpdater = &mockStatusUpdater{
-		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
-			updatedCondition = condition
-			return nil
-		},
-	}
+		canSkip, err := bt.SyncLogBackupState(backup)
+		if err != nil {
+			t.Fatalf("expected pause query failure to skip sync without error, got %v", err)
+		}
+		if !canSkip {
+			t.Error("expected sync to skip when pause state is unknown")
+		}
+		if updatedCondition != nil {
+			t.Fatalf("expected no status update for pause query failure, got %#v", updatedCondition)
+		}
 
-	canSkip, err := bt.SyncLogBackupState(backup)
-	if err != nil {
-		t.Fatalf("expected pause query failure to skip sync without error, got %v", err)
-	}
-	if !canSkip {
-		t.Error("expected sync to skip when pause state is unknown")
-	}
-	if updatedCondition != nil {
-		t.Fatalf("expected no status update for pause query failure, got %#v", updatedCondition)
-	}
+		dep := bt.logBackups[logkey]
+		dep.mutex.RLock()
+		failureStart := dep.stateQueryFailureStartTime
+		dep.mutex.RUnlock()
+		if !failureStart.IsZero() {
+			t.Fatalf("expected pause query failure not to start failure countdown, got %v", failureStart)
+		}
+	})
 
-	dep := bt.logBackups[logkey]
-	dep.mutex.RLock()
-	failureStart := dep.stateQueryFailureStartTime
-	dep.mutex.RUnlock()
-	if !failureStart.IsZero() {
-		t.Fatalf("expected pause query failure not to start failure countdown, got %v", failureStart)
-	}
+	t.Run("refresh keeps checkpoint update", func(t *testing.T) {
+		bt := &backupTracker{}
+		dep := &trackDepends{
+			tc: &v1alpha1.TidbCluster{},
+			etcdClient: &mockPDEtcdClient{
+				getResponse: map[string][]*pdapi.KeyValue{
+					"/tidb/br-stream/info/test-backup": {
+						{Value: []byte("info")},
+					},
+					"/tidb/br-stream/checkpoint/test-backup": {
+						{Value: encodeUint64(123)},
+					},
+					"/tidb/br-stream/last-error/test-backup": {},
+				},
+				getErrors: map[string]error{
+					"/tidb/br-stream/pause/test-backup": queryErr,
+				},
+			},
+		}
+
+		var updatedStatus *controller.BackupUpdateStatus
+		bt.statusUpdater = &mockStatusUpdater{
+			updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+				updatedStatus = status
+				return nil
+			},
+		}
+
+		bt.doRefreshLogBackupState(backup, dep)
+		if updatedStatus == nil || updatedStatus.LogCheckpointTs == nil {
+			t.Fatal("expected checkpoint status update")
+		}
+		if *updatedStatus.LogCheckpointTs != "123" {
+			t.Errorf("expected checkpoint 123, got %s", *updatedStatus.LogCheckpointTs)
+		}
+	})
 }
 
 func TestGetLogBackupKernelState(t *testing.T) {
@@ -401,7 +443,7 @@ func TestGetLogBackupKernelState(t *testing.T) {
 	}
 }
 
-func TestSyncLogBackupStateMarksQueryFailureAfterLongStateQueryFailure(t *testing.T) {
+func TestSyncLogBackupStateReportsPersistentQueryFailureWithRetryAndLatch(t *testing.T) {
 	queryErr := errors.New("pd etcd unavailable")
 	bt := &backupTracker{
 		logBackups: make(map[string]*trackDepends),
@@ -433,118 +475,6 @@ func TestSyncLogBackupStateMarksQueryFailureAfterLongStateQueryFailure(t *testin
 	}
 
 	var updatedCondition *v1alpha1.BackupCondition
-	bt.statusUpdater = &mockStatusUpdater{
-		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
-			updatedCondition = condition
-			return nil
-		},
-	}
-
-	canSkip, err := bt.SyncLogBackupState(backup)
-	if err == nil {
-		t.Fatal("expected query failure error, got nil")
-	}
-	if canSkip {
-		t.Error("expected sync not to skip when query failure is confirmed")
-	}
-	if updatedCondition == nil {
-		t.Fatal("expected status update after persistent query failures")
-	}
-	if updatedCondition.Type != v1alpha1.BackupFailed {
-		t.Errorf("expected condition type %s, got %s", v1alpha1.BackupFailed, updatedCondition.Type)
-	}
-	if updatedCondition.Reason != "LogBackupStateQueryFailed" {
-		t.Errorf("expected reason LogBackupStateQueryFailed, got %s", updatedCondition.Reason)
-	}
-	if updatedCondition.Reason == "LogBackupTaskNotFound" {
-		t.Error("query failure must not be reported as task not found")
-	}
-}
-
-func TestSyncLogBackupStateReportsPersistentQueryFailureOnlyOnce(t *testing.T) {
-	queryErr := errors.New("pd etcd unavailable")
-	bt := &backupTracker{
-		logBackups: make(map[string]*trackDepends),
-	}
-
-	backup := &v1alpha1.Backup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-backup",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.BackupSpec{
-			Mode:          v1alpha1.BackupModeLog,
-			LogSubcommand: v1alpha1.LogStartCommand,
-		},
-		Status: v1alpha1.BackupStatus{
-			Phase: v1alpha1.BackupRunning,
-		},
-	}
-
-	logkey := genLogBackupKey("default", "test-backup")
-	bt.logBackups[logkey] = &trackDepends{
-		tc: &v1alpha1.TidbCluster{},
-		etcdClient: &mockPDEtcdClient{
-			getErrors: map[string]error{
-				"/tidb/br-stream/info/test-backup": queryErr,
-			},
-		},
-		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
-	}
-
-	updateCalls := 0
-	bt.statusUpdater = &mockStatusUpdater{
-		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
-			updateCalls++
-			return nil
-		},
-	}
-
-	for i := 0; i < 2; i++ {
-		canSkip, err := bt.SyncLogBackupState(backup)
-		if err == nil {
-			t.Fatal("expected query failure error, got nil")
-		}
-		if canSkip {
-			t.Error("expected sync not to skip when query failure is confirmed")
-		}
-	}
-	if updateCalls != 1 {
-		t.Fatalf("expected persistent query failure status to be updated once, got %d", updateCalls)
-	}
-}
-
-func TestSyncLogBackupStateRetriesReportWhenPersistentQueryFailureUpdateFails(t *testing.T) {
-	queryErr := errors.New("pd etcd unavailable")
-	bt := &backupTracker{
-		logBackups: make(map[string]*trackDepends),
-	}
-
-	backup := &v1alpha1.Backup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-backup",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.BackupSpec{
-			Mode:          v1alpha1.BackupModeLog,
-			LogSubcommand: v1alpha1.LogStartCommand,
-		},
-		Status: v1alpha1.BackupStatus{
-			Phase: v1alpha1.BackupRunning,
-		},
-	}
-
-	logkey := genLogBackupKey("default", "test-backup")
-	bt.logBackups[logkey] = &trackDepends{
-		tc: &v1alpha1.TidbCluster{},
-		etcdClient: &mockPDEtcdClient{
-			getErrors: map[string]error{
-				"/tidb/br-stream/info/test-backup": queryErr,
-			},
-		},
-		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
-	}
-
 	updateCalls := 0
 	bt.statusUpdater = &mockStatusUpdater{
 		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
@@ -552,6 +482,7 @@ func TestSyncLogBackupStateRetriesReportWhenPersistentQueryFailureUpdateFails(t 
 			if updateCalls == 1 {
 				return errors.New("update status failed")
 			}
+			updatedCondition = condition
 			return nil
 		},
 	}
@@ -566,7 +497,27 @@ func TestSyncLogBackupStateRetriesReportWhenPersistentQueryFailureUpdateFails(t 
 		}
 	}
 	if updateCalls != 2 {
-		t.Fatalf("expected status update to be retried after failure, got %d calls", updateCalls)
+		t.Fatalf("expected failed status update to be retried, got %d calls", updateCalls)
+	}
+	if updatedCondition == nil {
+		t.Fatal("expected successful retry to update status")
+	}
+	if updatedCondition.Type != v1alpha1.BackupFailed {
+		t.Errorf("expected condition type %s, got %s", v1alpha1.BackupFailed, updatedCondition.Type)
+	}
+	if updatedCondition.Reason != "LogBackupStateQueryFailed" {
+		t.Errorf("expected reason LogBackupStateQueryFailed, got %s", updatedCondition.Reason)
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err == nil {
+		t.Fatal("expected query failure error, got nil")
+	}
+	if canSkip {
+		t.Error("expected sync not to skip when query failure is confirmed")
+	}
+	if updateCalls != 2 {
+		t.Fatalf("expected successful query failure report to be latched, got %d calls", updateCalls)
 	}
 }
 
@@ -784,57 +735,6 @@ func TestDoRefreshLogBackupStateRecordsEtcdClientFailure(t *testing.T) {
 	dep.mutex.RUnlock()
 	if failureStart.IsZero() {
 		t.Fatal("expected etcd client failure to start query failure countdown")
-	}
-}
-
-func TestDoRefreshLogBackupStateUpdatesCheckpointWhenPauseQueryFails(t *testing.T) {
-	bt := &backupTracker{}
-	backup := &v1alpha1.Backup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-backup",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.BackupSpec{
-			Mode:          v1alpha1.BackupModeLog,
-			LogSubcommand: v1alpha1.LogStartCommand,
-		},
-		Status: v1alpha1.BackupStatus{
-			Phase: v1alpha1.BackupRunning,
-		},
-	}
-
-	dep := &trackDepends{
-		tc: &v1alpha1.TidbCluster{},
-		etcdClient: &mockPDEtcdClient{
-			getResponse: map[string][]*pdapi.KeyValue{
-				"/tidb/br-stream/info/test-backup": {
-					{Value: []byte("info")},
-				},
-				"/tidb/br-stream/checkpoint/test-backup": {
-					{Value: encodeUint64(123)},
-				},
-				"/tidb/br-stream/last-error/test-backup": {},
-			},
-			getErrors: map[string]error{
-				"/tidb/br-stream/pause/test-backup": errors.New("pd etcd unavailable"),
-			},
-		},
-	}
-
-	var updatedStatus *controller.BackupUpdateStatus
-	bt.statusUpdater = &mockStatusUpdater{
-		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
-			updatedStatus = status
-			return nil
-		},
-	}
-
-	bt.doRefreshLogBackupState(backup, dep)
-	if updatedStatus == nil || updatedStatus.LogCheckpointTs == nil {
-		t.Fatal("expected checkpoint status update")
-	}
-	if *updatedStatus.LogCheckpointTs != "123" {
-		t.Errorf("expected checkpoint 123, got %s", *updatedStatus.LogCheckpointTs)
 	}
 }
 

--- a/pkg/backup/backup/backup_tracker_test.go
+++ b/pkg/backup/backup/backup_tracker_test.go
@@ -14,8 +14,10 @@
 package backup
 
 import (
+	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -257,6 +259,131 @@ func TestQueryAllLogBackupKeys(t *testing.T) {
 	})
 }
 
+func TestQueryAllLogBackupKeysReturnsErrorWhenInfoQueryFails(t *testing.T) {
+	bt := &backupTracker{}
+	mockClient := &mockPDEtcdClient{
+		getResponse: map[string][]*pdapi.KeyValue{
+			"/tidb/br-stream/checkpoint/test-backup": {
+				{Value: encodeUint64(123)},
+			},
+			"/tidb/br-stream/pause/test-backup":      {},
+			"/tidb/br-stream/last-error/test-backup": {},
+		},
+		getErrors: map[string]error{
+			"/tidb/br-stream/info/test-backup": errors.New("pd etcd unavailable"),
+		},
+	}
+
+	state, err := bt.queryAllLogBackupKeys(mockClient, "test-backup")
+	if err == nil {
+		t.Fatal("expected info key query error, got nil")
+	}
+	if state != nil {
+		t.Fatalf("expected no state on info key query error, got %#v", state)
+	}
+}
+
+func TestQueryAllLogBackupKeysReturnsPartialStateWhenPauseQueryFails(t *testing.T) {
+	bt := &backupTracker{}
+	mockClient := &mockPDEtcdClient{
+		getResponse: map[string][]*pdapi.KeyValue{
+			"/tidb/br-stream/checkpoint/test-backup": {
+				{Value: encodeUint64(123)},
+			},
+			"/tidb/br-stream/info/test-backup": {
+				{Value: []byte("info")},
+			},
+			"/tidb/br-stream/last-error/test-backup": {},
+		},
+		getErrors: map[string]error{
+			"/tidb/br-stream/pause/test-backup": errors.New("pd etcd unavailable"),
+		},
+	}
+
+	state, err := bt.queryAllLogBackupKeys(mockClient, "test-backup")
+	if err != nil {
+		t.Fatalf("expected pause key query failure to return partial state, got error %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected partial state on pause key query error, got nil")
+	}
+	if !state.InfoExists {
+		t.Error("expected InfoExists to be true from successful info query")
+	}
+	if state.CheckpointTS != 123 {
+		t.Errorf("expected CheckpointTS 123 from successful checkpoint query, got %d", state.CheckpointTS)
+	}
+	if !errors.Is(state.QueryError, errLogBackupPauseKeyQueryFailed) {
+		t.Fatalf("expected pause query error in partial state, got %v", state.QueryError)
+	}
+	if state.KernelState != "" {
+		t.Fatalf("expected no kernel state when pause state is unknown, got %s", state.KernelState)
+	}
+}
+
+func TestSyncLogBackupStateDoesNotStartQueryFailureCountdownWhenPauseQueryFails(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getResponse: map[string][]*pdapi.KeyValue{
+				"/tidb/br-stream/info/test-backup": {
+					{Value: []byte("info")},
+				},
+			},
+			getErrors: map[string]error{
+				"/tidb/br-stream/pause/test-backup": queryErr,
+			},
+		},
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err != nil {
+		t.Fatalf("expected pause query failure to skip sync without error, got %v", err)
+	}
+	if !canSkip {
+		t.Error("expected sync to skip when pause state is unknown")
+	}
+	if updatedCondition != nil {
+		t.Fatalf("expected no status update for pause query failure, got %#v", updatedCondition)
+	}
+
+	dep := bt.logBackups[logkey]
+	dep.mutex.RLock()
+	failureStart := dep.stateQueryFailureStartTime
+	dep.mutex.RUnlock()
+	if !failureStart.IsZero() {
+		t.Fatalf("expected pause query failure not to start failure countdown, got %v", failureStart)
+	}
+}
+
 func TestGetLogBackupKernelState(t *testing.T) {
 	tests := []struct {
 		paused   bool
@@ -271,6 +398,443 @@ func TestGetLogBackupKernelState(t *testing.T) {
 		if result != tt.expected {
 			t.Errorf("getLogBackupKernelState(%v) = %s, want %s", tt.paused, result, tt.expected)
 		}
+	}
+}
+
+func TestSyncLogBackupStateMarksQueryFailureAfterLongStateQueryFailure(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getErrors: map[string]error{
+				"/tidb/br-stream/info/test-backup": queryErr,
+			},
+		},
+		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err == nil {
+		t.Fatal("expected query failure error, got nil")
+	}
+	if canSkip {
+		t.Error("expected sync not to skip when query failure is confirmed")
+	}
+	if updatedCondition == nil {
+		t.Fatal("expected status update after persistent query failures")
+	}
+	if updatedCondition.Type != v1alpha1.BackupFailed {
+		t.Errorf("expected condition type %s, got %s", v1alpha1.BackupFailed, updatedCondition.Type)
+	}
+	if updatedCondition.Reason != "LogBackupStateQueryFailed" {
+		t.Errorf("expected reason LogBackupStateQueryFailed, got %s", updatedCondition.Reason)
+	}
+	if updatedCondition.Reason == "LogBackupTaskNotFound" {
+		t.Error("query failure must not be reported as task not found")
+	}
+}
+
+func TestSyncLogBackupStateReportsPersistentQueryFailureOnlyOnce(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getErrors: map[string]error{
+				"/tidb/br-stream/info/test-backup": queryErr,
+			},
+		},
+		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
+	}
+
+	updateCalls := 0
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updateCalls++
+			return nil
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		canSkip, err := bt.SyncLogBackupState(backup)
+		if err == nil {
+			t.Fatal("expected query failure error, got nil")
+		}
+		if canSkip {
+			t.Error("expected sync not to skip when query failure is confirmed")
+		}
+	}
+	if updateCalls != 1 {
+		t.Fatalf("expected persistent query failure status to be updated once, got %d", updateCalls)
+	}
+}
+
+func TestSyncLogBackupStateRetriesReportWhenPersistentQueryFailureUpdateFails(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getErrors: map[string]error{
+				"/tidb/br-stream/info/test-backup": queryErr,
+			},
+		},
+		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
+	}
+
+	updateCalls := 0
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updateCalls++
+			if updateCalls == 1 {
+				return errors.New("update status failed")
+			}
+			return nil
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		canSkip, err := bt.SyncLogBackupState(backup)
+		if err == nil {
+			t.Fatal("expected query failure error, got nil")
+		}
+		if canSkip {
+			t.Error("expected sync not to skip when query failure is confirmed")
+		}
+	}
+	if updateCalls != 2 {
+		t.Fatalf("expected status update to be retried after failure, got %d calls", updateCalls)
+	}
+}
+
+func TestRefreshLogBackupStateClearsQueryFailureReportAfterSuccessfulQuery(t *testing.T) {
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode: v1alpha1.BackupModeLog,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getResponse: map[string][]*pdapi.KeyValue{
+				"/tidb/br-stream/info/test-backup": {
+					{Value: []byte("info")},
+				},
+				"/tidb/br-stream/checkpoint/test-backup": {
+					{Value: encodeUint64(123)},
+				},
+				"/tidb/br-stream/pause/test-backup":      {},
+				"/tidb/br-stream/last-error/test-backup": {},
+			},
+		},
+		stateQueryFailureStartTime: time.Now().Add(-logBackupStateQueryFailureGracePeriod - time.Minute),
+		stateQueryFailureReported:  true,
+	}
+
+	if _, err := bt.RefreshLogBackupState(backup); err != nil {
+		t.Fatalf("RefreshLogBackupState failed: %v", err)
+	}
+
+	dep := bt.logBackups[logkey]
+	dep.mutex.RLock()
+	failureStart := dep.stateQueryFailureStartTime
+	failureReported := dep.stateQueryFailureReported
+	dep.mutex.RUnlock()
+	if !failureStart.IsZero() {
+		t.Fatalf("expected successful query to clear failure start time, got %v", failureStart)
+	}
+	if failureReported {
+		t.Fatal("expected successful query to clear failure reported latch")
+	}
+}
+
+func TestSyncLogBackupStateStartsQueryFailureCountdownBeforeGracePeriod(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getErrors: map[string]error{
+				"/tidb/br-stream/info/test-backup": queryErr,
+			},
+		},
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err == nil {
+		t.Fatal("expected query failure error, got nil")
+	}
+	if canSkip {
+		t.Error("expected sync not to skip when query fails")
+	}
+	if updatedCondition != nil {
+		t.Fatalf("expected no status update before grace period, got %#v", updatedCondition)
+	}
+
+	dep := bt.logBackups[logkey]
+	dep.mutex.RLock()
+	failureStart := dep.stateQueryFailureStartTime
+	dep.mutex.RUnlock()
+	if failureStart.IsZero() {
+		t.Fatal("expected query failure countdown to start")
+	}
+}
+
+func TestSyncLogBackupStateMarksInfoMissingAsTaskNotFound(t *testing.T) {
+	bt := &backupTracker{
+		logBackups: make(map[string]*trackDepends),
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	logkey := genLogBackupKey("default", "test-backup")
+	bt.logBackups[logkey] = &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		state: &LogBackupState{
+			InfoExists:  false,
+			KernelState: LogBackupKernelRunning,
+		},
+		lastRefresh: time.Now(),
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	canSkip, err := bt.SyncLogBackupState(backup)
+	if err == nil {
+		t.Fatal("expected task not found error, got nil")
+	}
+	if canSkip {
+		t.Error("expected sync not to skip when task is missing")
+	}
+	if updatedCondition == nil {
+		t.Fatal("expected status update for missing info key")
+	}
+	if updatedCondition.Reason != "LogBackupTaskNotFound" {
+		t.Errorf("expected reason LogBackupTaskNotFound, got %s", updatedCondition.Reason)
+	}
+}
+
+func TestDoRefreshLogBackupStateRecordsEtcdClientFailure(t *testing.T) {
+	queryErr := errors.New("pd etcd unavailable")
+	bt := &backupTracker{
+		deps: &controller.Dependencies{
+			Controls: controller.Controls{
+				PDControl: &mockPDControl{
+					getPDEtcdClientErr: queryErr,
+				},
+			},
+		},
+	}
+
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	dep := &trackDepends{
+		tc: &v1alpha1.TidbCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tc",
+				Namespace: "default",
+			},
+		},
+	}
+
+	var updatedCondition *v1alpha1.BackupCondition
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedCondition = condition
+			return nil
+		},
+	}
+
+	bt.doRefreshLogBackupState(backup, dep)
+	if updatedCondition != nil {
+		t.Fatalf("expected no status update before grace period, got %#v", updatedCondition)
+	}
+
+	dep.mutex.RLock()
+	failureStart := dep.stateQueryFailureStartTime
+	dep.mutex.RUnlock()
+	if failureStart.IsZero() {
+		t.Fatal("expected etcd client failure to start query failure countdown")
+	}
+}
+
+func TestDoRefreshLogBackupStateUpdatesCheckpointWhenPauseQueryFails(t *testing.T) {
+	bt := &backupTracker{}
+	backup := &v1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.BackupSpec{
+			Mode:          v1alpha1.BackupModeLog,
+			LogSubcommand: v1alpha1.LogStartCommand,
+		},
+		Status: v1alpha1.BackupStatus{
+			Phase: v1alpha1.BackupRunning,
+		},
+	}
+
+	dep := &trackDepends{
+		tc: &v1alpha1.TidbCluster{},
+		etcdClient: &mockPDEtcdClient{
+			getResponse: map[string][]*pdapi.KeyValue{
+				"/tidb/br-stream/info/test-backup": {
+					{Value: []byte("info")},
+				},
+				"/tidb/br-stream/checkpoint/test-backup": {
+					{Value: encodeUint64(123)},
+				},
+				"/tidb/br-stream/last-error/test-backup": {},
+			},
+			getErrors: map[string]error{
+				"/tidb/br-stream/pause/test-backup": errors.New("pd etcd unavailable"),
+			},
+		},
+	}
+
+	var updatedStatus *controller.BackupUpdateStatus
+	bt.statusUpdater = &mockStatusUpdater{
+		updateFunc: func(backup *v1alpha1.Backup, condition *v1alpha1.BackupCondition, status *controller.BackupUpdateStatus) error {
+			updatedStatus = status
+			return nil
+		},
+	}
+
+	bt.doRefreshLogBackupState(backup, dep)
+	if updatedStatus == nil || updatedStatus.LogCheckpointTs == nil {
+		t.Fatal("expected checkpoint status update")
+	}
+	if *updatedStatus.LogCheckpointTs != "123" {
+		t.Errorf("expected checkpoint 123, got %s", *updatedStatus.LogCheckpointTs)
 	}
 }
 
@@ -491,10 +1055,15 @@ func TestParsePauseReason(t *testing.T) {
 
 type mockPDEtcdClient struct {
 	getResponse map[string][]*pdapi.KeyValue
+	getErrors   map[string]error
 	getError    error
 }
 
 func (m *mockPDEtcdClient) Get(key string, recursive bool) ([]*pdapi.KeyValue, error) {
+	if err, exists := m.getErrors[key]; exists {
+		return nil, err
+	}
+
 	if m.getError != nil {
 		return nil, m.getError
 	}
@@ -721,6 +1290,27 @@ func (m *mockStatusUpdater) Update(backup *v1alpha1.Backup, condition *v1alpha1.
 	if m.updateFunc != nil {
 		return m.updateFunc(backup, condition, status)
 	}
+	return nil
+}
+
+type mockPDControl struct {
+	getPDEtcdClient    pdapi.PDEtcdClient
+	getPDEtcdClientErr error
+}
+
+func (m *mockPDControl) GetPDClient(namespace pdapi.Namespace, tcName string, tlsEnabled bool, opts ...pdapi.Option) pdapi.PDClient {
+	return nil
+}
+
+func (m *mockPDControl) GetPDEtcdClient(namespace pdapi.Namespace, tcName string, tlsEnabled bool, opts ...pdapi.Option) (pdapi.PDEtcdClient, error) {
+	return m.getPDEtcdClient, m.getPDEtcdClientErr
+}
+
+func (m *mockPDControl) GetEndpoints(namespace pdapi.Namespace, tcName string, tlsEnabled bool, opts ...pdapi.Option) ([]string, *tls.Config, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPDControl) GetPDMSClient(namespace pdapi.Namespace, tcName, serviceName string, tlsEnabled bool, opts ...pdapi.Option) pdapi.PDMSClient {
 	return nil
 }
 


### PR DESCRIPTION
## What changed

This updates log backup tracker state queries to distinguish critical PD etcd query failures from confirmed missing metadata:

- Treat `info` key query failures as unknown state instead of task-not-found.
- Start a 10-minute critical query failure countdown for `info` query failures and PD etcd client creation failures.
- Report `BackupFailed / LogBackupStateQueryFailed` only once per continuous failure window, and retry reporting if the status update itself fails.
- Treat `pause` key query failures as partial state: keep usable `info`/checkpoint data, skip kernel state sync, and avoid marking the backup failed.
- Preserve checkpoint updates when pause state is unknown.

## Why

A transient PD/etcd/DNS issue could previously leave `InfoExists=false` and be interpreted as `LogBackupTaskNotFound`, incorrectly failing log backup even though task existence was unknown.

## Validation

- `GOCACHE=/tmp/go-cache go test ./pkg/backup/backup -count=1`
- `GOCACHE=/tmp/go-cache go test -race ./pkg/backup/backup -count=1`
