### PR TITLE
feat: record failed pod create events

### DIFF
--- a/pkg/controllers/dm/builder.go
+++ b/pkg/controllers/dm/builder.go
@@ -68,7 +68,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		// normal process
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.DM](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.DM](state),
 		common.TaskInstanceConditionReady[scope.DM](state),
 		common.TaskInstanceConditionRunning[scope.DM](state),

--- a/pkg/controllers/dm/controller.go
+++ b/pkg/controllers/dm/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,6 +41,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
 }
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("DM"),
+		EventRecorder:         mgr.GetEventRecorderFor("dm"),
 		Client:                c,
 		VolumeModifierFactory: vm,
 		Tracker:               t,

--- a/pkg/controllers/dm/tasks/pod.go
+++ b/pkg/controllers/dm/tasks/pod.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -37,7 +39,7 @@ import (
 
 const metricsPath = "/metrics"
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
@@ -45,6 +47,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of dm: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/dmworker/builder.go
+++ b/pkg/controllers/dmworker/builder.go
@@ -65,7 +65,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		// normal process
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.DMWorker](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.DMWorker](state),
 		common.TaskInstanceConditionReady[scope.DMWorker](state),
 		common.TaskInstanceConditionRunning[scope.DMWorker](state),

--- a/pkg/controllers/dmworker/controller.go
+++ b/pkg/controllers/dmworker/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,6 +41,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
 }
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("DMWorker"),
+		EventRecorder:         mgr.GetEventRecorderFor("dmworker"),
 		Client:                c,
 		VolumeModifierFactory: vm,
 		Tracker:               t,

--- a/pkg/controllers/dmworker/tasks/pod.go
+++ b/pkg/controllers/dmworker/tasks/pod.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -37,7 +39,7 @@ import (
 
 const metricsPath = "/metrics"
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
@@ -45,6 +47,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of dm-worker: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/pd/builder.go
+++ b/pkg/controllers/pd/builder.go
@@ -65,7 +65,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		common.TaskContextPeerSlice[scope.PD](state, r.Client),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.PD](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.PD](state),
 		common.TaskInstanceConditionReady[scope.PD](state),
 		common.TaskInstanceConditionRunning[scope.PD](state),

--- a/pkg/controllers/pd/controller.go
+++ b/pkg/controllers/pd/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -42,6 +43,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -56,6 +58,7 @@ func Setup(
 ) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("PD"),
+		EventRecorder:         mgr.GetEventRecorderFor("pd"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/pd/tasks/pod.go
+++ b/pkg/controllers/pd/tasks/pod.go
@@ -26,6 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -49,7 +51,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 		expected := newPod(state.Cluster(), state.PD(), state.FeatureGates(), state.ClusterID, state.MemberID)
@@ -63,6 +65,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 				return task.Wait().With("wait until pd's status becomes unhealthy")
 			}
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of pd: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/resourcemanager/builder.go
+++ b/pkg/controllers/resourcemanager/builder.go
@@ -59,7 +59,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.ResourceManager](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.ResourceManager]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.ResourceManager](state),
 		common.TaskInstanceConditionReady[scope.ResourceManager](state),
 		common.TaskInstanceConditionRunning[scope.ResourceManager](state),

--- a/pkg/controllers/resourcemanager/controller.go
+++ b/pkg/controllers/resourcemanager/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("ResourceManager"),
+		EventRecorder:         mgr.GetEventRecorderFor("resourcemanager"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/resourcemanager/tasks/pod.go
+++ b/pkg/controllers/resourcemanager/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -41,7 +43,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -50,6 +52,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of resource manager: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/router/builder.go
+++ b/pkg/controllers/router/builder.go
@@ -59,7 +59,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.Router](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.Router]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.Router](state),
 		common.TaskInstanceConditionReady[scope.Router](state),
 		common.TaskInstanceConditionRunning[scope.Router](state),

--- a/pkg/controllers/router/controller.go
+++ b/pkg/controllers/router/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("Router"),
+		EventRecorder:         mgr.GetEventRecorderFor("router"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/router/tasks/pod.go
+++ b/pkg/controllers/router/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -40,7 +42,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -49,6 +51,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of router: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/scheduler/builder.go
+++ b/pkg/controllers/scheduler/builder.go
@@ -68,7 +68,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.Scheduler](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.Scheduler]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.Scheduler](state),
 		common.TaskInstanceConditionReady[scope.Scheduler](state),
 		common.TaskInstanceConditionRunning[scope.Scheduler](state),

--- a/pkg/controllers/scheduler/controller.go
+++ b/pkg/controllers/scheduler/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("Scheduler"),
+		EventRecorder:         mgr.GetEventRecorderFor("scheduler"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/scheduler/tasks/pod.go
+++ b/pkg/controllers/scheduler/tasks/pod.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -38,7 +40,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -47,6 +49,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of scheduler: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/scheduling/builder.go
+++ b/pkg/controllers/scheduling/builder.go
@@ -68,7 +68,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.Scheduling](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.Scheduling]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.Scheduling](state),
 		common.TaskInstanceConditionReady[scope.Scheduling](state),
 		common.TaskInstanceConditionRunning[scope.Scheduling](state),

--- a/pkg/controllers/scheduling/controller.go
+++ b/pkg/controllers/scheduling/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("Scheduling"),
+		EventRecorder:         mgr.GetEventRecorderFor("scheduling"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/scheduling/tasks/pod.go
+++ b/pkg/controllers/scheduling/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -42,7 +44,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -51,6 +53,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of scheduling: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/ticdc/builder.go
+++ b/pkg/controllers/ticdc/builder.go
@@ -67,7 +67,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		tasks.TaskContextInfoFromTiCDC(state, r.Client),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiCDC](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.TiCDC](state),
 		common.TaskInstanceConditionReady[scope.TiCDC](state),
 		common.TaskInstanceConditionRunning[scope.TiCDC](state),

--- a/pkg/controllers/ticdc/controller.go
+++ b/pkg/controllers/ticdc/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -38,6 +39,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
 }
@@ -45,6 +47,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiCDC"),
+		EventRecorder:         mgr.GetEventRecorderFor("ticdc"),
 		Client:                c,
 		VolumeModifierFactory: vm,
 		Tracker:               t,

--- a/pkg/controllers/ticdc/tasks/pod.go
+++ b/pkg/controllers/ticdc/tasks/pod.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -50,7 +52,7 @@ const (
 	resourceSyncerHealthzPort = 8081
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
@@ -62,6 +64,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 				return task.Wait().With("wait until pd's status is set")
 			}
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of ticdc: %w", err)
 			}
 

--- a/pkg/controllers/tidb/builder.go
+++ b/pkg/controllers/tidb/builder.go
@@ -73,7 +73,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		tasks.TaskContextInfoFromPDAndTiDB(state, r.Client, r.PDClientManager),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiDB](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		tasks.TaskActivate(state, r.Client),
 		common.TaskServerLabels[scope.TiDB](state, r.Client, r.PDClientManager, func(ctx context.Context, labels map[string]string) error {
 			// standby tidb cannot set server labels

--- a/pkg/controllers/tidb/controller.go
+++ b/pkg/controllers/tidb/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -40,6 +41,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -56,6 +58,7 @@ func Setup(
 ) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiDB"),
+		EventRecorder:         mgr.GetEventRecorderFor("tidb"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/tidb/tasks/pod.go
+++ b/pkg/controllers/tidb/tasks/pod.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -57,7 +59,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
@@ -65,6 +67,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of tidb: %w", err)
 			}
 

--- a/pkg/controllers/tidb/tasks/pod_test.go
+++ b/pkg/controllers/tidb/tasks/pod_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -335,6 +337,39 @@ func TestTaskPod(t *testing.T) {
 				assert.Equal(tt, expectedPod, actual, c.desc)
 			}
 		})
+	}
+}
+
+func TestTaskPodRecordsFailedCreateEvent(t *testing.T) {
+	ctx := context.Background()
+	state := NewState(types.NamespacedName{Namespace: "default", Name: "aaa-xxx"})
+	tidb := fake.FakeObj("aaa-xxx", func(obj *v1alpha1.TiDB) *v1alpha1.TiDB {
+		obj.Spec.Version = fakeVersion
+		return obj
+	})
+	cluster := fake.FakeObj[v1alpha1.Cluster]("aaa")
+	state.SetObject(tidb)
+	state.SetCluster(cluster)
+	rtx := &ReconcileContext{State: state}
+
+	fc := client.NewFakeClient(rtx.TiDB(), rtx.Cluster())
+	fc.WithError("patch", "*", errors.NewForbidden(schema.GroupResource{Resource: "pods"}, "aaa-xxx", fmt.Errorf("exceeded quota: compute-resources")))
+	recorder := record.NewFakeRecorder(1)
+
+	res, done := task.RunTask(ctx, TaskPod(rtx, fc, recorder))
+
+	assert.Equal(t, task.SFail.String(), res.Status().String(), res.Message())
+	assert.False(t, done)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, corev1.EventTypeWarning)
+		assert.Contains(t, event, "FailedCreate")
+		assert.Contains(t, event, "Error creating: pods \"aaa-xxx\" is forbidden")
+		assert.Contains(t, event, "exceeded quota: compute-resources")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event")
+	default:
+		t.Fatal("expected failed create event")
 	}
 }
 

--- a/pkg/controllers/tiflash/builder.go
+++ b/pkg/controllers/tiflash/builder.go
@@ -78,7 +78,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		tasks.TaskOfflineStore(state, r.PDClientManager),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiFlash](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		tasks.TaskStoreLabels(state, r.Client, r.PDClientManager),
 		common.TaskInstanceConditionSynced[scope.TiFlash](state),
 		// only set ready if pd is synced

--- a/pkg/controllers/tiflash/controller.go
+++ b/pkg/controllers/tiflash/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -41,6 +42,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	VolumeModifierFactory volumes.ModifierFactory
 	PDClientManager       pdm.PDClientManager
 	TiFlashClientManager  fm.TiFlashClientManager
@@ -57,6 +59,7 @@ func Setup(
 ) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiFlash"),
+		EventRecorder:         mgr.GetEventRecorderFor("tiflash"),
 		Client:                c,
 		VolumeModifierFactory: vm,
 		PDClientManager:       pdcm,

--- a/pkg/controllers/tiflash/tasks/pod.go
+++ b/pkg/controllers/tiflash/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -44,13 +46,14 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 		expected := newPod(state.Cluster(), state.TiFlash(), state.Store, state.FeatureGates())
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't apply pod of tiflash: %w", err)
 			}
 

--- a/pkg/controllers/tikv/builder.go
+++ b/pkg/controllers/tikv/builder.go
@@ -88,7 +88,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		tasks.TaskOfflineStore(state, r.PDClientManager),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiKV](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client, r.PDClientManager),
+		tasks.TaskPod(state, r.Client, r.PDClientManager, r.EventRecorder),
 		tasks.TaskStoreLabels(state, r.Client, r.PDClientManager),
 		tasks.TaskEvictLeader(state, r.PDClientManager),
 		common.TaskInstanceConditionSynced[scope.TiKV](state),

--- a/pkg/controllers/tikv/controller.go
+++ b/pkg/controllers/tikv/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -40,6 +41,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -48,6 +50,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiKV"),
+		EventRecorder:         mgr.GetEventRecorderFor("tikv"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/tikv/tasks/pod.go
+++ b/pkg/controllers/tikv/tasks/pod.go
@@ -26,6 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -70,7 +72,7 @@ func TaskSuspendPod(state *ReconcileContext, c client.Client) task.Task {
 	})
 }
 
-func TaskPod(state *ReconcileContext, c client.Client, cm pdm.PDClientManager) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, cm pdm.PDClientManager, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 		expected := newPod(state.Cluster(), state.TiKV(), state.Store, state.FeatureGates())
@@ -78,6 +80,7 @@ func TaskPod(state *ReconcileContext, c client.Client, cm pdm.PDClientManager) t
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't apply pod of tikv: %w", err)
 			}
 

--- a/pkg/controllers/tikvworker/builder.go
+++ b/pkg/controllers/tikvworker/builder.go
@@ -67,7 +67,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		// normal process
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiKVWorker](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.TiKVWorker]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.TiKVWorker](state),
 		common.TaskInstanceConditionReady[scope.TiKVWorker](state),
 		common.TaskInstanceConditionRunning[scope.TiKVWorker](state),

--- a/pkg/controllers/tikvworker/controller.go
+++ b/pkg/controllers/tikvworker/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiKVWorker"),
+		EventRecorder:         mgr.GetEventRecorderFor("tikvworker"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/tikvworker/tasks/pod.go
+++ b/pkg/controllers/tikvworker/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -41,7 +43,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state State, c client.Client) task.Task {
+func TaskPod(state State, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -50,6 +52,7 @@ func TaskPod(state State, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of tikv worker: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/controllers/tiproxy/builder.go
+++ b/pkg/controllers/tiproxy/builder.go
@@ -90,7 +90,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 		tasks.TaskContextInfoFromTiProxy(state, r.Client),
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TiProxy](state, r.Client, r.VolumeModifierFactory, tasks.PVCNewer()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.TiProxy](state),
 		common.TaskInstanceConditionReady[scope.TiProxy](state),
 		common.TaskInstanceConditionRunning[scope.TiProxy](state),

--- a/pkg/controllers/tiproxy/controller.go
+++ b/pkg/controllers/tiproxy/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	VolumeModifierFactory volumes.ModifierFactory
 	Tracker               tracker.Tracker
@@ -47,6 +49,7 @@ type Reconciler struct {
 func Setup(mgr manager.Manager, c client.Client, pdcm pdm.PDClientManager, vm volumes.ModifierFactory, t tracker.Tracker) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TiProxy"),
+		EventRecorder:         mgr.GetEventRecorderFor("tiproxy"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		VolumeModifierFactory: vm,

--- a/pkg/controllers/tiproxy/tasks/pod.go
+++ b/pkg/controllers/tiproxy/tasks/pod.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
@@ -47,7 +49,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		logger := logr.FromContextOrDiscard(ctx)
 
@@ -55,6 +57,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of tiproxy: %w", err)
 			}
 

--- a/pkg/controllers/tso/builder.go
+++ b/pkg/controllers/tso/builder.go
@@ -74,7 +74,7 @@ func (r *Reconciler) NewRunner(state *tasks.ReconcileContext, reporter task.Task
 
 		tasks.TaskConfigMap(state, r.Client),
 		common.TaskPVC[scope.TSO](state, r.Client, r.VolumeModifierFactory, common.DefaultPVCNewer[scope.TSO]()),
-		tasks.TaskPod(state, r.Client),
+		tasks.TaskPod(state, r.Client, r.EventRecorder),
 		common.TaskInstanceConditionSynced[scope.TSO](state),
 		common.TaskInstanceConditionReady[scope.TSO](state),
 		common.TaskInstanceConditionRunning[scope.TSO](state),

--- a/pkg/controllers/tso/controller.go
+++ b/pkg/controllers/tso/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -41,6 +42,7 @@ import (
 type Reconciler struct {
 	Logger                logr.Logger
 	Client                client.Client
+	EventRecorder         record.EventRecorder
 	PDClientManager       pdm.PDClientManager
 	TSOClientManager      tsom.TSOClientManager
 	VolumeModifierFactory volumes.ModifierFactory
@@ -57,6 +59,7 @@ func Setup(
 ) error {
 	r := &Reconciler{
 		Logger:                mgr.GetLogger().WithName("TSO"),
+		EventRecorder:         mgr.GetEventRecorderFor("tso"),
 		Client:                c,
 		PDClientManager:       pdcm,
 		TSOClientManager:      tsocm,

--- a/pkg/controllers/tso/tasks/pod.go
+++ b/pkg/controllers/tso/tasks/pod.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	metav1alpha1 "github.com/pingcap/tidb-operator/api/v2/meta/v1alpha1"
 	coreutil "github.com/pingcap/tidb-operator/v2/pkg/apiutil/core/v1alpha1"
@@ -44,7 +46,7 @@ const (
 	metricsPath = "/metrics"
 )
 
-func TaskPod(state *ReconcileContext, c client.Client) task.Task {
+func TaskPod(state *ReconcileContext, c client.Client, recorder ...record.EventRecorder) task.Task {
 	return task.NameTaskFunc("Pod", func(ctx context.Context) task.Result {
 		ck := state.Cluster()
 		obj := state.Object()
@@ -53,6 +55,7 @@ func TaskPod(state *ReconcileContext, c client.Client) task.Task {
 		pod := state.Pod()
 		if pod == nil {
 			if err := c.Apply(ctx, expected); err != nil {
+				k8s.RecordFailedCreatePod(recorder, state.Object(), err)
 				return task.Fail().With("can't create pod of tso: %v", err)
 			}
 			state.SetPod(expected)

--- a/pkg/utils/k8s/event.go
+++ b/pkg/utils/k8s/event.go
@@ -1,0 +1,45 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+const FailedCreatePodReason = "FailedCreate"
+
+// RecordFailedCreatePod records a warning event on the owner object when a Pod
+// create request fails, matching the reason/message style used by Kubernetes
+// built-in workload controllers.
+func RecordFailedCreatePod(recorders []record.EventRecorder, object runtime.Object, err error) {
+	if len(recorders) == 0 || recorders[0] == nil || object == nil || err == nil {
+		return
+	}
+
+	recorders[0].Eventf(object, corev1.EventTypeWarning, FailedCreatePodReason, "Error creating: %v", apiError(err))
+}
+
+func apiError(err error) error {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- wire event recorders into v2 Pod-owning component controllers on `main`
- record Warning `FailedCreate` events on the owning component CR when direct Pod creation fails
- unwrap Kubernetes `StatusError` before recording so admission failures look like built-in controller events

## Test Plan
- `go test ./pkg/controllers/tidb/tasks -run TestTaskPodRecordsFailedCreateEvent -count=1`
- `go test ./pkg/controllers/{tiproxy,pd,resourcemanager,tikv,ticdc,scheduling,tikvworker,scheduler,tidb,tiflash,dm,dmworker,tso,router} ./pkg/controllers/{tiproxy,pd,resourcemanager,tikv,ticdc,scheduling,tikvworker,scheduler,tidb,tiflash,dm,dmworker,tso,router}/tasks ./pkg/utils/k8s`
- `go test ./pkg/controllers/... ./pkg/utils/k8s`
- `git diff --check`

Note: an earlier draft PR was opened against `feature/v2` and is now closed after changing the base. This PR targets `pingcap:main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes warning events are now recorded when managed pod creation fails.
  * Failure events include a clear `FailedCreate` reason and the underlying error details.
  * This visibility is available across workload, worker, scheduling, and resource-management controllers.

* **Tests**
  * Added coverage verifying that pod-creation failures produce the expected warning event and reconciliation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->