### PR TITLE
monitor: skip semver parsing when remote_write is not configured

### DIFF
--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -1503,24 +1503,14 @@ func buildExternalLabels(monitor *v1alpha1.TidbMonitor) model.LabelSet {
 }
 
 func generateRemoteWrite(monitor *v1alpha1.TidbMonitor, store *Store) (*yaml.MapItem, error) {
-	// remote_write is optional. The prometheus version is only used inside the loop
-	// below, to decide whether version-specific remote_write fields (headers, name,
-	// min_shards, metadata_config) should be rendered. So the version only needs to be
-	// parsed when at least one remote_write spec is configured.
+	// Operator expects a semver tag in the common case, but it's not guaranteed (for example a git commit hash pinned
+	// as the image tag), and we see such cases in some OP customers. So we choose not to parse the version
+	// unconditionally. Otherwise, if the version is not a semver tag, reconciliation fails with an "Invalid Semantic
+	// version" error and the basic-monitor StatefulSet is never created, even though remote_write is not configured
+	// and the version is not needed at all.
 	//
-	// Parsing the version unconditionally is wrong because the prometheus image tag
-	// is not guaranteed to be a semver string. Operator expects a semver tag in the
-	// common case, but the tag is ultimately user-supplied and may be a non-semver
-	// value such as a hex string (for example a git commit hash pinned as the image
-	// tag, i.e. image:<hex>). Parsing such a value fails. When that happens while
-	// remote_write is unused, reconciliation fails with an "Invalid Semantic version"
-	// error and the basic-monitor StatefulSet is never created, even though
-	// remote_write plays no part in the failure.
-	//
-	// Returning nil here also lets the renderer omit the remote_write key entirely.
-	// It is not strictly required: Prometheus tolerates a redundant `remote_write: []`
-	// (yaml.v2 writes a nil slice as an empty list), but omitting the key keeps the
-	// rendered config cleaner.
+	// Returning nil here also lets the renderer omit the remote_write key entirely, i.e. the rendered config will
+	// not contain a `remote_write: []` entry, which is the cleaner.
 	if len(monitor.Spec.Prometheus.RemoteWrite) == 0 {
 		return nil, nil
 	}

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -171,7 +171,7 @@ func getPromConfigMap(monitor *v1alpha1.TidbMonitor, monitorClusterInfos []Clust
 	if err != nil {
 		return nil, err
 	}
-	model.RemoteWriteCfg = &remoteWriteCfg
+	model.RemoteWriteCfg = remoteWriteCfg
 	content, err := RenderPrometheusConfig(model)
 	if err != nil {
 		return nil, err
@@ -1502,12 +1502,31 @@ func buildExternalLabels(monitor *v1alpha1.TidbMonitor) model.LabelSet {
 	return m
 }
 
-func generateRemoteWrite(monitor *v1alpha1.TidbMonitor, store *Store) (yaml.MapItem, error) {
-	var cfgs []yaml.MapSlice
+func generateRemoteWrite(monitor *v1alpha1.TidbMonitor, store *Store) (*yaml.MapItem, error) {
+	// remote_write is optional. The prometheus version is only used inside the loop
+	// below, to decide whether version-specific remote_write fields (headers, name,
+	// min_shards, metadata_config) should be rendered. So the version only needs to be
+	// parsed when at least one remote_write spec is configured.
+	//
+	// Parsing the version unconditionally is wrong because the prometheus image tag is
+	// not always a semver string. We have seen real deployments reference the prometheus
+	// image by a SHA256 digest instead of a version tag, and parsing such a value fails.
+	// When that happens while remote_write is unused, reconciliation fails with an
+	// "Invalid Semantic version" error and the basic-monitor StatefulSet is never
+	// created, even though remote_write plays no part in the failure.
+	//
+	// Returning nil here also lets the renderer omit the remote_write key entirely.
+	// It is not strictly required: Prometheus tolerates a redundant `remote_write: []`
+	// (yaml.v2 writes a nil slice as an empty list), but omitting the key keeps the
+	// rendered config cleaner.
+	if len(monitor.Spec.Prometheus.RemoteWrite) == 0 {
+		return nil, nil
+	}
 	version, err := semver.NewVersion(monitor.Spec.Prometheus.Version)
 	if err != nil {
-		return yaml.MapItem{}, err
+		return nil, err
 	}
+	var cfgs []yaml.MapSlice
 	for i, spec := range monitor.Spec.Prometheus.RemoteWrite {
 		//defaults
 		if spec.RemoteTimeout == "" {
@@ -1639,7 +1658,7 @@ func generateRemoteWrite(monitor *v1alpha1.TidbMonitor, store *Store) (yaml.MapI
 		cfgs = append(cfgs, cfg)
 	}
 
-	return yaml.MapItem{
+	return &yaml.MapItem{
 		Key:   "remote_write",
 		Value: cfgs,
 	}, nil

--- a/pkg/monitor/monitor/util.go
+++ b/pkg/monitor/monitor/util.go
@@ -1508,12 +1508,14 @@ func generateRemoteWrite(monitor *v1alpha1.TidbMonitor, store *Store) (*yaml.Map
 	// min_shards, metadata_config) should be rendered. So the version only needs to be
 	// parsed when at least one remote_write spec is configured.
 	//
-	// Parsing the version unconditionally is wrong because the prometheus image tag is
-	// not always a semver string. We have seen real deployments reference the prometheus
-	// image by a SHA256 digest instead of a version tag, and parsing such a value fails.
-	// When that happens while remote_write is unused, reconciliation fails with an
-	// "Invalid Semantic version" error and the basic-monitor StatefulSet is never
-	// created, even though remote_write plays no part in the failure.
+	// Parsing the version unconditionally is wrong because the prometheus image tag
+	// is not guaranteed to be a semver string. Operator expects a semver tag in the
+	// common case, but the tag is ultimately user-supplied and may be a non-semver
+	// value such as a hex string (for example a git commit hash pinned as the image
+	// tag, i.e. image:<hex>). Parsing such a value fails. When that happens while
+	// remote_write is unused, reconciliation fails with an "Invalid Semantic version"
+	// error and the basic-monitor StatefulSet is never created, even though
+	// remote_write plays no part in the failure.
 	//
 	// Returning nil here also lets the renderer omit the remote_write key entirely.
 	// It is not strictly required: Prometheus tolerates a redundant `remote_write: []`

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -122,6 +122,7 @@ func TestGenerateRemoteWrite(t *testing.T) {
 	}
 	remoteWriteConfig, err := generateRemoteWrite(&monitor, store)
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remoteWriteConfig).NotTo(BeNil())
 
 	prometheusYaml, err := yaml.Marshal(remoteWriteConfig.Value)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -227,6 +228,7 @@ func TestGenerateRemoteWriteWithHighVersion(t *testing.T) {
 	}
 	remoteWriteConfig, err := generateRemoteWrite(&monitor, store)
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remoteWriteConfig).NotTo(BeNil())
 
 	prometheusYaml, err := yaml.Marshal(remoteWriteConfig.Value)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -235,6 +237,90 @@ func TestGenerateRemoteWriteWithHighVersion(t *testing.T) {
 	var expectedContentBytes bytes.Buffer
 	expectedContentParsed.Execute(&expectedContentBytes, promCfgModel)
 	g.Expect(yaml).Should(Equal(expectedContentBytes.String()))
+}
+
+func TestGenerateRemoteWriteWithEmptyRemoteWrite(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// A non-semver prometheus image tag (such as a SHA256 digest) must not break
+	// reconciliation when remote_write is not configured, because the version is only
+	// used inside the remote_write loop, which never runs when the list is empty. The
+	// function returns nil so the renderer does not emit a remote_write key.
+	monitor := v1alpha1.TidbMonitor{
+		Spec: v1alpha1.TidbMonitorSpec{
+			Prometheus: v1alpha1.PrometheusSpec{
+				MonitorContainer: v1alpha1.MonitorContainer{
+					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+				},
+			},
+		},
+	}
+	store := &Store{
+		secretLister: nil,
+		TLSAssets:    make(map[TLSAssetKey]TLSAsset),
+	}
+
+	remoteWriteCfg, err := generateRemoteWrite(&monitor, store)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remoteWriteCfg).To(BeNil())
+}
+
+func TestGenerateRemoteWriteWithNonSemVerVersionAndRemoteWrite(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// When remote_write IS configured, the prometheus version must be parsed to gate
+	// version-specific fields, so a non-semver tag remains a real error here. This is
+	// the intended boundary: parsing is only skipped when remote_write is unused; it is
+	// not relaxed for users who actually configure remote_write.
+	monitor := v1alpha1.TidbMonitor{
+		Spec: v1alpha1.TidbMonitorSpec{
+			Prometheus: v1alpha1.PrometheusSpec{
+				RemoteWrite: []*v1alpha1.RemoteWriteSpec{
+					{URL: "http://127.0.0.1/a/b/c"},
+				},
+				MonitorContainer: v1alpha1.MonitorContainer{
+					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+				},
+			},
+		},
+	}
+	store := &Store{
+		secretLister: nil,
+		TLSAssets:    make(map[TLSAssetKey]TLSAsset),
+	}
+
+	_, err := generateRemoteWrite(&monitor, store)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestGetPromConfigMapWithoutRemoteWrite(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// End-to-end check: when remote_write is not configured and the prometheus image
+	// tag is not a semver string, getPromConfigMap must not fail. The rendered
+	// prometheus.yml should not contain a remote_write key; we prefer to omit it
+	// rather than emit a redundant `remote_write: []`.
+	monitor := v1alpha1.TidbMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.TidbMonitorSpec{
+			Prometheus: v1alpha1.PrometheusSpec{
+				MonitorContainer: v1alpha1.MonitorContainer{
+					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+				},
+			},
+		},
+	}
+
+	cm, err := getPromConfigMap(&monitor, []ClusterRegexInfo{{Name: "basic", Namespace: "ns"}}, nil, 0, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cm).NotTo(BeNil())
+
+	content, ok := cm.Data["prometheus.yml"]
+	g.Expect(ok).To(BeTrue())
+	g.Expect(content).NotTo(ContainSubstring("remote_write"))
 }
 
 func TestGetMonitorConfigMap(t *testing.T) {

--- a/pkg/monitor/monitor/util_test.go
+++ b/pkg/monitor/monitor/util_test.go
@@ -242,15 +242,16 @@ func TestGenerateRemoteWriteWithHighVersion(t *testing.T) {
 func TestGenerateRemoteWriteWithEmptyRemoteWrite(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	// A non-semver prometheus image tag (such as a SHA256 digest) must not break
-	// reconciliation when remote_write is not configured, because the version is only
-	// used inside the remote_write loop, which never runs when the list is empty. The
-	// function returns nil so the renderer does not emit a remote_write key.
+	// A non-semver prometheus image tag (for example a hex string such as a git
+	// commit hash pinned as the tag, i.e. image:<hex>) must not break reconciliation
+	// when remote_write is not configured, because the version is only used inside
+	// the remote_write loop, which never runs when the list is empty. The function
+	// returns nil so the renderer does not emit a remote_write key.
 	monitor := v1alpha1.TidbMonitor{
 		Spec: v1alpha1.TidbMonitorSpec{
 			Prometheus: v1alpha1.PrometheusSpec{
 				MonitorContainer: v1alpha1.MonitorContainer{
-					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+					Version: "356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b",
 				},
 			},
 		},
@@ -279,7 +280,7 @@ func TestGenerateRemoteWriteWithNonSemVerVersionAndRemoteWrite(t *testing.T) {
 					{URL: "http://127.0.0.1/a/b/c"},
 				},
 				MonitorContainer: v1alpha1.MonitorContainer{
-					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+					Version: "356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b",
 				},
 			},
 		},
@@ -297,9 +298,9 @@ func TestGetPromConfigMapWithoutRemoteWrite(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	// End-to-end check: when remote_write is not configured and the prometheus image
-	// tag is not a semver string, getPromConfigMap must not fail. The rendered
-	// prometheus.yml should not contain a remote_write key; we prefer to omit it
-	// rather than emit a redundant `remote_write: []`.
+	// tag is not a semver string (here a hex string used as the tag, i.e. image:<hex>),
+	// getPromConfigMap must not fail. The rendered prometheus.yml should not contain a
+	// remote_write key; we prefer to omit it rather than emit a redundant `remote_write: []`.
 	monitor := v1alpha1.TidbMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -308,7 +309,7 @@ func TestGetPromConfigMapWithoutRemoteWrite(t *testing.T) {
 		Spec: v1alpha1.TidbMonitorSpec{
 			Prometheus: v1alpha1.PrometheusSpec{
 				MonitorContainer: v1alpha1.MonitorContainer{
-					Version: "sha256:356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+					Version: "356f96b6c85a0a1b2c3d4e5f6a7b8c9d0e1f2a3b",
 				},
 			},
 		},


### PR DESCRIPTION
### What problem does this PR solve?

`generateRemoteWrite` parsed `monitor.Spec.Prometheus.Version` as a semver string unconditionally, even though the parsed version is only used inside the `remote_write` loop to gate version-specific fields (`headers`, `name`, `min_shards`, `metadata_config`). When `remote_write` is not configured, the loop never runs and the version is never used — but the parse still runs and fails if the prometheus image tag is not semver-compatible.

The prometheus image tag is user-supplied and not guaranteed to be a semver string. Operator still expects a semver tag in the common case; this PR does not change that. But a non-semver tag — for example a hex string such as a git commit hash pinned as the image tag (i.e. `image:<hex>`) — is a valid image reference, and Operator should not fail reconciliation outright over it. In that case, with no `remote_write` configured, TidbMonitor reconciliation fails with `Invalid Semantic version`, and the `basic-monitor` StatefulSet is never created, even though `remote_write` plays no part in the failure.

The failure happens early in the reconcile path: `SyncMonitor` → `syncTidbMonitorStatefulset` → `syncTidbMonitorConfig` → `getPromConfigMap` → `generateRemoteWrite`. The semver parse fails before the StatefulSet creation step, so the StatefulSet is never created.

### What is changed and how does it work?

- Gate the semver parse behind `len(monitor.Spec.Prometheus.RemoteWrite) > 0`. When `remote_write` is empty, `generateRemoteWrite` returns `nil` without parsing the version.
- Change the return type of `generateRemoteWrite` from `yaml.MapItem` to `*yaml.MapItem` so the caller can assign the (possibly nil) pointer directly to `model.RemoteWriteCfg`. The renderer already skips the `remote_write` key when `RemoteWriteCfg` is `nil`, so this avoids emitting a redundant `remote_write: []` (Prometheus tolerates it, but omitting the key is cleaner).
- When `remote_write` IS configured, the version must still be parsed to gate the version-specific fields, so a non-semver tag remains a real error in that case. This is the intended boundary: parsing is only skipped when `remote_write` is unused.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [x] Unit test
  - `TestGenerateRemoteWriteWithEmptyRemoteWrite`: empty `remote_write` + a non-semver (hex) tag does not error and returns `nil`.
  - `TestGenerateRemoteWriteWithNonSemVerVersionAndRemoteWrite`: non-empty `remote_write` + a non-semver (hex) tag still errors (intended boundary).
  - `TestGetPromConfigMapWithoutRemoteWrite`: end-to-end, `getPromConfigMap` does not fail and the rendered `prometheus.yml` has no `remote_write` key.
  - Existing tests `TestGenerateRemoteWrite` and `TestGenerateRemoteWriteWithHighVersion` continue to pass.
- [ ] E2E test
- [ ] Manual test
- [ ] No code

### Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects

No behavior change for users who configure `remote_write` or use a semver-compatible prometheus image tag. Only the case where `remote_write` is unused and the image tag is not semver-compatible is fixed.

### Related changes

- [x] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

This bugfix should be cherry-picked to `release-1.6` as well.

### Release Notes

```release-note
Fix TidbMonitor reconciliation failure ("Invalid Semantic version") when the prometheus image tag is not semver-compatible and `remote_write` is not configured.
```