### PR TITLE
pdms: use evict API for TSO primary transfer

### DIFF
--- a/pkg/pdapi/pdms_api.go
+++ b/pkg/pdapi/pdms_api.go
@@ -35,6 +35,7 @@ type PDMSClient interface {
 
 var (
 	pdMSHealthPrefix          = "api/v1/health"
+	pdMSPrimaryEvictPrefix    = "api/v1/primary/evict"
 	pdMSPrimaryTransferPrefix = "api/v1/primary/transfer"
 )
 
@@ -76,7 +77,6 @@ func (c *pdMSClient) GetHealth() error {
 }
 
 func (c *pdMSClient) TransferPrimary(newPrimary string) error {
-	apiURL := fmt.Sprintf("%s/%s/%s", c.url, c.serviceName, pdMSPrimaryTransferPrefix)
 	data, err := json.Marshal(struct {
 		NewPrimary string `json:"new_primary"`
 	}{
@@ -85,10 +85,14 @@ func (c *pdMSClient) TransferPrimary(newPrimary string) error {
 	if err != nil {
 		return err
 	}
-	_, err = httputil.PostBodyOK(c.httpClient, apiURL, bytes.NewBuffer(data))
-	if err != nil {
-		return err
+	if c.serviceName == TSOServiceName {
+		evictURL := fmt.Sprintf("%s/%s/%s", c.url, c.serviceName, pdMSPrimaryEvictPrefix)
+		_, err := httputil.PostBodyOK(c.httpClient, evictURL, bytes.NewBuffer(data))
+		if err == nil {
+			return nil
+		}
 	}
-
-	return nil
+	apiURL := fmt.Sprintf("%s/%s/%s", c.url, c.serviceName, pdMSPrimaryTransferPrefix)
+	_, err = httputil.PostBodyOK(c.httpClient, apiURL, bytes.NewBuffer(data))
+	return err
 }


### PR DESCRIPTION
### What problem does this PR solve?

TSO service may have multiple keyspace groups, each with its own primary. The old transfer API only handles a single group's primary. This PR uses the new evict API (introduced in tikv/pd#10968) that transfers all keyspace group primaries from the TSO node at once.

### What is changed and how does it work?

- Add `pdMSPrimaryEvictPrefix = "api/v1/primary/evict"` constant
- In `TransferPrimary`, for TSO service, try the evict API first (POST /tso/api/v1/primary/evict). If it succeeds, return. On failure (old PD without evict support), fall back to the old transfer API (POST /tso/api/v1/primary/transfer).
- Non-TSO services (router, scheduler) continue to use the transfer API directly.

### Code changes

- Has Go code change

### Tests

- Unit test (existing tests pass)

### Related changes

Related to tikv/pd#10968