### PR TITLE
fix(updater): preserve topology when canceling offline stores

### DIFF
--- a/pkg/controllers/tiflashgroup/tasks/updater.go
+++ b/pkg/controllers/tiflashgroup/tasks/updater.go
@@ -102,6 +102,9 @@ func TaskUpdater(state *ReconcileContext, c client.Client, af tracker.AllocateFa
 			WithScaleInPreferPolicy(
 				topoPolicy.PolicyScaleIn(),
 			).
+			WithCancelOfflinePreferPolicy(
+				topoPolicy.PolicyCancelOffline(),
+			).
 			WithMinReadySeconds(coreutil.MinReadySeconds[scope.TiFlashGroup](fg)).
 			Build().
 			Do(ctx)

--- a/pkg/controllers/tikvgroup/tasks/updater.go
+++ b/pkg/controllers/tikvgroup/tasks/updater.go
@@ -103,6 +103,9 @@ func TaskUpdater(state *ReconcileContext, c client.Client, af tracker.AllocateFa
 			WithScaleInPreferPolicy(
 				topoPolicy.PolicyScaleIn(),
 			).
+			WithCancelOfflinePreferPolicy(
+				topoPolicy.PolicyCancelOffline(),
+			).
 			WithMinReadySeconds(coreutil.MinReadySeconds[scope.TiKVGroup](kvg)).
 			Build().
 			Do(ctx)

--- a/pkg/controllers/tikvgroup/tasks/updater_test.go
+++ b/pkg/controllers/tikvgroup/tasks/updater_test.go
@@ -289,6 +289,107 @@ func TestTaskUpdater(t *testing.T) {
 	}
 }
 
+// TestTaskUpdaterCancelOfflinePrefersTopologyAwareCandidate ensures that when
+// scaling out can be satisfied by canceling an offlining instance, the
+// topology-aware candidate is chosen instead of the lexicographically first
+// one. Without the cancel-offline topology wiring, "00-offline-a" would be
+// picked because it sorts first, even though "10-offline-b" is the
+// topology-correct choice under 1:2 zone weights.
+func TestTaskUpdaterCancelOfflinePrefersTopologyAwareCandidate(t *testing.T) {
+	const (
+		zoneA = "us-west-1a"
+		zoneB = "us-west-1b"
+	)
+
+	kvg := fake.FakeObj("aaa", func(obj *v1alpha1.TiKVGroup) *v1alpha1.TiKVGroup {
+		obj.Spec.Replicas = ptr.To[int32](3)
+		obj.Spec.SchedulePolicies = append(obj.Spec.SchedulePolicies, v1alpha1.SchedulePolicy{
+			Type: v1alpha1.SchedulePolicyTypeEvenlySpread,
+			EvenlySpread: &v1alpha1.SchedulePolicyEvenlySpread{
+				Topologies: []v1alpha1.ScheduleTopology{
+					{
+						Topology: v1alpha1.Topology{"zone": zoneA},
+						Weight:   ptr.To[int32](1),
+					},
+					{
+						Topology: v1alpha1.Topology{"zone": zoneB},
+						Weight:   ptr.To[int32](2),
+					},
+				},
+			},
+		})
+		return obj
+	})
+
+	activeA := fakeAvailableTiKVWithTopology("active-a", kvg, zoneA, false)
+	activeB := fakeAvailableTiKVWithTopology("active-b", kvg, zoneB, false)
+	offlineA := fakeAvailableTiKVWithTopology("00-offline-a", kvg, zoneA, true)
+	offlineB := fakeAvailableTiKVWithTopology("10-offline-b", kvg, zoneB, true)
+
+	st := &ReconcileContext{
+		State: &state{
+			kvg:     kvg,
+			cluster: fake.FakeObj[v1alpha1.Cluster]("cluster"),
+			kvs:     []*v1alpha1.TiKV{activeA, activeB, offlineA, offlineB},
+
+			updateRevision: newRevision,
+		},
+	}
+	s := st.State.(*state)
+	s.IFeatureGates = stateutil.NewFeatureGates[scope.TiKVGroup](s)
+
+	ctx := context.Background()
+	objs := []client.Object{st.TiKVGroup(), st.Cluster()}
+	fc := client.NewFakeClient(objs...)
+	for _, obj := range st.TiKVSlice() {
+		require.NoError(t, fc.Apply(ctx, obj.DeepCopy()))
+		require.NoError(t, fc.Status().Update(ctx, obj.DeepCopy()))
+	}
+
+	af := tracker.New().AllocateFactory("tikv")
+	res, done := task.RunTask(ctx, TaskUpdater(st, fc, af))
+	assert.Equal(t, task.SWait.String(), res.Status().String())
+	assert.False(t, done)
+
+	kvs := v1alpha1.TiKVList{}
+	require.NoError(t, fc.List(ctx, &kvs))
+	assert.Len(t, kvs.Items, 4, "no new TiKV should be created")
+
+	var got00, got10 *v1alpha1.TiKV
+	for i := range kvs.Items {
+		switch kvs.Items[i].Name {
+		case "00-offline-a":
+			got00 = &kvs.Items[i]
+		case "10-offline-b":
+			got10 = &kvs.Items[i]
+		}
+	}
+	require.NotNil(t, got00)
+	require.NotNil(t, got10)
+
+	assert.True(t, ptr.Deref(got00.Spec.Offline, false), "00-offline-a should remain offline")
+	assert.False(t, ptr.Deref(got10.Spec.Offline, false), "10-offline-b should be canceled")
+}
+
+func fakeAvailableTiKVWithTopology(name string, kvg *v1alpha1.TiKVGroup, zone string, offline bool) *v1alpha1.TiKV {
+	return fake.FakeObj(name, func(obj *v1alpha1.TiKV) *v1alpha1.TiKV {
+		tikv := runtime.ToTiKV(TiKVNewer(kvg, newRevision, features.NewFromFeatures(nil)).New())
+		tikv.Name = ""
+		tikv.Spec.Topology = v1alpha1.Topology{"zone": zone}
+		tikv.Spec.Offline = ptr.To(offline)
+		if !offline {
+			tikv.Status.Conditions = append(tikv.Status.Conditions, metav1.Condition{
+				Type:               v1alpha1.CondReady,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Unix(0, 0),
+			})
+			tikv.Status.CurrentRevision = newRevision
+		}
+		tikv.DeepCopyInto(obj)
+		return obj
+	})
+}
+
 func fakeAvailableTiKV(name string, kvg *v1alpha1.TiKVGroup, rev string) *v1alpha1.TiKV {
 	return fake.FakeObj(name, func(obj *v1alpha1.TiKV) *v1alpha1.TiKV {
 		tikv := runtime.ToTiKV(TiKVNewer(kvg, rev, features.NewFromFeatures(nil)).New())

--- a/pkg/updater/actor.go
+++ b/pkg/updater/actor.go
@@ -97,8 +97,9 @@ type actor[T runtime.Tuple[O, R], O client.Object, R runtime.Instance] struct {
 	updateHooks []UpdateHook[R]
 	delHooks    []DelHook[R]
 
-	scaleInSelector Selector[R]
-	updateSelector  Selector[R]
+	scaleInSelector       Selector[R]
+	updateSelector        Selector[R]
+	cancelOfflineSelector Selector[R]
 
 	actions []action
 }
@@ -127,6 +128,18 @@ func (act *actor[T, O, R]) chooseToScaleIn(s []R) (string, error) {
 	return name, nil
 }
 
+// chooseToCancelOffline selects a beingOffline instance to restore.
+// Uses the cancelOfflineSelector to determine which instance should be canceled next.
+// Returns the name of the selected instance or an error if no instance can be canceled.
+func (act *actor[T, O, R]) chooseToCancelOffline(s []R) (string, error) {
+	name := act.cancelOfflineSelector.Choose(s)
+	if name == "" {
+		return "", fmt.Errorf("no instance can be canceled offline")
+	}
+
+	return name, nil
+}
+
 // cancelOneOfflining cancels offline operation for one beingOffline instance and moves it back to update state
 func (act *actor[T, O, R]) cancelOneOfflining(ctx context.Context, obj R) error {
 	logger := logr.FromContextOrDiscard(ctx)
@@ -147,8 +160,11 @@ func (act *actor[T, O, R]) ScaleOut(ctx context.Context) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	if act.beingOffline.Len() > 0 {
-		// TODO: could implement more sophisticated selection logic
-		if err := act.cancelOneOfflining(ctx, act.beingOffline.List()[0]); err != nil {
+		name, err := act.chooseToCancelOffline(act.beingOffline.List())
+		if err != nil {
+			return err
+		}
+		if err := act.cancelOneOfflining(ctx, act.beingOffline.Get(name)); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/updater/builder.go
+++ b/pkg/updater/builder.go
@@ -37,6 +37,7 @@ type Builder[R runtime.Instance] interface {
 	WithDelHooks(hooks ...DelHook[R]) Builder[R]
 	WithScaleInPreferPolicy(ps ...PreferPolicy[R]) Builder[R]
 	WithUpdatePreferPolicy(ps ...PreferPolicy[R]) Builder[R]
+	WithCancelOfflinePreferPolicy(ps ...PreferPolicy[R]) Builder[R]
 	// NoInPlaceUpdate if true, actor will use Scale in and Scale out to replace Update operation
 	WithNoInPaceUpdate(noUpdate bool) Builder[R]
 	// MinReadySeconds means instances are available only when they keep ready more than minReadySeconds
@@ -62,8 +63,9 @@ type builder[T runtime.Tuple[O, R], O client.Object, R runtime.Instance] struct 
 	updateHooks []UpdateHook[R]
 	delHooks    []DelHook[R]
 
-	scaleInPreferPolicies []PreferPolicy[R]
-	updatePreferPolicies  []PreferPolicy[R]
+	scaleInPreferPolicies       []PreferPolicy[R]
+	updatePreferPolicies        []PreferPolicy[R]
+	cancelOfflinePreferPolicies []PreferPolicy[R]
 }
 
 func (b *builder[T, O, R]) Build() Executor {
@@ -100,6 +102,10 @@ func (b *builder[T, O, R]) Build() Executor {
 
 		scaleInSelector: NewSelector(scaleInPolicies...),
 		updateSelector:  NewSelector(updatePolicies...),
+		// Cancel-offline restores an instance, so the deletion/update
+		// preference defaults above have the wrong meaning here and are not
+		// prepended.
+		cancelOfflineSelector: NewSelector(b.cancelOfflinePreferPolicies...),
 	}
 	return NewExecutor(
 		actor,
@@ -174,6 +180,11 @@ func (b *builder[T, O, R]) WithScaleInPreferPolicy(ps ...PreferPolicy[R]) Builde
 
 func (b *builder[T, O, R]) WithUpdatePreferPolicy(ps ...PreferPolicy[R]) Builder[R] {
 	b.updatePreferPolicies = append(b.updatePreferPolicies, ps...)
+	return b
+}
+
+func (b *builder[T, O, R]) WithCancelOfflinePreferPolicy(ps ...PreferPolicy[R]) Builder[R] {
+	b.cancelOfflinePreferPolicies = append(b.cancelOfflinePreferPolicies, ps...)
 	return b
 }
 

--- a/pkg/updater/policy/topology.go
+++ b/pkg/updater/policy/topology.go
@@ -38,6 +38,7 @@ type TopologyPolicy[R runtime.Instance] interface {
 	updater.UpdateHook[R]
 	PolicyScaleIn() updater.PreferPolicy[R]
 	PolicyUpdate() updater.PreferPolicy[R]
+	PolicyCancelOffline() updater.PreferPolicy[R]
 }
 
 func NewTopologyPolicy[R runtime.Instance](ts []v1alpha1.ScheduleTopology, rev string, rs ...R) (TopologyPolicy[R], error) {
@@ -117,6 +118,12 @@ func (p *topologyPolicy[R]) PolicyUpdate() updater.PreferPolicy[R] {
 	}
 }
 
+func (p *topologyPolicy[R]) PolicyCancelOffline() updater.PreferPolicy[R] {
+	return &cancelOfflinePreferPolicy[R]{
+		p: p,
+	}
+}
+
 type deletePreferPolicy[R runtime.Instance] struct {
 	p *topologyPolicy[R]
 }
@@ -162,6 +169,40 @@ func (p *updatePreferPolicy[R]) Prefer(allowed []R) []R {
 			if maps.Equal(topo, item.GetTopology()) {
 				preferred = append(preferred, item)
 			}
+		}
+	}
+
+	return preferred
+}
+
+type cancelOfflinePreferPolicy[R runtime.Instance] struct {
+	p *topologyPolicy[R]
+}
+
+// Prefer chooses the best topology among the candidates that can still be
+// canceled, rather than the global best topology, which may have no
+// cancelable candidate at all.
+func (p *cancelOfflinePreferPolicy[R]) Prefer(allowed []R) []R {
+	if len(allowed) == 0 {
+		return nil
+	}
+
+	candidates := make([]v1alpha1.Topology, 0, len(allowed))
+	for _, item := range allowed {
+		candidates = append(candidates, item.GetTopology())
+	}
+
+	all := p.p.all.NextAdd(candidates...)
+	updated := p.p.updated.NextAdd(candidates...)
+	topo := choose(all, updated)
+	if topo == nil {
+		return nil
+	}
+
+	var preferred []R
+	for _, item := range allowed {
+		if maps.Equal(topo, item.GetTopology()) {
+			preferred = append(preferred, item)
 		}
 	}
 

--- a/pkg/updater/policy/topology.go
+++ b/pkg/updater/policy/topology.go
@@ -89,9 +89,12 @@ func (p *topologyPolicy[R]) Add(update R) R {
 func (p *topologyPolicy[R]) Update(update, outdated R) R {
 	update.SetTopology(outdated.GetTopology())
 
-	p.all.Add(update.GetName(), update.GetTopology())
+	// Update hooks run before KeepName, so use the existing instance name to
+	// keep the in-memory scheduler keyed by the instance being updated.
+	name := outdated.GetName()
+	p.all.Add(name, update.GetTopology())
 	if update.GetUpdateRevision() == p.rev {
-		p.updated.Add(update.GetName(), update.GetTopology())
+		p.updated.Add(name, update.GetTopology())
 	}
 
 	return update

--- a/pkg/updater/policy/topology.go
+++ b/pkg/updater/policy/topology.go
@@ -15,7 +15,6 @@
 package policy
 
 import (
-	"fmt"
 	"maps"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
@@ -61,7 +60,6 @@ func NewTopologyPolicy[R runtime.Instance](ts []v1alpha1.ScheduleTopology, rev s
 			continue
 		}
 		p.all.Add(r.GetName(), r.GetTopology())
-		fmt.Println("preferred delete, add:", r.GetName(), r.GetTopology())
 		if r.GetUpdateRevision() == rev {
 			p.updated.Add(r.GetName(), r.GetTopology())
 		}
@@ -134,18 +132,14 @@ func (p *deletePreferPolicy[R]) Prefer(allowed []R) []R {
 	}
 	names := p.p.all.NextDel()
 
-	fmt.Println("preferred delete, next del:", names)
-
 	var preferred []R
 	for _, item := range allowed {
 		for _, name := range names {
 			if item.GetName() == name {
-				fmt.Println("preferred delete: ", name)
 				preferred = append(preferred, item)
 			}
 		}
 	}
-	fmt.Println("preferred delete done")
 
 	return preferred
 }

--- a/pkg/updater/policy/topology_test.go
+++ b/pkg/updater/policy/topology_test.go
@@ -245,6 +245,48 @@ func fakeTiKV(name, rev, zone string, offline bool) *v1alpha1.TiKV {
 	return tikv
 }
 
+// TestPolicyCancelOfflinePreferBestAvailableTopology ensures cancel-offline
+// selection scores only the cancelable candidates rather than the global
+// best topology, which may have no cancelable candidate at all.
+func TestPolicyCancelOfflinePreferBestAvailableTopology(t *testing.T) {
+	const rev = "rev"
+
+	const (
+		zoneA = "us-west-1a"
+		zoneB = "us-west-1b"
+		zoneC = "us-west-1c"
+	)
+
+	active := []*v1alpha1.TiKV{
+		fakeTiKV("active-b0", rev, zoneB, false),
+		fakeTiKV("active-b1", rev, zoneB, false),
+		fakeTiKV("active-b2", rev, zoneB, false),
+		fakeTiKV("active-c0", rev, zoneC, false),
+	}
+
+	// The zone-b candidate has the lexicographically smaller name, so the
+	// old list-first cancellation would incorrectly prefer it over zone-c.
+	candidateB := fakeTiKV("candidate-b", rev, zoneB, true)
+	candidateC := fakeTiKV("candidate-c", rev, zoneC, true)
+
+	all := append(append([]*v1alpha1.TiKV{}, active...), candidateB, candidateC)
+
+	// IsDeleting excludes offline objects, so the active scheduler counts
+	// stay at a=0,b=3,c=1 even though the candidates are passed in here.
+	policy, err := NewTopologyPolicy([]v1alpha1.ScheduleTopology{
+		{Topology: v1alpha1.Topology{"zone": zoneA}},
+		{Topology: v1alpha1.Topology{"zone": zoneB}},
+		{Topology: v1alpha1.Topology{"zone": zoneC}},
+	}, rev, runtime.FromTiKVSlice(all)...)
+	require.NoError(t, err)
+
+	allowed := runtime.FromTiKVSlice([]*v1alpha1.TiKV{candidateB, candidateC})
+	preferred := policy.PolicyCancelOffline().Prefer(allowed)
+
+	require.Len(t, preferred, 1)
+	assert.Equal(t, candidateC.GetName(), preferred[0].GetName())
+}
+
 // TestTopologyPolicyUpdateKeysSchedulerByOutdatedName ensures Update keys
 // the in-memory schedulers by the outdated instance's name. Custom update
 // hooks run before KeepName, so the new object's name is still empty; using

--- a/pkg/updater/policy/topology_test.go
+++ b/pkg/updater/policy/topology_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime"
@@ -229,4 +230,55 @@ func fakePD(name, rev, zone string) *v1alpha1.PD {
 		}
 	}
 	return pd
+}
+
+func fakeTiKV(name, rev, zone string, offline bool) *v1alpha1.TiKV {
+	tikv := fake.FakeObj(name, fake.Label[v1alpha1.TiKV](v1alpha1.LabelKeyInstanceRevisionHash, rev))
+	if zone != "" {
+		tikv.Spec.Topology = v1alpha1.Topology{
+			"zone": zone,
+		}
+	}
+	if offline {
+		tikv.Spec.Offline = ptr.To(true)
+	}
+	return tikv
+}
+
+// TestTopologyPolicyUpdateKeysSchedulerByOutdatedName ensures Update keys
+// the in-memory schedulers by the outdated instance's name. Custom update
+// hooks run before KeepName, so the new object's name is still empty; using
+// update.GetName() would corrupt the scheduler state across repeated
+// updates in one updater execution.
+func TestTopologyPolicyUpdateKeysSchedulerByOutdatedName(t *testing.T) {
+	const rev = "rev"
+
+	const (
+		zoneA = "us-west-1a"
+		zoneB = "us-west-1b"
+	)
+
+	p, err := NewTopologyPolicy[*runtime.TiKV]([]v1alpha1.ScheduleTopology{
+		{Topology: v1alpha1.Topology{"zone": zoneA}},
+		{Topology: v1alpha1.Topology{"zone": zoneB}},
+	}, rev)
+	require.NoError(t, err)
+
+	concrete, ok := p.(*topologyPolicy[*runtime.TiKV])
+	require.True(t, ok)
+
+	outdatedA := runtime.FromTiKV(fakeTiKV("tikv-a", "old", zoneA, false))
+	outdatedB := runtime.FromTiKV(fakeTiKV("tikv-b", "old", zoneB, false))
+	// TiKVNewer/TiFlashNewer produce a new object whose name is initially
+	// empty; KeepName fills it in after update hooks have already run.
+	newA := runtime.FromTiKV(fakeTiKV("", rev, "", false))
+	newB := runtime.FromTiKV(fakeTiKV("", rev, "", false))
+
+	p.Update(newA, outdatedA)
+	p.Update(newB, outdatedB)
+
+	assert.NotContains(t, concrete.all.NextDel(), "")
+	assert.NotContains(t, concrete.updated.NextDel(), "")
+	assert.Equal(t, []string{"tikv-a", "tikv-b"}, concrete.all.NextDel())
+	assert.Equal(t, []string{"tikv-a", "tikv-b"}, concrete.updated.NextDel())
 }

--- a/pkg/updater/two_steps_deletion_test.go
+++ b/pkg/updater/two_steps_deletion_test.go
@@ -50,6 +50,20 @@ func newMockPreferPolicy(items []*runtime.TiKV) PreferPolicy[*runtime.TiKV] {
 	return &mockPreferPolicy{items: items}
 }
 
+// mockNamePreferPolicy prefers the allowed instance matching name, if present.
+type mockNamePreferPolicy struct {
+	name string
+}
+
+func (m *mockNamePreferPolicy) Prefer(items []*runtime.TiKV) []*runtime.TiKV {
+	for _, item := range items {
+		if item.GetName() == m.name {
+			return []*runtime.TiKV{item}
+		}
+	}
+	return nil
+}
+
 // assertTiKVState verifies the expected TiKV count and offline status
 func assertTiKVState(t *testing.T, cli client.Client, expectedTotal, expectedOffline int) {
 	var tikvs v1alpha1.TiKVList
@@ -131,9 +145,10 @@ func testTiKVNewer() NewFactory[*runtime.TiKV] {
 
 func TestExecutorForCancelableScaleIn(t *testing.T) {
 	tests := []struct {
-		name                  string
-		setupStates           func() (update, outdated, beingOffline, deleted []*runtime.TiKV, objs []client.Object)
-		scaleInPreferPolicies []PreferPolicy[*runtime.TiKV]
+		name                        string
+		setupStates                 func() (update, outdated, beingOffline, deleted []*runtime.TiKV, objs []client.Object)
+		scaleInPreferPolicies       []PreferPolicy[*runtime.TiKV]
+		cancelOfflinePreferPolicies []PreferPolicy[*runtime.TiKV]
 
 		desired             int
 		unavailableUpdate   int
@@ -144,6 +159,11 @@ func TestExecutorForCancelableScaleIn(t *testing.T) {
 		expectedError   bool
 		expectedTotal   int
 		expectedOffline int
+		// expectedCanceledName and expectedStillOfflineName, when set, assert
+		// which specific instance the cancel-offline selector chose, not just
+		// the resulting offline count.
+		expectedCanceledName     string
+		expectedStillOfflineName string
 	}{
 		// Normal scale in scenarios
 		{
@@ -332,6 +352,30 @@ func TestExecutorForCancelableScaleIn(t *testing.T) {
 			expectedWait:    true,
 		},
 		{
+			name: "cancel offline prefers the instance chosen by a custom cancel-offline policy",
+			setupStates: func() (update, outdated, beingOffline, deleted []*runtime.TiKV, objs []client.Object) {
+				t1 := buildTestTiKV("1", 1, false, offline())
+				t2 := buildTestTiKV("2", 1, false, offline())
+				t3 := buildTestTiKV("3", 1, true)
+				update = []*runtime.TiKV{t3}
+				beingOffline = []*runtime.TiKV{t1, t2}
+				objs = buildObjects(t1, t2, t3)
+				return
+			},
+			desired: 2,
+			cancelOfflinePreferPolicies: []PreferPolicy[*runtime.TiKV]{
+				&mockNamePreferPolicy{name: "tikv-2"},
+			},
+			expectedActions: []action{
+				actionCancelOffline,
+			},
+			expectedTotal:            3,
+			expectedOffline:          1,
+			expectedWait:             true,
+			expectedCanceledName:     "tikv-2",
+			expectedStillOfflineName: "tikv-1",
+		},
+		{
 			name: "scale in from 3 to 1, cancel partially it by increasing desired to 2 (2)",
 			setupStates: func() (update, outdated, beingOffline, deleted []*runtime.TiKV, objs []client.Object) {
 				t1 := buildTestTiKV("1", 1, false)
@@ -357,16 +401,17 @@ func TestExecutorForCancelableScaleIn(t *testing.T) {
 			update, outdated, beingOffline, deleted, objs := tt.setupStates()
 			fakeCli := client.NewFakeClient(objs...)
 			act := &actor[runtime.TiKVTuple, *v1alpha1.TiKV, *runtime.TiKV]{
-				f:               testTiKVNewer(),
-				c:               fakeCli,
-				update:          NewState(update),
-				outdated:        NewState(outdated),
-				beingOffline:    NewState(beingOffline),
-				deleted:         NewState(deleted),
-				scaleInSelector: NewSelector(newMockPreferPolicy(update)),
-				updateSelector:  NewSelector(newMockPreferPolicy(outdated)),
-				updateHooks:     []UpdateHook[*runtime.TiKV]{KeepName[*runtime.TiKV]()},
-				actions:         make([]action, 0),
+				f:                     testTiKVNewer(),
+				c:                     fakeCli,
+				update:                NewState(update),
+				outdated:              NewState(outdated),
+				beingOffline:          NewState(beingOffline),
+				deleted:               NewState(deleted),
+				scaleInSelector:       NewSelector(newMockPreferPolicy(update)),
+				updateSelector:        NewSelector(newMockPreferPolicy(outdated)),
+				cancelOfflineSelector: NewSelector(tt.cancelOfflinePreferPolicies...),
+				updateHooks:           []UpdateHook[*runtime.TiKV]{KeepName[*runtime.TiKV]()},
+				actions:               make([]action, 0),
 			}
 			e := NewExecutor(act, len(update), len(outdated), tt.desired,
 				tt.unavailableUpdate, tt.unavailableOutdated, 0, 1)
@@ -381,6 +426,21 @@ func TestExecutorForCancelableScaleIn(t *testing.T) {
 			assert.Equal(t, tt.expectedActions, act.RecordedActions(), "actions mismatch")
 
 			assertTiKVState(t, fakeCli, tt.expectedTotal, tt.expectedOffline)
+
+			if tt.expectedCanceledName != "" {
+				var tikv v1alpha1.TiKV
+				require.NoError(t, fakeCli.Get(context.TODO(),
+					client.ObjectKey{Name: tt.expectedCanceledName}, &tikv))
+				assert.False(t, coreutil.IsOffline[scope.TiKV](&tikv),
+					"expected %s to be canceled (offline=false)", tt.expectedCanceledName)
+			}
+			if tt.expectedStillOfflineName != "" {
+				var tikv v1alpha1.TiKV
+				require.NoError(t, fakeCli.Get(context.TODO(),
+					client.ObjectKey{Name: tt.expectedStillOfflineName}, &tikv))
+				assert.True(t, coreutil.IsOffline[scope.TiKV](&tikv),
+					"expected %s to remain offline", tt.expectedStillOfflineName)
+			}
 		})
 	}
 }

--- a/pkg/utils/topology/scheduler.go
+++ b/pkg/utils/topology/scheduler.go
@@ -28,8 +28,12 @@ type Scheduler interface {
 	// Add adds an scheduled instance.
 	// All scheduled instances should be added before calling Next()
 	Add(name string, topo v1alpha1.Topology)
-	// NextAdd returns available topologies of the next pending instance
-	NextAdd() []v1alpha1.Topology
+	// NextAdd returns available topologies of the next pending instance.
+	// An empty candidate list means all configured topologies are eligible.
+	// A non-empty candidate list restricts the choice to the supplied
+	// topologies while still scoring them against the full active counts
+	// and weights.
+	NextAdd(candidates ...v1alpha1.Topology) []v1alpha1.Topology
 	// Del removes an scheduled instance.
 	Del(name string)
 	// NextDel returns names which can be choosed to del
@@ -123,14 +127,51 @@ func (s *topologyScheduler) Del(name string) {
 	}
 }
 
-func (s *topologyScheduler) NextAdd() []v1alpha1.Topology {
+func (s *topologyScheduler) NextAdd(candidates ...v1alpha1.Topology) []v1alpha1.Topology {
 	// only unknown topo
 	if len(s.info) == 1 {
 		return nil
 	}
+
+	if len(candidates) == 0 {
+		return s.nextAdd(nil)
+	}
+
+	// Restrict scoring to known candidate topologies. Multiple offlining
+	// instances may share a topology, so dedup via the set.
+	allowed := sets.New[int]()
+	for _, c := range candidates {
+		hash := s.e.Encode(c)
+		index, ok := s.hashToIndex[hash]
+		if !ok {
+			// ignore unknown topology
+			continue
+		}
+		allowed.Insert(index)
+	}
+	if allowed.Len() == 0 {
+		return nil
+	}
+
+	return s.nextAdd(allowed)
+}
+
+// nextAdd scores configured topologies using the existing add score:
+// score = weight*totalCount - effectiveCount*totalWeight.
+//
+// allowed == nil means every configured topology is eligible and the
+// maximum starts at zero, matching the historical unrestricted behavior.
+// A non-nil allowed set restricts eligible topologies; the maximum is then
+// seeded from the first eligible candidate instead of zero, since a
+// restricted candidate set can have every score be negative.
+func (s *topologyScheduler) nextAdd(allowed sets.Set[int]) []v1alpha1.Topology {
 	maximum := int64(0)
+	seeded := allowed == nil
 	var choosed []int
 	for i, v := range s.info[:len(s.info)-1] {
+		if allowed != nil && !allowed.Has(i) {
+			continue
+		}
 		count := v.names.Len()
 		// avoid some topos are starved
 		if v.names.Len() == 0 {
@@ -141,10 +182,16 @@ func (s *topologyScheduler) NextAdd() []v1alpha1.Topology {
 			count = -len(s.info) + 1
 		}
 		score := int64(v.weight)*int64(s.totalCount) - int64(count)*s.totalWeight
-		if score > maximum {
+
+		switch {
+		case !seeded:
 			maximum = score
 			choosed = []int{i}
-		} else if score == maximum {
+			seeded = true
+		case score > maximum:
+			maximum = score
+			choosed = []int{i}
+		case score == maximum:
 			choosed = append(choosed, i)
 		}
 	}

--- a/pkg/utils/topology/scheduler_test.go
+++ b/pkg/utils/topology/scheduler_test.go
@@ -422,6 +422,53 @@ func TestSchedulerAdd(t *testing.T) {
 	}
 }
 
+func TestSchedulerNextAddCandidates(t *testing.T) {
+	st := []v1alpha1.ScheduleTopology{
+		{Topology: v1alpha1.Topology{"zone": "aaa"}},
+		{Topology: v1alpha1.Topology{"zone": "bbb"}},
+		{Topology: v1alpha1.Topology{"zone": "ccc"}},
+	}
+
+	newSchedulerWithCounts := func(tt *testing.T, counts []int) Scheduler {
+		s, err := New(st)
+		require.NoError(tt, err)
+		for topoIndex, count := range counts {
+			for i := range count {
+				s.Add(genInstanceName(topoIndex, i), st[topoIndex].Topology)
+			}
+		}
+		return s
+	}
+
+	t.Run("best available candidate when global best is unavailable", func(tt *testing.T) {
+		// a=0,b=3,c=1: global NextAdd() would choose a, but a has no
+		// cancelable candidate.
+		s := newSchedulerWithCounts(tt, []int{0, 3, 1})
+		topos := s.NextAdd(st[1].Topology, st[2].Topology)
+		assert.Equal(tt, []v1alpha1.Topology{st[2].Topology}, topos)
+	})
+
+	t.Run("all restricted scores negative still returns the tied candidates", func(tt *testing.T) {
+		// a=0,b=2,c=2: both candidate scores are negative, which must not
+		// be dropped by a maximum initialized to zero.
+		s := newSchedulerWithCounts(tt, []int{0, 2, 2})
+		topos := s.NextAdd(st[1].Topology, st[2].Topology)
+		assert.Equal(tt, []v1alpha1.Topology{st[1].Topology, st[2].Topology}, topos)
+	})
+
+	t.Run("unknown candidate topology returns no preference", func(tt *testing.T) {
+		s := newSchedulerWithCounts(tt, []int{0, 3, 1})
+		topos := s.NextAdd(v1alpha1.Topology{"zone": "ddd"})
+		assert.Nil(tt, topos)
+	})
+
+	t.Run("no arguments keeps the existing global behavior", func(tt *testing.T) {
+		s := newSchedulerWithCounts(tt, []int{0, 3, 1})
+		topos := s.NextAdd()
+		assert.Equal(tt, []v1alpha1.Topology{st[0].Topology}, topos)
+	})
+}
+
 func genInstanceName(topoIndex, round int) string {
 	return strconv.Itoa(topoIndex) + ":" + strconv.Itoa(round)
 }

--- a/tests/e2e/tikv/tikv.go
+++ b/tests/e2e/tikv/tikv.go
@@ -15,8 +15,10 @@
 package tikv
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -359,7 +361,7 @@ replica-schedule-limit = 8
 			}
 		})
 
-		ginkgo.It("should handle partial cancellation of scale-in", func(ctx context.Context) {
+		ginkgo.It("should handle partial cancellation of scale-in", label.MultipleAZ, label.Scale, func(ctx context.Context) {
 			// Slow down the speed of data migration for testing
 			pdg := f.MustCreatePD(ctx, data.GroupPatchFunc[*v1alpha1.PDGroup](func(pdg *v1alpha1.PDGroup) {
 				pdg.Spec.Template.Spec.Config = `[schedule]
@@ -367,7 +369,12 @@ region-schedule-limit = 32
 replica-schedule-limit = 16
 `
 			}))
-			kvg := f.MustCreateTiKV(ctx, data.WithReplicas[scope.TiKVGroup](5))
+			kvg := f.MustCreateTiKV(ctx,
+				data.WithReplicas[scope.TiKVGroup](5),
+				data.GroupPatchFunc[*v1alpha1.TiKVGroup](func(kvg *v1alpha1.TiKVGroup) {
+					setTwoAZTiKVEvenlySpreadPolicy(kvg, 1, 1)
+				}),
+			)
 			dbg := f.MustCreateTiDB(ctx)
 
 			f.WaitForPDGroupReady(ctx, pdg)
@@ -375,26 +382,59 @@ replica-schedule-limit = 16
 			f.WaitForTiDBGroupReady(ctx, dbg)
 			workload.MustImportData(ctx, data.DefaultTiDBServiceName)
 
-			ginkgo.By("Scaling in TiKV from 5 to 3 replicas")
+			ginkgo.By("Changing weights to 2:1 and scaling in TiKV from 5 to 3 replicas")
 			patch := client.MergeFrom(kvg.DeepCopy())
+			setTwoAZTiKVEvenlySpreadPolicy(kvg, 2, 1)
 			kvg.Spec.Replicas = ptr.To[int32](3)
 			f.Must(f.Client.Patch(ctx, kvg, patch))
 
-			ginkgo.By("Verifying 2 TiKV instances are marked for offline")
+			ginkgo.By("Verifying 2 TiKV instances are marked for offline, one per zone")
 			offliningKVs := findOffliningTiKVs(ctx, f, kvg, 2)
 			gomega.Expect(offliningKVs).To(gomega.HaveLen(2))
+			gomega.Expect(zonesOf(offliningKVs)).To(gomega.ConsistOf(zoneA, zoneB))
 
-			ginkgo.By("Partially cancelling by scaling up to 4 replicas")
+			// Instance names are random, so choose the final weights after
+			// sorting the offlining instances. This makes the old
+			// list-first cancellation pick the wrong topology
+			// deterministically: the old code always cancels
+			// sortedCandidates[0], while the correct topology-aware choice
+			// is sortedCandidates[1] under the weights picked below.
+			sortedCandidates := append([]*v1alpha1.TiKV{}, offliningKVs...)
+			slices.SortFunc(sortedCandidates, func(a, b *v1alpha1.TiKV) int {
+				return cmp.Compare(a.GetName(), b.GetName())
+			})
+			firstZone := sortedCandidates[0].Spec.Topology["zone"]
+
+			var finalWeightA, finalWeightB int32
+			var expectedCanceledZone, expectedStillOfflineZone string
+			var expectedFinalCountA, expectedFinalCountB int
+			switch firstZone {
+			case zoneA:
+				finalWeightA, finalWeightB = 3, 2
+				expectedCanceledZone = zoneB
+				expectedStillOfflineZone = zoneA
+				expectedFinalCountA, expectedFinalCountB = 2, 2
+			case zoneB:
+				finalWeightA, finalWeightB = 3, 1
+				expectedCanceledZone = zoneA
+				expectedStillOfflineZone = zoneB
+				expectedFinalCountA, expectedFinalCountB = 3, 1
+			default:
+				ginkgo.Fail(fmt.Sprintf("unexpected zone %q for offlining candidate", firstZone))
+			}
+
+			ginkgo.By("Setting the final weights and partially cancelling by scaling up to 4 replicas")
 			patch = client.MergeFrom(kvg.DeepCopy())
+			setTwoAZTiKVEvenlySpreadPolicy(kvg, finalWeightA, finalWeightB)
 			kvg.Spec.Replicas = ptr.To[int32](4)
 			f.Must(f.Client.Patch(ctx, kvg, patch))
 
-			ginkgo.By("Verifying one offline operation is cancelled and the other continue")
+			ginkgo.By("Verifying the topology-aware candidate is cancelled and the other continues")
 			var cancelledKVs, remainingOffliningKVs []*v1alpha1.TiKV
 			gomega.Eventually(func(g gomega.Gomega) {
 				cancelledKVs = nil
 				remainingOffliningKVs = nil
-				for _, kv := range offliningKVs {
+				for _, kv := range sortedCandidates {
 					instance := &v1alpha1.TiKV{}
 					g.Expect(f.Client.Get(ctx, client.ObjectKeyFromObject(kv), instance)).To(gomega.Succeed())
 					if !coreutil.IsOffline[scope.TiKV](instance) {
@@ -406,6 +446,13 @@ replica-schedule-limit = 16
 				g.Expect(cancelledKVs).To(gomega.HaveLen(1), "Expected 1 offline operation to be cancelled")
 				g.Expect(remainingOffliningKVs).To(gomega.HaveLen(1), "Expected 1 offline operations to continue")
 			}, 5*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+			gomega.Expect(cancelledKVs[0].GetName()).To(gomega.Equal(sortedCandidates[1].GetName()),
+				"the second name-sorted candidate should be the one cancelled")
+			gomega.Expect(cancelledKVs[0].Spec.Topology["zone"]).To(gomega.Equal(expectedCanceledZone))
+			gomega.Expect(remainingOffliningKVs[0].GetName()).To(gomega.Equal(sortedCandidates[0].GetName()),
+				"the first name-sorted candidate should remain offline")
+			gomega.Expect(remainingOffliningKVs[0].Spec.Topology["zone"]).To(gomega.Equal(expectedStillOfflineZone))
 
 			ginkgo.By("Verifying the cancelled instance status is updated")
 			// When offline operation is cancelled, the TiKV instance should no longer be marked for offline
@@ -440,11 +487,23 @@ replica-schedule-limit = 16
 			cancel()
 			<-ch
 
-			ginkgo.By("Verifying TiKVGroup stabilizes at 4 replicas")
+			ginkgo.By("Verifying TiKVGroup stabilizes at 4 replicas with the expected topology")
 			f.WaitForTiKVGroupReady(ctx, kvg)
 			finalTiKVs, err := apicall.ListInstances[scope.TiKVGroup](ctx, f.Client, kvg)
 			f.Must(err)
 			gomega.Expect(finalTiKVs).To(gomega.HaveLen(4))
+
+			var finalCountA, finalCountB int
+			for _, kv := range finalTiKVs {
+				switch kv.Spec.Topology["zone"] {
+				case zoneA:
+					finalCountA++
+				case zoneB:
+					finalCountB++
+				}
+			}
+			gomega.Expect(finalCountA).To(gomega.Equal(expectedFinalCountA))
+			gomega.Expect(finalCountB).To(gomega.Equal(expectedFinalCountB))
 		})
 	})
 })
@@ -480,4 +539,41 @@ func newPDClient(ctx context.Context, f *framework.Framework, pdg *v1alpha1.PDGr
 	ginkgo.DeferCleanup(cancel)
 	ports := framework.PortForwardGroup[scope.PDGroup](forwardCtx, f, pdg, []string{fmt.Sprintf(":%d", v1alpha1.DefaultPDPortClient)})
 	return pdapi.NewPDClient(fmt.Sprintf("http://127.0.0.1:%d", ports[0].Local), 30*time.Second, nil)
+}
+
+const (
+	zoneA = "zone-a"
+	zoneB = "zone-b"
+)
+
+// setTwoAZTiKVEvenlySpreadPolicy replaces kvg.Spec.SchedulePolicies with a
+// single EvenlySpread policy across zone-a and zone-b at the given weights,
+// so a runtime weight change cannot leave stale policies behind.
+func setTwoAZTiKVEvenlySpreadPolicy(kvg *v1alpha1.TiKVGroup, zoneAWeight, zoneBWeight int32) {
+	kvg.Spec.SchedulePolicies = []v1alpha1.SchedulePolicy{
+		{
+			Type: v1alpha1.SchedulePolicyTypeEvenlySpread,
+			EvenlySpread: &v1alpha1.SchedulePolicyEvenlySpread{
+				Topologies: []v1alpha1.ScheduleTopology{
+					{
+						Topology: v1alpha1.Topology{"zone": zoneA},
+						Weight:   ptr.To(zoneAWeight),
+					},
+					{
+						Topology: v1alpha1.Topology{"zone": zoneB},
+						Weight:   ptr.To(zoneBWeight),
+					},
+				},
+			},
+		},
+	}
+}
+
+// zonesOf returns the "zone" topology label of each TiKV instance.
+func zonesOf(kvs []*v1alpha1.TiKV) []string {
+	zones := make([]string, 0, len(kvs))
+	for _, kv := range kvs {
+		zones = append(zones, kv.Spec.Topology["zone"])
+	}
+	return zones
 }


### PR DESCRIPTION
## Summary

Canceling an in-progress TiKV/TiFlash scale-in currently selects the lexicographically-first offlining instance to restore, instead of the topology-best candidate among the instances that can actually be canceled. This can leave the cluster's zone/rack distribution worse than necessary after a partial cancellation.

Closes #6991

## Why

`Selector.Choose` falls back to the first name-sorted item when no `PreferPolicy` prefers a candidate. Cancel-offline never had a topology-aware `PreferPolicy` wired in, so it always fell back to name order regardless of which zone/rack each offlining candidate belonged to.

## How

- `pkg/utils/topology/scheduler.go`: `NextAdd` now accepts an optional list of candidate topologies. When given, scoring is restricted to those candidates (using the existing weight/count formula) instead of scoring every configured topology — this lets the cancel-offline path ask "which of *these* candidates is best" rather than "what's the global best topology" (which may have no cancelable candidate at all).
- `pkg/updater/policy/topology.go`: adds `PolicyCancelOffline()` on `TopologyPolicy`, backed by a new `cancelOfflinePreferPolicy` that scores only the allowed (cancelable) candidates via the updated `NextAdd`. Also fixes `Update` to key the in-memory scheduler by the outdated instance's name, since update hooks run before `KeepName` fills in the new object's name.
- `pkg/updater/builder.go` / `pkg/updater/actor.go`: wires a `cancelOfflineSelector` (via `WithCancelOfflinePreferPolicy`) used by `chooseToCancelOffline`, falling back to existing name-order behavior when unconfigured.
- `pkg/controllers/tikvgroup/tasks/updater.go` and `pkg/controllers/tiflashgroup/tasks/updater.go`: register `topoPolicy.PolicyCancelOffline()` as the cancel-offline prefer policy.
- `tests/e2e/tikv/tikv.go`: extends the partial-cancellation scale-in test to use a two-zone weighted topology and assert that the topology-aware candidate (not the lexicographically-first one) is the one canceled, deterministically regardless of the random instance names PD assigns.

## Testing

- `make lint`: 0 issues.
- `make unit` (full repo, race-enabled): passes, aside from a pre-existing failure in `pkg/controllers/tiproxy/tasks/finalizer_test.go` (`TestTaskDrainPodForDelete*`) that reproduces identically on `main` without this change and has no dependency on any package touched here.
- `make verify` sub-targets (tidy, codegen, crd, runtimegen, gengo, overlaygen, doc, license, feature-gates) run clean against the committed tree — no generated-file drift.
- New unit tests: `TestSchedulerNextAddCandidates`, `TestPolicyCancelOfflinePreferBestAvailableTopology`, `TestTopologyPolicyUpdateKeysSchedulerByOutdatedName`, the new `two_steps_deletion_test.go` case, and `TestTaskUpdaterCancelOfflinePrefersTopologyAwareCandidate`.
- E2E: new deterministic assertions added to the existing "should handle partial cancellation of scale-in" case; requires the `pull-e2e-kind-v2` CI job (not run locally, per policy against running E2E outside an approved kind cluster).

## Risks

- Pre-existing `tiproxy` test failures noted above are unrelated but should be triaged separately.
- E2E correctness for this change has been validated by hand against the production scoring algorithm but not yet executed in CI; will trigger `/run-pull-e2e-kind-v2` and monitor once the PR is open.