### PR TITLE
deps: bump pingcap base image to v1.12.3

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/go/cache \
     V_PLATFORMS=$TARGETPLATFORM ./hack/build.sh $TARGET
 
-FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.4@sha256:3ba859533d570c7bc628e3cb6ef58315114923df262cdcc8ca22c9519950c4c5 AS tidb-operator
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.3@sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88 AS tidb-operator
 
 ARG TARGETPLATFORM
 
@@ -43,7 +43,7 @@ COPY --chown=pingcap:pingcap --from=builder /data/_output/$TARGETPLATFORM/bin/ti
 
 ENTRYPOINT ["/tidb-operator"]
 
-FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.4@sha256:3ba859533d570c7bc628e3cb6ef58315114923df262cdcc8ca22c9519950c4c5 AS prestop-checker
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.3@sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88 AS prestop-checker
 
 ARG TARGETPLATFORM
 
@@ -55,7 +55,7 @@ COPY --chown=pingcap:pingcap --from=builder /data/_output/$TARGETPLATFORM/bin/pr
 
 ENTRYPOINT ["/prestop-checker"]
 
-FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.4@sha256:3ba859533d570c7bc628e3cb6ef58315114923df262cdcc8ca22c9519950c4c5 AS testing-workload
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.3@sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88 AS testing-workload
 
 ARG TARGETPLATFORM
 
@@ -69,7 +69,7 @@ COPY --chown=pingcap:pingcap --from=builder /data/_output/$TARGETPLATFORM/bin/te
 ENTRYPOINT ["/testing-workload"]
 
 
-FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.4@sha256:3ba859533d570c7bc628e3cb6ef58315114923df262cdcc8ca22c9519950c4c5 AS tidb-backup-manager
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.3@sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88 AS tidb-backup-manager
 
 ARG TARGETPLATFORM
 
@@ -82,7 +82,7 @@ COPY --chown=pingcap:pingcap --from=builder /data/_output/$TARGETPLATFORM/bin/ti
 ENTRYPOINT ["/tidb-backup-manager"]
 
 
-FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.4@sha256:3ba859533d570c7bc628e3cb6ef58315114923df262cdcc8ca22c9519950c4c5 AS resource-syncer
+FROM --platform=$TARGETPLATFORM ghcr.io/pingcap-qe/bases/pingcap-base:v1.12.3@sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88 AS resource-syncer
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
### What problem does this PR solve?

Bump the `ghcr.io/pingcap-qe/bases/pingcap-base` base image from v1.11.4 to v1.12.3 (digest-pinned) in `image/Dockerfile`. This is a routine base-image refresh, picking up the latest base image releases to stay in sync with the other branches.

### What is changed and how does it work?

No operator code changes. Only the five `FROM` lines of `image/Dockerfile` are updated.

The tag moves `v1.11.4` -> `v1.12.3` and the digest is re-pinned to the v1.12.3 manifest-list digest (`sha256:eee0c7a72ce382ec2bca340c6ab4c996e56a5d9deb3745ebcbe43d65bec86b88`), obtained from the ghcr.io registry (anonymous token + `Docker-Content-Digest` header on the manifest-list media type). This matches the digest-pinning convention used in previous bumps (#6997, #7006, #7026).

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test
- [x] No code

Local verification:
- `git diff` shows exactly the five `FROM` lines changed, nothing else.
- The digest matches the v1.12.3 manifest-list digest returned by the ghcr registry, and the v1.11.4 digest (`3ba8...`) previously pinned in this file matches the same query against the v1.11.4 tag, confirming the digest type is consistent.

### Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects: base image patch release; no functional change expected. CI image builds will pull the new base layer.

### Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

No cherry-pick is required: counterpart PRs covering all currently maintained release branches are opened directly (release-1.x (#7040), release-1.6 (#7041), main (#7038)).

### Release Notes

```release-note
Bump the pingcap base image to v1.12.3.
```