### PR TITLE
ci: retry backup manager downloads with shell loop

### DIFF
--- a/images/tidb-backup-manager/Dockerfile
+++ b/images/tidb-backup-manager/Dockerfile
@@ -2,15 +2,24 @@ FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.1@sha256:24ecefceae6b114e11f6ae
 ARG TARGETARCH
 ARG RCLONE_VERSION=v1.71.2
 ARG SHUSH_VERSION=v1.5.5
+ARG WGET_RETRY_OPTS="--timeout=60 --waitretry=5 --retry-connrefused"
 RUN dnf install -y ca-certificates bind-utils wget nc unzip && dnf clean all
 
-RUN wget -nv https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
+RUN for i in 1 2 3 4 5; do \
+        wget -nv ${WGET_RETRY_OPTS} https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done \
     && unzip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
     && mv rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone /usr/local/bin \
     && chmod 755 /usr/local/bin/rclone \
     && rm -rf rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}
 
-RUN wget -nv https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} \
+RUN for i in 1 2 3 4 5; do \
+        wget -nv ${WGET_RETRY_OPTS} https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done \
     && mv shush_linux_${TARGETARCH} /usr/local/bin/shush \
     && chmod 755 /usr/local/bin/shush
 

--- a/images/tidb-backup-manager/Dockerfile.e2e
+++ b/images/tidb-backup-manager/Dockerfile.e2e
@@ -2,15 +2,24 @@ FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.1@sha256:24ecefceae6b114e11f6ae
 ARG TARGETARCH=amd64
 ARG RCLONE_VERSION=v1.71.2
 ARG SHUSH_VERSION=v1.5.5
+ARG WGET_RETRY_OPTS="--timeout=60 --waitretry=5 --retry-connrefused"
 RUN dnf install -y ca-certificates bind-utils wget nc unzip && dnf clean all
 
-RUN wget -nv https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
+RUN for i in 1 2 3 4 5; do \
+        wget -nv ${WGET_RETRY_OPTS} https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done \
     && unzip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip \
     && mv rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone /usr/local/bin \
     && chmod 755 /usr/local/bin/rclone \
     && rm -rf rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip rclone-${RCLONE_VERSION}-linux-${TARGETARCH}
 
-RUN wget -nv https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} \
+RUN for i in 1 2 3 4 5; do \
+        wget -nv ${WGET_RETRY_OPTS} https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done \
     && mv shush_linux_${TARGETARCH} /usr/local/bin/shush \
     && chmod 755 /usr/local/bin/shush
 

--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -20,12 +20,13 @@ RUN for i in 1 2 3 4 5; do \
         sleep 5; \
     done && \
     chmod +x /usr/local/bin/kubectl && \
-    for i in 1 2 3 4 5; do \
-        curl ${CURL_RETRY_OPTS} https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
-            -o helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && break; \
-        if [ "$i" = "5" ]; then exit 1; fi; \
-        sleep 5; \
+    for url in https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://mirrors.huaweicloud.com/helm/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz; do \
+        for i in 1 2 3; do \
+            curl ${CURL_RETRY_OPTS} "$url" -o helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && helm_downloaded=1 && break 2; \
+            sleep 5; \
+        done; \
     done && \
+    test "${helm_downloaded:-}" = "1" && \
     tar -zxvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/helm && \
     rm -rf linux-${TARGETARCH} && \

--- a/tests/images/e2e/Dockerfile
+++ b/tests/images/e2e/Dockerfile
@@ -4,6 +4,7 @@ ENV KUBECTL_VERSION=v1.28.5
 ENV HELM_VERSION=v3.11.0
 
 ARG TARGETARCH
+ARG CURL_RETRY_OPTS="--fail --location --connect-timeout 30 --max-time 180"
 
 # python is required by gcloud
 RUN apt-get update && \
@@ -12,20 +13,36 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean -y
 
-RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
-    -o /usr/local/bin/kubectl && \
+RUN for i in 1 2 3 4 5; do \
+        curl ${CURL_RETRY_OPTS} https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
+            -o /usr/local/bin/kubectl && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done && \
     chmod +x /usr/local/bin/kubectl && \
-    curl https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
-    -o helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    for i in 1 2 3 4 5; do \
+        curl ${CURL_RETRY_OPTS} https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
+            -o helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done && \
     tar -zxvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/helm && \
     rm -rf linux-${TARGETARCH} && \
     rm helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN for i in 1 2 3 4 5; do \
+        curl ${CURL_RETRY_OPTS} "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -r aws awscliv2.zip
-RUN curl -L "https://github.com/jetstack/cert-manager/releases/download/v1.15.1/cert-manager.yaml" -o "/cert-manager.yaml"
+RUN for i in 1 2 3 4 5; do \
+        curl ${CURL_RETRY_OPTS} "https://github.com/jetstack/cert-manager/releases/download/v1.15.1/cert-manager.yaml" -o "/cert-manager.yaml" && break; \
+        if [ "$i" = "5" ]; then exit 1; fi; \
+        sleep 5; \
+    done
 ADD minio /minio
 
 ADD tidb-operator /charts/e2e/tidb-operator


### PR DESCRIPTION
## Summary
- retry backup-manager `rclone` downloads with an explicit shell loop
- retry backup-manager `shush` downloads with the same loop
- keep wget timeout/retry-connrefused options, but retry any non-zero wget exit (including SSL connection failures)

## Motivation
PR #6919 e2e jobs failed while building `images/tidb-backup-manager/Dockerfile.e2e`:

```text
Unable to establish SSL connection.
ERROR: failed to build: failed to solve: process "... wget ... rclone-v1.71.2-linux-amd64.zip ..." did not complete successfully: exit code: 4
```

`wget --tries` did not cover this failure mode reliably in Prow, so this change wraps the download in an explicit retry loop.

## Test Plan
- `git diff --check`
- Extracted the Dockerfile `RUN` shell snippets and validated them with `sh -n`

Docker build was not run locally because Docker Desktop daemon is not running in this environment.
