### PR TITLE
opt: better suspend support

### DIFF
--- a/api/core/v1alpha1/common_types.go
+++ b/api/core/v1alpha1/common_types.go
@@ -375,6 +375,11 @@ type CommonStatus struct {
 	// It's used to determine whether the controller has reconciled the latest spec.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// ObservedClusterGeneration is the most recent generation of the referenced
+	// Cluster for which the controller completed its cluster-dependent status
+	// calculations.
+	ObservedClusterGeneration int64 `json:"observedClusterGeneration,omitempty"`
+
 	// CurrentRevision is the revision of the Controller that created the resource.
 	CurrentRevision string `json:"currentRevision,omitempty"`
 

--- a/cmd/runtime-gen/generators/namer.go
+++ b/cmd/runtime-gen/generators/namer.go
@@ -39,6 +39,16 @@ func GroupToInstanceName(t *types.Type) string {
 	return strings.TrimSuffix(t.Name.Name, "Group")
 }
 
+// GroupToComponentName returns the component constant suffix for an instance
+// or group type. DM masters use DMMaster in the public component constants.
+func GroupToComponentName(t *types.Type) string {
+	name := GroupToInstanceName(t)
+	if name == "DM" {
+		return "DMMaster"
+	}
+	return name
+}
+
 // GroupToSecurityTypeName returns security type name from group type
 // TiDB and TiProxy have their own security type
 // Others: Security

--- a/cmd/runtime-gen/generators/runtime.go
+++ b/cmd/runtime-gen/generators/runtime.go
@@ -56,6 +56,7 @@ func (g *runtimeGenerator) Namers(*generator.Context) namer.NameSystems {
 	return namer.NameSystems{
 		"pub":          namer.NewPublicNamer(0),
 		"instance":     NameFunc(GroupToInstanceName),
+		"component":    NameFunc(GroupToComponentName),
 		"security":     NameFunc(GroupToSecurityTypeName),
 		"tls":          NameFunc(GroupToTLSTypeName),
 		"internaltls":  NameFunc(GroupToInternalTLSTypeName),
@@ -232,6 +233,14 @@ func (in *$.|pub$) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *$.|pub$) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *$.|pub$) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *$.|pub$) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -241,7 +250,7 @@ func (in *$.|pub$) Cluster() string {
 }
 
 func (*$.|pub$) Component() string {
-	return v1alpha1.LabelValComponent$.|pub$
+	return v1alpha1.LabelValComponent$.|component$
 }
 
 func (in *$.|pub$) Volumes() []v1alpha1.Volume {
@@ -417,7 +426,7 @@ func (g *$.|pub$) Cluster() string {
 }
 
 func (*$.|pub$) Component() string {
-	return v1alpha1.LabelValComponent$.|instance$
+	return v1alpha1.LabelValComponent$.|component$
 }
 
 func (g *$.|pub$) Conditions() []metav1.Condition {
@@ -434,6 +443,14 @@ func (g *$.|pub$) ObservedGeneration() int64 {
 
 func (g *$.|pub$) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *$.|pub$) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *$.|pub$) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *$.|pub$) SetStatusVersion(version string) {

--- a/cmd/runtime-gen/generators/scope.go
+++ b/cmd/runtime-gen/generators/scope.go
@@ -54,8 +54,9 @@ func (g *scopeGenerator) Filter(_ *generator.Context, t *types.Type) bool {
 
 func (g *scopeGenerator) Namers(*generator.Context) namer.NameSystems {
 	return namer.NameSystems{
-		"pub":      namer.NewPublicNamer(0),
-		"instance": NameFunc(GroupToInstanceName),
+		"pub":       namer.NewPublicNamer(0),
+		"instance":  NameFunc(GroupToInstanceName),
+		"component": NameFunc(GroupToComponentName),
 	}
 }
 
@@ -96,7 +97,7 @@ func ($.|pub$) To(t *runtime.$.|pub$) *v1alpha1.$.|pub$ {
 }
 
 func ($.|pub$) Component() string {
-	return v1alpha1.LabelValComponent$.|pub$
+	return v1alpha1.LabelValComponent$.|component$
 }
 
 func ($.|pub$) GVK() schema.GroupVersionKind {
@@ -134,7 +135,7 @@ func ($.|pub$) To(t *runtime.$.|pub$) *v1alpha1.$.|pub$ {
 }
 
 func ($.|pub$) Component() string {
-	return v1alpha1.LabelValComponent$.|instance$
+	return v1alpha1.LabelValComponent$.|component$
 }
 
 func ($.|pub$) GVK() schema.GroupVersionKind {

--- a/cmd/runtime-gen/main.go
+++ b/cmd/runtime-gen/main.go
@@ -125,6 +125,8 @@ func getTargets(_ *generator.Context, args *Args) []generator.Target {
 		"resourcemanager",
 		"tiproxy",
 		"tikvworker",
+		"dm",
+		"dmworker",
 	}
 
 	runtimeTargetPkg := "github.com/pingcap/tidb-operator/v2/pkg/runtime"

--- a/manifests/crd/br.pingcap.com_tibrs.yaml
+++ b/manifests/crd/br.pingcap.com_tibrs.yaml
@@ -8492,6 +8492,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_dmgroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmgroups.yaml
@@ -8933,6 +8933,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_dms.yaml
+++ b/manifests/crd/core.pingcap.com_dms.yaml
@@ -8657,6 +8657,13 @@ spec:
               memberID:
                 description: MemberID is the etcd member ID of this DM master instance
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_dmworkergroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkergroups.yaml
@@ -8937,6 +8937,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_dmworkers.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkers.yaml
@@ -8657,6 +8657,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_pdgroups.yaml
+++ b/manifests/crd/core.pingcap.com_pdgroups.yaml
@@ -8891,6 +8891,13 @@ spec:
                 description: Mode is the actual PD mode after all desired PD instances
                   have converged.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_pds.yaml
+++ b/manifests/crd/core.pingcap.com_pds.yaml
@@ -8614,6 +8614,13 @@ spec:
                   IsLeader indicates whether this pd is the leader
                   NOTE: it's a snapshot from PD, not always up to date
                 type: boolean
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_resourcemanagergroups.yaml
+++ b/manifests/crd/core.pingcap.com_resourcemanagergroups.yaml
@@ -8858,6 +8858,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_resourcemanagers.yaml
+++ b/manifests/crd/core.pingcap.com_resourcemanagers.yaml
@@ -8588,6 +8588,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_routergroups.yaml
+++ b/manifests/crd/core.pingcap.com_routergroups.yaml
@@ -8859,6 +8859,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_routers.yaml
+++ b/manifests/crd/core.pingcap.com_routers.yaml
@@ -8588,6 +8588,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_schedulergroups.yaml
+++ b/manifests/crd/core.pingcap.com_schedulergroups.yaml
@@ -8873,6 +8873,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_schedulers.yaml
+++ b/manifests/crd/core.pingcap.com_schedulers.yaml
@@ -8597,6 +8597,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_schedulinggroups.yaml
+++ b/manifests/crd/core.pingcap.com_schedulinggroups.yaml
@@ -8862,6 +8862,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_schedulings.yaml
+++ b/manifests/crd/core.pingcap.com_schedulings.yaml
@@ -8591,6 +8591,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_ticdcgroups.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcgroups.yaml
@@ -8886,6 +8886,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_ticdcs.yaml
+++ b/manifests/crd/core.pingcap.com_ticdcs.yaml
@@ -8627,6 +8627,13 @@ spec:
                   should we need to save IsOwner in status?
                   but this value may be changed when scaling in or rolling update
                 type: boolean
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tidbgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tidbgroups.yaml
@@ -9058,6 +9058,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tidbs.yaml
+++ b/manifests/crd/core.pingcap.com_tidbs.yaml
@@ -8782,6 +8782,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tiflashes.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashes.yaml
@@ -8683,6 +8683,13 @@ spec:
               id:
                 description: ID is the store id.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tiflashgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiflashgroups.yaml
@@ -8937,6 +8937,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tikvgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tikvgroups.yaml
@@ -8961,6 +8961,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tikvs.yaml
+++ b/manifests/crd/core.pingcap.com_tikvs.yaml
@@ -8707,6 +8707,13 @@ spec:
               id:
                 description: ID is the store id.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tikvworkergroups.yaml
+++ b/manifests/crd/core.pingcap.com_tikvworkergroups.yaml
@@ -8858,6 +8858,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tikvworkers.yaml
+++ b/manifests/crd/core.pingcap.com_tikvworkers.yaml
@@ -8586,6 +8586,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tiproxies.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxies.yaml
@@ -8754,6 +8754,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tiproxygroups.yaml
+++ b/manifests/crd/core.pingcap.com_tiproxygroups.yaml
@@ -9035,6 +9035,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tsogroups.yaml
+++ b/manifests/crd/core.pingcap.com_tsogroups.yaml
@@ -8860,6 +8860,13 @@ spec:
                 description: CurrentRevision is the revision of the Controller that
                   created the resource.
                 type: string
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/manifests/crd/core.pingcap.com_tsos.yaml
+++ b/manifests/crd/core.pingcap.com_tsos.yaml
@@ -8594,6 +8594,13 @@ spec:
                 description: IsDefaultPrimary indicates whether this TSO instance
                   is the primary for the default keyspace group.
                 type: boolean
+              observedClusterGeneration:
+                description: |-
+                  ObservedClusterGeneration is the most recent generation of the referenced
+                  Cluster for which the controller completed its cluster-dependent status
+                  calculations.
+                format: int64
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed by the controller.

--- a/pkg/apiutil/core/v1alpha1/object.go
+++ b/pkg/apiutil/core/v1alpha1/object.go
@@ -68,6 +68,38 @@ func SetStatusObservedGeneration[
 	return false
 }
 
+func SetStatusObservedClusterGeneration[
+	S scope.Object[F, T],
+	F client.Object,
+	T runtime.ClusterObservedObject,
+](f F, generation int64) bool {
+	t := scope.From[S](f)
+	observed := t.ObservedClusterGeneration()
+	if compare.SetIfChanged(&observed, generation) {
+		t.SetObservedClusterGeneration(observed)
+		return true
+	}
+
+	return false
+}
+
+func IsStatusConditionTrueForCluster[
+	S scope.Object[F, T],
+	F client.Object,
+	T runtime.ClusterObservedObject,
+](f F, conditionType string, clusterGeneration int64) bool {
+	t := scope.From[S](f)
+	if t.ObservedGeneration() != t.GetGeneration() ||
+		t.ObservedClusterGeneration() != clusterGeneration {
+		return false
+	}
+
+	condition := meta.FindStatusCondition(t.Conditions(), conditionType)
+	return condition != nil &&
+		condition.Status == metav1.ConditionTrue &&
+		condition.ObservedGeneration == t.GetGeneration()
+}
+
 func SetStatusCondition[
 	S scope.Object[F, T],
 	F client.Object,

--- a/pkg/apiutil/core/v1alpha1/object_test.go
+++ b/pkg/apiutil/core/v1alpha1/object_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apiutil/core/v1alpha1/object_test.go
+++ b/pkg/apiutil/core/v1alpha1/object_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coreutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
+	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
+)
+
+func TestIsStatusConditionTrueForCluster(t *testing.T) {
+	const (
+		generation        = int64(7)
+		clusterGeneration = int64(11)
+	)
+
+	newGroup := func() *v1alpha1.PDGroup {
+		return &v1alpha1.PDGroup{
+			ObjectMeta: metav1.ObjectMeta{Generation: generation},
+			Status: v1alpha1.PDGroupStatus{CommonStatus: v1alpha1.CommonStatus{
+				ObservedGeneration:        generation,
+				ObservedClusterGeneration: clusterGeneration,
+				Conditions: []metav1.Condition{{
+					Type:               v1alpha1.CondSuspended,
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: generation,
+				}},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*v1alpha1.PDGroup)
+		want   bool
+	}{
+		{name: "all generations current", want: true},
+		{
+			name: "status generation stale",
+			mutate: func(group *v1alpha1.PDGroup) {
+				group.Status.ObservedGeneration--
+			},
+		},
+		{
+			name: "cluster generation stale",
+			mutate: func(group *v1alpha1.PDGroup) {
+				group.Status.ObservedClusterGeneration--
+			},
+		},
+		{
+			name: "condition generation stale",
+			mutate: func(group *v1alpha1.PDGroup) {
+				group.Status.Conditions[0].ObservedGeneration--
+			},
+		},
+		{
+			name: "condition false",
+			mutate: func(group *v1alpha1.PDGroup) {
+				group.Status.Conditions[0].Status = metav1.ConditionFalse
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group := newGroup()
+			if tt.mutate != nil {
+				tt.mutate(group)
+			}
+			assert.Equal(t, tt.want, IsStatusConditionTrueForCluster[scope.PDGroup](
+				group,
+				v1alpha1.CondSuspended,
+				clusterGeneration,
+			))
+		})
+	}
+}

--- a/pkg/controllers/cluster/controller.go
+++ b/pkg/controllers/cluster/controller.go
@@ -62,6 +62,8 @@ func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager) error
 		Watches(&v1alpha1.TiCDCGroup{}, handler.EnqueueRequestsFromMapFunc(enqueueForGroupFunc[scope.TiCDCGroup]())).
 		Watches(&v1alpha1.TiProxyGroup{}, handler.EnqueueRequestsFromMapFunc(enqueueForGroupFunc[scope.TiProxyGroup]())).
 		Watches(&v1alpha1.TiKVWorkerGroup{}, handler.EnqueueRequestsFromMapFunc(enqueueForGroupFunc[scope.TiKVWorkerGroup]())).
+		Watches(&v1alpha1.DMGroup{}, handler.EnqueueRequestsFromMapFunc(enqueueForGroupFunc[scope.DMGroup]())).
+		Watches(&v1alpha1.DMWorkerGroup{}, handler.EnqueueRequestsFromMapFunc(enqueueForGroupFunc[scope.DMWorkerGroup]())).
 		WithOptions(controller.Options{RateLimiter: k8s.RateLimiter}).
 		Complete(r)
 }

--- a/pkg/controllers/cluster/controller_test.go
+++ b/pkg/controllers/cluster/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controllers/cluster/controller_test.go
+++ b/pkg/controllers/cluster/controller_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
+	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
+)
+
+func TestDMGroupEventsEnqueueCluster(t *testing.T) {
+	expected := []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Namespace: "test-ns",
+		Name:      "test-cluster",
+	}}}
+
+	dmGroup := &v1alpha1.DMGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+		Spec: v1alpha1.DMGroupSpec{Cluster: v1alpha1.ClusterReference{
+			Name: "test-cluster",
+		}},
+	}
+	dmWorkerGroup := &v1alpha1.DMWorkerGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+		Spec: v1alpha1.DMWorkerGroupSpec{Cluster: v1alpha1.ClusterReference{
+			Name: "test-cluster",
+		}},
+	}
+
+	assert.Equal(t, expected, enqueueForGroupFunc[scope.DMGroup]()(context.Background(), dmGroup))
+	assert.Equal(t, expected, enqueueForGroupFunc[scope.DMWorkerGroup]()(context.Background(), dmWorkerGroup))
+}

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
+	"github.com/pingcap/tidb-operator/v2/pkg/runtime"
+	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 	"github.com/pingcap/tidb-operator/v2/pkg/timanager"
 	pdm "github.com/pingcap/tidb-operator/v2/pkg/timanager/pd"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/compare"
@@ -203,7 +205,6 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 		Reason:             v1alpha1.ClusterAvailableReason,
 		Message:            "Cluster is not available",
 	}
-	suspended := true
 	for _, tidbg := range rtx.TiDBGroups {
 		if meta.IsStatusConditionTrue(tidbg.Status.Conditions, v1alpha1.TiDBGroupCondAvailable) {
 			// if any tidb group is available, the cluster is available
@@ -211,46 +212,24 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 			availCond.Message = "Cluster is available"
 			break
 		}
-		if !meta.IsStatusConditionTrue(tidbg.Status.Conditions, v1alpha1.CondSuspended) {
-			// if any group is not suspended, the cluster is not suspended
-			suspended = false
-		}
 	}
 	changed = meta.SetStatusCondition(&rtx.Cluster.Status.Conditions, availCond) || changed
 
-	if suspended {
-		for _, pdg := range rtx.PDGroups {
-			if !meta.IsStatusConditionTrue(pdg.Status.Conditions, v1alpha1.CondSuspended) {
-				suspended = false
-				break
-			}
-		}
-
-		for _, tikvGroup := range rtx.TiKVGroups {
-			if !meta.IsStatusConditionTrue(tikvGroup.Status.Conditions, v1alpha1.CondSuspended) {
-				suspended = false
-				break
-			}
-		}
-		for _, tiflashGroup := range rtx.TiFlashGroups {
-			if !meta.IsStatusConditionTrue(tiflashGroup.Status.Conditions, v1alpha1.CondSuspended) {
-				suspended = false
-				break
-			}
-		}
-		for _, ticdcGroup := range rtx.TiCDCGroups {
-			if !meta.IsStatusConditionTrue(ticdcGroup.Status.Conditions, v1alpha1.CondSuspended) {
-				suspended = false
-				break
-			}
-		}
-		for _, wg := range rtx.TiKVWorkerGroups {
-			if !meta.IsStatusConditionTrue(wg.Status.Conditions, v1alpha1.CondSuspended) {
-				suspended = false
-				break
-			}
-		}
-	}
+	clusterGeneration := rtx.Cluster.Generation
+	suspended := groupsSuspended[scope.PDGroup](rtx.PDGroups, clusterGeneration) &&
+		groupsSuspended[scope.ResourceManagerGroup](rtx.ResourceManagerGroups, clusterGeneration) &&
+		groupsSuspended[scope.RouterGroup](rtx.RouterGroups, clusterGeneration) &&
+		groupsSuspended[scope.TSOGroup](rtx.TSOGroups, clusterGeneration) &&
+		groupsSuspended[scope.SchedulingGroup](rtx.SchedulingGroups, clusterGeneration) &&
+		groupsSuspended[scope.SchedulerGroup](rtx.SchedulerGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiKVGroup](rtx.TiKVGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiFlashGroup](rtx.TiFlashGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiDBGroup](rtx.TiDBGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiCDCGroup](rtx.TiCDCGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiProxyGroup](rtx.TiProxyGroups, clusterGeneration) &&
+		groupsSuspended[scope.TiKVWorkerGroup](rtx.TiKVWorkerGroups, clusterGeneration) &&
+		groupsSuspended[scope.DMGroup](rtx.DMGroups, clusterGeneration) &&
+		groupsSuspended[scope.DMWorkerGroup](rtx.DMWorkerGroups, clusterGeneration)
 	var (
 		suspendStatus  = metav1.ConditionFalse
 		suspendMessage = "Cluster is not suspended"
@@ -271,6 +250,24 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 		Reason:             v1alpha1.ClusterSuspendReason,
 		Message:            suspendMessage,
 	}) || changed
+}
+
+func groupsSuspended[
+	S scope.Group[F, T],
+	F client.Object,
+	T runtime.Group,
+](groups []F, clusterGeneration int64) bool {
+	for _, group := range groups {
+		if !coreutil.IsStatusConditionTrueForCluster[S](
+			group,
+			v1alpha1.CondSuspended,
+			clusterGeneration,
+		) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (t *TaskStatus) syncClusterID(ctx context.Context, rtx *ReconcileContext) bool {

--- a/pkg/controllers/cluster/tasks/status_test.go
+++ b/pkg/controllers/cluster/tasks/status_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -118,6 +119,101 @@ func TestStatusUpdater(t *testing.T) {
 			}
 			assert.Equal(tt, c.conditions, conditions)
 			assert.Equal(tt, strconv.FormatUint(c.clusterID, 10), c.cluster.Status.ID)
+		})
+	}
+}
+
+func TestSyncSuspendedConditionCoversAllGroupTypes(t *testing.T) {
+	const (
+		groupGeneration   = int64(7)
+		clusterGeneration = int64(11)
+	)
+
+	newStatus := func() v1alpha1.CommonStatus {
+		return v1alpha1.CommonStatus{
+			ObservedGeneration:        groupGeneration,
+			ObservedClusterGeneration: clusterGeneration,
+			Conditions: []metav1.Condition{{
+				Type:               v1alpha1.CondSuspended,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: groupGeneration,
+			}},
+		}
+	}
+	objectMeta := func() metav1.ObjectMeta {
+		return metav1.ObjectMeta{Generation: groupGeneration}
+	}
+
+	pdg := &v1alpha1.PDGroup{ObjectMeta: objectMeta(), Status: v1alpha1.PDGroupStatus{CommonStatus: newStatus()}}
+	rmg := &v1alpha1.ResourceManagerGroup{ObjectMeta: objectMeta(), Status: v1alpha1.ResourceManagerGroupStatus{CommonStatus: newStatus()}}
+	rg := &v1alpha1.RouterGroup{ObjectMeta: objectMeta(), Status: v1alpha1.RouterGroupStatus{CommonStatus: newStatus()}}
+	tsog := &v1alpha1.TSOGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TSOGroupStatus{CommonStatus: newStatus()}}
+	schedulingg := &v1alpha1.SchedulingGroup{ObjectMeta: objectMeta(), Status: v1alpha1.SchedulingGroupStatus{CommonStatus: newStatus()}}
+	schedulerg := &v1alpha1.SchedulerGroup{ObjectMeta: objectMeta(), Status: v1alpha1.SchedulerGroupStatus{CommonStatus: newStatus()}}
+	tikvg := &v1alpha1.TiKVGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiKVGroupStatus{CommonStatus: newStatus()}}
+	tiflashg := &v1alpha1.TiFlashGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiFlashGroupStatus{CommonStatus: newStatus()}}
+	tidbg := &v1alpha1.TiDBGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiDBGroupStatus{CommonStatus: newStatus()}}
+	ticdcg := &v1alpha1.TiCDCGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiCDCGroupStatus{CommonStatus: newStatus()}}
+	tiproxyg := &v1alpha1.TiProxyGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiProxyGroupStatus{CommonStatus: newStatus()}}
+	tikvworkerg := &v1alpha1.TiKVWorkerGroup{ObjectMeta: objectMeta(), Status: v1alpha1.TiKVWorkerGroupStatus{CommonStatus: newStatus()}}
+	dmg := &v1alpha1.DMGroup{ObjectMeta: objectMeta(), Status: v1alpha1.DMGroupStatus{CommonStatus: newStatus()}}
+	dmworkerg := &v1alpha1.DMWorkerGroup{ObjectMeta: objectMeta(), Status: v1alpha1.DMWorkerGroupStatus{CommonStatus: newStatus()}}
+
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Generation: clusterGeneration},
+		Spec: v1alpha1.ClusterSpec{SuspendAction: &v1alpha1.SuspendAction{
+			SuspendCompute: true,
+		}},
+	}
+	rtx := &ReconcileContext{
+		Cluster:               cluster,
+		PDGroups:              []*v1alpha1.PDGroup{pdg},
+		ResourceManagerGroups: []*v1alpha1.ResourceManagerGroup{rmg},
+		RouterGroups:          []*v1alpha1.RouterGroup{rg},
+		TSOGroups:             []*v1alpha1.TSOGroup{tsog},
+		SchedulingGroups:      []*v1alpha1.SchedulingGroup{schedulingg},
+		SchedulerGroups:       []*v1alpha1.SchedulerGroup{schedulerg},
+		TiKVGroups:            []*v1alpha1.TiKVGroup{tikvg},
+		TiFlashGroups:         []*v1alpha1.TiFlashGroup{tiflashg},
+		TiDBGroups:            []*v1alpha1.TiDBGroup{tidbg},
+		TiCDCGroups:           []*v1alpha1.TiCDCGroup{ticdcg},
+		TiProxyGroups:         []*v1alpha1.TiProxyGroup{tiproxyg},
+		TiKVWorkerGroups:      []*v1alpha1.TiKVWorkerGroup{tikvworkerg},
+		DMGroups:              []*v1alpha1.DMGroup{dmg},
+		DMWorkerGroups:        []*v1alpha1.DMWorkerGroup{dmworkerg},
+	}
+
+	statusByType := map[string]*v1alpha1.CommonStatus{
+		"PDGroup":              &pdg.Status.CommonStatus,
+		"ResourceManagerGroup": &rmg.Status.CommonStatus,
+		"RouterGroup":          &rg.Status.CommonStatus,
+		"TSOGroup":             &tsog.Status.CommonStatus,
+		"SchedulingGroup":      &schedulingg.Status.CommonStatus,
+		"SchedulerGroup":       &schedulerg.Status.CommonStatus,
+		"TiKVGroup":            &tikvg.Status.CommonStatus,
+		"TiFlashGroup":         &tiflashg.Status.CommonStatus,
+		"TiDBGroup":            &tidbg.Status.CommonStatus,
+		"TiCDCGroup":           &ticdcg.Status.CommonStatus,
+		"TiProxyGroup":         &tiproxyg.Status.CommonStatus,
+		"TiKVWorkerGroup":      &tikvworkerg.Status.CommonStatus,
+		"DMGroup":              &dmg.Status.CommonStatus,
+		"DMWorkerGroup":        &dmworkerg.Status.CommonStatus,
+	}
+
+	taskStatus := &TaskStatus{}
+	taskStatus.syncConditions(rtx)
+	require.True(t, meta.IsStatusConditionTrue(cluster.Status.Conditions, v1alpha1.ClusterCondSuspended))
+	suspendedCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1alpha1.ClusterCondSuspended)
+	require.NotNil(t, suspendedCondition)
+	assert.Equal(t, clusterGeneration, suspendedCondition.ObservedGeneration)
+
+	for groupType, status := range statusByType {
+		t.Run(groupType+" stale", func(t *testing.T) {
+			status.ObservedClusterGeneration--
+			cluster.Status.Conditions = nil
+			taskStatus.syncConditions(rtx)
+			assert.False(t, meta.IsStatusConditionTrue(cluster.Status.Conditions, v1alpha1.ClusterCondSuspended))
+			status.ObservedClusterGeneration++
 		})
 	}
 }

--- a/pkg/controllers/common/task_status.go
+++ b/pkg/controllers/common/task_status.go
@@ -18,7 +18,6 @@ package common
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
@@ -96,6 +95,10 @@ func TaskInstanceConditionSuspended[
 				*coreutil.Unsuspended(),
 			) || needUpdate
 		}
+		needUpdate = coreutil.SetStatusObservedClusterGeneration[S](
+			instance,
+			cluster.Generation,
+		) || needUpdate
 
 		if needUpdate {
 			state.SetStatusChanged()
@@ -329,7 +332,11 @@ func TaskGroupConditionSuspended[
 		if coreutil.ShouldSuspendCompute(cluster) {
 			suspended := true
 			for _, obj := range objs {
-				if !meta.IsStatusConditionTrue(coreutil.StatusConditions[IS](obj), v1alpha1.CondSuspended) {
+				if !coreutil.IsStatusConditionTrueForCluster[IS](
+					obj,
+					v1alpha1.CondSuspended,
+					cluster.Generation,
+				) {
 					suspended = false
 				}
 			}
@@ -350,6 +357,10 @@ func TaskGroupConditionSuspended[
 				*coreutil.Unsuspended(),
 			) || needUpdate
 		}
+		needUpdate = coreutil.SetStatusObservedClusterGeneration[S](
+			g,
+			cluster.Generation,
+		) || needUpdate
 
 		if needUpdate {
 			state.SetStatusChanged()

--- a/pkg/controllers/common/task_status_test.go
+++ b/pkg/controllers/common/task_status_test.go
@@ -231,6 +231,35 @@ func TestTaskInstanceConditionSuspended(t *testing.T) {
 				return obj
 			}),
 		},
+		{
+			desc: "existing pod invalidates old suspended condition and advances cluster generation",
+			obj: fake.FakeObj("aaa", func(obj *v1alpha1.PD) *v1alpha1.PD {
+				obj.Generation = 7
+				cond := coreutil.Suspended()
+				cond.ObservedGeneration = obj.Generation
+				obj.Status.Conditions = []metav1.Condition{*cond}
+				obj.Status.ObservedClusterGeneration = 10
+				return obj
+			}),
+			cluster: fake.FakeObj("aaa", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
+				obj.Generation = 11
+				obj.Spec.SuspendAction = &v1alpha1.SuspendAction{SuspendCompute: true}
+				return obj
+			}),
+			pod: fake.FakeObj("aaa", func(obj *corev1.Pod) *corev1.Pod {
+				return obj
+			}),
+			expectedStatusChanged: true,
+			expectedStatus:        task.SComplete,
+			expectedObj: fake.FakeObj("aaa", func(obj *v1alpha1.PD) *v1alpha1.PD {
+				obj.Generation = 7
+				cond := coreutil.Suspending()
+				cond.ObservedGeneration = obj.Generation
+				obj.Status.Conditions = []metav1.Condition{*cond}
+				obj.Status.ObservedClusterGeneration = 11
+				return obj
+			}),
+		},
 	}
 
 	for i := range cases {
@@ -891,6 +920,72 @@ func TestTaskGroupConditionSuspended(t *testing.T) {
 				obj.Status.Conditions = []metav1.Condition{
 					*coreutil.Suspending(),
 				}
+				return obj
+			}),
+		},
+		{
+			desc: "stale parent cluster generation is not suspended",
+			obj: fake.FakeObj("aaa", func(obj *v1alpha1.PDGroup) *v1alpha1.PDGroup {
+				obj.Generation = 4
+				return obj
+			}),
+			cluster: fake.FakeObj("aaa", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
+				obj.Generation = 11
+				obj.Spec.SuspendAction = &v1alpha1.SuspendAction{SuspendCompute: true}
+				return obj
+			}),
+			instances: []*v1alpha1.PD{
+				fake.FakeObj("aaa", func(obj *v1alpha1.PD) *v1alpha1.PD {
+					obj.Generation = 7
+					obj.Status.ObservedGeneration = obj.Generation
+					obj.Status.ObservedClusterGeneration = 10
+					cond := coreutil.Suspended()
+					cond.ObservedGeneration = obj.Generation
+					obj.Status.Conditions = []metav1.Condition{*cond}
+					return obj
+				}),
+			},
+			expectedStatusChanged: true,
+			expectedStatus:        task.SComplete,
+			expectedObj: fake.FakeObj("aaa", func(obj *v1alpha1.PDGroup) *v1alpha1.PDGroup {
+				obj.Generation = 4
+				obj.Status.ObservedClusterGeneration = 11
+				cond := coreutil.Suspending()
+				cond.ObservedGeneration = obj.Generation
+				obj.Status.Conditions = []metav1.Condition{*cond}
+				return obj
+			}),
+		},
+		{
+			desc: "all instance and parent generations are current",
+			obj: fake.FakeObj("aaa", func(obj *v1alpha1.PDGroup) *v1alpha1.PDGroup {
+				obj.Generation = 4
+				return obj
+			}),
+			cluster: fake.FakeObj("aaa", func(obj *v1alpha1.Cluster) *v1alpha1.Cluster {
+				obj.Generation = 11
+				obj.Spec.SuspendAction = &v1alpha1.SuspendAction{SuspendCompute: true}
+				return obj
+			}),
+			instances: []*v1alpha1.PD{
+				fake.FakeObj("aaa", func(obj *v1alpha1.PD) *v1alpha1.PD {
+					obj.Generation = 7
+					obj.Status.ObservedGeneration = obj.Generation
+					obj.Status.ObservedClusterGeneration = 11
+					cond := coreutil.Suspended()
+					cond.ObservedGeneration = obj.Generation
+					obj.Status.Conditions = []metav1.Condition{*cond}
+					return obj
+				}),
+			},
+			expectedStatusChanged: true,
+			expectedStatus:        task.SComplete,
+			expectedObj: fake.FakeObj("aaa", func(obj *v1alpha1.PDGroup) *v1alpha1.PDGroup {
+				obj.Generation = 4
+				obj.Status.ObservedClusterGeneration = 11
+				cond := coreutil.Suspended()
+				cond.ObservedGeneration = obj.Generation
+				obj.Status.Conditions = []metav1.Condition{*cond}
 				return obj
 			}),
 		},

--- a/pkg/controllers/dm/builder.go
+++ b/pkg/controllers/dm/builder.go
@@ -51,13 +51,13 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.DM](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.DM](state),
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.DM](state),
 			common.TaskInstanceConditionSynced[scope.DM](state),
 			common.TaskInstanceConditionReady[scope.DM](state),
 			common.TaskInstanceConditionRunning[scope.DM](state),
 			common.TaskStatusPersister[scope.DM](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// list peer DM instances (for config generation)

--- a/pkg/controllers/dmworker/builder.go
+++ b/pkg/controllers/dmworker/builder.go
@@ -50,13 +50,13 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.DMWorker](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.DMWorker](state),
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.DMWorker](state),
 			common.TaskInstanceConditionSynced[scope.DMWorker](state),
 			common.TaskInstanceConditionReady[scope.DMWorker](state),
 			common.TaskInstanceConditionRunning[scope.DMWorker](state),
 			common.TaskStatusPersister[scope.DMWorker](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// health check

--- a/pkg/controllers/pd/builder.go
+++ b/pkg/controllers/pd/builder.go
@@ -51,14 +51,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod
 		common.TaskContextPod[scope.PD](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.PD](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.PD](state), common.TaskInstanceConditionSynced[scope.PD](state),
+			common.TaskInstanceConditionSynced[scope.PD](state),
 			common.TaskInstanceConditionReady[scope.PD](state),
 			common.TaskInstanceConditionRunning[scope.PD](state),
 			common.TaskStatusPersister[scope.PD](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		common.TaskContextPeerSlice[scope.PD](state, r.Client),

--- a/pkg/controllers/resourcemanager/builder.go
+++ b/pkg/controllers/resourcemanager/builder.go
@@ -46,15 +46,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		common.TaskContextPod[scope.ResourceManager](state, r.Client),
 		tasks.TaskContextClient(state, r.PDClientManager),
+		common.TaskInstanceConditionSuspended[scope.ResourceManager](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.ResourceManager](state),
 			common.TaskInstanceConditionSynced[scope.ResourceManager](state),
 			common.TaskInstanceConditionReady[scope.ResourceManager](state),
 			common.TaskInstanceConditionRunning[scope.ResourceManager](state),
 			common.TaskStatusPersister[scope.ResourceManager](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		tasks.TaskConfigMap(state, r.Client),

--- a/pkg/controllers/router/builder.go
+++ b/pkg/controllers/router/builder.go
@@ -46,15 +46,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskFinalizerAdd[scope.Router](state, r.Client),
 
 		common.TaskContextPod[scope.Router](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.Router](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.Router](state),
 			common.TaskInstanceConditionSynced[scope.Router](state),
 			common.TaskInstanceConditionReady[scope.Router](state),
 			common.TaskInstanceConditionRunning[scope.Router](state),
 			common.TaskStatusPersister[scope.Router](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		tasks.TaskConfigMap(state, r.Client),

--- a/pkg/controllers/scheduler/builder.go
+++ b/pkg/controllers/scheduler/builder.go
@@ -55,15 +55,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod
 		common.TaskContextPod[scope.Scheduler](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.Scheduler](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.Scheduler](state),
 			common.TaskInstanceConditionSynced[scope.Scheduler](state),
 			common.TaskInstanceConditionReady[scope.Scheduler](state),
 			common.TaskInstanceConditionRunning[scope.Scheduler](state),
 			common.TaskStatusPersister[scope.Scheduler](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		tasks.TaskConfigMap(state, r.Client),

--- a/pkg/controllers/scheduling/builder.go
+++ b/pkg/controllers/scheduling/builder.go
@@ -55,15 +55,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod
 		common.TaskContextPod[scope.Scheduling](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.Scheduling](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.Scheduling](state),
 			common.TaskInstanceConditionSynced[scope.Scheduling](state),
 			common.TaskInstanceConditionReady[scope.Scheduling](state),
 			common.TaskInstanceConditionRunning[scope.Scheduling](state),
 			common.TaskStatusPersister[scope.Scheduling](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		tasks.TaskConfigMap(state, r.Client),

--- a/pkg/controllers/ticdc/builder.go
+++ b/pkg/controllers/ticdc/builder.go
@@ -54,13 +54,13 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.TiCDC](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiCDC](state),
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiCDC](state),
 			common.TaskInstanceConditionSynced[scope.TiCDC](state),
 			common.TaskInstanceConditionReady[scope.TiCDC](state),
 			common.TaskInstanceConditionRunning[scope.TiCDC](state),
 			common.TaskStatusPersister[scope.TiCDC](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tidb/builder.go
+++ b/pkg/controllers/tidb/builder.go
@@ -60,13 +60,13 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.TiDB](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiDB](state),
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiDB](state),
 			common.TaskInstanceConditionSynced[scope.TiDB](state),
 			common.TaskInstanceConditionReady[scope.TiDB](state),
 			common.TaskInstanceConditionRunning[scope.TiDB](state),
 			common.TaskStatusPersister[scope.TiDB](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tiflash/builder.go
+++ b/pkg/controllers/tiflash/builder.go
@@ -62,16 +62,16 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		),
 
 		common.TaskFinalizerAdd[scope.TiFlash](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiFlash](state),
 
 		// check whether the cluster is suspending
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiFlash](state),
 			common.TaskInstanceConditionSynced[scope.TiFlash](state),
 			common.TaskInstanceConditionReady[scope.TiFlash](state),
 			common.TaskInstanceConditionRunning[scope.TiFlash](state),
 			common.TaskInstanceConditionOffline[scope.TiFlash](state),
 			common.TaskStatusPersister[scope.TiFlash](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tikv/builder.go
+++ b/pkg/controllers/tikv/builder.go
@@ -69,19 +69,19 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		),
 
 		common.TaskFinalizerAdd[scope.TiKV](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiKV](state),
 
 		// check whether the cluster is suspending
 		// if cluster is suspending, we cannot handle any tikv deletion
 		task.IfBreak(common.CondClusterIsSuspending(state),
 			// NOTE: suspend tikv pod should delete with grace peroid
 			// TODO(liubo02): combine with the common one
-			tasks.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiKV](state),
 			common.TaskInstanceConditionSynced[scope.TiKV](state),
 			common.TaskInstanceConditionReady[scope.TiKV](state),
 			common.TaskInstanceConditionRunning[scope.TiKV](state),
 			common.TaskInstanceConditionOffline[scope.TiKV](state),
 			common.TaskStatusPersister[scope.TiKV](state, r.Client),
+			tasks.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tikvworker/builder.go
+++ b/pkg/controllers/tikvworker/builder.go
@@ -54,14 +54,14 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod and check whether the cluster is suspending
 		common.TaskContextPod[scope.TiKVWorker](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiKVWorker](state),
 
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiKVWorker](state),
 			common.TaskInstanceConditionSynced[scope.TiKVWorker](state),
 			common.TaskInstanceConditionReady[scope.TiKVWorker](state),
 			common.TaskInstanceConditionRunning[scope.TiKVWorker](state),
 			common.TaskStatusPersister[scope.TiKVWorker](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tiproxy/builder.go
+++ b/pkg/controllers/tiproxy/builder.go
@@ -55,15 +55,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 			common.TaskStatusPersister[scope.TiProxy](state, r.Client),
 		),
 		common.TaskFinalizerAdd[scope.TiProxy](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TiProxy](state),
 
 		// check whether the cluster is suspending
 		task.IfBreak(common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TiProxy](state),
 			common.TaskInstanceConditionSynced[scope.TiProxy](state),
 			common.TaskInstanceConditionReady[scope.TiProxy](state),
 			common.TaskInstanceConditionRunning[scope.TiProxy](state),
 			common.TaskStatusPersister[scope.TiProxy](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// normal process

--- a/pkg/controllers/tso/builder.go
+++ b/pkg/controllers/tso/builder.go
@@ -56,15 +56,15 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		// get pod
 		common.TaskContextPod[scope.TSO](state, r.Client),
+		common.TaskInstanceConditionSuspended[scope.TSO](state),
 
 		task.IfBreak(
 			common.CondClusterIsSuspending(state),
-			common.TaskSuspendPod(state, r.Client),
-			common.TaskInstanceConditionSuspended[scope.TSO](state),
 			common.TaskInstanceConditionSynced[scope.TSO](state),
 			common.TaskInstanceConditionReady[scope.TSO](state),
 			common.TaskInstanceConditionRunning[scope.TSO](state),
 			common.TaskStatusPersister[scope.TSO](state, r.Client),
+			common.TaskSuspendPod(state, r.Client),
 		),
 
 		// get peers

--- a/pkg/runtime/group.go
+++ b/pkg/runtime/group.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Group interface {
-	Object
+	ClusterObservedObject
 
 	SetReplicas(replicas int32)
 	Replicas() int32

--- a/pkg/runtime/instance.go
+++ b/pkg/runtime/instance.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Instance interface {
-	Object
+	ClusterObservedObject
 
 	GetTopology() v1alpha1.Topology
 	SetTopology(topo v1alpha1.Topology)

--- a/pkg/runtime/instance_mock_generated.go
+++ b/pkg/runtime/instance_mock_generated.go
@@ -474,6 +474,20 @@ func (mr *MockInstanceMockRecorder) IsUpToDate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUpToDate", reflect.TypeOf((*MockInstance)(nil).IsUpToDate))
 }
 
+// ObservedClusterGeneration mocks base method.
+func (m *MockInstance) ObservedClusterGeneration() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObservedClusterGeneration")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// ObservedClusterGeneration indicates an expected call of ObservedClusterGeneration.
+func (mr *MockInstanceMockRecorder) ObservedClusterGeneration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObservedClusterGeneration", reflect.TypeOf((*MockInstance)(nil).ObservedClusterGeneration))
+}
+
 // ObservedGeneration mocks base method.
 func (m *MockInstance) ObservedGeneration() int64 {
 	m.ctrl.T.Helper()
@@ -708,6 +722,18 @@ func (m *MockInstance) SetNamespace(namespace string) {
 func (mr *MockInstanceMockRecorder) SetNamespace(namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespace", reflect.TypeOf((*MockInstance)(nil).SetNamespace), namespace)
+}
+
+// SetObservedClusterGeneration mocks base method.
+func (m *MockInstance) SetObservedClusterGeneration(arg0 int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetObservedClusterGeneration", arg0)
+}
+
+// SetObservedClusterGeneration indicates an expected call of SetObservedClusterGeneration.
+func (mr *MockInstanceMockRecorder) SetObservedClusterGeneration(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObservedClusterGeneration", reflect.TypeOf((*MockInstance)(nil).SetObservedClusterGeneration), arg0)
 }
 
 // SetObservedGeneration mocks base method.

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -47,6 +47,13 @@ type Object interface {
 	ClusterCASecretName() string
 }
 
+type ClusterObservedObject interface {
+	Object
+
+	SetObservedClusterGeneration(int64)
+	ObservedClusterGeneration() int64
+}
+
 type ObjectT[T ObjectSet] interface {
 	Object
 

--- a/pkg/runtime/zz_generated.runtime.dm.go
+++ b/pkg/runtime/zz_generated.runtime.dm.go
@@ -169,6 +169,14 @@ func (in *DM) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *DM) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *DM) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *DM) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *DMGroup) ObservedGeneration() int64 {
 
 func (g *DMGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *DMGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *DMGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *DMGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.dmworker.go
+++ b/pkg/runtime/zz_generated.runtime.dmworker.go
@@ -169,6 +169,14 @@ func (in *DMWorker) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *DMWorker) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *DMWorker) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *DMWorker) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *DMWorkerGroup) ObservedGeneration() int64 {
 
 func (g *DMWorkerGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *DMWorkerGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *DMWorkerGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *DMWorkerGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.pd.go
+++ b/pkg/runtime/zz_generated.runtime.pd.go
@@ -169,6 +169,14 @@ func (in *PD) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *PD) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *PD) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *PD) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *PDGroup) ObservedGeneration() int64 {
 
 func (g *PDGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *PDGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *PDGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *PDGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.resourcemanager.go
+++ b/pkg/runtime/zz_generated.runtime.resourcemanager.go
@@ -169,6 +169,14 @@ func (in *ResourceManager) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *ResourceManager) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *ResourceManager) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *ResourceManager) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *ResourceManagerGroup) ObservedGeneration() int64 {
 
 func (g *ResourceManagerGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *ResourceManagerGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *ResourceManagerGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *ResourceManagerGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.router.go
+++ b/pkg/runtime/zz_generated.runtime.router.go
@@ -169,6 +169,14 @@ func (in *Router) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *Router) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *Router) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *Router) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *RouterGroup) ObservedGeneration() int64 {
 
 func (g *RouterGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *RouterGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *RouterGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *RouterGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.scheduler.go
+++ b/pkg/runtime/zz_generated.runtime.scheduler.go
@@ -169,6 +169,14 @@ func (in *Scheduler) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *Scheduler) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *Scheduler) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *Scheduler) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *SchedulerGroup) ObservedGeneration() int64 {
 
 func (g *SchedulerGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *SchedulerGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *SchedulerGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *SchedulerGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.scheduling.go
+++ b/pkg/runtime/zz_generated.runtime.scheduling.go
@@ -169,6 +169,14 @@ func (in *Scheduling) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *Scheduling) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *Scheduling) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *Scheduling) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *SchedulingGroup) ObservedGeneration() int64 {
 
 func (g *SchedulingGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *SchedulingGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *SchedulingGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *SchedulingGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.ticdc.go
+++ b/pkg/runtime/zz_generated.runtime.ticdc.go
@@ -169,6 +169,14 @@ func (in *TiCDC) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiCDC) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiCDC) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiCDC) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiCDCGroup) ObservedGeneration() int64 {
 
 func (g *TiCDCGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiCDCGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiCDCGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiCDCGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tidb.go
+++ b/pkg/runtime/zz_generated.runtime.tidb.go
@@ -169,6 +169,14 @@ func (in *TiDB) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiDB) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiDB) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiDB) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiDBGroup) ObservedGeneration() int64 {
 
 func (g *TiDBGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiDBGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiDBGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiDBGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tiflash.go
+++ b/pkg/runtime/zz_generated.runtime.tiflash.go
@@ -169,6 +169,14 @@ func (in *TiFlash) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiFlash) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiFlash) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiFlash) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiFlashGroup) ObservedGeneration() int64 {
 
 func (g *TiFlashGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiFlashGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiFlashGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiFlashGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tikv.go
+++ b/pkg/runtime/zz_generated.runtime.tikv.go
@@ -169,6 +169,14 @@ func (in *TiKV) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiKV) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiKV) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiKV) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiKVGroup) ObservedGeneration() int64 {
 
 func (g *TiKVGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiKVGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiKVGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiKVGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tikvworker.go
+++ b/pkg/runtime/zz_generated.runtime.tikvworker.go
@@ -169,6 +169,14 @@ func (in *TiKVWorker) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiKVWorker) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiKVWorker) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiKVWorker) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiKVWorkerGroup) ObservedGeneration() int64 {
 
 func (g *TiKVWorkerGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiKVWorkerGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiKVWorkerGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiKVWorkerGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tiproxy.go
+++ b/pkg/runtime/zz_generated.runtime.tiproxy.go
@@ -169,6 +169,14 @@ func (in *TiProxy) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TiProxy) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TiProxy) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TiProxy) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TiProxyGroup) ObservedGeneration() int64 {
 
 func (g *TiProxyGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TiProxyGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TiProxyGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TiProxyGroup) SetStatusVersion(version string) {

--- a/pkg/runtime/zz_generated.runtime.tso.go
+++ b/pkg/runtime/zz_generated.runtime.tso.go
@@ -169,6 +169,14 @@ func (in *TSO) SetObservedGeneration(gen int64) {
 	in.Status.ObservedGeneration = gen
 }
 
+func (in *TSO) ObservedClusterGeneration() int64 {
+	return in.Status.ObservedClusterGeneration
+}
+
+func (in *TSO) SetObservedClusterGeneration(gen int64) {
+	in.Status.ObservedClusterGeneration = gen
+}
+
 func (in *TSO) SetCluster(cluster string) {
 	in.Spec.Cluster.Name = cluster
 }
@@ -348,6 +356,14 @@ func (g *TSOGroup) ObservedGeneration() int64 {
 
 func (g *TSOGroup) SetObservedGeneration(gen int64) {
 	g.Status.ObservedGeneration = gen
+}
+
+func (g *TSOGroup) ObservedClusterGeneration() int64 {
+	return g.Status.ObservedClusterGeneration
+}
+
+func (g *TSOGroup) SetObservedClusterGeneration(gen int64) {
+	g.Status.ObservedClusterGeneration = gen
 }
 
 func (g *TSOGroup) SetStatusVersion(version string) {

--- a/pkg/utils/hasher/hasher_test.go
+++ b/pkg/utils/hasher/hasher_test.go
@@ -42,7 +42,7 @@ func TestHash(t *testing.T) {
 				},
 			},
 			// not important, feel free to change if tidb group is changed
-			expected: "6c9dc4f5cd",
+			expected: "7cfcc6559b",
 		},
 	}
 

--- a/tests/e2e/cluster/cluster.go
+++ b/tests/e2e/cluster/cluster.go
@@ -67,6 +67,21 @@ const (
 	logLevelConfig = "log.level = 'warn'"
 )
 
+func expectCommonSuspendStatus(
+	g Gomega,
+	status v1alpha1.CommonStatus,
+	resourceGeneration int64,
+	clusterGeneration int64,
+	conditionStatus metav1.ConditionStatus,
+) {
+	g.Expect(status.ObservedGeneration).To(Equal(resourceGeneration))
+	g.Expect(status.ObservedClusterGeneration).To(Equal(clusterGeneration))
+	condition := meta.FindStatusCondition(status.Conditions, v1alpha1.CondSuspended)
+	g.Expect(condition).NotTo(BeNil())
+	g.Expect(condition.Status).To(Equal(conditionStatus))
+	g.Expect(condition.ObservedGeneration).To(Equal(resourceGeneration))
+}
+
 func initK8sClient() (kubernetes.Interface, client.Client, *rest.Config) {
 	restConfig, err := k8s.LoadConfig()
 	Expect(err).NotTo(HaveOccurred())
@@ -438,27 +453,28 @@ var _ = Describe("TiDB Cluster", func() {
 
 		It("should suspend and resume the tidb cluster", func() {
 			checkSuspendCondtion := func(g Gomega, condStatus metav1.ConditionStatus) {
+				var tcGet v1alpha1.Cluster
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: tc.Name}, &tcGet)).To(Succeed())
+
 				var pdGroup v1alpha1.PDGroup
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "pdg"}, &pdGroup)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(pdGroup.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, pdGroup.Status.CommonStatus, pdGroup.Generation, tcGet.Generation, condStatus)
 
 				var tikvGroup v1alpha1.TiKVGroup
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "kvg"}, &tikvGroup)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(tikvGroup.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, tikvGroup.Status.CommonStatus, tikvGroup.Generation, tcGet.Generation, condStatus)
 
 				var tidbGroup v1alpha1.TiDBGroup
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "dbg"}, &tidbGroup)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(tidbGroup.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, tidbGroup.Status.CommonStatus, tidbGroup.Generation, tcGet.Generation, condStatus)
 
 				var flashGroup v1alpha1.TiFlashGroup
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "flashg"}, &flashGroup)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(
-					flashGroup.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, flashGroup.Status.CommonStatus, flashGroup.Generation, tcGet.Generation, condStatus)
 
 				var cdcGroup v1alpha1.TiCDCGroup
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "cdcg"}, &cdcGroup)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(
-					cdcGroup.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, cdcGroup.Status.CommonStatus, cdcGroup.Generation, tcGet.Generation, condStatus)
 
 				var pdList v1alpha1.PDList
 				g.Expect(k8sClient.List(ctx, &pdList, client.InNamespace(tc.Namespace), client.MatchingLabels{
@@ -470,7 +486,7 @@ var _ = Describe("TiDB Cluster", func() {
 				g.Expect(len(pdList.Items)).To(Equal(1))
 				pd := pdList.Items[0]
 				g.Expect(pd.Spec.Cluster.Name).To(Equal(tc.Name))
-				g.Expect(meta.IsStatusConditionPresentAndEqual(pd.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, pd.Status.CommonStatus, pd.Generation, tcGet.Generation, condStatus)
 
 				var tikvList v1alpha1.TiKVList
 				g.Expect(k8sClient.List(ctx, &tikvList, client.InNamespace(tc.Namespace), client.MatchingLabels{
@@ -482,7 +498,7 @@ var _ = Describe("TiDB Cluster", func() {
 				g.Expect(len(tikvList.Items)).To(Equal(1))
 				tikv := tikvList.Items[0]
 				g.Expect(tikv.Spec.Cluster.Name).To(Equal(tc.Name))
-				g.Expect(meta.IsStatusConditionPresentAndEqual(tikv.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, tikv.Status.CommonStatus, tikv.Generation, tcGet.Generation, condStatus)
 
 				var tidbList v1alpha1.TiDBList
 				g.Expect(k8sClient.List(ctx, &tidbList, client.InNamespace(tc.Namespace), client.MatchingLabels{
@@ -494,7 +510,7 @@ var _ = Describe("TiDB Cluster", func() {
 				g.Expect(len(tidbList.Items)).To(Equal(1))
 				tidb := tidbList.Items[0]
 				g.Expect(tidb.Spec.Cluster.Name).To(Equal(tc.Name))
-				g.Expect(meta.IsStatusConditionPresentAndEqual(tidb.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, tidb.Status.CommonStatus, tidb.Generation, tcGet.Generation, condStatus)
 
 				var flashList v1alpha1.TiFlashList
 				g.Expect(k8sClient.List(ctx, &flashList, client.InNamespace(tc.Namespace), client.MatchingLabels{
@@ -506,7 +522,7 @@ var _ = Describe("TiDB Cluster", func() {
 				g.Expect(len(flashList.Items)).To(Equal(1))
 				flash := flashList.Items[0]
 				g.Expect(flash.Spec.Cluster.Name).To(Equal(tc.Name))
-				g.Expect(meta.IsStatusConditionPresentAndEqual(flash.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, flash.Status.CommonStatus, flash.Generation, tcGet.Generation, condStatus)
 
 				var cdcList v1alpha1.TiCDCList
 				g.Expect(k8sClient.List(ctx, &cdcList, client.InNamespace(tc.Namespace), client.MatchingLabels{
@@ -518,11 +534,12 @@ var _ = Describe("TiDB Cluster", func() {
 				g.Expect(len(cdcList.Items)).To(Equal(1))
 				cdc := cdcList.Items[0]
 				g.Expect(cdc.Spec.Cluster.Name).To(Equal(tc.Name))
-				g.Expect(meta.IsStatusConditionPresentAndEqual(cdc.Status.Conditions, v1alpha1.CondSuspended, condStatus)).To(BeTrue())
+				expectCommonSuspendStatus(g, cdc.Status.CommonStatus, cdc.Generation, tcGet.Generation, condStatus)
 
-				var tcGet v1alpha1.Cluster
-				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: tc.Name}, &tcGet)).To(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(tcGet.Status.Conditions, v1alpha1.ClusterCondSuspended, condStatus)).To(BeTrue())
+				clusterCondition := meta.FindStatusCondition(tcGet.Status.Conditions, v1alpha1.ClusterCondSuspended)
+				g.Expect(clusterCondition).NotTo(BeNil())
+				g.Expect(clusterCondition.Status).To(Equal(condStatus))
+				g.Expect(clusterCondition.ObservedGeneration).To(Equal(tcGet.Generation))
 			}
 
 			pdg := data.NewPDGroup(ns.Name, "pdg", tc.Name, ptr.To(int32(1)), nil)


### PR DESCRIPTION
## What problem does this PR solve?

The existing suspend status propagation can aggregate stale child conditions and only covers a subset of component groups. As a result, `ClusterCondSuspended=True` may not represent the latest Cluster generation or all supported compute components.

## What is changed?

- Add `status.observedClusterGeneration` to Group and Instance common status as a parent Cluster reconcile watermark.
- Make Instance suspend status reflect the cached Pod state and persist `False/Suspending` before deleting an existing Pod.
- Require Group aggregation to validate the Instance resource generation, observed Cluster generation, condition generation, and condition status.
- Apply the same freshness checks when Cluster aggregates Group conditions, without making the Cluster controller query Pods directly.
- Extend Cluster suspend aggregation to all supported Group types:
  - PD, TiKV, TiDB, TiFlash, TiCDC, TiProxy
  - ResourceManager, Router, TSO, Scheduling, Scheduler
  - TiKVWorker, DM, and DMWorker
- Add the missing DMGroup and DMWorkerGroup watches to the Cluster controller.
- Update runtime generation, CRD manifests, mocks, unit tests, and the existing suspend/resume E2E assertions.

This remains an informer-cache-based, eventually consistent contract. Consumers should only accept the current Cluster suspend result when:

```text
Cluster.spec.suspendAction.suspendCompute == true
ClusterCondSuspended.status == True
ClusterCondSuspended.observedGeneration == Cluster.metadata.generation
```

## Tests

- `go test ./pkg/... ./cmd/... ./manifests/... ./third_party/...`
- `go test ./tests/e2e/cluster` (compile check)
- `make lint`

The unit tests cover stale resource generations, stale parent Cluster generations, stale condition generations, all 14 Group types, and DM/DMWorker event mapping.
