### PR TITLE
fix: support PVC overlays for DM built-in volumes

### DIFF
--- a/api/core/v1alpha1/dm_types.go
+++ b/api/core/v1alpha1/dm_types.go
@@ -133,7 +133,7 @@ type DMTemplate struct {
 }
 
 // DMTemplateSpec can only be specified in DMGroup
-// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || (has(self.volumes) && self.overlay.volumeClaims.all(vc, vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in volumes"
+// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, vc.name == self.dataVolume.name || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in dataVolume or volumes"
 type DMTemplateSpec struct {
 	// Version must be a semantic version.
 	// It can have a v prefix or not.

--- a/api/core/v1alpha1/dm_types.go
+++ b/api/core/v1alpha1/dm_types.go
@@ -133,7 +133,7 @@ type DMTemplate struct {
 }
 
 // DMTemplateSpec can only be specified in DMGroup
-// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, vc.name == self.dataVolume.name || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in dataVolume or volumes"
+// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, vc.name in [self.dataVolume.name] || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in dataVolume or volumes"
 type DMTemplateSpec struct {
 	// Version must be a semantic version.
 	// It can have a v prefix or not.

--- a/api/core/v1alpha1/dmworker_types.go
+++ b/api/core/v1alpha1/dmworker_types.go
@@ -140,7 +140,7 @@ type DMWorkerTemplate struct {
 }
 
 // DMWorkerTemplateSpec can only be specified in DMWorkerGroup
-// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, (has(self.relayVolume) && vc.name == self.relayVolume.name) || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in relayVolume or volumes"
+// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, (has(self.relayVolume) && vc.name in [self.relayVolume.name]) || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in relayVolume or volumes"
 type DMWorkerTemplateSpec struct {
 	// Version must be a semantic version.
 	// It can have a v prefix or not.

--- a/api/core/v1alpha1/dmworker_types.go
+++ b/api/core/v1alpha1/dmworker_types.go
@@ -140,7 +140,7 @@ type DMWorkerTemplate struct {
 }
 
 // DMWorkerTemplateSpec can only be specified in DMWorkerGroup
-// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || (has(self.volumes) && self.overlay.volumeClaims.all(vc, vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in volumes"
+// +kubebuilder:validation:XValidation:rule="!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc, (has(self.relayVolume) && vc.name == self.relayVolume.name) || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))",message="overlay volumeClaims names must exist in relayVolume or volumes"
 type DMWorkerTemplateSpec struct {
 	// Version must be a semantic version.
 	// It can have a v prefix or not.

--- a/manifests/crd/core.pingcap.com_dmgroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmgroups.yaml
@@ -8841,10 +8841,11 @@ spec:
                     - version
                     type: object
                     x-kubernetes-validations:
-                    - message: overlay volumeClaims names must exist in volumes
+                    - message: overlay volumeClaims names must exist in dataVolume
+                        or volumes
                       rule: '!has(self.overlay) || !has(self.overlay.volumeClaims)
-                        || (has(self.volumes) && self.overlay.volumeClaims.all(vc,
-                        vc.name in self.volumes.map(v, v.name)))'
+                        || self.overlay.volumeClaims.all(vc, vc.name == self.dataVolume.name
+                        || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))'
                 required:
                 - spec
                 type: object

--- a/manifests/crd/core.pingcap.com_dmgroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmgroups.yaml
@@ -8844,7 +8844,7 @@ spec:
                     - message: overlay volumeClaims names must exist in dataVolume
                         or volumes
                       rule: '!has(self.overlay) || !has(self.overlay.volumeClaims)
-                        || self.overlay.volumeClaims.all(vc, vc.name == self.dataVolume.name
+                        || self.overlay.volumeClaims.all(vc, vc.name in [self.dataVolume.name]
                         || (has(self.volumes) && vc.name in self.volumes.map(v, v.name)))'
                 required:
                 - spec

--- a/manifests/crd/core.pingcap.com_dms.yaml
+++ b/manifests/crd/core.pingcap.com_dms.yaml
@@ -8578,8 +8578,8 @@ spec:
                 && has(self.topology))
             - message: overlay volumeClaims names must exist in dataVolume or volumes
               rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc,
-                vc.name == self.dataVolume.name || (has(self.volumes) && vc.name in
-                self.volumes.map(v, v.name)))'
+                vc.name in [self.dataVolume.name] || (has(self.volumes) && vc.name
+                in self.volumes.map(v, v.name)))'
           status:
             description: DMStatus defines the observed state of a DM master instance
             properties:

--- a/manifests/crd/core.pingcap.com_dms.yaml
+++ b/manifests/crd/core.pingcap.com_dms.yaml
@@ -8576,10 +8576,10 @@ spec:
               message: topology can only be set when creating
               rule: (!has(oldSelf.topology) && !has(self.topology)) || (has(oldSelf.topology)
                 && has(self.topology))
-            - message: overlay volumeClaims names must exist in volumes
-              rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || (has(self.volumes)
-                && self.overlay.volumeClaims.all(vc, vc.name in self.volumes.map(v,
-                v.name)))'
+            - message: overlay volumeClaims names must exist in dataVolume or volumes
+              rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc,
+                vc.name == self.dataVolume.name || (has(self.volumes) && vc.name in
+                self.volumes.map(v, v.name)))'
           status:
             description: DMStatus defines the observed state of a DM master instance
             properties:

--- a/manifests/crd/core.pingcap.com_dmworkergroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkergroups.yaml
@@ -8844,10 +8844,12 @@ spec:
                     - version
                     type: object
                     x-kubernetes-validations:
-                    - message: overlay volumeClaims names must exist in volumes
+                    - message: overlay volumeClaims names must exist in relayVolume
+                        or volumes
                       rule: '!has(self.overlay) || !has(self.overlay.volumeClaims)
-                        || (has(self.volumes) && self.overlay.volumeClaims.all(vc,
-                        vc.name in self.volumes.map(v, v.name)))'
+                        || self.overlay.volumeClaims.all(vc, (has(self.relayVolume)
+                        && vc.name == self.relayVolume.name) || (has(self.volumes)
+                        && vc.name in self.volumes.map(v, v.name)))'
                 required:
                 - spec
                 type: object

--- a/manifests/crd/core.pingcap.com_dmworkergroups.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkergroups.yaml
@@ -8848,7 +8848,7 @@ spec:
                         or volumes
                       rule: '!has(self.overlay) || !has(self.overlay.volumeClaims)
                         || self.overlay.volumeClaims.all(vc, (has(self.relayVolume)
-                        && vc.name == self.relayVolume.name) || (has(self.volumes)
+                        && vc.name in [self.relayVolume.name]) || (has(self.volumes)
                         && vc.name in self.volumes.map(v, v.name)))'
                 required:
                 - spec

--- a/manifests/crd/core.pingcap.com_dmworkers.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkers.yaml
@@ -8578,10 +8578,10 @@ spec:
               message: topology can only be set when creating
               rule: (!has(oldSelf.topology) && !has(self.topology)) || (has(oldSelf.topology)
                 && has(self.topology))
-            - message: overlay volumeClaims names must exist in volumes
-              rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || (has(self.volumes)
-                && self.overlay.volumeClaims.all(vc, vc.name in self.volumes.map(v,
-                v.name)))'
+            - message: overlay volumeClaims names must exist in relayVolume or volumes
+              rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc,
+                (has(self.relayVolume) && vc.name == self.relayVolume.name) || (has(self.volumes)
+                && vc.name in self.volumes.map(v, v.name)))'
           status:
             description: DMWorkerStatus defines the observed state of a DM worker
               instance

--- a/manifests/crd/core.pingcap.com_dmworkers.yaml
+++ b/manifests/crd/core.pingcap.com_dmworkers.yaml
@@ -8580,7 +8580,7 @@ spec:
                 && has(self.topology))
             - message: overlay volumeClaims names must exist in relayVolume or volumes
               rule: '!has(self.overlay) || !has(self.overlay.volumeClaims) || self.overlay.volumeClaims.all(vc,
-                (has(self.relayVolume) && vc.name == self.relayVolume.name) || (has(self.volumes)
+                (has(self.relayVolume) && vc.name in [self.relayVolume.name]) || (has(self.volumes)
                 && vc.name in self.volumes.map(v, v.name)))'
           status:
             description: DMWorkerStatus defines the observed state of a DM worker

--- a/pkg/controllers/dm/tasks/pvc.go
+++ b/pkg/controllers/dm/tasks/pvc.go
@@ -15,6 +15,8 @@
 package tasks
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -23,6 +25,7 @@ import (
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/controllers/common"
 	"github.com/pingcap/tidb-operator/v2/pkg/features"
+	"github.com/pingcap/tidb-operator/v2/pkg/overlay"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 )
 
@@ -59,13 +62,30 @@ func PVCNewer() common.PVCNewer[*v1alpha1.DM] {
 			if cluster.Status.ID != "" {
 				dataPVC.Labels[v1alpha1.LabelKeyClusterID] = cluster.Status.ID
 			}
+			pvcOverlays := coreutil.PVCOverlay[scope.DM](dm)
+			for i := range pvcOverlays {
+				pvcOverlay := &pvcOverlays[i]
+				if pvcOverlay.Name == dataVol.Name {
+					overlay.OverlayPersistentVolumeClaim(dataPVC, &pvcOverlay.PersistentVolumeClaim)
+					break
+				}
+			}
 
 			pvcs := []*corev1.PersistentVolumeClaim{dataPVC}
 
 			// Additional volumes
+			additionalDM := dm.DeepCopy()
+			if additionalDM.Spec.Overlay != nil {
+				additionalDM.Spec.Overlay.PersistentVolumeClaims = slices.DeleteFunc(
+					additionalDM.Spec.Overlay.PersistentVolumeClaims,
+					func(item v1alpha1.NamedPersistentVolumeClaimOverlay) bool {
+						return item.Name == dataVol.Name
+					},
+				)
+			}
 			additionalPVCs := coreutil.PVCs[scope.DM](
 				cluster,
-				dm,
+				additionalDM,
 				coreutil.EnableVAC(fg.Enabled(meta.VolumeAttributesClass)),
 				coreutil.PVCPatchFunc(func(_ *v1alpha1.Volume, pvc *corev1.PersistentVolumeClaim) {
 					// legacy labels in v1

--- a/pkg/controllers/dm/tasks/pvc_test.go
+++ b/pkg/controllers/dm/tasks/pvc_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -62,4 +63,41 @@ func TestPVCNewer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPVCNewerAppliesDataAndAdditionalVolumeOverlays(t *testing.T) {
+	cluster := fake.FakeObj[v1alpha1.Cluster]("cluster")
+	dm := newTestDM("aaa-0", func(dm *v1alpha1.DM) {
+		dm.Spec.Volumes = []v1alpha1.Volume{{
+			Name:    "extra",
+			Storage: resource.MustParse("5Gi"),
+		}}
+		dm.Spec.Overlay = &v1alpha1.Overlay{
+			PersistentVolumeClaims: []v1alpha1.NamedPersistentVolumeClaimOverlay{
+				{
+					Name: "data",
+					PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimOverlay{
+						ObjectMeta: v1alpha1.ObjectMeta{
+							Labels:      map[string]string{"cloud-tag": "dm-master"},
+							Annotations: map[string]string{"owner": "data"},
+						},
+					},
+				},
+				{
+					Name: "extra",
+					PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimOverlay{
+						ObjectMeta: v1alpha1.ObjectMeta{
+							Labels: map[string]string{"cloud-tag": "extra"},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	pvcs := PVCNewer().NewPVCs(cluster, dm, features.NewFromFeatures(nil))
+	require.Len(t, pvcs, 2)
+	assert.Equal(t, "dm-master", pvcs[0].Labels["cloud-tag"])
+	assert.Equal(t, "data", pvcs[0].Annotations["owner"])
+	assert.Equal(t, "extra", pvcs[1].Labels["cloud-tag"])
 }

--- a/pkg/controllers/dmworker/tasks/pvc.go
+++ b/pkg/controllers/dmworker/tasks/pvc.go
@@ -15,6 +15,8 @@
 package tasks
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -23,6 +25,7 @@ import (
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/controllers/common"
 	"github.com/pingcap/tidb-operator/v2/pkg/features"
+	"github.com/pingcap/tidb-operator/v2/pkg/overlay"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 )
 
@@ -30,6 +33,7 @@ func PVCNewer() common.PVCNewer[*v1alpha1.DMWorker] {
 	return common.PVCNewerFunc[*v1alpha1.DMWorker](
 		func(cluster *v1alpha1.Cluster, dw *v1alpha1.DMWorker, fg features.Gates) []*corev1.PersistentVolumeClaim {
 			var pvcs []*corev1.PersistentVolumeClaim
+			additionalDMWorker := dw.DeepCopy()
 
 			// RelayVolume PVC (optional relay log storage for dm-worker)
 			if relayVol := dw.Spec.RelayVolume; relayVol != nil {
@@ -60,13 +64,30 @@ func PVCNewer() common.PVCNewer[*v1alpha1.DMWorker] {
 				if cluster.Status.ID != "" {
 					relayPVC.Labels[v1alpha1.LabelKeyClusterID] = cluster.Status.ID
 				}
+				pvcOverlays := coreutil.PVCOverlay[scope.DMWorker](dw)
+				for i := range pvcOverlays {
+					pvcOverlay := &pvcOverlays[i]
+					if pvcOverlay.Name == relayVol.Name {
+						overlay.OverlayPersistentVolumeClaim(relayPVC, &pvcOverlay.PersistentVolumeClaim)
+						break
+					}
+				}
 				pvcs = append(pvcs, relayPVC)
+
+				if additionalDMWorker.Spec.Overlay != nil {
+					additionalDMWorker.Spec.Overlay.PersistentVolumeClaims = slices.DeleteFunc(
+						additionalDMWorker.Spec.Overlay.PersistentVolumeClaims,
+						func(item v1alpha1.NamedPersistentVolumeClaimOverlay) bool {
+							return item.Name == relayVol.Name
+						},
+					)
+				}
 			}
 
 			// Additional volumes
 			additionalPVCs := coreutil.PVCs[scope.DMWorker](
 				cluster,
-				dw,
+				additionalDMWorker,
 				coreutil.EnableVAC(fg.Enabled(meta.VolumeAttributesClass)),
 				coreutil.PVCPatchFunc(func(_ *v1alpha1.Volume, pvc *corev1.PersistentVolumeClaim) {
 					if cluster.Status.ID != "" {

--- a/pkg/controllers/dmworker/tasks/pvc_test.go
+++ b/pkg/controllers/dmworker/tasks/pvc_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -62,4 +63,41 @@ func TestPVCNewer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPVCNewerAppliesRelayAndAdditionalVolumeOverlays(t *testing.T) {
+	cluster := fake.FakeObj[v1alpha1.Cluster]("cluster")
+	dw := newTestDMWorker("aaa-0", func(dw *v1alpha1.DMWorker) {
+		dw.Spec.Volumes = []v1alpha1.Volume{{
+			Name:    "extra",
+			Storage: resource.MustParse("5Gi"),
+		}}
+		dw.Spec.Overlay = &v1alpha1.Overlay{
+			PersistentVolumeClaims: []v1alpha1.NamedPersistentVolumeClaimOverlay{
+				{
+					Name: "relay",
+					PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimOverlay{
+						ObjectMeta: v1alpha1.ObjectMeta{
+							Labels:      map[string]string{"cloud-tag": "dm-worker"},
+							Annotations: map[string]string{"owner": "relay"},
+						},
+					},
+				},
+				{
+					Name: "extra",
+					PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimOverlay{
+						ObjectMeta: v1alpha1.ObjectMeta{
+							Labels: map[string]string{"cloud-tag": "extra"},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	pvcs := PVCNewer().NewPVCs(cluster, dw, features.NewFromFeatures(nil))
+	require.Len(t, pvcs, 2)
+	assert.Equal(t, "dm-worker", pvcs[0].Labels["cloud-tag"])
+	assert.Equal(t, "relay", pvcs[0].Annotations["owner"])
+	assert.Equal(t, "extra", pvcs[1].Labels["cloud-tag"])
 }

--- a/tests/e2e/dm/dm.go
+++ b/tests/e2e/dm/dm.go
@@ -18,7 +18,9 @@ import (
 	"context"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
@@ -38,6 +40,76 @@ var _ = ginkgo.Describe("DM", label.DM, func() {
 	f.Setup()
 
 	ginkgo.Context("Basic Lifecycle", label.P0, func() {
+		ginkgo.It("applies PVC overlays to built-in and additional volumes", label.KindBasic, func(ctx context.Context) {
+			const (
+				labelKey      = "tags.tidbcloud.com/volume"
+				annotationKey = "test.pingcap.com/volume"
+				extraVolume   = "extra"
+			)
+			newOverlay := func(names ...string) *v1alpha1.Overlay {
+				overlay := &v1alpha1.Overlay{}
+				for _, name := range names {
+					overlay.PersistentVolumeClaims = append(overlay.PersistentVolumeClaims, v1alpha1.NamedPersistentVolumeClaimOverlay{
+						Name: name,
+						PersistentVolumeClaim: v1alpha1.PersistentVolumeClaimOverlay{
+							ObjectMeta: v1alpha1.ObjectMeta{
+								Labels:      map[string]string{labelKey: name},
+								Annotations: map[string]string{annotationKey: name},
+							},
+						},
+					})
+				}
+				return overlay
+			}
+			extra := v1alpha1.Volume{
+				Name:    extraVolume,
+				Storage: resource.MustParse("1Gi"),
+				Mounts:  []v1alpha1.VolumeMount{{MountPath: "/extra"}},
+			}
+
+			pdg := f.MustCreatePD(ctx)
+			kvg := f.MustCreateTiKV(ctx)
+			dmg := f.MustCreateDM(ctx, data.GroupPatchFunc[*v1alpha1.DMGroup](func(obj *v1alpha1.DMGroup) {
+				obj.Spec.Template.Spec.Volumes = []v1alpha1.Volume{extra}
+				obj.Spec.Template.Spec.Overlay = newOverlay(obj.Spec.Template.Spec.DataVolume.Name, extraVolume)
+			}))
+			dwg := f.MustCreateDMWorker(ctx, data.GroupPatchFunc[*v1alpha1.DMWorkerGroup](func(obj *v1alpha1.DMWorkerGroup) {
+				obj.Spec.Template.Spec.Volumes = []v1alpha1.Volume{extra}
+				obj.Spec.Template.Spec.Overlay = newOverlay(obj.Spec.Template.Spec.RelayVolume.Name, extraVolume)
+			}))
+
+			f.WaitForPDGroupReady(ctx, pdg)
+			f.WaitForTiKVGroupReady(ctx, kvg)
+			f.WaitForDMGroupReady(ctx, dmg)
+			f.WaitForDMWorkerGroupReady(ctx, dwg)
+
+			// Check persisted PVCs so both CRD admission and controller propagation are covered.
+			ginkgo.By("Checking labels and annotations on built-in and additional PVCs")
+			for _, group := range []struct {
+				name      string
+				component string
+				builtIn   string
+			}{
+				{dmg.Name, v1alpha1.LabelValComponentDMMaster, dmg.Spec.Template.Spec.DataVolume.Name},
+				{dwg.Name, v1alpha1.LabelValComponentDMWorker, dwg.Spec.Template.Spec.RelayVolume.Name},
+			} {
+				var pvcs corev1.PersistentVolumeClaimList
+				f.Must(f.Client.List(ctx, &pvcs, client.InNamespace(f.Namespace.Name), client.MatchingLabels{
+					v1alpha1.LabelKeyGroup:     group.name,
+					v1alpha1.LabelKeyComponent: group.component,
+				}))
+				var names []string
+				for _, pvc := range pvcs.Items {
+					name := pvc.Labels[v1alpha1.LabelKeyVolumeName]
+					names = append(names, name)
+					gomega.Expect(pvc.Labels).To(gomega.HaveKeyWithValue(labelKey, name), pvc.Name)
+					gomega.Expect(pvc.Annotations).To(gomega.HaveKeyWithValue(annotationKey, name), pvc.Name)
+					gomega.Expect(pvc.Status.Phase).To(gomega.Equal(corev1.ClaimBound), pvc.Name)
+				}
+				gomega.Expect(names).To(gomega.ConsistOf(group.builtIn, extraVolume), group.name)
+			}
+		})
+
 		ginkgo.It("deploys and reaches Ready state", label.KindBasic, func(ctx context.Context) {
 			pdg := f.MustCreatePD(ctx)
 			kvg := f.MustCreateTiKV(ctx)

--- a/tests/e2e/dm/dm.go
+++ b/tests/e2e/dm/dm.go
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe("DM", label.DM, func() {
 	ginkgo.Context("Basic Lifecycle", label.P0, func() {
 		ginkgo.It("applies PVC overlays to built-in and additional volumes", label.KindBasic, func(ctx context.Context) {
 			const (
-				labelKey      = "tags.tidbcloud.com/volume"
+				labelKey      = "test.pingcap.com/volume"
 				annotationKey = "test.pingcap.com/volume"
 				extraVolume   = "extra"
 			)

--- a/tests/validation/common_test.go
+++ b/tests/validation/common_test.go
@@ -699,6 +699,63 @@ func OverlayVolumeClaims(requireDataVolume bool) []Case {
 	return cases
 }
 
+func BuiltInVolumeClaimsOverlay(builtInVolumeName, errMsg string) []Case {
+	volumeClaimOverlay := func(name string) map[string]any {
+		return map[string]any{
+			"name": name,
+			"volumeClaim": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{"test": "value"},
+				},
+			},
+		}
+	}
+
+	return []Case{
+		{
+			desc:     "overlay built-in volume claim",
+			isCreate: true,
+			mode:     PatchModeMerge,
+			current: map[string]any{
+				"overlay": map[string]any{
+					"volumeClaims": []any{volumeClaimOverlay(builtInVolumeName)},
+				},
+			},
+		},
+		{
+			desc:     "overlay built-in and additional volume claims",
+			isCreate: true,
+			mode:     PatchModeMerge,
+			current: map[string]any{
+				"volumes": []any{
+					map[string]any{
+						"name":    "extra",
+						"mounts":  []any{map[string]any{"mountPath": "/extra"}},
+						"storage": "5Gi",
+					},
+				},
+				"overlay": map[string]any{
+					"volumeClaims": []any{
+						volumeClaimOverlay(builtInVolumeName),
+						volumeClaimOverlay("extra"),
+					},
+				},
+			},
+		},
+		{
+			desc:     "reject unknown volume claim overlay",
+			isCreate: true,
+			mode:     PatchModeMerge,
+			current: map[string]any{
+				"overlay": map[string]any{
+					"volumeClaims": []any{volumeClaimOverlay("unknown")},
+				},
+			},
+			wantErrs: []string{errMsg},
+		},
+	}
+}
+
 func DataVolumeRequired() []Case {
 	baseSpec := map[string]any{
 		"cluster": map[string]any{

--- a/tests/validation/dm_test.go
+++ b/tests/validation/dm_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestDMGroup(t *testing.T) {
+	validateCELStaticCosts(t, "crd/core.pingcap.com_dmgroups.yaml", "spec", "template", "spec")
+	validateCELStaticCosts(t, "crd/core.pingcap.com_dms.yaml", "spec")
+
 	var cases []Case
 	cases = append(cases, transferDMGroupCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferDMGroupCases(t, NameLength(groupNameLengthLimit), "metadata", "name")...)

--- a/tests/validation/dm_test.go
+++ b/tests/validation/dm_test.go
@@ -25,6 +25,10 @@ func TestDMGroup(t *testing.T) {
 	cases = append(cases, transferDMGroupCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferDMGroupCases(t, NameLength(groupNameLengthLimit), "metadata", "name")...)
 	cases = append(cases, transferDMGroupCases(t, MinReadySeconds(), "spec", "minReadySeconds")...)
+	cases = append(cases, transferDMGroupCases(t, BuiltInVolumeClaimsOverlay(
+		"data",
+		`spec.template.spec: Invalid value: "object": overlay volumeClaims names must exist in dataVolume or volumes`,
+	), "spec", "template", "spec")...)
 	Validate(t, "crd/core.pingcap.com_dmgroups.yaml", cases)
 }
 

--- a/tests/validation/dmworker_test.go
+++ b/tests/validation/dmworker_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestDMWorkerGroup(t *testing.T) {
+	validateCELStaticCosts(t, "crd/core.pingcap.com_dmworkergroups.yaml", "spec", "template", "spec")
+	validateCELStaticCosts(t, "crd/core.pingcap.com_dmworkers.yaml", "spec")
+
 	var cases []Case
 	cases = append(cases, transferDMWorkerGroupCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferDMWorkerGroupCases(t, NameLength(groupNameLengthLimit), "metadata", "name")...)

--- a/tests/validation/dmworker_test.go
+++ b/tests/validation/dmworker_test.go
@@ -26,6 +26,10 @@ func TestDMWorkerGroup(t *testing.T) {
 	cases = append(cases, transferDMWorkerGroupCases(t, NameLength(groupNameLengthLimit), "metadata", "name")...)
 	cases = append(cases, transferDMWorkerGroupCases(t, MinReadySeconds(), "spec", "minReadySeconds")...)
 	cases = append(cases, transferDMWorkerGroupCases(t, DMGroupRefRequired(), "spec", "dmGroupRef")...)
+	cases = append(cases, transferDMWorkerGroupCases(t, BuiltInVolumeClaimsOverlay(
+		"relay",
+		`spec.template.spec: Invalid value: "object": overlay volumeClaims names must exist in relayVolume or volumes`,
+	), "spec", "template", "spec")...)
 	Validate(t, "crd/core.pingcap.com_dmworkergroups.yaml", cases)
 }
 

--- a/tests/validation/validation.go
+++ b/tests/validation/validation.go
@@ -158,6 +158,7 @@ func validateCELStaticCosts(t *testing.T, crdPath string, fields ...string) {
 		cel.NewExpressionsEnvLoader(),
 	)
 	require.NoError(t, err, crdPath)
+	require.NotEmpty(t, results, "no CEL validation rules found in %s", crdPath)
 	for i, result := range results {
 		require.Nil(t, result.Error, "%s validation rule %d", crdPath, i)
 		require.LessOrEqual(

--- a/tests/validation/validation.go
+++ b/tests/validation/validation.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/environment"
 )
 
 type Case struct {
@@ -136,6 +138,37 @@ func structuralSchemaFromCRD(t *testing.T, crdPath, version string) *schema.Stru
 	require.FailNowf(t, "failed to find crd %s version %s", crdPath, version)
 
 	return nil
+}
+
+func validateCELStaticCosts(t *testing.T, crdPath string, fields ...string) {
+	t.Helper()
+
+	s := structuralSchemaFromCRD(t, crdPath, "v1alpha1")
+	for _, fieldName := range fields {
+		property, ok := s.Properties[fieldName]
+		require.True(t, ok, "field %s not found in %s", strings.Join(fields, "."), crdPath)
+		s = &property
+	}
+
+	results, err := cel.Compile(
+		s,
+		model.SchemaDeclType(s, false),
+		celconfig.PerCallLimit,
+		environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true),
+		cel.NewExpressionsEnvLoader(),
+	)
+	require.NoError(t, err, crdPath)
+	for i, result := range results {
+		require.Nil(t, result.Error, "%s validation rule %d", crdPath, i)
+		require.LessOrEqual(
+			t,
+			result.MaxCost,
+			uint64(celconfig.RuntimeCELCostBudget),
+			"%s validation rule %d exceeds the static CEL cost budget",
+			crdPath,
+			i,
+		)
+	}
 }
 
 type PatchMode string


### PR DESCRIPTION
## Summary

Allow PVC overlays to target DM's built-in `dataVolume` and DMWorker's built-in `relayVolume`, in addition to additional volumes.

## Why

Built-in DM volumes could not receive custom PVC labels or annotations through `overlay.volumeClaims`.

## How

- Extend CEL validation to accept built-in volume names while rejecting unknown names, and regenerate the four affected CRDs.
- Apply the existing metadata overlay logic to built-in PVCs, then exclude those overlays from additional-volume processing using a deep copy.
- Add unit, validation, CEL cost, and E2E coverage. The E2E case checks persisted labels, annotations, and Bound status for built-in and additional PVCs.

## Testing

- Passed: `go test ./pkg/controllers/dm/tasks ./pkg/controllers/dmworker/tasks`.
- Passed: `cd tests/validation && go test ./...`.
- E2E suite compilation: `go test ./tests/e2e -run '^$'`.
- The new E2E case requires a configured Kubernetes test environment; execution is pending CI.

## Risks and Reviewer Focus

- Install compatible CRDs and an Operator version before configuring built-in volume overlays.
- PVC naming, storage specifications, and ownership are unchanged. Metadata overlays can also be applied to existing PVCs during reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PVC overlays can now target built-in data volumes for DM resources and relay volumes for DMWorker resources, in addition to extra volumes.
  * Labels and annotations from these overlays are correctly applied to the corresponding generated PVCs.
  * Validation now accepts built-in volume claim names while continuing to reject unknown names.

* **Bug Fixes**
  * Prevented built-in volume overlays from being applied twice during PVC generation.
  * Added end-to-end coverage for PVC metadata, binding, and volume creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->