### PR TITLE
feat: support cache ttl config for tikvgroup

### DIFF
--- a/api/core/v1alpha1/tikv_types.go
+++ b/api/core/v1alpha1/tikv_types.go
@@ -156,6 +156,12 @@ type TiKVGroupSpec struct {
 	// +optional
 	MinReadySeconds *int64 `json:"minReadySeconds,omitempty"`
 
+	// CacheTTLSeconds specifies how long to wait after all leaders have been evicted
+	// before restarting a TiKV instance, allowing TiDB region caches to refresh.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	CacheTTLSeconds *int64 `json:"cacheTTLSeconds,omitempty"`
+
 	Template TiKVTemplate `json:"template"`
 }
 
@@ -299,6 +305,12 @@ type TiKVSpec struct {
 	// +default:value=1
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// CacheTTLSeconds is managed by TiKVGroup and specifies how long to wait after
+	// all leaders have been evicted before restarting this TiKV instance.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	CacheTTLSeconds *int64 `json:"cacheTTLSeconds,omitempty"`
 
 	// TiKVTemplateSpec embedded some fields managed by TiKVGroup
 	TiKVTemplateSpec `json:",inline"`

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -5051,6 +5051,11 @@ func (in *TiKVGroupSpec) DeepCopyInto(out *TiKVGroupSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CacheTTLSeconds != nil {
+		in, out := &in.CacheTTLSeconds, &out.CacheTTLSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
 }
@@ -5238,6 +5243,11 @@ func (in *TiKVSpec) DeepCopyInto(out *TiKVSpec) {
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)
+		**out = **in
+	}
+	if in.CacheTTLSeconds != nil {
+		in, out := &in.CacheTTLSeconds, &out.CacheTTLSeconds
+		*out = new(int64)
 		**out = **in
 	}
 	in.TiKVTemplateSpec.DeepCopyInto(&out.TiKVTemplateSpec)

--- a/manifests/crd/core.pingcap.com_tikvgroups.yaml
+++ b/manifests/crd/core.pingcap.com_tikvgroups.yaml
@@ -72,6 +72,13 @@ spec:
           spec:
             description: TiKVGroupSpec describes the common attributes of a TiKVGroup
             properties:
+              cacheTTLSeconds:
+                description: |-
+                  CacheTTLSeconds specifies how long to wait after all leaders have been evicted
+                  before restarting a TiKV instance, allowing TiDB region caches to refresh.
+                format: int64
+                minimum: 0
+                type: integer
               cluster:
                 description: |-
                   ClusterReference is a reference to cluster

--- a/manifests/crd/core.pingcap.com_tikvs.yaml
+++ b/manifests/crd/core.pingcap.com_tikvs.yaml
@@ -64,6 +64,13 @@ spec:
           spec:
             description: TiKVSpec defines the spec of tikv instance
             properties:
+              cacheTTLSeconds:
+                description: |-
+                  CacheTTLSeconds is managed by TiKVGroup and specifies how long to wait after
+                  all leaders have been evicted before restarting this TiKV instance.
+                format: int64
+                minimum: 0
+                type: integer
               cluster:
                 description: Cluster is a reference of tidb cluster
                 properties:

--- a/pkg/apicall/group.go
+++ b/pkg/apicall/group.go
@@ -67,7 +67,7 @@ func ListPods[
 	S scope.Group[F, T],
 	F client.Object,
 	T runtime.Group,
-](ctx context.Context, c ctrlclient.Client, g F) (*corev1.PodList, error) {
+](ctx context.Context, c ctrlclient.Client, g F) ([]*corev1.Pod, error) {
 	group := scope.From[S](g)
 	list := &corev1.PodList{}
 	if err := c.List(ctx, list, client.InNamespace(g.GetNamespace()), client.MatchingLabels{
@@ -83,7 +83,12 @@ func ListPods[
 		return cmp.Compare(a.GetName(), b.GetName())
 	})
 
-	return list, nil
+	pods := make([]*corev1.Pod, len(list.Items))
+	for i := range list.Items {
+		pods[i] = &list.Items[i]
+	}
+
+	return pods, nil
 }
 
 // ListPeerInstances returns peers of an instance in a same cluster

--- a/pkg/apicall/group_test.go
+++ b/pkg/apicall/group_test.go
@@ -52,7 +52,7 @@ func TestListPods(t *testing.T) {
 	pods, err := ListPods[scope.PDGroup](context.Background(), cli, pdg)
 
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 2)
-	require.Equal(t, "pod-a", pods.Items[0].Name)
-	require.Equal(t, "pod-b", pods.Items[1].Name)
+	require.Len(t, pods, 2)
+	require.Equal(t, "pod-a", pods[0].Name)
+	require.Equal(t, "pod-b", pods[1].Name)
 }

--- a/pkg/controllers/tikv/tasks/pod.go
+++ b/pkg/controllers/tikv/tasks/pod.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -108,6 +109,9 @@ func TaskPod(state *ReconcileContext, c client.Client, cm pdm.PDClientManager) t
 
 			if err := CheckTiKVLeadersEvicted(state.TiKV()); err != nil {
 				return task.Retry(defaultTaskWaitDuration).With("cannot recreate pod, check leader count: %v", err)
+			}
+			if remaining := cacheTTLRemaining(state.TiKV(), time.Now()); remaining > 0 {
+				return task.Retry(remaining).With("cannot recreate pod, wait for TiDB region cache to refresh")
 			}
 
 			logger.Info("will recreate the pod")

--- a/pkg/controllers/tikv/tasks/pod_test.go
+++ b/pkg/controllers/tikv/tasks/pod_test.go
@@ -151,6 +151,33 @@ func TestTaskPod(t *testing.T) {
 			pdClientReady:            true,
 		},
 		{
+			desc: "version is changed but cache ttl has not expired",
+			state: &ReconcileContext{
+				State: &state{
+					tikv: fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiKV) *v1alpha1.TiKV {
+						obj.Spec.Version = fakeVersion
+						obj.Spec.CacheTTLSeconds = ptr.To[int64](60)
+						setLeadersEvictedAt(obj, metav1.Now())
+						return obj
+					}),
+					cluster: fake.FakeObj[v1alpha1.Cluster]("aaa"),
+					pod: fakePod(
+						fake.FakeObj[v1alpha1.Cluster]("aaa"),
+						fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiKV) *v1alpha1.TiKV {
+							obj.Spec.Version = fakeNewVersion
+							return obj
+						}),
+					),
+				},
+			},
+
+			downPeerCount:            0,
+			expectedPodIsTerminating: false,
+			expectedStatus:           task.SRetry,
+			expectedShouldEvict:      true,
+			pdClientReady:            true,
+		},
+		{
 			desc: "version is changed, failed to delete",
 			state: &ReconcileContext{
 				State: &state{
@@ -586,9 +613,14 @@ func fakePod(c *v1alpha1.Cluster, tikv *v1alpha1.TiKV) *corev1.Pod {
 }
 
 func setLeadersEvicted(tikv *v1alpha1.TiKV) {
+	setLeadersEvictedAt(tikv, metav1.Time{})
+}
+
+func setLeadersEvictedAt(tikv *v1alpha1.TiKV, at metav1.Time) {
 	tikv.Status.Conditions = append(tikv.Status.Conditions, metav1.Condition{
-		Type:   v1alpha1.TiKVCondLeadersEvicted,
-		Status: metav1.ConditionTrue,
-		Reason: v1alpha1.ReasonEvicted,
+		Type:               v1alpha1.TiKVCondLeadersEvicted,
+		Status:             metav1.ConditionTrue,
+		Reason:             v1alpha1.ReasonEvicted,
+		LastTransitionTime: at,
 	})
 }

--- a/pkg/controllers/tikv/tasks/util.go
+++ b/pkg/controllers/tikv/tasks/util.go
@@ -90,6 +90,24 @@ func CheckTiKVLeadersEvicted(tikv *v1alpha1.TiKV) error {
 	return fmt.Errorf("tikv leaders are not evicted: %v, %v", cond.Reason, cond.Message)
 }
 
+func cacheTTLRemaining(tikv *v1alpha1.TiKV, now time.Time) time.Duration {
+	if tikv.Spec.CacheTTLSeconds == nil || *tikv.Spec.CacheTTLSeconds <= 0 {
+		return 0
+	}
+
+	cond := meta.FindStatusCondition(tikv.Status.Conditions, v1alpha1.TiKVCondLeadersEvicted)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		return 0
+	}
+
+	remaining := cond.LastTransitionTime.Add(time.Duration(*tikv.Spec.CacheTTLSeconds) * time.Second).Sub(now)
+	if remaining <= 0 {
+		return 0
+	}
+
+	return remaining
+}
+
 func CheckTiKVLeadersEvictedOrTimeout(tikv *v1alpha1.TiKV, timeout time.Duration) error {
 	cond := meta.FindStatusCondition(tikv.Status.Conditions, v1alpha1.TiKVCondLeadersEvicted)
 	if cond == nil {

--- a/pkg/controllers/tikv/tasks/util_test.go
+++ b/pkg/controllers/tikv/tasks/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controllers/tikv/tasks/util_test.go
+++ b/pkg/controllers/tikv/tasks/util_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
+)
+
+func TestCacheTTLRemaining(t *testing.T) {
+	now := time.Unix(100, 0)
+
+	tests := []struct {
+		name     string
+		tikv     *v1alpha1.TiKV
+		expected time.Duration
+	}{
+		{
+			name: "ttl is unset",
+			tikv: &v1alpha1.TiKV{},
+		},
+		{
+			name: "leaders are not evicted",
+			tikv: &v1alpha1.TiKV{
+				Spec: v1alpha1.TiKVSpec{CacheTTLSeconds: ptr.To[int64](30)},
+			},
+		},
+		{
+			name: "ttl has not expired",
+			tikv: &v1alpha1.TiKV{
+				Spec: v1alpha1.TiKVSpec{CacheTTLSeconds: ptr.To[int64](30)},
+				Status: v1alpha1.TiKVStatus{CommonStatus: v1alpha1.CommonStatus{
+					Conditions: []metav1.Condition{{
+						Type:               v1alpha1.TiKVCondLeadersEvicted,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now.Add(-10 * time.Second)),
+					}},
+				}},
+			},
+			expected: 20 * time.Second,
+		},
+		{
+			name: "ttl has expired",
+			tikv: &v1alpha1.TiKV{
+				Spec: v1alpha1.TiKVSpec{CacheTTLSeconds: ptr.To[int64](30)},
+				Status: v1alpha1.TiKVStatus{CommonStatus: v1alpha1.CommonStatus{
+					Conditions: []metav1.Condition{{
+						Type:               v1alpha1.TiKVCondLeadersEvicted,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now.Add(-31 * time.Second)),
+					}},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cacheTTLRemaining(tt.tikv, now))
+		})
+	}
+}

--- a/pkg/controllers/tikvgroup/tasks/updater.go
+++ b/pkg/controllers/tikvgroup/tasks/updater.go
@@ -139,6 +139,7 @@ func TiKVNewer(kvg *v1alpha1.TiKVGroup, rev string, fg features.Gates) updater.N
 				Cluster:          kvg.Spec.Cluster,
 				Features:         kvg.Spec.Features,
 				Subdomain:        coreutil.HeadlessServiceName[scope.TiKVGroup](kvg),
+				CacheTTLSeconds:  kvg.Spec.CacheTTLSeconds,
 				TiKVTemplateSpec: *spec,
 				Offline:          ptr.To(false),
 			},

--- a/pkg/controllers/tikvgroup/tasks/updater_test.go
+++ b/pkg/controllers/tikvgroup/tasks/updater_test.go
@@ -289,6 +289,17 @@ func TestTaskUpdater(t *testing.T) {
 	}
 }
 
+func TestTiKVNewerCopiesCacheTTLSeconds(t *testing.T) {
+	kvg := fake.FakeObj("aaa", func(obj *v1alpha1.TiKVGroup) *v1alpha1.TiKVGroup {
+		obj.Spec.CacheTTLSeconds = ptr.To[int64](600)
+		return obj
+	})
+
+	tikv := runtime.ToTiKV(TiKVNewer(kvg, newRevision, features.NewFromFeatures(nil)).New())
+	require.NotNil(t, tikv.Spec.CacheTTLSeconds)
+	assert.Equal(t, int64(600), *tikv.Spec.CacheTTLSeconds)
+}
+
 func fakeAvailableTiKV(name string, kvg *v1alpha1.TiKVGroup, rev string) *v1alpha1.TiKV {
 	return fake.FakeObj(name, func(obj *v1alpha1.TiKV) *v1alpha1.TiKV {
 		tikv := runtime.ToTiKV(TiKVNewer(kvg, rev, features.NewFromFeatures(nil)).New())

--- a/tests/e2e/cluster/cluster.go
+++ b/tests/e2e/cluster/cluster.go
@@ -437,15 +437,15 @@ var _ = Describe("TiDB Cluster", func() {
 			By("Checking log tailer sidercar container")
 			tidbPodList, err := apicall.ListPods[scope.TiDBGroup](ctx, k8sClient, dbg)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(tidbPodList.Items)).To(Equal(1))
-			tidbPod := tidbPodList.Items[0]
+			Expect(len(tidbPodList)).To(Equal(1))
+			tidbPod := tidbPodList[0]
 			Expect(tidbPod.Spec.InitContainers).To(HaveLen(1)) // sidercar container in `initContainers`
 			Expect(tidbPod.Spec.InitContainers[0].Name).To(Equal(v1alpha1.ContainerNameTiDBSlowLog))
 
 			tiflashPodList, err := apicall.ListPods[scope.TiFlashGroup](ctx, k8sClient, flashg)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(tiflashPodList.Items)).To(Equal(1))
-			tiflashPod := tiflashPodList.Items[0]
+			Expect(len(tiflashPodList)).To(Equal(1))
+			tiflashPod := tiflashPodList[0]
 			Expect(tiflashPod.Spec.InitContainers).To(HaveLen(2))
 			Expect(tiflashPod.Spec.InitContainers[0].Name).To(Equal(v1alpha1.ContainerNameTiFlashServerLog))
 			Expect(tiflashPod.Spec.InitContainers[1].Name).To(Equal(v1alpha1.ContainerNameTiFlashErrorLog))
@@ -1273,7 +1273,7 @@ var _ = Describe("TiDB Cluster", func() {
 					g.Expect(pdgGet.Status.Version).To(Equal(newVersion))
 					pdPods, err := apicall.ListPods[scope.PDGroup](ctx, k8sClient, &pdgGet)
 					g.Expect(err).ToNot(HaveOccurred())
-					for _, pod := range pdPods.Items {
+					for _, pod := range pdPods {
 						for _, container := range pod.Spec.Containers {
 							if container.Name == v1alpha1.ContainerNamePD {
 								g.Expect(strings.Contains(container.Image, newVersion)).To(BeTrue())
@@ -1286,7 +1286,7 @@ var _ = Describe("TiDB Cluster", func() {
 					g.Expect(kvgGet.Status.Version).To(Equal(newVersion))
 					tikvPods, err := apicall.ListPods[scope.TiKVGroup](ctx, k8sClient, &kvgGet)
 					g.Expect(err).ToNot(HaveOccurred())
-					for _, pod := range tikvPods.Items {
+					for _, pod := range tikvPods {
 						for _, container := range pod.Spec.Containers {
 							if container.Name == v1alpha1.ContainerNameTiKV {
 								g.Expect(strings.Contains(container.Image, newVersion)).To(BeTrue())

--- a/tests/e2e/data/tikv.go
+++ b/tests/e2e/data/tikv.go
@@ -54,6 +54,12 @@ func NewTiKVGroup(ns string, patches ...GroupPatch[*v1alpha1.TiKVGroup]) *v1alph
 	return kvg
 }
 
+func WithTiKVCacheTTLSeconds(seconds int64) GroupPatch[*v1alpha1.TiKVGroup] {
+	return GroupPatchFunc[*v1alpha1.TiKVGroup](func(obj *v1alpha1.TiKVGroup) {
+		obj.Spec.CacheTTLSeconds = ptr.To(seconds)
+	})
+}
+
 // TODO: combine with WithTiDBEvenlySpreadPolicy
 func WithTiKVEvenlySpreadPolicy() GroupPatch[*v1alpha1.TiKVGroup] {
 	return GroupPatchFunc[*v1alpha1.TiKVGroup](func(obj *v1alpha1.TiKVGroup) {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -320,9 +320,9 @@ func PortForwardGroup[
 ](ctx context.Context, f *Framework, group G, ports []string) []portforward.ForwardedPort {
 	pods, err := apicall.ListPods[S](ctx, f.Client, group)
 	f.Must(err)
-	gomega.ExpectWithOffset(1, pods.Items).ToNot(gomega.BeEmpty())
+	gomega.ExpectWithOffset(1, pods).ToNot(gomega.BeEmpty())
 
-	return f.PortForwardPod(ctx, &pods.Items[0], ports)
+	return f.PortForwardPod(ctx, pods[0], ports)
 }
 
 func AsyncWaitPodsRollingUpdateOnce[

--- a/tests/e2e/pd/pd.go
+++ b/tests/e2e/pd/pd.go
@@ -127,8 +127,8 @@ var _ = ginkgo.Describe("PD", label.PD, func() {
 				pods, err := apicall.ListPods[scope.PDGroup](ctx, f.Client, pdg)
 				f.Must(err)
 
-				gomega.Expect(len(pods.Items)).To(gomega.Equal(3), "Should have 3 PD pods")
-				for _, pod := range pods.Items {
+				gomega.Expect(len(pods)).To(gomega.Equal(3), "Should have 3 PD pods")
+				for _, pod := range pods {
 					gomega.Expect(pod.Spec.Containers).To(gomega.HaveLen(1), "PD pod should have 1 container")
 					probe := pod.Spec.Containers[0].ReadinessProbe
 					gomega.Expect(probe).ToNot(gomega.BeNil(), "PD container should have readiness probe")

--- a/tests/e2e/suite/scale/tikv.go
+++ b/tests/e2e/suite/scale/tikv.go
@@ -50,6 +50,60 @@ var _ = ginkgo.Describe("Scale TiKV", label.TiKV, label.MultipleAZ, label.P0, la
 		framework.MustEvenlySpread[scope.TiKVGroup](ctx, f, kvg)
 	})
 
+	ginkgo.It("support cache TTL wait during rolling restart", ginkgo.Serial, label.Update, func(ctx context.Context) {
+		const (
+			replicas              = 3
+			cacheTTLSeconds int64 = 15
+		)
+
+		pdg := f.MustCreatePD(ctx)
+		kvg := f.MustCreateTiKV(ctx,
+			data.WithReplicas[scope.TiKVGroup](replicas),
+			data.WithTiKVEvenlySpreadPolicy(),
+			data.WithTiKVCacheTTLSeconds(cacheTTLSeconds),
+		)
+
+		f.WaitForPDGroupReady(ctx, pdg)
+		f.WaitForTiKVGroupReady(ctx, kvg)
+		framework.MustEvenlySpread[scope.TiKVGroup](ctx, f, kvg)
+
+		nctx, cancel := context.WithCancel(ctx)
+		watchDone := make(chan struct{})
+		watchSynced := make(chan struct{})
+		go func() {
+			defer close(watchDone)
+			defer ginkgo.GinkgoRecover()
+			f.Must(waiter.WatchUntilTiKVsRestartedAfterCacheTTL(
+				nctx,
+				f.Client,
+				kvg.DeepCopy(),
+				waiter.LongTaskTimeout,
+				watchSynced,
+			))
+		}()
+		defer func() {
+			cancel()
+			<-watchDone
+		}()
+
+		// Start the rolling restart only after the watch cache is synced so no
+		// LeadersEvicted transition can be missed.
+		<-watchSynced
+
+		rollingDone := framework.AsyncWaitPodsRollingUpdateOnce[scope.TiKVGroup](nctx, f, kvg, replicas)
+		defer func() {
+			cancel()
+			<-rollingDone
+		}()
+
+		action.MustRollingRestart[scope.TiKVGroup](ctx, f, kvg)
+
+		<-watchDone
+		f.WaitForTiKVGroupReady(ctx, kvg)
+
+		framework.MustEvenlySpread[scope.TiKVGroup](ctx, f, kvg)
+	})
+
 	ginkgo.It("support scale in from 4 to 3", func(ctx context.Context) {
 		pdg := f.MustCreatePD(ctx)
 		kvg := f.MustCreateTiKV(ctx,

--- a/tests/e2e/tidb/tidb.go
+++ b/tests/e2e/tidb/tidb.go
@@ -329,9 +329,9 @@ GRANT ALL PRIVILEGES ON *.* TO '%s'@'%s';`, sub, iss, email, sub, "%")
 			f.WaitForTiCDCGroupReady(ctx, cdcg)
 
 			ginkgo.By("Checking the status of the cluster and the connection to the TiDB service")
-			checkComponent := func(podList *corev1.PodList, groupName, componentName string, expectedReplicas *int32) {
-				gomega.Expect(len(podList.Items)).To(gomega.Equal(int(*expectedReplicas)))
-				for _, pod := range podList.Items {
+			checkComponent := func(pods []*corev1.Pod, groupName, componentName string, expectedReplicas *int32) {
+				gomega.Expect(len(pods)).To(gomega.Equal(int(*expectedReplicas)))
+				for _, pod := range pods {
 					gomega.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
 
 					// check for mTLS
@@ -421,8 +421,8 @@ GRANT ALL PRIVILEGES ON *.* TO '%s'@'%s';`, sub, iss, email, sub, "%")
 			podList, err := apicall.ListPods[scope.TiDBGroup](ctx, f.Client, dbg)
 			f.Must(err)
 
-			gomega.Expect(len(podList.Items)).To(gomega.BeNumerically(">", 0))
-			for _, pod := range podList.Items {
+			gomega.Expect(len(podList)).To(gomega.BeNumerically(">", 0))
+			for _, pod := range podList {
 				gomega.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
 
 				// Check for session token signing cert volume

--- a/tests/e2e/tikv/tikv.go
+++ b/tests/e2e/tikv/tikv.go
@@ -63,9 +63,9 @@ max-replicas = 1
 
 		sourcePods, err := apicall.ListPods[scope.TiKVGroup](ctx, f.Client, source)
 		f.Must(err)
-		gomega.Expect(sourcePods.Items).To(gomega.HaveLen(1))
-		sourcePodName := sourcePods.Items[0].Name
-		sourcePodUID := sourcePods.Items[0].UID
+		gomega.Expect(sourcePods).To(gomega.HaveLen(1))
+		sourcePodName := sourcePods[0].Name
+		sourcePodUID := sourcePods[0].UID
 
 		target := f.MustCreateTiKV(ctx, data.WithName[scope.TiKVGroup]("kvg-target"))
 		f.WaitForTiKVGroupReady(ctx, target)
@@ -84,9 +84,9 @@ max-replicas = 1
 		ginkgo.By("Checking source TiKV pod is not restarted")
 		currentSourcePods, err := apicall.ListPods[scope.TiKVGroup](ctx, f.Client, &latest)
 		f.Must(err)
-		gomega.Expect(currentSourcePods.Items).To(gomega.HaveLen(1))
-		gomega.Expect(currentSourcePods.Items[0].Name).To(gomega.Equal(sourcePodName))
-		gomega.Expect(currentSourcePods.Items[0].UID).To(gomega.Equal(sourcePodUID))
+		gomega.Expect(currentSourcePods).To(gomega.HaveLen(1))
+		gomega.Expect(currentSourcePods[0].Name).To(gomega.Equal(sourcePodName))
+		gomega.Expect(currentSourcePods[0].UID).To(gomega.Equal(sourcePodUID))
 
 		ginkgo.By("Checking source TiKVGroup is exclusive and regions are migrated away")
 		f.Must(waiter.WaitForStoreLabelValue(ctx, f.Client, pdc, &latest, waiter.LongTaskTimeout))

--- a/tests/e2e/tiproxy/tiproxy.go
+++ b/tests/e2e/tiproxy/tiproxy.go
@@ -689,7 +689,7 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 
 			pods, err := apicall.ListPods[scope.TiProxyGroup](ctx, f.Client, proxyg)
 			f.Must(err)
-			gomega.Expect(pods.Items).To(gomega.HaveLen(int(replicas)))
+			gomega.Expect(pods).To(gomega.HaveLen(int(replicas)))
 		})
 
 		ginkgo.It("revive draining TiProxy pods on scale-out instead of creating new ones", label.Scale, func(ctx context.Context) {
@@ -1184,9 +1184,9 @@ var _ = ginkgo.Describe("TiProxy", label.TiProxy, func() {
 			f.WaitForTiProxyGroupReady(ctx, pg)
 
 			ginkgo.By("Checking the status of the cluster and the connection to the TiProxy service")
-			checkComponent := func(podList *corev1.PodList, groupName, componentName string, expectedReplicas *int32) {
-				gomega.Expect(len(podList.Items)).To(gomega.Equal(int(*expectedReplicas)))
-				for _, pod := range podList.Items {
+			checkComponent := func(pods []*corev1.Pod, groupName, componentName string, expectedReplicas *int32) {
+				gomega.Expect(len(pods)).To(gomega.Equal(int(*expectedReplicas)))
+				for _, pod := range pods {
 					gomega.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
 
 					// check for mTLS

--- a/tests/e2e/utils/tidb/tidb.go
+++ b/tests/e2e/utils/tidb/tidb.go
@@ -282,11 +282,10 @@ func AreAllPDHealthy(cli client.Client, pdg *v1alpha1.PDGroup, checkGroup bool) 
 	if err != nil {
 		return fmt.Errorf("failed to list pd pod %s/%s: %w", pdg.Namespace, pdg.Name, err)
 	}
-	if len(podList.Items) != int(*pdg.Spec.Replicas) {
-		return fmt.Errorf("pd %s/%s pod replicas %d not equal to %d", pdg.Namespace, pdg.Name, len(podList.Items), *pdg.Spec.Replicas)
+	if len(podList) != int(*pdg.Spec.Replicas) {
+		return fmt.Errorf("pd %s/%s pod replicas %d not equal to %d", pdg.Namespace, pdg.Name, len(podList), *pdg.Spec.Replicas)
 	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for _, pod := range podList {
 		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("pd %s/%s pod %s is not running, current phase: %s", pdg.Namespace, pdg.Name, pod.Name, pod.Status.Phase)
 		}
@@ -326,11 +325,10 @@ func AreAllTiKVHealthy(cli client.Client, kvg *v1alpha1.TiKVGroup, checkGroup bo
 	if err != nil {
 		return fmt.Errorf("failed to list tikv pod %s/%s: %w", kvg.Namespace, kvg.Name, err)
 	}
-	if len(podList.Items) != int(*kvg.Spec.Replicas) {
-		return fmt.Errorf("tikv %s/%s pod replicas %d not equal to %d", kvg.Namespace, kvg.Name, len(podList.Items), *kvg.Spec.Replicas)
+	if len(podList) != int(*kvg.Spec.Replicas) {
+		return fmt.Errorf("tikv %s/%s pod replicas %d not equal to %d", kvg.Namespace, kvg.Name, len(podList), *kvg.Spec.Replicas)
 	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for _, pod := range podList {
 		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("tikv %s/%s pod %s is not running, current phase: %s", kvg.Namespace, kvg.Name, pod.Name, pod.Status.Phase)
 		}
@@ -370,11 +368,10 @@ func AreAllTiDBHealthy(cli client.Client, dbg *v1alpha1.TiDBGroup, checkGroup bo
 	if err != nil {
 		return fmt.Errorf("failed to list tidb pod %s/%s: %w", dbg.Namespace, dbg.Name, err)
 	}
-	if len(podList.Items) != int(*dbg.Spec.Replicas) {
-		return fmt.Errorf("tidb %s/%s pod replicas %d not equal to %d", dbg.Namespace, dbg.Name, len(podList.Items), *dbg.Spec.Replicas)
+	if len(podList) != int(*dbg.Spec.Replicas) {
+		return fmt.Errorf("tidb %s/%s pod replicas %d not equal to %d", dbg.Namespace, dbg.Name, len(podList), *dbg.Spec.Replicas)
 	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for _, pod := range podList {
 		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("tidb %s/%s pod %s is not running, current phase: %s", dbg.Namespace, dbg.Name, pod.Name, pod.Status.Phase)
 		}
@@ -414,12 +411,11 @@ func AreAllTiFlashHealthy(cli client.Client, flashg *v1alpha1.TiFlashGroup, chec
 	if err != nil {
 		return fmt.Errorf("failed to list tiflash pod %s/%s: %w", flashg.Namespace, flashg.Name, err)
 	}
-	if len(podList.Items) != int(*flashg.Spec.Replicas) {
+	if len(podList) != int(*flashg.Spec.Replicas) {
 		return fmt.Errorf("tiflash %s/%s pod replicas %d not equal to %d",
-			flashg.Namespace, flashg.Name, len(podList.Items), *flashg.Spec.Replicas)
+			flashg.Namespace, flashg.Name, len(podList), *flashg.Spec.Replicas)
 	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for _, pod := range podList {
 		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("tiflash %s/%s pod %s is not running, current phase: %s", flashg.Namespace, flashg.Name, pod.Name, pod.Status.Phase)
 		}
@@ -459,11 +455,10 @@ func AreAllTiCDCHealthy(cli client.Client, ticdcg *v1alpha1.TiCDCGroup, checkGro
 	if err != nil {
 		return fmt.Errorf("failed to list ticdc pod %s/%s: %w", ticdcg.Namespace, ticdcg.Name, err)
 	}
-	if len(podList.Items) != int(*ticdcg.Spec.Replicas) {
-		return fmt.Errorf("ticdc %s/%s pod replicas %d not equal to %d", ticdcg.Namespace, ticdcg.Name, len(podList.Items), *ticdcg.Spec.Replicas)
+	if len(podList) != int(*ticdcg.Spec.Replicas) {
+		return fmt.Errorf("ticdc %s/%s pod replicas %d not equal to %d", ticdcg.Namespace, ticdcg.Name, len(podList), *ticdcg.Spec.Replicas)
 	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for _, pod := range podList {
 		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("ticdc %s/%s pod %s is not running, current phase: %s", ticdcg.Namespace, ticdcg.Name, pod.Name, pod.Status.Phase)
 		}

--- a/tests/e2e/utils/waiter/pod.go
+++ b/tests/e2e/utils/waiter/pod.go
@@ -330,8 +330,8 @@ func WaitForPodsDeleted[
 		if err != nil {
 			return false, fmt.Errorf("can't list pods for group %s/%s: %w", g.GetNamespace(), g.GetName(), err)
 		}
-		if len(list.Items) != 0 {
-			lastErr = fmt.Errorf("group %s/%s still has %d pods", g.GetNamespace(), g.GetName(), len(list.Items))
+		if len(list) != 0 {
+			lastErr = fmt.Errorf("group %s/%s still has %d pods", g.GetNamespace(), g.GetName(), len(list))
 			return false, nil
 		}
 
@@ -361,8 +361,7 @@ func MaxPodsCreateTimestamp[
 		return nil, err
 	}
 	maxTime := &time.Time{}
-	for i := range list.Items {
-		pod := &list.Items[i]
+	for _, pod := range list {
 		if pod.CreationTimestamp.After(*maxTime) {
 			maxTime = &pod.CreationTimestamp.Time
 		}

--- a/tests/e2e/utils/waiter/tikv.go
+++ b/tests/e2e/utils/waiter/tikv.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
+	"github.com/pingcap/tidb-operator/v2/pkg/apicall"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
+	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 )
 
 func WaitForTiKVsHealthy(ctx context.Context, c client.Client, kvg *v1alpha1.TiKVGroup, timeout time.Duration) error {
@@ -46,6 +49,82 @@ func WaitForTiKVsHealthy(ctx context.Context, c client.Client, kvg *v1alpha1.TiK
 		v1alpha1.LabelKeyGroup:     kvg.Name,
 		v1alpha1.LabelKeyComponent: v1alpha1.LabelValComponentTiKV,
 	})
+}
+
+// WatchUntilTiKVsRestartedAfterCacheTTL watches TiKV leader eviction and recovery
+// transitions and verifies every recreated Pod observes the configured cache TTL.
+func WatchUntilTiKVsRestartedAfterCacheTTL(
+	ctx context.Context,
+	c client.Client,
+	kvg *v1alpha1.TiKVGroup,
+	timeout time.Duration,
+	synced chan struct{},
+) error {
+	replicas := 0
+	if kvg.Spec.Replicas != nil {
+		replicas = int(*kvg.Spec.Replicas)
+	}
+	cacheTTLSeconds := int64(-1)
+	if kvg.Spec.CacheTTLSeconds != nil {
+		cacheTTLSeconds = *kvg.Spec.CacheTTLSeconds
+	}
+
+	leadersEvictedAt := make(map[string]time.Time, replicas)
+	comparedTiKVs := make(map[string]struct{}, replicas)
+	return WatchUntilInstanceList[scope.TiKVGroup](ctx, c, kvg, func(tikv *v1alpha1.TiKV) (bool, error) {
+		cond := meta.FindStatusCondition(tikv.Status.Conditions, v1alpha1.TiKVCondLeadersEvicted)
+		if cond == nil {
+			return false, nil
+		}
+
+		if cond.Status == metav1.ConditionTrue {
+			if tikv.Spec.CacheTTLSeconds == nil {
+				return false, fmt.Errorf("tikv %s/%s has no cacheTTLSeconds", tikv.Namespace, tikv.Name)
+			}
+			if *tikv.Spec.CacheTTLSeconds != cacheTTLSeconds {
+				return false, fmt.Errorf("tikv %s/%s cacheTTLSeconds is %d, want %d", tikv.Namespace, tikv.Name, *tikv.Spec.CacheTTLSeconds, cacheTTLSeconds)
+			}
+			if cond.LastTransitionTime.IsZero() {
+				return false, fmt.Errorf("tikv %s/%s has no leader eviction transition time", tikv.Namespace, tikv.Name)
+			}
+			if _, recorded := leadersEvictedAt[tikv.Name]; !recorded {
+				leadersEvictedAt[tikv.Name] = cond.LastTransitionTime.Time
+			}
+			return false, nil
+		}
+
+		if cond.Status != metav1.ConditionFalse || cond.Reason != v1alpha1.ReasonNotEvicted {
+			return false, nil
+		}
+		if _, compared := comparedTiKVs[tikv.Name]; compared {
+			return false, nil
+		}
+		evictedAt, recorded := leadersEvictedAt[tikv.Name]
+		if !recorded {
+			return false, nil
+		}
+
+		pod, err := apicall.GetPod[scope.TiKV](ctx, c, tikv)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		earliestRestartAt := evictedAt.Add(time.Duration(cacheTTLSeconds) * time.Second)
+		if pod.CreationTimestamp.Time.Before(earliestRestartAt) {
+			return false, fmt.Errorf(
+				"tikv pod %s/%s was recreated at %s before cache TTL expired at %s",
+				pod.Namespace,
+				pod.Name,
+				pod.CreationTimestamp,
+				earliestRestartAt,
+			)
+		}
+
+		comparedTiKVs[tikv.Name] = struct{}{}
+		return len(comparedTiKVs) == replicas, nil
+	}, timeout, synced)
 }
 
 func EvictLeaderBeforeStoreIsRemoving(deleting int) func(kv *v1alpha1.TiKV) (bool, error) {

--- a/tests/validation/tikv_test.go
+++ b/tests/validation/tikv_test.go
@@ -15,6 +15,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -31,6 +32,7 @@ func TestTiKV(t *testing.T) {
 	cases = append(cases, transferTiKVCases(t, VolumeAttributesClassNameValidation(), "spec", "volumes")...)
 	cases = append(cases, transferTiKVCases(t, Version(), "spec", "version")...)
 	cases = append(cases, transferTiKVCases(t, NameLength(instanceNameLengthLimit), "metadata", "name")...)
+	cases = append(cases, transferTiKVCases(t, cacheTTLSeconds("spec.cacheTTLSeconds"), "spec", "cacheTTLSeconds")...)
 	Validate(t, "crd/core.pingcap.com_tikvs.yaml", cases)
 }
 
@@ -39,8 +41,37 @@ func TestTiKVGroup(t *testing.T) {
 	cases = append(cases, transferTiKVGroupCases(t, ClusterReference(), "spec", "cluster")...)
 	cases = append(cases, transferTiKVGroupCases(t, NameLength(groupNameLengthLimit), "metadata", "name")...)
 	cases = append(cases, transferTiKVGroupCases(t, MinReadySeconds(), "spec", "minReadySeconds")...)
+	cases = append(cases, transferTiKVGroupCases(t, cacheTTLSeconds("spec.cacheTTLSeconds"), "spec", "cacheTTLSeconds")...)
 	cases = append(cases, transferTiKVGroupCases(t, PlacementServerLabels("spec", "template", "spec", "server", "labels"), "spec", "template", "spec", "server", "labels")...)
 	Validate(t, "crd/core.pingcap.com_tikvgroups.yaml", cases)
+}
+
+func cacheTTLSeconds(fieldPath string) []Case {
+	return []Case{
+		{
+			desc:     "cache ttl seconds may be omitted",
+			isCreate: true,
+			current:  nil,
+		},
+		{
+			desc:     "cache ttl seconds may be zero",
+			isCreate: true,
+			current:  int64(0),
+		},
+		{
+			desc:     "cache ttl seconds may be positive",
+			isCreate: true,
+			current:  int64(600),
+		},
+		{
+			desc:     "cache ttl seconds must not be negative",
+			isCreate: true,
+			current:  int64(-1),
+			wantErrs: []string{
+				fmt.Sprintf("%s: Invalid value: -1: %s in body should be greater than or equal to 0", fieldPath, fieldPath),
+			},
+		},
+	}
 }
 
 func basicTiKV() map[string]any {


### PR DESCRIPTION
## What problem does this PR solve?

After all leaders of a TiKV store are evicted, TiDB may still retain stale region cache entries. Restarting the TiKV Pod immediately can make the rolling restart proceed before TiDB has had enough time to refresh its region cache.

## What is changed and how it works?

- Add the optional spec.cacheTTLSeconds field to TiKVGroup.
- Propagate the configured value to each managed TiKV.
- After LeadersEvicted=True, delay Pod recreation until LastTransitionTime plus cacheTTLSeconds.
- Keep the existing behavior when the field is omitted or set to zero.
- Change apicall.ListPods to return a slice of Pod pointers and update its callers.
- Add a scale e2e case for rolling restart:
  - start watching TiKV objects before triggering the restart;
  - record the first leader eviction transition time for every TiKV;
  - when leader eviction ends, get the corresponding Pod and verify its creation time is not earlier than the eviction time plus the configured cache TTL;
  - finish only after every TiKV Pod has been checked.

## Tests

- Unit tests for cache TTL calculation and Pod recreation behavior.
- Unit test for propagating cacheTTLSeconds from TiKVGroup to TiKV.
- CRD validation tests for omitted, zero, positive, and negative values.
- API, controller, validation, and affected e2e packages pass locally.
- The new e2e case compiles but has not been run against a Kubernetes cluster locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional cache TTL setting for TiKV and TiKVGroup resources.
  * TiKV rolling restarts now wait for the configured cache TTL after leader eviction.
  * Added validation requiring cache TTL values to be zero or greater.

* **Bug Fixes**
  * Improved TiKV restart behavior when the cache TTL has not yet expired.

* **Tests**
  * Added coverage for cache TTL validation, propagation, and rolling restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->