### PR TITLE
charts: bump advanced-statefulset to v0.7.1

### DIFF
--- a/charts/tidb-operator/values.yaml
+++ b/charts/tidb-operator/values.yaml
@@ -208,7 +208,7 @@ advancedStatefulset:
   ## resourceLock indicates the type of resource object that will be used for locking during leader election.
   ## If using "endpoints" before and want to migrate to "leases", you should migrate to "endpointsleases" first.
   # resourceLock: "leases"
-  image: pingcap/advanced-statefulset:v0.7.0
+  image: pingcap/advanced-statefulset:v0.7.1
   imagePullPolicy: IfNotPresent
   serviceAccount: advanced-statefulset-controller
   logLevel: 4


### PR DESCRIPTION
## Summary

- Update the `release-1.x` chart default AdvancedStatefulSet controller image from v0.7.0 to v0.7.1.
- Pick up the v0.7 maintenance fix that makes ControllerRevision adoption retries idempotent.
- Backport this dependency update to `release-1.6` after the source PR merges.

## Why

AdvancedStatefulSet v0.7.0 can retry a partially completed native StatefulSet migration with a mix of orphaned and already-owned ControllerRevisions. The retry may fail with `attempt to adopt revision owned by ...` before Pod lifecycle reconciliation, preventing a missing Pod from being recreated.

The fix was backported in [pingcap/advanced-statefulset#133](https://github.com/pingcap/advanced-statefulset/pull/133) and released as v0.7.1.

## How

- Change only `advancedStatefulset.image` in the Helm chart defaults.
- Keep the existing v0.7 API, CRD, command-line flags, and dependencies unchanged.
- Leave installations with an explicit `advancedStatefulset.image` override unaffected.

## Testing

- [x] `helm lint charts/tidb-operator --set advancedStatefulset.create=true`
- [x] `helm template tidb-operator charts/tidb-operator --namespace tidb-admin --set advancedStatefulset.create=true --show-only templates/advanced-statefulset-deployment.yaml` rendered `pingcap/advanced-statefulset:v0.7.1`
- [x] `git diff --check origin/release-1.x..HEAD`
- [x] `docker buildx imagetools inspect docker.io/pingcap/advanced-statefulset:v0.7.1` verified linux/amd64 and linux/arm64 manifests

## Risks and Reviewer Focus

- When `advancedStatefulset.create=true` and no image override is set, applying the updated chart rolls the ASTS controller to v0.7.1.
- No TiDB Operator binary, ASTS CRD, or workload specification changes are included.
- Cluster-backed E2E was not run for this chart-only change; [the source fix](https://github.com/pingcap/advanced-statefulset/pull/132) passed a local kind migration E2E, and the release-0.7 backport carries the same regression coverage.

## Repository Checklist

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test
- [ ] E2E test
- [x] Manual test
- [x] No code

### Side effects

- [ ] Breaking backward compatibility
- [x] Other side effects: updates the default ASTS controller image when ASTS chart deployment is enabled

### Related changes

- [x] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

### Release Notes

```release-note
Upgrade the default AdvancedStatefulSet controller image to v0.7.1 to fix ControllerRevision adoption retries that can block Pod reconciliation after StatefulSet migration.
```
