### PR TITLE
feat: aggregate group readiness in cluster status

### DIFF
--- a/api/core/v1alpha1/cluster_types.go
+++ b/api/core/v1alpha1/cluster_types.go
@@ -260,8 +260,6 @@ const (
 	ClusterCondSuspended = "Suspended"
 	ClusterSuspendReason = "ClusterSuspend"
 
-	ClusterCondReady    = "Ready"
 	ClusterReadyReason  = "ClusterReady"
-	ClusterCondSynced   = "Synced"
 	ClusterSyncedReason = "ClusterSynced"
 )

--- a/api/core/v1alpha1/cluster_types.go
+++ b/api/core/v1alpha1/cluster_types.go
@@ -259,4 +259,7 @@ const (
 
 	ClusterCondSuspended = "Suspended"
 	ClusterSuspendReason = "ClusterSuspend"
+
+	ClusterCondReady  = "Ready"
+	ClusterCondSynced = "Synced"
 )

--- a/api/core/v1alpha1/cluster_types.go
+++ b/api/core/v1alpha1/cluster_types.go
@@ -260,6 +260,8 @@ const (
 	ClusterCondSuspended = "Suspended"
 	ClusterSuspendReason = "ClusterSuspend"
 
-	ClusterCondReady  = "Ready"
-	ClusterCondSynced = "Synced"
+	ClusterCondReady    = "Ready"
+	ClusterReadyReason  = "ClusterReady"
+	ClusterCondSynced   = "Synced"
+	ClusterSyncedReason = "ClusterSynced"
 )

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -216,20 +216,39 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	changed = meta.SetStatusCondition(&rtx.Cluster.Status.Conditions, availCond) || changed
 
 	clusterGeneration := rtx.Cluster.Generation
-	suspended := groupsSuspended[scope.PDGroup](rtx.PDGroups, clusterGeneration) &&
-		groupsSuspended[scope.ResourceManagerGroup](rtx.ResourceManagerGroups, clusterGeneration) &&
-		groupsSuspended[scope.RouterGroup](rtx.RouterGroups, clusterGeneration) &&
-		groupsSuspended[scope.TSOGroup](rtx.TSOGroups, clusterGeneration) &&
-		groupsSuspended[scope.SchedulingGroup](rtx.SchedulingGroups, clusterGeneration) &&
-		groupsSuspended[scope.SchedulerGroup](rtx.SchedulerGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiKVGroup](rtx.TiKVGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiFlashGroup](rtx.TiFlashGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiDBGroup](rtx.TiDBGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiCDCGroup](rtx.TiCDCGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiProxyGroup](rtx.TiProxyGroups, clusterGeneration) &&
-		groupsSuspended[scope.TiKVWorkerGroup](rtx.TiKVWorkerGroups, clusterGeneration) &&
-		groupsSuspended[scope.DMGroup](rtx.DMGroups, clusterGeneration) &&
-		groupsSuspended[scope.DMWorkerGroup](rtx.DMWorkerGroups, clusterGeneration)
+	suspended := allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSuspended)
+	// Cluster does not own the desired Group topology, so Ready and Synced aggregate only Groups
+	// currently observed by the cache. Callers must keep the topology complete and stable while
+	// using these conditions as pause/resume completion signals.
+	groupCount := len(rtx.PDGroups) + len(rtx.ResourceManagerGroups) + len(rtx.RouterGroups) +
+		len(rtx.TSOGroups) + len(rtx.SchedulingGroups) + len(rtx.SchedulerGroups) +
+		len(rtx.TiKVGroups) + len(rtx.TiFlashGroups) + len(rtx.TiDBGroups) +
+		len(rtx.TiCDCGroups) + len(rtx.TiProxyGroups) + len(rtx.TiKVWorkerGroups) +
+		len(rtx.DMGroups) + len(rtx.DMWorkerGroups)
+	// TODO: Bind observedClusterGeneration to Group/Instance Ready and Synced updates, so lower-level
+	// conditions can become true only after reconciling the current Cluster generation. For now, the
+	// Cluster aggregation validates observedClusterGeneration separately.
+	for _, condition := range []struct {
+		conditionType string
+		allTrue       bool
+	}{
+		{v1alpha1.ClusterCondReady, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady)},
+		{v1alpha1.ClusterCondSynced, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced)},
+	} {
+		status := metav1.ConditionFalse
+		message := fmt.Sprintf("Not all Groups have %s=True for the current Cluster generation", condition.conditionType)
+		if condition.allTrue {
+			status = metav1.ConditionTrue
+			message = fmt.Sprintf("All Groups have %s=True for the current Cluster generation", condition.conditionType)
+		}
+		changed = meta.SetStatusCondition(&rtx.Cluster.Status.Conditions, metav1.Condition{
+			Type:               condition.conditionType,
+			Status:             status,
+			ObservedGeneration: rtx.Cluster.Generation,
+			Reason:             "Cluster" + condition.conditionType,
+			Message:            message,
+		}) || changed
+	}
 	var (
 		suspendStatus  = metav1.ConditionFalse
 		suspendMessage = "Cluster is not suspended"
@@ -252,22 +271,37 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	}) || changed
 }
 
-func groupsSuspended[
+func groupsConditionsTrue[
 	S scope.Group[F, T],
 	F client.Object,
 	T runtime.Group,
-](groups []F, clusterGeneration int64) bool {
+](groups []F, clusterGeneration int64, conditionTypes ...string) bool {
 	for _, group := range groups {
-		if !coreutil.IsStatusConditionTrueForCluster[S](
-			group,
-			v1alpha1.CondSuspended,
-			clusterGeneration,
-		) {
-			return false
+		for _, conditionType := range conditionTypes {
+			if !coreutil.IsStatusConditionTrueForCluster[S](group, conditionType, clusterGeneration) {
+				return false
+			}
 		}
 	}
 
 	return true
+}
+
+func allGroupConditionsTrue(rtx *ReconcileContext, clusterGeneration int64, conditionTypes ...string) bool {
+	return groupsConditionsTrue[scope.PDGroup](rtx.PDGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.ResourceManagerGroup](rtx.ResourceManagerGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.RouterGroup](rtx.RouterGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TSOGroup](rtx.TSOGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.SchedulingGroup](rtx.SchedulingGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.SchedulerGroup](rtx.SchedulerGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiKVGroup](rtx.TiKVGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiFlashGroup](rtx.TiFlashGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiDBGroup](rtx.TiDBGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiCDCGroup](rtx.TiCDCGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiProxyGroup](rtx.TiProxyGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.TiKVWorkerGroup](rtx.TiKVWorkerGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.DMGroup](rtx.DMGroups, clusterGeneration, conditionTypes...) &&
+		groupsConditionsTrue[scope.DMWorkerGroup](rtx.DMWorkerGroups, clusterGeneration, conditionTypes...)
 }
 
 func (t *TaskStatus) syncClusterID(ctx context.Context, rtx *ReconcileContext) bool {

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -233,8 +233,16 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 		reason        string
 		allTrue       bool
 	}{
-		{v1alpha1.ClusterCondReady, v1alpha1.ClusterReadyReason, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady)},
-		{v1alpha1.ClusterCondSynced, v1alpha1.ClusterSyncedReason, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced)},
+		{
+			v1alpha1.ClusterCondReady,
+			v1alpha1.ClusterReadyReason,
+			groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady),
+		},
+		{
+			v1alpha1.ClusterCondSynced,
+			v1alpha1.ClusterSyncedReason,
+			groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced),
+		},
 	} {
 		status := metav1.ConditionFalse
 		message := fmt.Sprintf("Not all Groups have %s=True for the current Cluster generation", condition.conditionType)

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -230,14 +230,17 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	// Cluster aggregation validates observedClusterGeneration separately.
 	for _, condition := range []struct {
 		conditionType string
+		reason        string
 		allTrue       bool
 	}{
-		{v1alpha1.ClusterCondReady, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady)},
-		{v1alpha1.ClusterCondSynced, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced)},
+		{v1alpha1.ClusterCondReady, v1alpha1.ClusterReadyReason, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady)},
+		{v1alpha1.ClusterCondSynced, v1alpha1.ClusterSyncedReason, groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced)},
 	} {
 		status := metav1.ConditionFalse
 		message := fmt.Sprintf("Not all Groups have %s=True for the current Cluster generation", condition.conditionType)
-		if condition.allTrue {
+		if groupCount == 0 {
+			message = "No Groups are currently observed by the controller cache"
+		} else if condition.allTrue {
 			status = metav1.ConditionTrue
 			message = fmt.Sprintf("All Groups have %s=True for the current Cluster generation", condition.conditionType)
 		}
@@ -245,7 +248,7 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 			Type:               condition.conditionType,
 			Status:             status,
 			ObservedGeneration: rtx.Cluster.Generation,
-			Reason:             "Cluster" + condition.conditionType,
+			Reason:             condition.reason,
 			Message:            message,
 		}) || changed
 	}

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -216,7 +217,7 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	changed = meta.SetStatusCondition(&rtx.Cluster.Status.Conditions, availCond) || changed
 
 	clusterGeneration := rtx.Cluster.Generation
-	suspended := allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSuspended)
+	suspended := len(groupsNotSatisfyingCondition(rtx, clusterGeneration, v1alpha1.CondSuspended)) == 0
 	// Cluster does not own the desired Group topology, so Ready and Synced aggregate only Groups
 	// currently observed by the cache. Callers must keep the topology complete and stable while
 	// using these conditions as pause/resume completion signals.
@@ -228,29 +229,37 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	// TODO: Bind observedClusterGeneration to Group/Instance Ready and Synced updates, so lower-level
 	// conditions can become true only after reconciling the current Cluster generation. For now, the
 	// Cluster aggregation validates observedClusterGeneration separately.
+	groupsNotReady := groupsNotSatisfyingCondition(rtx, clusterGeneration, v1alpha1.CondReady)
+	groupsNotSynced := groupsNotSatisfyingCondition(rtx, clusterGeneration, v1alpha1.CondSynced)
 	for _, condition := range []struct {
 		conditionType string
 		reason        string
-		allTrue       bool
+		failedGroups  []string
 	}{
 		{
-			v1alpha1.ClusterCondReady,
+			v1alpha1.CondReady,
 			v1alpha1.ClusterReadyReason,
-			groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondReady),
+			groupsNotReady,
 		},
 		{
-			v1alpha1.ClusterCondSynced,
+			v1alpha1.CondSynced,
 			v1alpha1.ClusterSyncedReason,
-			groupCount > 0 && allGroupConditionsTrue(rtx, clusterGeneration, v1alpha1.CondSynced),
+			groupsNotSynced,
 		},
 	} {
 		status := metav1.ConditionFalse
-		message := fmt.Sprintf("Not all Groups have %s=True for the current Cluster generation", condition.conditionType)
-		if groupCount == 0 {
-			message = "No Groups are currently observed by the controller cache"
-		} else if condition.allTrue {
-			status = metav1.ConditionTrue
-			message = fmt.Sprintf("All Groups have %s=True for the current Cluster generation", condition.conditionType)
+		message := "No Groups are currently observed by the controller cache"
+		if groupCount > 0 {
+			if len(condition.failedGroups) == 0 {
+				status = metav1.ConditionTrue
+				message = fmt.Sprintf("All Groups have %s=True for the current Cluster generation", condition.conditionType)
+			} else {
+				message = fmt.Sprintf(
+					"Groups not satisfying %s for the current Cluster generation: %s",
+					condition.conditionType,
+					strings.Join(condition.failedGroups, ", "),
+				)
+			}
 		}
 		changed = meta.SetStatusCondition(&rtx.Cluster.Status.Conditions, metav1.Condition{
 			Type:               condition.conditionType,
@@ -282,37 +291,38 @@ func (*TaskStatus) syncConditions(rtx *ReconcileContext) bool {
 	}) || changed
 }
 
-func groupsConditionsTrue[
+func appendGroupsNotSatisfyingCondition[
 	S scope.Group[F, T],
 	F client.Object,
 	T runtime.Group,
-](groups []F, clusterGeneration int64, conditionTypes ...string) bool {
+](failedGroups []string, groups []F, clusterGeneration int64, conditionType string) []string {
+	kind := scope.GVK[S]().Kind
 	for _, group := range groups {
-		for _, conditionType := range conditionTypes {
-			if !coreutil.IsStatusConditionTrueForCluster[S](group, conditionType, clusterGeneration) {
-				return false
-			}
+		if !coreutil.IsStatusConditionTrueForCluster[S](group, conditionType, clusterGeneration) {
+			failedGroups = append(failedGroups, kind+"/"+group.GetName())
 		}
 	}
 
-	return true
+	return failedGroups
 }
 
-func allGroupConditionsTrue(rtx *ReconcileContext, clusterGeneration int64, conditionTypes ...string) bool {
-	return groupsConditionsTrue[scope.PDGroup](rtx.PDGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.ResourceManagerGroup](rtx.ResourceManagerGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.RouterGroup](rtx.RouterGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TSOGroup](rtx.TSOGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.SchedulingGroup](rtx.SchedulingGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.SchedulerGroup](rtx.SchedulerGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiKVGroup](rtx.TiKVGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiFlashGroup](rtx.TiFlashGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiDBGroup](rtx.TiDBGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiCDCGroup](rtx.TiCDCGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiProxyGroup](rtx.TiProxyGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.TiKVWorkerGroup](rtx.TiKVWorkerGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.DMGroup](rtx.DMGroups, clusterGeneration, conditionTypes...) &&
-		groupsConditionsTrue[scope.DMWorkerGroup](rtx.DMWorkerGroups, clusterGeneration, conditionTypes...)
+func groupsNotSatisfyingCondition(rtx *ReconcileContext, clusterGeneration int64, conditionType string) []string {
+	var groups []string
+	groups = appendGroupsNotSatisfyingCondition[scope.PDGroup](groups, rtx.PDGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.ResourceManagerGroup](groups, rtx.ResourceManagerGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.RouterGroup](groups, rtx.RouterGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TSOGroup](groups, rtx.TSOGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.SchedulingGroup](groups, rtx.SchedulingGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.SchedulerGroup](groups, rtx.SchedulerGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiKVGroup](groups, rtx.TiKVGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiFlashGroup](groups, rtx.TiFlashGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiDBGroup](groups, rtx.TiDBGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiCDCGroup](groups, rtx.TiCDCGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiProxyGroup](groups, rtx.TiProxyGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.TiKVWorkerGroup](groups, rtx.TiKVWorkerGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.DMGroup](groups, rtx.DMGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.DMWorkerGroup](groups, rtx.DMWorkerGroups, clusterGeneration, conditionType)
+	return groups
 }
 
 func (t *TaskStatus) syncClusterID(ctx context.Context, rtx *ReconcileContext) bool {

--- a/pkg/controllers/cluster/tasks/status.go
+++ b/pkg/controllers/cluster/tasks/status.go
@@ -309,7 +309,9 @@ func appendGroupsNotSatisfyingCondition[
 func groupsNotSatisfyingCondition(rtx *ReconcileContext, clusterGeneration int64, conditionType string) []string {
 	var groups []string
 	groups = appendGroupsNotSatisfyingCondition[scope.PDGroup](groups, rtx.PDGroups, clusterGeneration, conditionType)
-	groups = appendGroupsNotSatisfyingCondition[scope.ResourceManagerGroup](groups, rtx.ResourceManagerGroups, clusterGeneration, conditionType)
+	groups = appendGroupsNotSatisfyingCondition[scope.ResourceManagerGroup](
+		groups, rtx.ResourceManagerGroups, clusterGeneration, conditionType,
+	)
 	groups = appendGroupsNotSatisfyingCondition[scope.RouterGroup](groups, rtx.RouterGroups, clusterGeneration, conditionType)
 	groups = appendGroupsNotSatisfyingCondition[scope.TSOGroup](groups, rtx.TSOGroups, clusterGeneration, conditionType)
 	groups = appendGroupsNotSatisfyingCondition[scope.SchedulingGroup](groups, rtx.SchedulingGroups, clusterGeneration, conditionType)

--- a/pkg/controllers/cluster/tasks/status_test.go
+++ b/pkg/controllers/cluster/tasks/status_test.go
@@ -267,6 +267,11 @@ func TestSyncConditionsAggregatesGroupReadiness(t *testing.T) {
 	assertReadyAndSynced(false, true)
 	rtx.PDGroups = nil
 	assertReadyAndSynced(false, false)
+	for _, conditionType := range []string{v1alpha1.ClusterCondReady, v1alpha1.ClusterCondSynced} {
+		condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
+		require.NotNil(t, condition)
+		assert.Equal(t, "No Groups are currently observed by the controller cache", condition.Message)
+	}
 }
 
 func newFakePDClientManager(t *testing.T, c client.Client, acts ...action) pdm.PDClientManager {

--- a/pkg/controllers/cluster/tasks/status_test.go
+++ b/pkg/controllers/cluster/tasks/status_test.go
@@ -79,6 +79,14 @@ func TestStatusUpdater(t *testing.T) {
 					Status: metav1.ConditionFalse,
 				},
 				{
+					Type:   v1alpha1.ClusterCondReady,
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   v1alpha1.ClusterCondSynced,
+					Status: metav1.ConditionFalse,
+				},
+				{
 					Type:   v1alpha1.ClusterCondSuspended,
 					Status: metav1.ConditionFalse,
 				},
@@ -216,6 +224,49 @@ func TestSyncSuspendedConditionCoversAllGroupTypes(t *testing.T) {
 			status.ObservedClusterGeneration++
 		})
 	}
+}
+
+func TestSyncConditionsAggregatesGroupReadiness(t *testing.T) {
+	const groupGeneration, clusterGeneration = int64(3), int64(7)
+	group := &v1alpha1.PDGroup{
+		ObjectMeta: metav1.ObjectMeta{Generation: groupGeneration},
+		Status: v1alpha1.PDGroupStatus{CommonStatus: v1alpha1.CommonStatus{
+			ObservedGeneration:        groupGeneration,
+			ObservedClusterGeneration: clusterGeneration,
+			Conditions: []metav1.Condition{
+				{Type: v1alpha1.CondReady, Status: metav1.ConditionTrue, ObservedGeneration: groupGeneration},
+				{Type: v1alpha1.CondSynced, Status: metav1.ConditionTrue, ObservedGeneration: groupGeneration},
+			},
+		}},
+	}
+	cluster := &v1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Generation: clusterGeneration}}
+	rtx := &ReconcileContext{Cluster: cluster, PDGroups: []*v1alpha1.PDGroup{group}}
+	taskStatus := &TaskStatus{}
+	assertReadyAndSynced := func(wantReady, wantSynced bool) {
+		t.Helper()
+		taskStatus.syncConditions(rtx)
+		for conditionType, want := range map[string]bool{
+			v1alpha1.ClusterCondReady:  wantReady,
+			v1alpha1.ClusterCondSynced: wantSynced,
+		} {
+			condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
+			require.NotNil(t, condition)
+			assert.Equal(t, want, condition.Status == metav1.ConditionTrue)
+			assert.Equal(t, clusterGeneration, condition.ObservedGeneration)
+		}
+	}
+
+	assertReadyAndSynced(true, true)
+	group.Status.ObservedClusterGeneration--
+	assertReadyAndSynced(false, false)
+	group.Status.ObservedClusterGeneration++
+	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondSynced).Status = metav1.ConditionFalse
+	assertReadyAndSynced(true, false)
+	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondReady).Status = metav1.ConditionFalse
+	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondSynced).Status = metav1.ConditionTrue
+	assertReadyAndSynced(false, true)
+	rtx.PDGroups = nil
+	assertReadyAndSynced(false, false)
 }
 
 func newFakePDClientManager(t *testing.T, c client.Client, acts ...action) pdm.PDClientManager {

--- a/pkg/controllers/cluster/tasks/status_test.go
+++ b/pkg/controllers/cluster/tasks/status_test.go
@@ -79,11 +79,11 @@ func TestStatusUpdater(t *testing.T) {
 					Status: metav1.ConditionFalse,
 				},
 				{
-					Type:   v1alpha1.ClusterCondReady,
+					Type:   v1alpha1.CondReady,
 					Status: metav1.ConditionFalse,
 				},
 				{
-					Type:   v1alpha1.ClusterCondSynced,
+					Type:   v1alpha1.CondSynced,
 					Status: metav1.ConditionFalse,
 				},
 				{
@@ -229,7 +229,7 @@ func TestSyncSuspendedConditionCoversAllGroupTypes(t *testing.T) {
 func TestSyncConditionsAggregatesGroupReadiness(t *testing.T) {
 	const groupGeneration, clusterGeneration = int64(3), int64(7)
 	group := &v1alpha1.PDGroup{
-		ObjectMeta: metav1.ObjectMeta{Generation: groupGeneration},
+		ObjectMeta: metav1.ObjectMeta{Name: "pd-0", Generation: groupGeneration},
 		Status: v1alpha1.PDGroupStatus{CommonStatus: v1alpha1.CommonStatus{
 			ObservedGeneration:        groupGeneration,
 			ObservedClusterGeneration: clusterGeneration,
@@ -246,8 +246,8 @@ func TestSyncConditionsAggregatesGroupReadiness(t *testing.T) {
 		t.Helper()
 		taskStatus.syncConditions(rtx)
 		for conditionType, want := range map[string]bool{
-			v1alpha1.ClusterCondReady:  wantReady,
-			v1alpha1.ClusterCondSynced: wantSynced,
+			v1alpha1.CondReady:  wantReady,
+			v1alpha1.CondSynced: wantSynced,
 		} {
 			condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
 			require.NotNil(t, condition)
@@ -262,12 +262,13 @@ func TestSyncConditionsAggregatesGroupReadiness(t *testing.T) {
 	group.Status.ObservedClusterGeneration++
 	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondSynced).Status = metav1.ConditionFalse
 	assertReadyAndSynced(true, false)
+	assert.Contains(t, meta.FindStatusCondition(cluster.Status.Conditions, v1alpha1.CondSynced).Message, "PDGroup/pd-0")
 	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondReady).Status = metav1.ConditionFalse
 	meta.FindStatusCondition(group.Status.Conditions, v1alpha1.CondSynced).Status = metav1.ConditionTrue
 	assertReadyAndSynced(false, true)
 	rtx.PDGroups = nil
 	assertReadyAndSynced(false, false)
-	for _, conditionType := range []string{v1alpha1.ClusterCondReady, v1alpha1.ClusterCondSynced} {
+	for _, conditionType := range []string{v1alpha1.CondReady, v1alpha1.CondSynced} {
 		condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
 		require.NotNil(t, condition)
 		assert.Equal(t, "No Groups are currently observed by the controller cache", condition.Message)


### PR DESCRIPTION
## What

- add Cluster-level `Ready` and `Synced` conditions
- aggregate each condition independently across all observed Group types
- require every Group condition to be `True` for the current Group and Cluster generations
- keep the existing `Suspended` aggregation on the shared condition helper
- report `Ready=False` and `Synced=False` when no Groups are observed

## Why

`Suspended=False` only indicates that the desired state has switched to resume. It does not guarantee that all compute Groups have finished reconciling and become usable.

With these Cluster-level conditions, an upper-level controller can determine resume completion by reading only the Cluster:

- effective `suspendCompute == false`
- current-generation `Suspended=False`
- current-generation `Ready=True`
- current-generation `Synced=True`

`Ready` and `Synced` are aggregated independently, so they also show whether resume is waiting for readiness or synchronization.

## Notes

The Cluster API does not own the desired Group topology. The aggregation therefore covers Groups currently observed by the controller cache. Callers must ensure that the Group topology is complete and stable while using these conditions as pause/resume completion signals.

For now, `observedClusterGeneration` is validated by the Cluster aggregation. Binding it directly to Group/Instance `Ready` and `Synced` updates is left as a follow-up.

## Tests

```sh
go test ./pkg/controllers/cluster/...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear cluster status indicators for readiness and synchronization.
  * Cluster readiness and synchronization now reflect the status of all observed groups.
  * Conditions remain false when groups are missing, outdated, or not ready.
  * Status messages identify groups preventing the cluster from becoming ready or synchronized.

* **Bug Fixes**
  * Improved cluster status accuracy when group conditions change, become stale, or are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->