### PR TITLE
deps: bump pingcap base image to v1.12.2

### DIFF
--- a/cmd/http-service/Dockerfile
+++ b/cmd/http-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.1@sha256:0afd78a822c3ac0d0d572d4f43b434981870a7a79d577fe20238536659605b51
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.2@sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9
 
 ARG TARGETARCH
 RUN dnf install -y tzdata bind-utils && dnf clean all

--- a/images/br-federation-manager/Dockerfile
+++ b/images/br-federation-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.1@sha256:0afd78a822c3ac0d0d572d4f43b434981870a7a79d577fe20238536659605b51
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.2@sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9
 ARG TARGETARCH
 RUN dnf install -y bind-utils tzdata && dnf clean all
 ADD bin/${TARGETARCH}/br-federation-manager /usr/local/bin/br-federation-manager

--- a/images/br-federation-manager/Dockerfile.e2e
+++ b/images/br-federation-manager/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.1@sha256:0afd78a822c3ac0d0d572d4f43b434981870a7a79d577fe20238536659605b51
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.2@sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9
 
 ARG TARGETARCH
 RUN dnf install -y tzdata bind-utils && dnf clean all

--- a/images/tidb-operator/Dockerfile
+++ b/images/tidb-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.1@sha256:0afd78a822c3ac0d0d572d4f43b434981870a7a79d577fe20238536659605b51
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.2@sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9
 
 ARG TARGETARCH
 RUN dnf install -y tzdata bind-utils && dnf clean all

--- a/images/tidb-operator/Dockerfile.e2e
+++ b/images/tidb-operator/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.1@sha256:0afd78a822c3ac0d0d572d4f43b434981870a7a79d577fe20238536659605b51
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.2@sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9
 
 RUN dnf install -y tzdata bash bind-utils && dnf clean all
 


### PR DESCRIPTION
### What problem does this PR solve?

Bump the `ghcr.io/pingcap-qe/bases/pingcap-base` base image from v1.12.1 to v1.12.2 (digest-pinned) across the five Dockerfiles that reference it. This is a routine base-image refresh, picking up the latest base image patch release as a follow-up to #7018.

### What is changed and how does it work?

No operator code changes. Only the `FROM` line of five Dockerfiles is updated:

- `cmd/http-service/Dockerfile`
- `images/br-federation-manager/Dockerfile`
- `images/br-federation-manager/Dockerfile.e2e`
- `images/tidb-operator/Dockerfile`
- `images/tidb-operator/Dockerfile.e2e`

The tag moves `v1.12.1` -> `v1.12.2` and the digest is re-pinned to the v1.12.2 manifest-list digest (`sha256:07772021ca1a9e31f6f89c745c15a577a1cd752da3c6df0f64e9453b8091cfb9`), obtained from the ghcr.io registry (anonymous token + `Docker-Content-Digest` header on the manifest-list media type). This matches the digest-pinning convention used in #7018 / #7019.

A release-1.6 counterpart is opened separately (#7021) — independent edit, since the two branches' Dockerfiles are independent and a cherry-pick of a single-line FROM change adds no value over a direct edit.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test
- [x] No code

Local verification:
- `git diff` shows exactly the five `FROM` lines changed, nothing else.
- `grep -rn 'v1\.12\.1'` across the repo returns no remaining references; all five Dockerfiles now reference `pingcap-base:v1.12.2@sha256:07772021...`.
- The digest matches the v1.12.2 manifest-list digest returned by the ghcr registry, and the v1.12.1 digest (`0afd...`) previously pinned in these files matches the same query against the v1.12.1 tag, confirming the digest type is consistent.

### Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects: base image patch release; no functional change expected. CI image builds will pull the new base layer.

### Related changes

- [x] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Counterpart PR on release-1.6: #7021.

### Release Notes

```release-note
Bump the pingcap base image to v1.12.2.
```