### PR TITLE
fix: add prometheus scrape annotations to DM pods

### DIFF
--- a/pkg/controllers/dm/tasks/pod.go
+++ b/pkg/controllers/dm/tasks/pod.go
@@ -35,6 +35,8 @@ import (
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
 )
 
+const metricsPath = "/metrics"
+
 func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
@@ -166,6 +168,7 @@ func newPod(cluster *v1alpha1.Cluster, dm *v1alpha1.DM) *corev1.Pod {
 					k8s.LabelKeyK8sAppName: k8s.LabelValK8sAppNameDMCluster,
 				},
 			),
+			Annotations: maputil.Merge(k8s.AnnoProm(coreutil.DMPort(dm), metricsPath)),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(dm, v1alpha1.SchemeGroupVersion.WithKind("DM")),
 			},

--- a/pkg/controllers/dm/tasks/pod_test.go
+++ b/pkg/controllers/dm/tasks/pod_test.go
@@ -123,6 +123,9 @@ func TestTaskPod(t *testing.T) {
 			assert.Len(t, pod.Spec.Containers[0].Ports, 2)
 			assert.Equal(t, int32(8261), pod.Spec.Containers[0].Ports[0].ContainerPort)
 			assert.Equal(t, int32(8291), pod.Spec.Containers[0].Ports[1].ContainerPort)
+			assert.Equal(t, "true", pod.Annotations["prometheus.io/scrape"])
+			assert.Equal(t, "8261", pod.Annotations["prometheus.io/port"])
+			assert.Equal(t, "/metrics", pod.Annotations["prometheus.io/path"])
 		})
 	}
 }

--- a/pkg/controllers/dmworker/tasks/pod.go
+++ b/pkg/controllers/dmworker/tasks/pod.go
@@ -35,6 +35,8 @@ import (
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
 )
 
+const metricsPath = "/metrics"
+
 func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
@@ -166,6 +168,7 @@ func newPod(cluster *v1alpha1.Cluster, dw *v1alpha1.DMWorker) *corev1.Pod {
 					k8s.LabelKeyK8sAppName: k8s.LabelValK8sAppNameDMCluster,
 				},
 			),
+			Annotations: maputil.Merge(k8s.AnnoProm(coreutil.DMWorkerPort(dw), metricsPath)),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(dw, v1alpha1.SchemeGroupVersion.WithKind("DMWorker")),
 			},

--- a/pkg/controllers/dmworker/tasks/pod_test.go
+++ b/pkg/controllers/dmworker/tasks/pod_test.go
@@ -97,6 +97,9 @@ func TestTaskPod(t *testing.T) {
 			assert.Equal(t, k8s.LabelValK8sAppNameDMCluster, pod.Labels[k8s.LabelKeyK8sAppName])
 			require.Len(t, pod.Spec.Containers[0].Ports, 1)
 			assert.Equal(t, int32(8262), pod.Spec.Containers[0].Ports[0].ContainerPort)
+			assert.Equal(t, "true", pod.Annotations["prometheus.io/scrape"])
+			assert.Equal(t, "8262", pod.Annotations["prometheus.io/port"])
+			assert.Equal(t, "/metrics", pod.Annotations["prometheus.io/path"])
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path` annotations to dm-master and dm-worker pods via `k8s.AnnoProm`, matching PD/TiKV/TiDB and other operator v2 components.
- dm-master uses client port `8261`; dm-worker uses client port `8262`.
- Extend DM pod unit tests to assert the new annotations.

## Test plan
- [x] `go test ./pkg/controllers/dm/tasks/... ./pkg/controllers/dmworker/tasks/... -count=1`
- [ ] Deploy operator build and verify dm-master/dm-worker pods get `prometheus.io/scrape=true`
- [ ] Confirm Prometheus/o11y collector discovers DM metrics endpoints


Made with [Cursor](https://cursor.com)