### PR TITLE
feat: end evict leader only when pod is available

### DIFF
--- a/pkg/controllers/tikv/tasks/ctx.go
+++ b/pkg/controllers/tikv/tasks/ctx.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 	pdv1 "github.com/pingcap/tidb-operator/v2/pkg/timanager/apis/pd/v1"
 	pdm "github.com/pingcap/tidb-operator/v2/pkg/timanager/pd"
+	"github.com/pingcap/tidb-operator/v2/pkg/utils/podutil"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
-	"github.com/pingcap/tidb-operator/v2/third_party/kubernetes/pkg/controller/statefulset"
 )
 
 type ReconcileContext struct {
@@ -86,7 +86,7 @@ func TaskContextInfoFromPD(state *ReconcileContext, cm pdm.PDClientManager) task
 		state.SetStoreBusy(s.IsBusy)
 		state.IsStoreReady = IsStoreReady(state)
 		pod := state.Pod()
-		if state.IsStoreReady && pod != nil && statefulset.IsPodAvailable(pod, minReadySeconds, metav1.Now()) {
+		if state.IsStoreReady && podutil.IsAvailable(pod, minReadySeconds, metav1.Now()) {
 			state.SetHealthy()
 		}
 

--- a/pkg/controllers/tikv/tasks/evict_leader.go
+++ b/pkg/controllers/tikv/tasks/evict_leader.go
@@ -17,6 +17,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,7 @@ import (
 	"github.com/pingcap/tidb-operator/api/v2/core/v1alpha1"
 	pdv1 "github.com/pingcap/tidb-operator/v2/pkg/timanager/apis/pd/v1"
 	pdm "github.com/pingcap/tidb-operator/v2/pkg/timanager/pd"
+	"github.com/pingcap/tidb-operator/v2/pkg/utils/podutil"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
 )
 
@@ -47,7 +49,9 @@ func TaskEvictLeader(state *ReconcileContext, m pdm.PDClientManager) task.Task {
 			state.LeaderEvicting = true
 		}
 
-		if state.LeaderEvicting && !state.ShouldEvictLeader {
+		pod := state.Pod()
+		podAvailable := podutil.IsAvailable(pod, minReadySeconds, metav1.Now())
+		if state.LeaderEvicting && !state.ShouldEvictLeader && podAvailable {
 			if err := pc.Underlay().EndEvictLeader(ctx, state.Store.ID); err != nil {
 				return task.Fail().With("cannot remove evict leader scheduler: %v", err)
 			}
@@ -57,6 +61,11 @@ func TaskEvictLeader(state *ReconcileContext, m pdm.PDClientManager) task.Task {
 		needUpdate := syncLeadersEvictedCond(state.TiKV(), state.Store, state.LeaderEvicting)
 		if needUpdate {
 			state.SetStatusChanged()
+		}
+
+		if state.LeaderEvicting && !state.ShouldEvictLeader && podutil.IsReady(pod) {
+			return task.Retry(minReadySeconds*time.Second).
+				With("wait until pod has been ready for %ds before removing evict leader scheduler", minReadySeconds)
 		}
 
 		return task.Complete().With("sync evict leader scheduler, expected: %v, actual: %v", state.ShouldEvictLeader, state.LeaderEvicting)

--- a/pkg/controllers/tikv/tasks/evict_leader_test.go
+++ b/pkg/controllers/tikv/tasks/evict_leader_test.go
@@ -17,6 +17,7 @@ package tasks
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +61,31 @@ func TestTaskEvictLeader(t *testing.T) {
 			expectedStatus: task.SComplete,
 		},
 		{
-			desc: "end evict leader when annotation is absent",
+			desc: "end evict leader after restarted pod is available",
+			state: &ReconcileContext{
+				State: &state{
+					tikv: fake.FakeObj[v1alpha1.TiKV]("aaa-xxx"),
+					pod: fake.FakeObj("aaa-tikv-xxx", func(obj *corev1.Pod) *corev1.Pod {
+						obj.Status.Conditions = append(obj.Status.Conditions, corev1.PodCondition{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-(minReadySeconds + 1) * time.Second)),
+						})
+						return obj
+					}),
+				},
+				PDSynced:       true,
+				LeaderEvicting: true,
+				Store: &pdv1.Store{
+					ID: "1",
+				},
+			},
+			expectEnd:      true,
+			expectEvicting: false,
+			expectedStatus: task.SComplete,
+		},
+		{
+			desc: "keep evict leader while restarted pod is not ready",
 			state: &ReconcileContext{
 				State: &state{
 					tikv: fake.FakeObj[v1alpha1.TiKV]("aaa-xxx"),
@@ -72,9 +97,31 @@ func TestTaskEvictLeader(t *testing.T) {
 					ID: "1",
 				},
 			},
-			expectEnd:      true,
-			expectEvicting: false,
+			expectEvicting: true,
 			expectedStatus: task.SComplete,
+		},
+		{
+			desc: "keep evict leader while restarted pod is ready but not available",
+			state: &ReconcileContext{
+				State: &state{
+					tikv: fake.FakeObj[v1alpha1.TiKV]("aaa-xxx"),
+					pod: fake.FakeObj("aaa-tikv-xxx", func(obj *corev1.Pod) *corev1.Pod {
+						obj.Status.Conditions = append(obj.Status.Conditions, corev1.PodCondition{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Now(),
+						})
+						return obj
+					}),
+				},
+				PDSynced:       true,
+				LeaderEvicting: true,
+				Store: &pdv1.Store{
+					ID: "1",
+				},
+			},
+			expectEvicting: true,
+			expectedStatus: task.SRetry,
 		},
 		{
 			desc: "sync leaders evicted condition when store is absent",

--- a/pkg/controllers/tikv/tasks/status.go
+++ b/pkg/controllers/tikv/tasks/status.go
@@ -27,8 +27,8 @@ import (
 	"github.com/pingcap/tidb-operator/v2/pkg/client"
 	"github.com/pingcap/tidb-operator/v2/pkg/runtime/scope"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/compare"
+	"github.com/pingcap/tidb-operator/v2/pkg/utils/podutil"
 	"github.com/pingcap/tidb-operator/v2/pkg/utils/task/v3"
-	"github.com/pingcap/tidb-operator/v2/third_party/kubernetes/pkg/controller/statefulset"
 )
 
 const (
@@ -73,7 +73,7 @@ func TaskStatus(state *ReconcileContext, c client.Client) task.Task {
 		// If UseTiKVReadyAPI is enabled, no need to retry, just wait until pod is ready
 		if !state.FeatureGates().Enabled(metav1alpha1.UseTiKVReadyAPI) {
 			// pod available cannot be watched so that we have to retry
-			if !ready && state.IsStoreReady && pod != nil && statefulset.IsPodReady(pod) {
+			if !ready && state.IsStoreReady && podutil.IsReady(pod) {
 				return task.Retry(minReadySeconds * time.Second).With("pod is not ready more than 15s, retry")
 			}
 		}

--- a/pkg/utils/podutil/pod.go
+++ b/pkg/utils/podutil/pod.go
@@ -16,9 +16,43 @@ package podutil
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// IsReady returns whether the pod has a true Ready condition.
+func IsReady(pod *corev1.Pod) bool {
+	condition := readyCondition(pod)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// IsAvailable returns whether the pod has remained ready for minReadySeconds.
+func IsAvailable(pod *corev1.Pod, minReadySeconds int32, now metav1.Time) bool {
+	condition := readyCondition(pod)
+	if condition == nil || condition.Status != corev1.ConditionTrue {
+		return false
+	}
+	if minReadySeconds == 0 {
+		return true
+	}
+
+	minReadyDuration := time.Duration(minReadySeconds) * time.Second
+	return !condition.LastTransitionTime.IsZero() && condition.LastTransitionTime.Add(minReadyDuration).Before(now.Time)
+}
+
+func readyCondition(pod *corev1.Pod) *corev1.PodCondition {
+	if pod == nil {
+		return nil
+	}
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == corev1.PodReady {
+			return &pod.Status.Conditions[i]
+		}
+	}
+	return nil
+}
 
 // IsContainerRunning means the main container of this pod is running and deleting this pod may increase an unavailable instance
 func IsContainerRunning(pod *corev1.Pod, mainContainerName string) error {

--- a/pkg/utils/podutil/pod_test.go
+++ b/pkg/utils/podutil/pod_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/podutil/pod_test.go
+++ b/pkg/utils/podutil/pod_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsReady(t *testing.T) {
+	assert.False(t, IsReady(nil))
+	assert.False(t, IsReady(&corev1.Pod{}))
+	assert.False(t, IsReady(podWithReadyCondition(corev1.ConditionFalse, metav1.Now())))
+	assert.True(t, IsReady(podWithReadyCondition(corev1.ConditionTrue, metav1.Now())))
+}
+
+func TestIsAvailable(t *testing.T) {
+	now := metav1.NewTime(time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		minReadySeconds int32
+		expected        bool
+	}{
+		{
+			name:     "nil pod",
+			expected: false,
+		},
+		{
+			name:            "pod is not ready",
+			pod:             podWithReadyCondition(corev1.ConditionFalse, metav1.NewTime(now.Add(-time.Minute))),
+			minReadySeconds: 15,
+			expected:        false,
+		},
+		{
+			name:            "minimum ready duration is disabled",
+			pod:             podWithReadyCondition(corev1.ConditionTrue, metav1.Time{}),
+			minReadySeconds: 0,
+			expected:        true,
+		},
+		{
+			name:            "pod has not remained ready for the minimum duration",
+			pod:             podWithReadyCondition(corev1.ConditionTrue, metav1.NewTime(now.Add(-14*time.Second))),
+			minReadySeconds: 15,
+			expected:        false,
+		},
+		{
+			name:            "pod has remained ready for the minimum duration",
+			pod:             podWithReadyCondition(corev1.ConditionTrue, metav1.NewTime(now.Add(-16*time.Second))),
+			minReadySeconds: 15,
+			expected:        true,
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, IsAvailable(test.pod, test.minReadySeconds, now))
+		})
+	}
+}
+
+func podWithReadyCondition(status corev1.ConditionStatus, transitionTime metav1.Time) *corev1.Pod {
+	return &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             status,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

During a TiKV rolling restart, the evict leader scheduler could be removed immediately after the replacement Pod was created. At that point the Pod might not be Ready, or might not have remained Ready long enough to be considered available, allowing leaders to be scheduled to an unstable TiKV instance.

## What is changed and how does it work?

- Keep the evict leader scheduler until the restarted TiKV Pod is available.
- Consider the Pod available only after its Ready condition has remained true for the existing `minReadySeconds` window of 15 seconds.
- Requeue reconciliation when the Pod is Ready but has not yet passed the minimum readiness window.
- Add `podutil.IsReady` and `podutil.IsAvailable`, and use them throughout the TiKV tasks instead of depending directly on the vendored StatefulSet helpers.
- Preserve the existing deletion behavior when the TiKV store itself is being removed.

## Tests

- Unit tests verify that the scheduler is retained while the restarted Pod is unready or Ready but not yet available, and removed after it becomes available.
- Unit tests cover Pod readiness and availability boundary cases in `podutil`.
- Local checks:
  - `go test ./pkg/controllers/tikv/... ./pkg/utils/podutil -count=1`
  - `go vet ./pkg/controllers/tikv/... ./pkg/utils/podutil`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Leader eviction now continues until a restarted pod is ready and has remained available for the configured minimum duration.
  * Pod readiness and availability checks now handle missing pod data consistently.
* **New Features**
  * Added standardized checks for pod readiness and sustained availability.
* **Tests**
  * Added coverage for readiness, availability duration, and leader-eviction retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->