### PR TITLE
fix: use pd default location labels for placement rules

### DIFF
--- a/pkg/controllers/placementpolicy/controller.go
+++ b/pkg/controllers/placementpolicy/controller.go
@@ -421,9 +421,9 @@ func defaultRuleLocationLabels(ctx context.Context, pdc pdapi.PDClient) ([]strin
 		return nil, fmt.Errorf("default placement rule bundle %q is nil", pdDefaultRuleGroupID)
 	}
 
-	for _, rule := range bundle.Rules {
-		if rule.ID == pdDefaultRuleID {
-			return rule.LocationLabels, nil
+	for i := range bundle.Rules {
+		if bundle.Rules[i].ID == pdDefaultRuleID {
+			return bundle.Rules[i].LocationLabels, nil
 		}
 	}
 

--- a/pkg/controllers/placementpolicy/controller.go
+++ b/pkg/controllers/placementpolicy/controller.go
@@ -49,6 +49,8 @@ import (
 
 const (
 	pdPlacementRuleGroupIndex = 99
+	pdDefaultRuleGroupID      = "pd"
+	pdDefaultRuleID           = "default"
 
 	reasonSynced     = "Synced"
 	reasonSyncFailed = "SyncFailed"
@@ -396,10 +398,43 @@ func syncPolicyRules(
 	rulePrefix string,
 	rules []pdapi.PlacementRule,
 ) error {
+	if len(rules) > 0 {
+		locationLabels, err := defaultRuleLocationLabels(ctx, pdc)
+		if err != nil {
+			return err
+		}
+		setPlacementRulesLocationLabels(rules, locationLabels)
+	}
+
 	if err := pdc.SetPlacementRuleGroup(ctx, placementRuleGroup()); err != nil {
 		return err
 	}
 	return pdc.SetPlacementRuleGroupRulesByIDPrefix(ctx, coreutil.PlacementPolicyGroupID(), rulePrefix, rules)
+}
+
+func defaultRuleLocationLabels(ctx context.Context, pdc pdapi.PDClient) ([]string, error) {
+	bundle, err := pdc.GetPlacementRuleBundle(ctx, pdDefaultRuleGroupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default placement rule bundle: %w", err)
+	}
+	if bundle == nil {
+		return nil, fmt.Errorf("default placement rule bundle %q is nil", pdDefaultRuleGroupID)
+	}
+
+	for _, rule := range bundle.Rules {
+		if rule.ID == pdDefaultRuleID {
+			return rule.LocationLabels, nil
+		}
+	}
+
+	// not found, return empty location labels
+	return nil, nil
+}
+
+func setPlacementRulesLocationLabels(rules []pdapi.PlacementRule, locationLabels []string) {
+	for i := range rules {
+		rules[i].LocationLabels = locationLabels
+	}
 }
 
 func placementRuleGroup() *pdapi.PlacementRuleGroup {
@@ -427,6 +462,9 @@ func comparePlacementRule(a, b pdapi.PlacementRule) int { //nolint:gocritic // s
 	}
 	if a.Count > b.Count {
 		return 1
+	}
+	if c := slices.Compare(a.LocationLabels, b.LocationLabels); c != 0 {
+		return c
 	}
 
 	return slices.CompareFunc(a.LabelConstraints, b.LabelConstraints, comparePlacementLabelConstraint)

--- a/pkg/controllers/placementpolicy/controller.go
+++ b/pkg/controllers/placementpolicy/controller.go
@@ -432,6 +432,10 @@ func defaultRuleLocationLabels(ctx context.Context, pdc pdapi.PDClient) ([]strin
 }
 
 func setPlacementRulesLocationLabels(rules []pdapi.PlacementRule, locationLabels []string) {
+	if len(locationLabels) == 0 {
+		locationLabels = nil
+	}
+
 	for i := range rules {
 		rules[i].LocationLabels = locationLabels
 	}

--- a/pkg/controllers/placementpolicy/controller_test.go
+++ b/pkg/controllers/placementpolicy/controller_test.go
@@ -229,6 +229,76 @@ func TestTiKVGroupEventHandlerEnqueuesOnCreateDeleteAndExclusiveChange(t *testin
 
 func TestSyncPolicyRulesPostsRuleGroup(t *testing.T) {
 	ctx := context.Background()
+	locationLabels := []string{"zone", "rack"}
+	rules := []pdapi.PlacementRule{
+		{
+			GroupID: "tidb-operator",
+			ID:      "p:r1-1-raw",
+			Role:    v1alpha1.PlacementPolicyRoleVoter,
+			Count:   3,
+		},
+	}
+	expectedRules := []pdapi.PlacementRule{
+		{
+			GroupID:        "tidb-operator",
+			ID:             "p:r1-1-raw",
+			Role:           v1alpha1.PlacementPolicyRoleVoter,
+			Count:          3,
+			LocationLabels: locationLabels,
+		},
+	}
+	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
+	gomock.InOrder(
+		pdc.EXPECT().GetPlacementRuleBundle(gomock.Any(), "pd").Return(&pdapi.PlacementRuleGroupBundle{
+			ID: "pd",
+			Rules: []pdapi.PlacementRule{
+				{
+					GroupID:        "pd",
+					ID:             "default",
+					LocationLabels: locationLabels,
+				},
+			},
+		}, nil),
+		pdc.EXPECT().SetPlacementRuleGroup(gomock.Any(), &pdapi.PlacementRuleGroup{
+			ID:       "tidb-operator",
+			Index:    pdPlacementRuleGroupIndex,
+			Override: true,
+		}).Return(nil),
+		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", expectedRules).Return(nil),
+	)
+
+	err := syncPolicyRules(ctx, pdc, "p:", rules)
+	require.NoError(t, err)
+}
+
+func TestSyncPolicyRulesRequiresDefaultRule(t *testing.T) {
+	ctx := context.Background()
+	rules := []pdapi.PlacementRule{
+		{
+			GroupID: "tidb-operator",
+			ID:      "p:r1-1-raw",
+			Role:    v1alpha1.PlacementPolicyRoleVoter,
+			Count:   3,
+		},
+	}
+	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
+	pdc.EXPECT().GetPlacementRuleBundle(gomock.Any(), "pd").Return(&pdapi.PlacementRuleGroupBundle{
+		ID: "pd",
+		Rules: []pdapi.PlacementRule{
+			{
+				GroupID: "pd",
+				ID:      "other",
+			},
+		},
+	}, nil)
+
+	err := syncPolicyRules(ctx, pdc, "p:", rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default placement rule pd/default not found")
+}
+
+func TestSyncPolicyRulesNormalizesEmptyDefaultLocationLabels(t *testing.T) {
+	ctx := context.Background()
 	rules := []pdapi.PlacementRule{
 		{
 			GroupID: "tidb-operator",
@@ -239,6 +309,16 @@ func TestSyncPolicyRulesPostsRuleGroup(t *testing.T) {
 	}
 	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
 	gomock.InOrder(
+		pdc.EXPECT().GetPlacementRuleBundle(gomock.Any(), "pd").Return(&pdapi.PlacementRuleGroupBundle{
+			ID: "pd",
+			Rules: []pdapi.PlacementRule{
+				{
+					GroupID:        "pd",
+					ID:             "default",
+					LocationLabels: []string{},
+				},
+			},
+		}, nil),
 		pdc.EXPECT().SetPlacementRuleGroup(gomock.Any(), &pdapi.PlacementRuleGroup{
 			ID:       "tidb-operator",
 			Index:    pdPlacementRuleGroupIndex,
@@ -248,6 +328,27 @@ func TestSyncPolicyRulesPostsRuleGroup(t *testing.T) {
 	)
 
 	err := syncPolicyRules(ctx, pdc, "p:", rules)
+	require.NoError(t, err)
+}
+
+func TestSyncPolicyRulesSkipsDefaultRuleLookupWhenNoRules(t *testing.T) {
+	ctx := context.Background()
+	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
+	gomock.InOrder(
+		pdc.EXPECT().SetPlacementRuleGroup(gomock.Any(), &pdapi.PlacementRuleGroup{
+			ID:       "tidb-operator",
+			Index:    pdPlacementRuleGroupIndex,
+			Override: true,
+		}).Return(nil),
+		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(
+			gomock.Any(),
+			"tidb-operator",
+			"p:",
+			[]pdapi.PlacementRule(nil),
+		).Return(nil),
+	)
+
+	err := syncPolicyRules(ctx, pdc, "p:", nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/controllers/placementpolicy/controller_test.go
+++ b/pkg/controllers/placementpolicy/controller_test.go
@@ -281,6 +281,14 @@ func TestSyncPolicyRulesUsesEmptyLocationLabelsWhenDefaultRuleMissing(t *testing
 			Count:   3,
 		},
 	}
+	expectedRules := []pdapi.PlacementRule{
+		{
+			GroupID: "tidb-operator",
+			ID:      "p:r1-1-raw",
+			Role:    v1alpha1.PlacementPolicyRoleVoter,
+			Count:   3,
+		},
+	}
 	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
 	pdc.EXPECT().GetPlacementRuleBundle(gomock.Any(), "pd").Return(&pdapi.PlacementRuleGroupBundle{
 		ID: "pd",
@@ -297,7 +305,7 @@ func TestSyncPolicyRulesUsesEmptyLocationLabelsWhenDefaultRuleMissing(t *testing
 			Index:    pdPlacementRuleGroupIndex,
 			Override: true,
 		}).Return(nil),
-		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", rules).Return(nil),
+		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", expectedRules).Return(nil),
 	)
 
 	err := syncPolicyRules(ctx, pdc, "p:", rules)
@@ -307,6 +315,14 @@ func TestSyncPolicyRulesUsesEmptyLocationLabelsWhenDefaultRuleMissing(t *testing
 func TestSyncPolicyRulesNormalizesEmptyDefaultLocationLabels(t *testing.T) {
 	ctx := context.Background()
 	rules := []pdapi.PlacementRule{
+		{
+			GroupID: "tidb-operator",
+			ID:      "p:r1-1-raw",
+			Role:    v1alpha1.PlacementPolicyRoleVoter,
+			Count:   3,
+		},
+	}
+	expectedRules := []pdapi.PlacementRule{
 		{
 			GroupID: "tidb-operator",
 			ID:      "p:r1-1-raw",
@@ -331,11 +347,29 @@ func TestSyncPolicyRulesNormalizesEmptyDefaultLocationLabels(t *testing.T) {
 			Index:    pdPlacementRuleGroupIndex,
 			Override: true,
 		}).Return(nil),
-		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", rules).Return(nil),
+		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", expectedRules).Return(nil),
 	)
 
 	err := syncPolicyRules(ctx, pdc, "p:", rules)
 	require.NoError(t, err)
+}
+
+func TestSyncPolicyRulesReturnsDefaultRuleLookupError(t *testing.T) {
+	ctx := context.Background()
+	rules := []pdapi.PlacementRule{
+		{
+			GroupID: "tidb-operator",
+			ID:      "p:r1-1-raw",
+			Role:    v1alpha1.PlacementPolicyRoleVoter,
+			Count:   3,
+		},
+	}
+	pdc := pdapi.NewMockPDClient(gomock.NewController(t))
+	pdc.EXPECT().GetPlacementRuleBundle(gomock.Any(), "pd").Return(nil, errors.New("pd unavailable"))
+
+	err := syncPolicyRules(ctx, pdc, "p:", rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get default placement rule bundle")
 }
 
 func TestSyncPolicyRulesSkipsDefaultRuleLookupWhenNoRules(t *testing.T) {

--- a/pkg/controllers/placementpolicy/controller_test.go
+++ b/pkg/controllers/placementpolicy/controller_test.go
@@ -271,7 +271,7 @@ func TestSyncPolicyRulesPostsRuleGroup(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSyncPolicyRulesRequiresDefaultRule(t *testing.T) {
+func TestSyncPolicyRulesUsesEmptyLocationLabelsWhenDefaultRuleMissing(t *testing.T) {
 	ctx := context.Background()
 	rules := []pdapi.PlacementRule{
 		{
@@ -291,10 +291,17 @@ func TestSyncPolicyRulesRequiresDefaultRule(t *testing.T) {
 			},
 		},
 	}, nil)
+	gomock.InOrder(
+		pdc.EXPECT().SetPlacementRuleGroup(gomock.Any(), &pdapi.PlacementRuleGroup{
+			ID:       "tidb-operator",
+			Index:    pdPlacementRuleGroupIndex,
+			Override: true,
+		}).Return(nil),
+		pdc.EXPECT().SetPlacementRuleGroupRulesByIDPrefix(gomock.Any(), "tidb-operator", "p:", rules).Return(nil),
+	)
 
 	err := syncPolicyRules(ctx, pdc, "p:", rules)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "default placement rule pd/default not found")
+	require.NoError(t, err)
 }
 
 func TestSyncPolicyRulesNormalizesEmptyDefaultLocationLabels(t *testing.T) {

--- a/pkg/pdapi/v1/client.go
+++ b/pkg/pdapi/v1/client.go
@@ -482,9 +482,9 @@ func (c *pdClient) DeletePlacementRuleGroupRulesByIDPrefix(ctx context.Context, 
 
 func placementRuleAddOps(rules []PlacementRule) []PlacementRuleOp {
 	ruleOps := make([]PlacementRuleOp, 0, len(rules))
-	for _, rule := range rules {
+	for i := range rules {
 		ruleOps = append(ruleOps, PlacementRuleOp{
-			PlacementRule: rule,
+			PlacementRule: rules[i],
 			Action:        PlacementRuleOpAdd,
 		})
 	}
@@ -494,7 +494,8 @@ func placementRuleAddOps(rules []PlacementRule) []PlacementRuleOp {
 
 func placementRuleDiffOps(groupID string, currentRules, expectedRules []PlacementRule) ([]PlacementRuleOp, error) {
 	currentByID := make(map[string]PlacementRule, len(currentRules))
-	for _, rule := range currentRules {
+	for i := range currentRules {
+		rule := currentRules[i]
 		if _, ok := currentByID[rule.ID]; ok {
 			return nil, fmt.Errorf("duplicate current placement rule %q", rule.ID)
 		}
@@ -502,7 +503,8 @@ func placementRuleDiffOps(groupID string, currentRules, expectedRules []Placemen
 	}
 
 	expectedByID := make(map[string]PlacementRule, len(expectedRules))
-	for _, rule := range expectedRules {
+	for i := range expectedRules {
+		rule := expectedRules[i]
 		if _, ok := expectedByID[rule.ID]; ok {
 			return nil, fmt.Errorf("duplicate expected placement rule %q", rule.ID)
 		}
@@ -511,26 +513,26 @@ func placementRuleDiffOps(groupID string, currentRules, expectedRules []Placemen
 
 	ruleOps := []PlacementRuleOp{}
 	staleRules := make([]PlacementRule, 0, len(currentRules))
-	for _, rule := range currentRules {
-		if _, ok := expectedByID[rule.ID]; !ok {
-			staleRules = append(staleRules, rule)
+	for i := range currentRules {
+		if _, ok := expectedByID[currentRules[i].ID]; !ok {
+			staleRules = append(staleRules, currentRules[i])
 		}
 	}
-	for _, rule := range staleRules {
+	for i := range staleRules {
 		ruleOps = append(ruleOps, PlacementRuleOp{
 			PlacementRule: PlacementRule{
 				GroupID: groupID,
-				ID:      rule.ID,
+				ID:      staleRules[i].ID,
 			},
 			Action: PlacementRuleOpDel,
 		})
 	}
 
 	addRules := make([]PlacementRule, 0, len(expectedRules))
-	for _, rule := range expectedRules {
-		current, ok := currentByID[rule.ID]
-		if !ok || !reflect.DeepEqual(current, rule) {
-			addRules = append(addRules, rule)
+	for i := range expectedRules {
+		current, ok := currentByID[expectedRules[i].ID]
+		if !ok || !reflect.DeepEqual(current, expectedRules[i]) {
+			addRules = append(addRules, expectedRules[i])
 		}
 	}
 	addOps := placementRuleAddOps(addRules)
@@ -590,9 +592,9 @@ func (c *pdClient) ListPlacementRulesByGroupIDPrefix(ctx context.Context, groupI
 	}
 
 	rules := make([]PlacementRule, 0, len(allRules))
-	for _, rule := range allRules {
-		if strings.HasPrefix(rule.ID, idPrefix) {
-			rules = append(rules, rule)
+	for i := range allRules {
+		if strings.HasPrefix(allRules[i].ID, idPrefix) {
+			rules = append(rules, allRules[i])
 		}
 	}
 	return rules, nil

--- a/pkg/pdapi/v1/client_test.go
+++ b/pkg/pdapi/v1/client_test.go
@@ -1026,7 +1026,8 @@ func TestPDClient_GetPlacementRuleBundle(t *testing.T) {
       "start_key": "7800000100000000fb",
       "end_key": "7800000200000000fb",
       "role": "voter",
-      "count": 3
+      "count": 3,
+      "location_labels": ["zone", "rack"]
     }
   ]
 }`))
@@ -1047,6 +1048,7 @@ func TestPDClient_GetPlacementRuleBundle(t *testing.T) {
 	assert.Equal(t, "7800000200000000fb", bundle.Rules[0].EndKeyHex)
 	assert.Equal(t, "voter", bundle.Rules[0].Role)
 	assert.Equal(t, int32(3), bundle.Rules[0].Count)
+	assert.Equal(t, []string{"zone", "rack"}, bundle.Rules[0].LocationLabels)
 }
 
 func TestPDClient_DeleteStore(t *testing.T) {

--- a/pkg/pdapi/v1/types.go
+++ b/pkg/pdapi/v1/types.go
@@ -161,6 +161,7 @@ type PlacementRule struct {
 	EndKeyHex        string                     `json:"end_key"`
 	Role             string                     `json:"role"`
 	Count            int32                      `json:"count"`
+	LocationLabels   []string                   `json:"location_labels,omitempty"`
 	LabelConstraints []PlacementLabelConstraint `json:"label_constraints,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- read `location_labels` from the PD default placement rule `pd/default`
- set those location labels on all placement policy managed rules before syncing them to PD
- add `location_labels` support to the PD placement rule API type

## Tests
- `go test ./pkg/controllers/placementpolicy ./pkg/pdapi/v1`