### PR TITLE
upgrader: migrate StatefulSets of all pingcap.com owner kinds to ASTS

### DIFF
--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -16,6 +16,7 @@ package upgrader
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	asappsv1 "github.com/pingcap/advanced-statefulset/client/apis/apps/v1"
 	"github.com/pingcap/advanced-statefulset/client/apis/apps/v1/helper"
@@ -68,9 +69,15 @@ func (u *upgrader) Upgrade() error {
 		tidbClusters := make([]*v1alpha1.TidbCluster, 0)
 		for i := range stsList.Items {
 			sts := stsList.Items[i]
-			if ok, tcRef := util.IsOwnedByTidbCluster(&sts); ok {
+			if ok, ownerRef := util.IsOwnedByPingcapStatefulSet(&sts); ok {
 				stsToMigrate = append(stsToMigrate, sts)
-				tc, err := u.cli.PingcapV1alpha1().TidbClusters(sts.Namespace).Get(context.Background(), tcRef.Name, metav1.GetOptions{})
+				if ownerRef.Kind != v1alpha1.TiDBClusterKind {
+					// The delete slots safety check below only applies to
+					// TidbClusters; other pingcap.com owner kinds are migrated
+					// without it.
+					continue
+				}
+				tc, err := u.cli.PingcapV1alpha1().TidbClusters(sts.Namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -80,10 +87,10 @@ func (u *upgrader) Upgrade() error {
 			}
 		}
 		if len(stsToMigrate) <= 0 {
-			klog.Infof("upgrader: found 0 Kubernetes StatefulSets owned by TidbCluster, nothing need to do")
+			klog.Infof("upgrader: found 0 Kubernetes StatefulSets owned by pingcap.com StatefulSet owners, nothing need to do")
 			return nil
 		}
-		klog.Infof("Upgrader: %d Kubernetes Statfulsets owned by TidbCluster should be migrated to Advanced Statefulsets", len(stsToMigrate))
+		klog.Infof("Upgrader: %d Kubernetes Statefulsets owned by pingcap.com StatefulSet owners should be migrated to Advanced Statefulsets", len(stsToMigrate))
 		// Check if relavant TidbClusters have delete slots annotations set.
 		for _, tc := range tidbClusters {
 			// Existing delete slots annotations must be removed first. This is
@@ -93,7 +100,7 @@ func (u *upgrader) Upgrade() error {
 				return fmt.Errorf("upgrader: TidbCluster %s/%s has delete slot annotations %v, please remove them before enabling AdvancedStatefulSet feature", tc.Namespace, tc.Name, anns)
 			}
 		}
-		klog.Infof("upgrader: found %d Kubernetes StatefulSets owned by TidbCluster, trying to migrate one by one", len(stsToMigrate))
+		klog.Infof("upgrader: found %d Kubernetes StatefulSets owned by pingcap.com StatefulSet owners, trying to migrate one by one", len(stsToMigrate))
 		for i := range stsToMigrate {
 			sts := stsToMigrate[i]
 			_, err := helper.Upgrade(context.Background(), u.kubeCli, u.asCli, &sts)
@@ -116,20 +123,39 @@ func (u *upgrader) Upgrade() error {
 		stsToMigrate := make([]asappsv1.StatefulSet, 0)
 		for i := range stsList.Items {
 			sts := stsList.Items[i]
-			if ok, _ := util.IsOwnedByTidbCluster(&sts); ok {
+			if ok, _ := util.IsOwnedByPingcapStatefulSet(&sts); ok {
 				stsToMigrate = append(stsToMigrate, sts)
 			}
 		}
 		if len(stsToMigrate) <= 0 {
-			klog.Infof("upgrader: found %d Advanced StatefulSets owned by TidbCluster, nothing need to do", len(stsToMigrate))
+			klog.Infof("upgrader: found 0 Advanced StatefulSets owned by pingcap.com StatefulSet owners, nothing need to do")
 			return nil
 		}
 		// The upgrader cannot migrate Advanced StatefulSets to Kubernetes
 		// StatefulSets automatically right now.
 		// TODO try our best to allow users to revert AdvancedStatefulSet feature automaticaly
-		return fmt.Errorf("upgrader: found %d Advanced StatefulSets owned by TidbCluster, the operator cann't run with AdvancedStatefulSet feature disabled", len(stsToMigrate))
+		return fmt.Errorf("upgrader: found %d Advanced StatefulSets owned by pingcap.com StatefulSet owners, the operator cann't run with AdvancedStatefulSet feature disabled: %s", len(stsToMigrate), stsNames(stsToMigrate))
 	}
 	return nil
+}
+
+// stsNames lists the namespaced names of the given Advanced StatefulSets as
+// "StatefulSet namespace/name", truncated to the first maxStsNames entries.
+func stsNames(stss []asappsv1.StatefulSet) string {
+	const maxStsNames = 10
+	if len(stss) <= maxStsNames {
+		names := make([]string, 0, len(stss))
+		for i := range stss {
+			names = append(names, fmt.Sprintf("StatefulSet %s/%s", stss[i].Namespace, stss[i].Name))
+		}
+		return strings.Join(names, ", ")
+	}
+	names := make([]string, 0, maxStsNames+1)
+	for i := range stss[:maxStsNames] {
+		names = append(names, fmt.Sprintf("StatefulSet %s/%s", stss[i].Namespace, stss[i].Name))
+	}
+	names = append(names, fmt.Sprintf("... and %d more", len(stss)-maxStsNames))
+	return strings.Join(names, ", ")
 }
 
 func deleteSlotAnns(tc *v1alpha1.TidbCluster) map[string]string {

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -67,22 +67,28 @@ func (u *upgrader) Upgrade() error {
 		}
 		stsToMigrate := make([]appsv1.StatefulSet, 0)
 		tidbClusters := make([]*v1alpha1.TidbCluster, 0)
+		dmClusters := make([]*v1alpha1.DMCluster, 0)
 		for i := range stsList.Items {
 			sts := stsList.Items[i]
 			if ok, ownerRef := util.IsOwnedByPingcapStatefulSet(&sts); ok {
 				stsToMigrate = append(stsToMigrate, sts)
-				if ownerRef.Kind != v1alpha1.TiDBClusterKind {
-					// The delete slots safety check below only applies to
-					// TidbClusters; other pingcap.com owner kinds are migrated
-					// without it.
-					continue
-				}
-				tc, err := u.cli.PingcapV1alpha1().TidbClusters(sts.Namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-				if tc != nil {
-					tidbClusters = append(tidbClusters, tc)
+				switch ownerRef.Kind {
+				case v1alpha1.TiDBClusterKind:
+					tc, err := u.cli.PingcapV1alpha1().TidbClusters(sts.Namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+					if err != nil && !apierrors.IsNotFound(err) {
+						return err
+					}
+					if tc != nil {
+						tidbClusters = append(tidbClusters, tc)
+					}
+				case v1alpha1.DMClusterKind:
+					dc, err := u.cli.PingcapV1alpha1().DMClusters(sts.Namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+					if err != nil && !apierrors.IsNotFound(err) {
+						return err
+					}
+					if dc != nil {
+						dmClusters = append(dmClusters, dc)
+					}
 				}
 			}
 		}
@@ -91,13 +97,18 @@ func (u *upgrader) Upgrade() error {
 			return nil
 		}
 		klog.Infof("Upgrader: %d Kubernetes Statefulsets owned by pingcap.com StatefulSet owners should be migrated to Advanced Statefulsets", len(stsToMigrate))
-		// Check if relavant TidbClusters have delete slots annotations set.
+		// Check if relevant TidbClusters or DMClusters have delete slots annotations set.
 		for _, tc := range tidbClusters {
 			// Existing delete slots annotations must be removed first. This is
 			// a safety check to ensure no pods are affected in upgrading
 			// process.
 			if anns := deleteSlotAnns(tc); len(anns) > 0 {
 				return fmt.Errorf("upgrader: TidbCluster %s/%s has delete slot annotations %v, please remove them before enabling AdvancedStatefulSet feature", tc.Namespace, tc.Name, anns)
+			}
+		}
+		for _, dc := range dmClusters {
+			if anns := dmDeleteSlotAnns(dc); len(anns) > 0 {
+				return fmt.Errorf("upgrader: DMCluster %s/%s has delete slot annotations %v, please remove them before enabling AdvancedStatefulSet feature", dc.Namespace, dc.Name, anns)
 			}
 		}
 		klog.Infof("upgrader: found %d Kubernetes StatefulSets owned by pingcap.com StatefulSet owners, trying to migrate one by one", len(stsToMigrate))
@@ -166,6 +177,20 @@ func deleteSlotAnns(tc *v1alpha1.TidbCluster) map[string]string {
 
 	for _, key := range []string{label.AnnPDDeleteSlots, label.AnnTiDBDeleteSlots, label.AnnTiKVDeleteSlots, label.AnnTiFlashDeleteSlots, label.AnnTiProxyDeleteSlots, label.AnnTiCDCDeleteSlots} {
 		if v, ok := tc.Annotations[key]; ok {
+			anns[key] = v
+		}
+	}
+	return anns
+}
+
+func dmDeleteSlotAnns(dc *v1alpha1.DMCluster) map[string]string {
+	anns := make(map[string]string)
+	if dc == nil || dc.Annotations == nil {
+		return anns
+	}
+
+	for _, key := range []string{label.AnnDMMasterDeleteSlots, label.AnnDMWorkerDeleteSlots} {
+		if v, ok := dc.Annotations[key]; ok {
 			anns[key] = v
 		}
 	}

--- a/pkg/upgrader/upgrader_test.go
+++ b/pkg/upgrader/upgrader_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -90,6 +91,89 @@ func TestIsOwnedByTidbCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sts := tt.sts
 			ok, _ := util.IsOwnedByTidbCluster(&sts)
+			if tt.wantOK != ok {
+				t.Errorf("got %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsOwnedByPingcapStatefulSet(t *testing.T) {
+	ownerRef := func(apiVersion, kind string) []metav1.OwnerReference {
+		return []metav1.OwnerReference{
+			{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Controller: pointer.BoolPtr(true),
+			},
+		}
+	}
+	tests := []struct {
+		name   string
+		sts    appsv1.StatefulSet
+		wantOK bool
+	}{
+		{
+			name:   "owned by tidbcluster.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "TidbCluster")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by dmcluster.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "DMCluster")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by tidbmonitor.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "TidbMonitor")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by tidbdashboard.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "TidbDashboard")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by tidbngmonitoring.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "TidbNGMonitoring")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by tidbcluster.pingcap.com/v1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1", "TidbCluster")}},
+			wantOK: true,
+		},
+		{
+			name:   "owned by tidbcluster.example.com/v1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("example.com/v1", "TidbCluster")}},
+			wantOK: false,
+		},
+		{
+			name:   "owned by backup.pingcap.com/v1alpha1",
+			sts:    appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: ownerRef("pingcap.com/v1alpha1", "Backup")}},
+			wantOK: false,
+		},
+		{
+			name:   "no owner references",
+			sts:    appsv1.StatefulSet{},
+			wantOK: false,
+		},
+		{
+			name: "owner reference is not controller",
+			sts: appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "pingcap.com/v1alpha1",
+					Kind:       "TidbCluster",
+				},
+			}}},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := tt.sts
+			ok, _ := util.IsOwnedByPingcapStatefulSet(&sts)
 			if tt.wantOK != ok {
 				t.Errorf("got %v, want %v", ok, tt.wantOK)
 			}
@@ -173,6 +257,19 @@ var (
 		},
 	}
 	invalidOwnerRefs = []metav1.OwnerReference{}
+
+	// ownerRefsFor returns controller owner references of the given
+	// pingcap.com kind.
+	ownerRefsFor = func(kind string) []metav1.OwnerReference {
+		return []metav1.OwnerReference{
+			{
+				APIVersion: "pingcap.com/v1alpha1",
+				Kind:       kind,
+				Name:       ownerTCName,
+				Controller: pointer.BoolPtr(true),
+			},
+		}
+	}
 )
 
 func TestUpgrade(t *testing.T) {
@@ -187,6 +284,7 @@ func TestUpgrade(t *testing.T) {
 		wantAdvancedStatefulsets []asappsv1.StatefulSet
 		wantStatefulsets         []appsv1.StatefulSet
 		wantErr                  bool
+		wantErrMsg               string
 	}{
 		{
 			name: "basic",
@@ -625,6 +723,159 @@ func TestUpgrade(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should migrate sts owned by TidbMonitor",
+			statefulsets: []appsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+			feature: "AdvancedStatefulSet=true",
+			ns:      metav1.NamespaceAll,
+			wantErr: false,
+			wantAdvancedStatefulsets: []asappsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps.pingcap.com/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+			wantStatefulsets: nil,
+		},
+		{
+			name: "should migrate sts owned by DMCluster",
+			statefulsets: []appsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("DMCluster"),
+					},
+				},
+			},
+			feature: "AdvancedStatefulSet=true",
+			ns:      metav1.NamespaceAll,
+			wantErr: false,
+			wantAdvancedStatefulsets: []asappsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps.pingcap.com/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("DMCluster"),
+					},
+				},
+			},
+			wantStatefulsets: nil,
+		},
+		{
+			name: "should migrate sts owned by TidbMonitor even if delete slot annotations exist on other resources",
+			tidbClusters: []v1alpha1.TidbCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "sts",
+						Annotations: map[string]string{
+							label.AnnTiDBDeleteSlots: "[1,2]",
+						},
+					},
+				},
+			},
+			statefulsets: []appsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+			feature: "AdvancedStatefulSet=true",
+			ns:      metav1.NamespaceAll,
+			wantErr: false,
+			wantAdvancedStatefulsets: []asappsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps.pingcap.com/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+			wantStatefulsets: nil,
+		},
+		{
+			name:    "[AdvancedStatefulSet=false] should error listing asts owned by TidbMonitor",
+			feature: "AdvancedStatefulSet=false",
+			advancedStatefulsets: []asappsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps.pingcap.com/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+			ns: metav1.NamespaceAll,
+			apiResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "apps.pingcap.com/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Kind: "StatefulSet",
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "StatefulSet sts/sts1",
+			wantAdvancedStatefulsets: []asappsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps.pingcap.com/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("TidbMonitor"),
+					},
+				},
+			},
+		},
 	}
 
 	// these tests must run serially, because we share features.DefaultFeatureGate
@@ -668,6 +919,9 @@ func TestUpgrade(t *testing.T) {
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("expected err, got %v", err)
+			}
+			if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("expected err containing %q, got %q", tt.wantErrMsg, err.Error())
 			}
 		} else {
 			if err != nil {

--- a/pkg/upgrader/upgrader_test.go
+++ b/pkg/upgrader/upgrader_test.go
@@ -246,6 +246,83 @@ func TestDeleteSlotAnns(t *testing.T) {
 	}
 }
 
+func TestDMDeleteSlotAnns(t *testing.T) {
+	tests := []struct {
+		name string
+		dc   *v1alpha1.DMCluster
+		want map[string]string
+	}{
+		{
+			name: "dc nil",
+			want: map[string]string{},
+		},
+		{
+			name: "dc anns nil",
+			dc:   &v1alpha1.DMCluster{},
+			want: map[string]string{},
+		},
+		{
+			name: "dc anns no delete slots",
+			dc: &v1alpha1.DMCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "dc anns has dm-master delete slots",
+			dc: &v1alpha1.DMCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						label.AnnDMMasterDeleteSlots: "[1,2]",
+					},
+				},
+			},
+			want: map[string]string{
+				label.AnnDMMasterDeleteSlots: "[1,2]",
+			},
+		},
+		{
+			name: "dc anns has dm-worker delete slots",
+			dc: &v1alpha1.DMCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						label.AnnDMWorkerDeleteSlots: "[3]",
+					},
+				},
+			},
+			want: map[string]string{
+				label.AnnDMWorkerDeleteSlots: "[3]",
+			},
+		},
+		{
+			name: "dc anns has all delete slots",
+			dc: &v1alpha1.DMCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						label.AnnDMMasterDeleteSlots: "[1,2]",
+						label.AnnDMWorkerDeleteSlots: "[3]",
+					},
+				},
+			},
+			want: map[string]string{
+				label.AnnDMMasterDeleteSlots: "[1,2]",
+				label.AnnDMWorkerDeleteSlots: "[3]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dmDeleteSlotAnns(tt.dc)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("unexpected (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
 var (
 	ownerTCName    = "foo"
 	validOwnerRefs = []metav1.OwnerReference{
@@ -276,6 +353,7 @@ func TestUpgrade(t *testing.T) {
 	tests := []struct {
 		name                     string
 		tidbClusters             []v1alpha1.TidbCluster
+		dmClusters               []v1alpha1.DMCluster
 		statefulsets             []appsv1.StatefulSet
 		advancedStatefulsets     []asappsv1.StatefulSet
 		feature                  string
@@ -790,6 +868,52 @@ func TestUpgrade(t *testing.T) {
 			wantStatefulsets: nil,
 		},
 		{
+			name: "should not migrate sts owned by DMCluster with delete slot annotations",
+			dmClusters: []v1alpha1.DMCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ownerTCName,
+						Namespace: "sts",
+						Annotations: map[string]string{
+							label.AnnDMMasterDeleteSlots: "[1,2]",
+							label.AnnDMWorkerDeleteSlots: "[3]",
+						},
+					},
+				},
+			},
+			statefulsets: []appsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("DMCluster"),
+					},
+				},
+			},
+			feature:                  "AdvancedStatefulSet=true",
+			ns:                       metav1.NamespaceAll,
+			wantErr:                  true,
+			wantErrMsg:               "DMCluster sts/foo has delete slot annotations",
+			wantAdvancedStatefulsets: nil,
+			wantStatefulsets: []appsv1.StatefulSet{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "sts1",
+						Namespace:       "sts",
+						OwnerReferences: ownerRefsFor("DMCluster"),
+					},
+				},
+			},
+		},
+		{
 			name: "should migrate sts owned by TidbMonitor even if delete slot annotations exist on other resources",
 			tidbClusters: []v1alpha1.TidbCluster{
 				{
@@ -898,6 +1022,14 @@ func TestUpgrade(t *testing.T) {
 			}
 		}
 
+		for i := range tt.dmClusters {
+			dc := tt.dmClusters[i]
+			_, err = cli.PingcapV1alpha1().DMClusters(dc.Namespace).Create(context.TODO(), &dc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		for i := range tt.statefulsets {
 			sts := tt.statefulsets[i]
 			_, err = kubeCli.AppsV1().StatefulSets(sts.Namespace).Create(context.TODO(), &sts, metav1.CreateOptions{})
@@ -919,8 +1051,7 @@ func TestUpgrade(t *testing.T) {
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("expected err, got %v", err)
-			}
-			if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+			} else if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
 				t.Errorf("expected err containing %q, got %q", tt.wantErrMsg, err.Error())
 			}
 		} else {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -369,6 +369,34 @@ func IsOwnedByTidbCluster(obj metav1.Object) (bool, *metav1.OwnerReference) {
 	return ref.Kind == v1alpha1.TiDBClusterKind && gv.Group == v1alpha1.SchemeGroupVersion.Group, ref
 }
 
+// IsOwnedByPingcapStatefulSet checks if the given object is controller-owned by
+// a pingcap.com kind whose StatefulSets go through the (possibly hijacked)
+// StatefulSet client, i.e. kinds that must participate in the Kubernetes
+// StatefulSet <-> Advanced StatefulSet migration.
+// Schema Kind and Group are checked, Version is ignored.
+func IsOwnedByPingcapStatefulSet(obj metav1.Object) (bool, *metav1.OwnerReference) {
+	ref := metav1.GetControllerOf(obj)
+	if ref == nil {
+		return false, nil
+	}
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return false, nil
+	}
+	if gv.Group != v1alpha1.SchemeGroupVersion.Group {
+		return false, nil
+	}
+	switch ref.Kind {
+	case v1alpha1.TiDBClusterKind,
+		v1alpha1.DMClusterKind,
+		v1alpha1.TiDBMonitorKind,
+		v1alpha1.TiDBDashboardKind,
+		v1alpha1.TiDBNGMonitoringKind:
+		return true, ref
+	}
+	return false, nil
+}
+
 // RetainManagedFields retains the fields in the old object that are managed by kube-controller-manager, such as node ports
 func RetainManagedFields(desiredSvc, existedSvc *corev1.Service) {
 	// Retain healthCheckNodePort if it has been filled by controller

--- a/tests/e2e/tidbcluster/stability-asts.go
+++ b/tests/e2e/tidbcluster/stability-asts.go
@@ -24,8 +24,10 @@ import (
 	asclientset "github.com/pingcap/advanced-statefulset/client/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -34,9 +36,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/label"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/client/clientset/versioned"
 	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/monitor/monitor"
 	"github.com/pingcap/tidb-operator/pkg/scheme"
+	"github.com/pingcap/tidb-operator/pkg/third_party/k8s"
 	"github.com/pingcap/tidb-operator/tests"
 	e2econfig "github.com/pingcap/tidb-operator/tests/e2e/config"
 	e2eframework "github.com/pingcap/tidb-operator/tests/e2e/framework"
@@ -426,6 +431,168 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		ginkgo.By("Make sure pods are not changed")
 		err = utilpod.WaitForPodsAreChanged(c, podListBeforeUpgrade.Items, time.Minute*3)
 		framework.ExpectEqual(err, wait.ErrWaitTimeout, "Pods are changed after the operator is upgraded")
+	})
+
+	ginkgo.It("[Feature: AdvancedStatefulSet] Upgrade tidbmonitor to advanced statefulset", func() {
+		var ocfg *tests.OperatorConfig
+		var oa *tests.OperatorActions
+		var genericCli client.Client
+
+		ocfg = &tests.OperatorConfig{
+			Namespace:      ns,
+			ReleaseName:    "operator",
+			Image:          cfg.OperatorImage,
+			Tag:            cfg.OperatorTag,
+			SchedulerImage: "registry.k8s.io/kube-scheduler",
+			Features: []string{
+				"StableScheduling=true",
+				"AdvancedStatefulSet=false",
+			},
+			LogLevel:        "4",
+			ImagePullPolicy: v1.PullIfNotPresent,
+			TestMode:        true,
+		}
+		oa = tests.NewOperatorActions(cli, c, asCli, aggrCli, apiExtCli, tests.DefaultPollInterval, ocfg, e2econfig.TestConfig, fw, f)
+		ginkgo.By("Installing CRDs")
+		oa.CleanCRDOrDie()
+		oa.CreateCRDOrDie(ocfg)
+		ginkgo.By("Installing tidb-operator without AdvancedStatefulSet feature")
+		oa.CleanOperatorOrDie(ocfg)
+		oa.DeployOperatorOrDie(ocfg)
+		var err error
+		genericCli, err = client.New(config, client.Options{Scheme: scheme.Scheme})
+		framework.ExpectNoError(err, "failed to create clientset")
+
+		// The TidbMonitor target TidbCluster is empty (all components scaled
+		// down to 0 replicas), so that only the monitor workload is created;
+		// this matches the customer scenario where the monitor StatefulSet
+		// is the only one missed by the TidbCluster-only migration filter.
+		tc := fixture.GetTidbCluster(ns, "sts", utilimage.TiDBLatest)
+		tc.Spec.PD.Replicas = 0
+		tc.Spec.TiKV.Replicas = 0
+		tc.Spec.TiDB.Replicas = 0
+		err = genericCli.Create(context.TODO(), tc)
+		framework.ExpectNoError(err, "failed to create TidbCluster: %v", tc)
+
+		tm := fixture.NewTidbMonitor("monitor-sts", ns, tc, false, false, false)
+		err = genericCli.Create(context.TODO(), tm)
+		framework.ExpectNoError(err, "failed to create TidbMonitor: %v", tm)
+
+		defer func() {
+			// Delete the TidbMonitor first while the operator is still
+			// running so that the protection finalizer is processed;
+			// otherwise the namespace teardown blocks forever.
+			ginkgo.By("Deleting the tidbmonitor")
+			_ = genericCli.Delete(context.TODO(), tm)
+			err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (bool, error) {
+				tmGet := &v1alpha1.TidbMonitor{}
+				err := genericCli.Get(context.TODO(), types.NamespacedName{Namespace: tm.Namespace, Name: tm.Name}, tmGet)
+				if err != nil && apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				return false, nil
+			})
+			framework.ExpectNoError(err, "failed to wait for TidbMonitor deleted")
+			ginkgo.By("Uninstall tidb-operator")
+			oa.CleanOperatorOrDie(ocfg)
+			ginkgo.By("Uninstalling CRDs")
+			oa.CleanCRDOrDie()
+		}()
+
+		ginkgo.By("Waiting for the native monitor StatefulSet and its pod to be ready")
+		stsName := monitor.GetMonitorShardName(tm.Name, 0)
+		err = wait.PollImmediate(time.Second*5, time.Minute*10, func() (bool, error) {
+			sts, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			if sts.Status.ReadyReplicas != *sts.Spec.Replicas {
+				log.Logf("monitor sts %s/%s is not ready yet: %d/%d", ns, stsName, sts.Status.ReadyReplicas, *sts.Spec.Replicas)
+				return false, nil
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "failed to wait for monitor StatefulSet %s/%s ready", ns, stsName)
+
+		stsBefore, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get monitor StatefulSet: %v", stsName)
+		podListBeforeUpgrade, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(stsBefore.Spec.Selector.MatchLabels).String(),
+		})
+		framework.ExpectNoError(err, "failed to list monitor pods before upgrade")
+		if len(podListBeforeUpgrade.Items) == 0 {
+			log.Failf("no pods found for monitor StatefulSet %s/%s", ns, stsName)
+		}
+
+		ginkgo.By("Upgrading tidb-operator with AdvancedStatefulSet feature")
+		ocfg.Features = []string{
+			"StableScheduling=true",
+			"AdvancedStatefulSet=true",
+		}
+		oa.ReplaceCRDOrDie(ocfg)
+		oa.UpgradeOperatorOrDie(ocfg)
+
+		ginkgo.By("Wait for the advanced statefulset is created and the Kubernetes statefulset is deleted")
+		err = wait.PollImmediate(time.Second*5, time.Minute*5, func() (bool, error) {
+			asts, err := asCli.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			_, err = c.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
+			if err == nil {
+				log.Logf("Kubernetes statefulset %s/%s still exists", ns, stsName)
+				return false, nil
+			}
+			if !apierrors.IsNotFound(err) {
+				return false, err
+			}
+			if asts.Status.ReadyReplicas != *asts.Spec.Replicas {
+				log.Logf("advanced statefulset %s/%s is not ready yet: %d/%d", ns, stsName, asts.Status.ReadyReplicas, *asts.Spec.Replicas)
+				return false, nil
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "failed to wait for the advanced statefulset %s/%s ready", ns, stsName)
+
+		ginkgo.By("Check the monitor pod is still owned by the advanced statefulset and is ready")
+		err = wait.PollImmediate(time.Second*5, time.Minute*5, func() (bool, error) {
+			asts, err := asCli.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			podListAfterUpgrade, err := c.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: labels.SelectorFromSet(stsBefore.Spec.Selector.MatchLabels).String(),
+			})
+			if err != nil {
+				return false, err
+			}
+			if len(podListAfterUpgrade.Items) != len(podListBeforeUpgrade.Items) {
+				log.Logf("monitor pod count is %d, expects %d", len(podListAfterUpgrade.Items), len(podListBeforeUpgrade.Items))
+				return false, nil
+			}
+			for i := range podListAfterUpgrade.Items {
+				pod := &podListAfterUpgrade.Items[i]
+				if !k8s.IsPodReady(pod) {
+					log.Logf("monitor pod %s/%s is not ready", pod.Namespace, pod.Name)
+					return false, nil
+				}
+				if ref := metav1.GetControllerOf(pod); ref == nil || ref.UID != asts.UID {
+					log.Logf("monitor pod %s/%s is not controlled by advanced statefulset %s", pod.Namespace, pod.Name, asts.UID)
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "failed to wait for monitor pod ready under advanced statefulset")
 	})
 
 	ginkgo.It("[Feature: AdvancedStatefulSet] Upgrading tidb cluster while pods are not consecutive", func() {

--- a/tests/e2e/tidbcluster/stability-asts.go
+++ b/tests/e2e/tidbcluster/stability-asts.go
@@ -455,9 +455,17 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		oa = tests.NewOperatorActions(cli, c, asCli, aggrCli, apiExtCli, tests.DefaultPollInterval, ocfg, e2econfig.TestConfig, fw, f)
 		ginkgo.By("Installing CRDs")
 		oa.CleanCRDOrDie()
+		defer func() {
+			ginkgo.By("Uninstalling CRDs")
+			oa.CleanCRDOrDie()
+		}()
 		oa.CreateCRDOrDie(ocfg)
 		ginkgo.By("Installing tidb-operator without AdvancedStatefulSet feature")
 		oa.CleanOperatorOrDie(ocfg)
+		defer func() {
+			ginkgo.By("Uninstalling tidb-operator")
+			oa.CleanOperatorOrDie(ocfg)
+		}()
 		oa.DeployOperatorOrDie(ocfg)
 		var err error
 		genericCli, err = client.New(config, client.Options{Scheme: scheme.Scheme})
@@ -478,13 +486,8 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		err = genericCli.Create(context.TODO(), tm)
 		framework.ExpectNoError(err, "failed to create TidbMonitor: %v", tm)
 
-		defer func() {
-			// Delete the TidbMonitor first while the operator is still
-			// running so that the protection finalizer is processed;
-			// otherwise the namespace teardown blocks forever.
-			ginkgo.By("Deleting the tidbmonitor")
-			_ = genericCli.Delete(context.TODO(), tm)
-			err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (bool, error) {
+		waitForTidbMonitorDeleted := func(timeout time.Duration) error {
+			return wait.PollImmediate(time.Second*5, timeout, func() (bool, error) {
 				tmGet := &v1alpha1.TidbMonitor{}
 				err := genericCli.Get(context.TODO(), types.NamespacedName{Namespace: tm.Namespace, Name: tm.Name}, tmGet)
 				if err != nil && apierrors.IsNotFound(err) {
@@ -495,11 +498,27 @@ var _ = ginkgo.Describe("[Stability]", func() {
 				}
 				return false, nil
 			})
+		}
+		defer func() {
+			// Delete the TidbMonitor first while the operator is still
+			// running so that the protection finalizer is processed;
+			// otherwise force-remove finalizers from this test resource so
+			// that the CRD and namespace teardown cannot be blocked.
+			ginkgo.By("Deleting the tidbmonitor")
+			if err := genericCli.Delete(context.TODO(), tm); err != nil && !apierrors.IsNotFound(err) {
+				log.Logf("failed to delete TidbMonitor %s/%s: %v", tm.Namespace, tm.Name, err)
+			}
+			err := waitForTidbMonitorDeleted(time.Minute * 5)
+			if err != nil {
+				log.Logf("TidbMonitor %s/%s was not deleted normally: %v; force-removing finalizers", tm.Namespace, tm.Name, err)
+				patch := []byte(`{"metadata":{"finalizers":[]}}`)
+				_, patchErr := cli.PingcapV1alpha1().TidbMonitors(tm.Namespace).Patch(context.TODO(), tm.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+				if patchErr != nil && !apierrors.IsNotFound(patchErr) {
+					framework.ExpectNoError(patchErr, "failed to force-remove finalizers from TidbMonitor %s/%s", tm.Namespace, tm.Name)
+				}
+				err = waitForTidbMonitorDeleted(time.Minute)
+			}
 			framework.ExpectNoError(err, "failed to wait for TidbMonitor deleted")
-			ginkgo.By("Uninstall tidb-operator")
-			oa.CleanOperatorOrDie(ocfg)
-			ginkgo.By("Uninstalling CRDs")
-			oa.CleanCRDOrDie()
 		}()
 
 		ginkgo.By("Waiting for the native monitor StatefulSet and its pod to be ready")
@@ -528,6 +547,11 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		framework.ExpectNoError(err, "failed to list monitor pods before upgrade")
 		if len(podListBeforeUpgrade.Items) == 0 {
 			log.Failf("no pods found for monitor StatefulSet %s/%s", ns, stsName)
+		}
+		podUIDsBeforeUpgrade := make(map[string]types.UID, len(podListBeforeUpgrade.Items))
+		for i := range podListBeforeUpgrade.Items {
+			pod := &podListBeforeUpgrade.Items[i]
+			podUIDsBeforeUpgrade[pod.Name] = pod.UID
 		}
 
 		ginkgo.By("Upgrading tidb-operator with AdvancedStatefulSet feature")
@@ -563,7 +587,7 @@ var _ = ginkgo.Describe("[Stability]", func() {
 		})
 		framework.ExpectNoError(err, "failed to wait for the advanced statefulset %s/%s ready", ns, stsName)
 
-		ginkgo.By("Check the monitor pod is still owned by the advanced statefulset and is ready")
+		ginkgo.By("Check the monitor pod is not recreated, is owned by the advanced statefulset, and is ready")
 		err = wait.PollImmediate(time.Second*5, time.Minute*5, func() (bool, error) {
 			asts, err := asCli.AppsV1().StatefulSets(ns).Get(context.TODO(), stsName, metav1.GetOptions{})
 			if err != nil {
@@ -581,6 +605,13 @@ var _ = ginkgo.Describe("[Stability]", func() {
 			}
 			for i := range podListAfterUpgrade.Items {
 				pod := &podListAfterUpgrade.Items[i]
+				uidBeforeUpgrade, ok := podUIDsBeforeUpgrade[pod.Name]
+				if !ok {
+					return false, fmt.Errorf("monitor pod %s/%s did not exist before the operator upgrade", pod.Namespace, pod.Name)
+				}
+				if pod.UID != uidBeforeUpgrade {
+					return false, fmt.Errorf("monitor pod %s/%s was recreated during the operator upgrade: UID changed from %s to %s", pod.Namespace, pod.Name, uidBeforeUpgrade, pod.UID)
+				}
 				if !k8s.IsPodReady(pod) {
 					log.Logf("monitor pod %s/%s is not ready", pod.Namespace, pod.Name)
 					return false, nil


### PR DESCRIPTION
### What problem does this PR solve?

The ASTS startup migration skipped StatefulSets owned by TidbMonitor, leaving a duplicated native StatefulSet / Advanced StatefulSet pair that blocked pod rollouts. Background and root cause are tracked in #7037.

### What is changed and how does it work?

- Add `util.IsOwnedByPingcapStatefulSet`, a centralized predicate covering the 5 pingcap.com kinds whose StatefulSets go through the (possibly hijacked) StatefulSet client: TidbCluster, DMCluster, TidbMonitor, TidbDashboard, TidbNGMonitoring.
- Use it in both upgrader directions (`pkg/upgrader/upgrader.go`):
  - ASTS=true: migrate native StatefulSets of all these kinds (previously TidbCluster only). Before modifying any StatefulSet, reject the migration when an owning TidbCluster or DMCluster CR has component delete-slots annotations. The check deliberately reads the owner CR, matching the existing TidbCluster behavior.
  - ASTS=false: refuse to start if any matching Advanced StatefulSet exists, now also listing the offending `StatefulSet namespace/name` objects in the error (capped at 10).
- Keep the old `IsOwnedByTidbCluster` untouched; the new predicate sits beside it.

For a pre-split native/advanced StatefulSet pair, the migration treats the native StatefulSet spec as the current running state, updates the Advanced StatefulSet from it, and orphan-deletes the native StatefulSet. Normal reconciliation then applies the CR desired state. This PR intentionally does not add a spec-mismatch guard; the no-recreation guarantee applies to a clean migration with a stable spec, not to arbitrary already-inconsistent split states.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests

- [x] Unit test
- [x] E2E test
- [ ] Manual test
- [ ] No code

- Unit: predicate coverage for all supported owner kinds; upgrader coverage for migration in both feature-gate directions; DMCluster dm-master/dm-worker delete-slots extraction and preflight rejection before any StatefulSet is modified.
- E2E: `[Feature: AdvancedStatefulSet] Upgrade tidbmonitor to advanced statefulset` deploys a TidbMonitor with ASTS off, enables ASTS, and asserts that the native StatefulSet is deleted, the Advanced StatefulSet is ready, and the original Pod keeps the same name and UID while its controller owner changes to the Advanced StatefulSet. Its teardown independently cleans the TidbMonitor, operator, and CRDs, with a finalizer fallback for failed operator upgrades.
- Local checks: `go test ./pkg/upgrader -count=10`, `go test ./pkg/util -count=1`, `go vet ./pkg/upgrader ./pkg/util ./tests/e2e/tidbcluster`, and an e2e package compile check.
- Additional local kind validation before this follow-up: TidbMonitor STS→ASTS migration, reverse-direction startup rejection listing objects, idempotent re-run, config-change propagation after migration, and convergence of a pre-split double-StatefulSet state simulating #7037.

### Side effects

- [ ] Breaking backward compatibility
- [x] Other side effects: With ASTS disabled, the operator now refuses to start when Advanced StatefulSets of TidbMonitor/DMCluster/TidbDashboard/TidbNGMonitoring exist (previously only TidbCluster was checked). With ASTS enabled, DMCluster migration is rejected while dm-master or dm-worker delete-slots annotations are present. Both are intentional safety checks with actionable errors.

### Related changes

- [x] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

### Release Notes

```release-note
Fix the bug that the ASTS startup migration skipped StatefulSets owned by TidbMonitor and other pingcap.com owners, which could leave both a native StatefulSet and an Advanced StatefulSet managing the same pods and block rollouts. The operator now migrates StatefulSets of all supported pingcap.com owner kinds, rejects DMCluster migration while delete-slots are present, and, when AdvancedStatefulSet is disabled, refuses to start if any of these Advanced StatefulSets remain.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Advanced StatefulSet migration now supports resources managed by supported PingCAP controllers, including TiDB Monitor and DM.
  - Downgrade messages identify affected StatefulSets by namespaced name.

- **Bug Fixes**
  - Improved migration safety checks for TiDBCluster- and DM-managed StatefulSets, including delete-slot protections.
  - Corrected StatefulSet terminology in upgrader messages.

- **Tests**
  - Added coverage for controller ownership detection, DM migration safeguards, and TiDB Monitor migration stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
