### PR TITLE
fix(tici): fix whole-cluster suspension deadlocking on TiCI

### DIFF
--- a/pkg/manager/member/tici_member_manager.go
+++ b/pkg/manager/member/tici_member_manager.go
@@ -62,6 +62,38 @@ func (m *ticiMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	ns := tc.GetNamespace()
 	tcName := tc.GetName()
 
+	// Check suspension before the availability of dependencies (PD, TiKV and
+	// TiDB), so that TiCI meta/worker can still be suspended when its
+	// dependencies are not available, e.g. they have already been suspended
+	// during a whole-cluster suspension. Otherwise the whole-cluster
+	// suspension deadlocks here forever.
+	skipMeta, skipWorker := false, false
+	if tc.Spec.TiCI.Meta != nil {
+		needSuspend, err := m.suspender.SuspendComponent(tc, v1alpha1.TiCIMetaMemberType)
+		if err != nil {
+			return fmt.Errorf("suspend %s failed: %v", v1alpha1.TiCIMetaMemberType, err)
+		}
+		if needSuspend {
+			skipMeta = true
+			klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", v1alpha1.TiCIMetaMemberType, ns, tcName)
+		}
+	}
+	if tc.Spec.TiCI.Worker != nil {
+		needSuspend, err := m.suspender.SuspendComponent(tc, v1alpha1.TiCIWorkerMemberType)
+		if err != nil {
+			return fmt.Errorf("suspend %s failed: %v", v1alpha1.TiCIWorkerMemberType, err)
+		}
+		if needSuspend {
+			skipWorker = true
+			klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", v1alpha1.TiCIWorkerMemberType, ns, tcName)
+		}
+	}
+	if skipMeta && skipWorker {
+		return nil
+	}
+
+	// All TiCI operations, e.g. creation, scale, upgrade will be blocked
+	// if PD, TiKV or TiDB is not available.
 	if tc.Spec.PD != nil && !tc.PDIsAvailable() {
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], TiCI is waiting for PD cluster running", ns, tcName)
 	}
@@ -72,31 +104,14 @@ func (m *ticiMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return controller.RequeueErrorf("TidbCluster: [%s/%s], TiCI is waiting for TiDB cluster running", ns, tcName)
 	}
 
-	if tc.Spec.TiCI.Meta != nil {
-		needSuspend, err := m.suspender.SuspendComponent(tc, v1alpha1.TiCIMetaMemberType)
-		if err != nil {
-			return fmt.Errorf("suspend %s failed: %v", v1alpha1.TiCIMetaMemberType, err)
-		}
-		if !needSuspend {
-			if err := m.syncTiCIMeta(tc); err != nil {
-				return err
-			}
-		} else {
-			klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", v1alpha1.TiCIMetaMemberType, ns, tcName)
+	if tc.Spec.TiCI.Meta != nil && !skipMeta {
+		if err := m.syncTiCIMeta(tc); err != nil {
+			return err
 		}
 	}
-
-	if tc.Spec.TiCI.Worker != nil {
-		needSuspend, err := m.suspender.SuspendComponent(tc, v1alpha1.TiCIWorkerMemberType)
-		if err != nil {
-			return fmt.Errorf("suspend %s failed: %v", v1alpha1.TiCIWorkerMemberType, err)
-		}
-		if !needSuspend {
-			if err := m.syncTiCIWorker(tc); err != nil {
-				return err
-			}
-		} else {
-			klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", v1alpha1.TiCIWorkerMemberType, ns, tcName)
+	if tc.Spec.TiCI.Worker != nil && !skipWorker {
+		if err := m.syncTiCIWorker(tc); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/manager/member/tici_member_manager.go
+++ b/pkg/manager/member/tici_member_manager.go
@@ -88,7 +88,11 @@ func (m *ticiMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 			klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", v1alpha1.TiCIWorkerMemberType, ns, tcName)
 		}
 	}
-	if skipMeta && skipWorker {
+	// An unconfigured subcomponent is treated as skipped, so the invariant is
+	// "all configured subcomponents are suspended" and does not rely on
+	// defaulting filling an empty struct for a nil Meta/Worker.
+	if (tc.Spec.TiCI.Meta == nil || skipMeta) &&
+		(tc.Spec.TiCI.Worker == nil || skipWorker) {
 		return nil
 	}
 

--- a/pkg/manager/member/tici_member_manager_test.go
+++ b/pkg/manager/member/tici_member_manager_test.go
@@ -18,8 +18,12 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	tcconfig "github.com/pingcap/tidb-operator/pkg/apis/util/config"
+	"github.com/pingcap/tidb-operator/pkg/controller"
+	"github.com/pingcap/tidb-operator/pkg/manager/suspender"
+	"github.com/pingcap/tidb-operator/pkg/manager/volumes"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -193,5 +197,112 @@ func newTidbClusterForTiCIConfig() *v1alpha1.TidbCluster {
 				},
 			},
 		},
+	}
+}
+
+func newFakeTiCIMemberManager() *ticiMemberManager {
+	fakeDeps := controller.NewFakeDependencies()
+	return &ticiMemberManager{
+		deps:              fakeDeps,
+		scaler:            NewFakeTiCIScaler(),
+		suspender:         suspender.NewFakeSuspender(),
+		podVolumeModifier: &volumes.FakePodVolumeModifier{},
+	}
+}
+
+// newTidbClusterForTiCISync builds a cluster in the middle of a whole-cluster
+// suspension: TiDB has already been fully suspended (its members are cleared
+// by the suspender) while PD and TiKV are still running, so TiCI meta/worker
+// are next in the suspend order.
+func newTidbClusterForTiCISync() *v1alpha1.TidbCluster {
+	tc := newTidbClusterForTiCIConfig()
+	tc.Spec.PD = &v1alpha1.PDSpec{Replicas: 3}
+	tc.Spec.TiKV = &v1alpha1.TiKVSpec{Replicas: 1}
+	tc.Spec.TiDB = &v1alpha1.TiDBSpec{Replicas: 1}
+
+	// PD and TiKV are still running and available.
+	tc.Status.PD.Members = map[string]v1alpha1.PDMember{
+		"pd-0": {Name: "pd-0", Health: true},
+		"pd-1": {Name: "pd-1", Health: true},
+		"pd-2": {Name: "pd-2", Health: true},
+	}
+	tc.Status.PD.StatefulSet = &appsv1.StatefulSetStatus{ReadyReplicas: 3}
+	tc.Status.TiKV.Stores = map[string]v1alpha1.TiKVStore{
+		"1": {ID: "1", PodName: "tici-test-tikv-0", State: v1alpha1.TiKVStateUp},
+	}
+	tc.Status.TiKV.StatefulSet = &appsv1.StatefulSetStatus{ReadyReplicas: 1}
+
+	// TiDB has been suspended: members are cleared and it can never be ready.
+	tc.Status.TiDB.Members = nil
+	return tc
+}
+
+func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type testcase struct {
+		name          string
+		suspend       func(component v1alpha1.MemberType) (bool, error)
+		expectErr     bool
+		expectSuspend bool
+	}
+
+	testFn := func(test *testcase, t *testing.T) {
+		t.Log(test.name)
+
+		tc := newTidbClusterForTiCISync()
+		tmm := newFakeTiCIMemberManager()
+
+		suspendCalled := false
+		tmm.suspender.(*suspender.FakeSuspender).SuspendComponentFunc = func(c v1alpha1.Cluster, mt v1alpha1.MemberType) (bool, error) {
+			suspendCalled = true
+			return test.suspend(mt)
+		}
+
+		err := tmm.Sync(tc)
+		if test.expectErr {
+			g.Expect(err).To(HaveOccurred())
+		} else {
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+		g.Expect(suspendCalled).To(Equal(test.expectSuspend))
+	}
+
+	tests := []testcase{
+		{
+			// Regression test: TiCI meta/worker must be suspendable even if
+			// TiDB is not ready, e.g. TiDB has already been suspended during
+			// a whole-cluster suspension. Otherwise the whole-cluster
+			// suspension deadlocks on TiCI forever.
+			name: "suspend when TiDB has been suspended",
+			suspend: func(component v1alpha1.MemberType) (bool, error) {
+				return true, nil
+			},
+			expectErr:     false,
+			expectSuspend: true,
+		},
+		{
+			// Availability checks still apply when not suspending.
+			name: "requeue when TiDB is not ready and not suspending",
+			suspend: func(component v1alpha1.MemberType) (bool, error) {
+				return false, nil
+			},
+			expectErr:     true,
+			expectSuspend: true,
+		},
+		{
+			// Only meta is suspended while worker is still being synced
+			// normally: the availability checks still apply for worker.
+			name: "requeue when only meta is suspended and TiDB is not ready",
+			suspend: func(component v1alpha1.MemberType) (bool, error) {
+				return component == v1alpha1.TiCIMetaMemberType, nil
+			},
+			expectErr:     true,
+			expectSuspend: true,
+		},
+	}
+
+	for i := range tests {
+		testFn(&tests[i], t)
 	}
 }

--- a/pkg/manager/member/tici_member_manager_test.go
+++ b/pkg/manager/member/tici_member_manager_test.go
@@ -242,6 +242,7 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 
 	type testcase struct {
 		name          string
+		modify        func(tc *v1alpha1.TidbCluster)
 		suspend       func(component v1alpha1.MemberType) (bool, error)
 		expectErr     bool
 		expectSuspend bool
@@ -251,6 +252,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 		t.Log(test.name)
 
 		tc := newTidbClusterForTiCISync()
+		if test.modify != nil {
+			test.modify(tc)
+		}
 		tmm := newFakeTiCIMemberManager()
 
 		suspendCalled := false
@@ -298,6 +302,20 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 				return component == v1alpha1.TiCIMetaMemberType, nil
 			},
 			expectErr:     true,
+			expectSuspend: true,
+		},
+		{
+			// A cluster configuring only meta (worker is nil) must also be
+			// able to finish suspending. Note this state is not reachable
+			// through the API in practice — defaulting fills an empty struct
+			// for a nil worker — but the skip logic should treat nil as
+			// skipped rather than rely on defaulting.
+			name:   "suspend when only meta is configured",
+			modify: func(tc *v1alpha1.TidbCluster) { tc.Spec.TiCI.Worker = nil },
+			suspend: func(component v1alpha1.MemberType) (bool, error) {
+				return true, nil
+			},
+			expectErr:     false,
 			expectSuspend: true,
 		},
 	}

--- a/pkg/manager/member/tici_member_manager_test.go
+++ b/pkg/manager/member/tici_member_manager_test.go
@@ -246,6 +246,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 		suspend       func(component v1alpha1.MemberType) (bool, error)
 		expectErr     bool
 		expectSuspend bool
+		// expectMemberTypes asserts which member types SuspendComponent is
+		// called with; nil means no assertion.
+		expectMemberTypes []v1alpha1.MemberType
 	}
 
 	testFn := func(test *testcase, t *testing.T) {
@@ -258,8 +261,10 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 		tmm := newFakeTiCIMemberManager()
 
 		suspendCalled := false
+		var suspendedComponents []v1alpha1.MemberType
 		tmm.suspender.(*suspender.FakeSuspender).SuspendComponentFunc = func(c v1alpha1.Cluster, mt v1alpha1.MemberType) (bool, error) {
 			suspendCalled = true
+			suspendedComponents = append(suspendedComponents, mt)
 			return test.suspend(mt)
 		}
 
@@ -270,6 +275,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 		}
 		g.Expect(suspendCalled).To(Equal(test.expectSuspend))
+		if test.expectMemberTypes != nil {
+			g.Expect(suspendedComponents).To(ConsistOf(test.expectMemberTypes))
+		}
 	}
 
 	tests := []testcase{
@@ -284,6 +292,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 			},
 			expectErr:     false,
 			expectSuspend: true,
+			expectMemberTypes: []v1alpha1.MemberType{
+				v1alpha1.TiCIMetaMemberType, v1alpha1.TiCIWorkerMemberType,
+			},
 		},
 		{
 			// Availability checks still apply when not suspending.
@@ -293,6 +304,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 			},
 			expectErr:     true,
 			expectSuspend: true,
+			expectMemberTypes: []v1alpha1.MemberType{
+				v1alpha1.TiCIMetaMemberType, v1alpha1.TiCIWorkerMemberType,
+			},
 		},
 		{
 			// Only meta is suspended while worker is still being synced
@@ -303,6 +317,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 			},
 			expectErr:     true,
 			expectSuspend: true,
+			expectMemberTypes: []v1alpha1.MemberType{
+				v1alpha1.TiCIMetaMemberType, v1alpha1.TiCIWorkerMemberType,
+			},
 		},
 		{
 			// A cluster configuring only meta (worker is nil) must also be
@@ -317,6 +334,9 @@ func TestTiCIMemberManagerSyncSuspend(t *testing.T) {
 			},
 			expectErr:     false,
 			expectSuspend: true,
+			expectMemberTypes: []v1alpha1.MemberType{
+				v1alpha1.TiCIMetaMemberType,
+			},
 		},
 	}
 

--- a/pkg/manager/member/tiflash_member_manager.go
+++ b/pkg/manager/member/tiflash_member_manager.go
@@ -81,11 +81,6 @@ func (m *tiflashMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 		return nil
 	}
 
-	if tc.Spec.TiCI != nil && !tc.TiCIAllMembersReady() {
-		klog.Infof("TidbCluster: [%s/%s], TiFlash is waiting for TiCI meta/worker ready, skip syncing", tc.GetNamespace(), tc.GetName())
-		return nil
-	}
-
 	// skip sync if tiflash is suspended
 	component := v1alpha1.TiFlashMemberType
 	needSuspend, err := m.suspender.SuspendComponent(tc, component)
@@ -94,6 +89,15 @@ func (m *tiflashMemberManager) Sync(tc *v1alpha1.TidbCluster) error {
 	}
 	if needSuspend {
 		klog.Infof("component %s for cluster %s/%s is suspended, skip syncing", component, tc.GetNamespace(), tc.GetName())
+		return nil
+	}
+
+	// Wait for TiCI to be ready before syncing TiFlash: the FTS reader runs
+	// inside TiFlash, so TiCI meta/worker are deployed first. This is checked
+	// after the suspension check, so that suspending TiFlash is not blocked
+	// when TiCI is not available.
+	if tc.Spec.TiCI != nil && !tc.TiCIAllMembersReady() {
+		klog.Infof("TidbCluster: [%s/%s], TiFlash is waiting for TiCI meta/worker ready, skip syncing", tc.GetNamespace(), tc.GetName())
 		return nil
 	}
 

--- a/pkg/manager/member/tiflash_member_manager_test.go
+++ b/pkg/manager/member/tiflash_member_manager_test.go
@@ -1369,6 +1369,33 @@ func newFakeTiFlashMemberManager(tc *v1alpha1.TidbCluster) (
 	return tmm, setControl, svcControl, pdClient, podIndexer, nodeIndexer
 }
 
+func TestTiFlashMemberManagerSyncSuspendWhenTiCINotReady(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tc := newTidbClusterForTiflash()
+	// TiCI is enabled but not ready, e.g. its pods have not been deployed
+	// yet or are unhealthy.
+	tc.Spec.TiCI = &v1alpha1.TiCISpec{
+		Meta:   &v1alpha1.TiCIMetaSpec{},
+		Worker: &v1alpha1.TiCIWorkerSpec{},
+	}
+
+	tfmm, _, _, _, _, _ := newFakeTiFlashMemberManager(tc)
+
+	suspendCalled := false
+	tfmm.suspender.(*suspender.FakeSuspender).SuspendComponentFunc = func(c v1alpha1.Cluster, mt v1alpha1.MemberType) (bool, error) {
+		suspendCalled = true
+		return true, nil
+	}
+
+	err := tfmm.Sync(tc)
+	g.Expect(err).NotTo(HaveOccurred())
+	// Regression test: suspending TiFlash must not be blocked by TiCI
+	// readiness, otherwise a whole-cluster suspension may get stuck when
+	// TiCI is not ready.
+	g.Expect(suspendCalled).To(BeTrue())
+}
+
 func TestGetNewServiceForTidbCluster(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/manager/suspender/suspender_test.go
+++ b/pkg/manager/suspender/suspender_test.go
@@ -435,6 +435,32 @@ func TestCanSuspendComponent(t *testing.T) {
 				g.Expect(reason).To(BeEmpty())
 			},
 		},
+		"wait for TiCI to be suspended": {
+			setup: func(tc *v1alpha1.TidbCluster) {
+				tc.Status.TiKV.Phase = v1alpha1.NormalPhase
+
+				// TiCI is enabled and needs to be suspended as well
+				tc.Spec.TiCI = &v1alpha1.TiCISpec{
+					Meta:   &v1alpha1.TiCIMetaSpec{},
+					Worker: &v1alpha1.TiCIWorkerSpec{},
+				}
+
+				// prior components are fully suspended except TiCI worker
+				tc.Status.TiDB.Phase = v1alpha1.SuspendPhase
+				tc.Status.TiDB.StatefulSet = nil
+				tc.Status.TiFlash.Phase = v1alpha1.SuspendPhase
+				tc.Status.TiFlash.StatefulSet = nil
+				tc.Status.TiCDC.Phase = v1alpha1.SuspendPhase
+				tc.Status.TiCDC.StatefulSet = nil
+				tc.Status.TiCIMeta.Phase = v1alpha1.SuspendPhase
+				tc.Status.TiCIMeta.StatefulSet = nil
+			},
+			component: v1alpha1.TiKVMemberType,
+			expect: func(can bool, reason string) {
+				g.Expect(can).To(BeFalse())
+				g.Expect(reason).To(Equal("wait another component tici-worker to be suspended"))
+			},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
### What problem does this PR solve?

Suspending a whole cluster gets stuck forever when TiCI is enabled.

Closes #7063

In short: the suspender suspends components one by one in a fixed order (TiDB → TiFlash → TiCDC → TiCI meta/worker → TiKV → Pump → PD), and a component can only start suspending after the components before it are fully suspended. By the time it is TiCI's turn, TiDB is already suspended and `TiDBAllMembersReady()` can never return true again — but the TiCI member manager checked dependency availability *before* calling `SuspendComponent()`, so TiCI never started suspending and the whole suspension deadlocked. The TiFlash member manager had the same ordering problem with its TiCI readiness check. Full analysis in the issue.

### What is changed and how does it work?

Two pure reorderings that align the TiCI and TiFlash member managers with the convention every other member manager already follows (since #4640): call `SuspendComponent()` at the very beginning of `Sync()`, before any dependency checks.

- **`tici_member_manager.go`**: the suspension checks for meta/worker now run before the PD/TiKV/TiDB availability checks. A suspended subcomponent skips only its own sync; the availability checks still apply to the subcomponents that keep syncing (e.g. the intermediate state where meta is suspended but worker is not, which requeues harmlessly until worker gets its turn).
- **`tiflash_member_manager.go`**: the TiCI readiness check now runs after the suspension check. Suspending TiFlash no longer requires TiCI to be ready; normal syncing still waits for TiCI, preserving the deployment order (the FTS reader runs inside TiFlash, so TiCI meta/worker are deployed first).

No behavior change for normal (non-suspending) syncing.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test
- [ ] No code

Added:

- `TestTiCIMemberManagerSyncSuspend`: reproduces the deadlock scenario (TiDB fully suspended, PD/TiKV running) and verifies suspension proceeds; also covers the not-suspending and partially-suspended cases where the availability checks still apply.
- `TestTiFlashMemberManagerSyncSuspendWhenTiCINotReady`: verifies suspending TiFlash is not blocked when TiCI is not ready.
- New case in `TestCanSuspendComponent` locking the suspend order for TiCI (TiKV waits for `tici-worker` to be fully suspended).

All new tests fail before the fix and pass after it.

### Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects:

### Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

### Release Notes

```release-note
Fix a bug where suspending the whole cluster gets stuck forever when TiCI is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suspension handling so TiCI Meta and Worker components are evaluated independently.
  * Suspension now proceeds for eligible components even when other TiCI components are unavailable or not ready.
  * Unconfigured TiCI components are skipped, and suspension completes when all configured components are suspended.
  * TiFlash suspension is no longer blocked by unavailable TiCI components.
  * Coordinated suspension now waits appropriately for related components to complete suspension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->